### PR TITLE
feat: add minimum export price configuration for energy data service

### DIFF
--- a/custom_components/hsem/const.py
+++ b/custom_components/hsem/const.py
@@ -45,6 +45,7 @@ DEFAULT_CONFIG_VALUES = {
     "hsem_batteries_enable_batteries_schedule_3": False,
     "hsem_energi_data_service_export": "sensor.energi_data_service_produktion",
     "hsem_energi_data_service_import": "sensor.energi_data_service",
+    "hsem_energi_data_service_export_min_price": -0.15,
     "hsem_ev_charger_power": vol.UNDEFINED,
     "hsem_ev_charger_status": vol.UNDEFINED,
     "hsem_extended_attributes": False,

--- a/custom_components/hsem/custom_sensors/working_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/working_mode_sensor.py
@@ -91,6 +91,7 @@ class HSEMWorkingModeSensor(SensorEntity, HSEMEntity):
         self._hsem_solcast_pv_forecast_forecast_today = None
         self._hsem_energi_data_service_import = None
         self._hsem_energi_data_service_export = None
+        self._hsem_energi_data_service_export_min_price = None
         self._hsem_huawei_solar_inverter_active_power_control = None
         self._hsem_huawei_solar_batteries_working_mode_state = None
         self._hsem_huawei_solar_batteries_state_of_capacity_state = None
@@ -250,6 +251,12 @@ class HSEMWorkingModeSensor(SensorEntity, HSEMEntity):
         self._hsem_energi_data_service_export = get_config_value(
             self._config_entry,
             "hsem_energi_data_service_export",
+        )
+        self._hsem_energi_data_service_export_min_price = convert_to_float(
+            get_config_value(
+                self._config_entry,
+                "hsem_energi_data_service_export_min_price",
+            )
         )
         self._hsem_huawei_solar_inverter_active_power_control = get_config_value(
             self._config_entry,
@@ -441,6 +448,7 @@ class HSEMWorkingModeSensor(SensorEntity, HSEMEntity):
             "batteries_usable_capacity": self._hsem_batteries_usable_capacity,
             "energi_data_service_export_state": self._hsem_energi_data_service_export_state,
             "energi_data_service_import_state": self._hsem_energi_data_service_import_state,
+            "energi_data_service_export_min_price": self._hsem_energi_data_service_export_min_price,
             "energy_needs": self._energy_needs,
             "ev_charger_power_state": self._hsem_ev_charger_power_state,
             "ev_charger_status_state": self._hsem_ev_charger_status_state,
@@ -948,7 +956,11 @@ class HSEMWorkingModeSensor(SensorEntity, HSEMEntity):
         # Determine the appropriate TOU modes and working mode state. In priority order:
         if (
             isinstance(self._hsem_energi_data_service_import_state, (int, float))
-            and self._hsem_energi_data_service_import_state < 0
+            and isinstance(
+                self._hsem_energi_data_service_export_min_price, (int, float)
+            )
+            and self._hsem_energi_data_service_import_state
+            < self._hsem_energi_data_service_export_min_price
         ):
             # Negative import price. Force charge battery
             tou_modes = DEFAULT_HSEM_TOU_MODES_FORCE_CHARGE

--- a/custom_components/hsem/flows/energidataservice.py
+++ b/custom_components/hsem/flows/energidataservice.py
@@ -19,6 +19,22 @@ async def get_energidataservice_step_schema(config_entry) -> vol.Schema:
                     config_entry, "hsem_energi_data_service_export"
                 ),
             ): selector({"entity": {"domain": "sensor"}}),
+            vol.Required(
+                "hsem_energi_data_service_export_min_price",
+                default=get_config_value(
+                    config_entry, "hsem_energi_data_service_export_min_price"
+                ),
+            ): selector(
+                {
+                    "number": {
+                        "min": -10.00,
+                        "max": 0,
+                        "step": 0.01,
+                        "unit_of_measurement": "DKK",
+                        "mode": "slider",
+                    }
+                }
+            ),
         }
     )
 
@@ -29,6 +45,7 @@ async def validate_energidataservice_input(hass, user_input) -> dict[str, str]:
     required_fields = [
         "hsem_energi_data_service_import",
         "hsem_energi_data_service_export",
+        "hsem_energi_data_service_export_min_price",
     ]
 
     for field in required_fields:

--- a/custom_components/hsem/translations/en.json
+++ b/custom_components/hsem/translations/en.json
@@ -65,10 +65,12 @@
       "energidataservice": {
         "data": {
           "hsem_energi_data_service_export": "Energy Data Service Export Price Sensor",
+          "hsem_energi_data_service_export_min_price": "Export Minimum Price Required (DKK)",
           "hsem_energi_data_service_import": "Energy Data Service Import Price Sensor"
         },
         "data_description": {
           "hsem_energi_data_service_export": "Select the sensor that provides export prices from your Energy Data Service integration.",
+          "hsem_energi_data_service_export_min_price": "Set the minimum price for export from your Energy Data Service integration.",
           "hsem_energi_data_service_import": "Select the sensor that provides import prices from your Energy Data Service integration."
         },
         "description": "Select energy data services for HSEM.",
@@ -236,10 +238,12 @@
       "energidataservice": {
         "data": {
           "hsem_energi_data_service_export": "Energy Data Service Export Price Sensor",
+          "hsem_energi_data_service_export_min_price": "Export Minimum Price Required (DKK)",
           "hsem_energi_data_service_import": "Energy Data Service Import Price Sensor"
         },
         "data_description": {
           "hsem_energi_data_service_export": "Select the sensor that provides export prices from your Energy Data Service integration.",
+          "hsem_energi_data_service_export_min_price": "Set the minimum price for export from your Energy Data Service integration.",
           "hsem_energi_data_service_import": "Select the sensor that provides import prices from your Energy Data Service integration."
         },
         "description": "Select energy data services for HSEM.",


### PR DESCRIPTION
Fixes #113 

This pull request introduces a new configuration parameter, `hsem_energi_data_service_export_min_price`, to enhance the energy data service functionality by allowing users to define a minimum export price. The changes span across constants, sensor logic, UI schema, and translations to fully integrate this feature.

### New Feature: Minimum Export Price Configuration

* **Constants Update**:
  - Added `hsem_energi_data_service_export_min_price` with a default value of `-0.15` in `custom_components/hsem/const.py`.

* **Sensor Logic Enhancements**:
  - Added a new instance variable `_hsem_energi_data_service_export_min_price` in the `WorkingModeSensor` class.
  - Updated the `_update_settings` method to fetch and convert the `hsem_energi_data_service_export_min_price` configuration value.
  - Included `hsem_energi_data_service_export_min_price` in the sensor's extra state attributes.
  - Modified the `_async_set_working_mode` method to incorporate the minimum export price in determining the working mode.

* **UI Schema Updates**:
  - Added a slider input for `hsem_energi_data_service_export_min_price` with a range of `-10.00` to `0` DKK in the `get_energidataservice_step_schema` method.
  - Included `hsem_energi_data_service_export_min_price` in the required fields for validation in `validate_energidataservice_input`.

* **Translations**:
  - Updated `en.json` to add labels and descriptions for `hsem_energi_data_service_export_min_price`. [[1]](diffhunk://#diff-1e33b0efb8bd1aee04c668c5e4b4aa729cae0a8e397779c2cbd307ae06c181c3R68-R73) [[2]](diffhunk://#diff-1e33b0efb8bd1aee04c668c5e4b4aa729cae0a8e397779c2cbd307ae06c181c3R241-R246)113