### PR TITLE
feat(hsem): add spike-aware reweighting, capping, and reliability scaling for hourly energy averages

### DIFF
--- a/custom_components/hsem/const.py
+++ b/custom_components/hsem/const.py
@@ -47,10 +47,10 @@ DEFAULT_CONFIG_VALUES = {
     "hsem_ev_charger_power": vol.UNDEFINED,
     "hsem_ev_charger_status": vol.UNDEFINED,
     "hsem_extended_attributes": False,
-    "hsem_house_consumption_energy_weight_14d": 10,
+    "hsem_house_consumption_energy_weight_14d": 15,
     "hsem_house_consumption_energy_weight_1d": 25,
-    "hsem_house_consumption_energy_weight_3d": 50,
-    "hsem_house_consumption_energy_weight_7d": 15,
+    "hsem_house_consumption_energy_weight_3d": 30,
+    "hsem_house_consumption_energy_weight_7d": 30,
     "hsem_house_consumption_power": "sensor.power_house_load",
     "hsem_house_power_includes_ev_charger_power": True,
     "hsem_huawei_solar_batteries_excess_pv_energy_use_in_tou": "select.batteries_excess_pv_energy_use_in_tou",
@@ -73,3 +73,54 @@ DEFAULT_CONFIG_VALUES = {
     "hsem_update_interval": 5,
     "hsem_verbose_logging": False,
 }
+
+# --- Caps between 7d and 14d (very mild, fail-safe) ---
+CAP7_DOWN = 0.85  # 7d cannot go below 85% of 14d
+CAP7_UP = 1.15  # 7d cannot go above 115% of 14d
+CAP14_DOWN = 0.90  # 14d cannot go below 90% of 7d_eff
+CAP14_UP = 1.10  # 14d cannot go above 110% of 7d_eff
+
+# --- Spike detection thresholds (ratios) ---
+# 1d vs 7d
+SPIKE1_RATIO_MIN = 1.30  # ≤ → no spike
+SPIKE1_RATIO_MAX = 2.00  # ≥ → max severity
+SPIKE1_REDUCE_FRACTION_MAX = 0.50  # at max severity, reallocate up to 50% of 1d weight
+SPIKE1_REDIST_TO_3D = 0.20
+SPIKE1_REDIST_TO_7D = 0.55
+SPIKE1_REDIST_TO_14D = 0.25
+
+# 3d vs 7d (milder than 1d)
+SPIKE3_RATIO_MIN = 1.20
+SPIKE3_RATIO_MAX = 1.80
+SPIKE3_REDUCE_FRACTION_MAX = 0.30
+SPIKE3_REDIST_TO_7D = 0.60
+SPIKE3_REDIST_TO_14D = 0.40
+
+# 7d vs 14d (recent window vs longer history)
+# If 7d >> 14d, nudge some weight from 7d to 14d to avoid overreacting to short bursts.
+SPIKE7_RATIO_MIN = 1.20
+SPIKE7_RATIO_MAX = 1.60
+SPIKE7_REDUCE_FRACTION_MAX = 0.20
+SPIKE7_REDIST_TO_14D = 1.00  # all freed 7d weight goes to 14d
+
+# 14d vs 7d (long window dominating)
+# If 14d >> 7d, nudge some weight from 14d to 7d to adapt to newer reality.
+SPIKE14_RATIO_MIN = 1.15
+SPIKE14_RATIO_MAX = 1.50
+SPIKE14_REDUCE_FRACTION_MAX = 0.15
+SPIKE14_REDIST_TO_7D = 1.00  # all freed 14d weight goes to 7d
+
+# --- Capping of short windows vs calm baseline (7d/14d) ---
+BASELINE_7D_SHARE = 0.70  # baseline = 0.70*7d + 0.30*14d
+BASELINE_14D_SHARE = 0.30
+CHANGE_LIMIT_DOWN_FACTOR = (
+    0.80  # cap(yesterday, lower=0.8*baseline, upper=1.2*baseline)
+)
+CHANGE_LIMIT_UP_FACTOR = 1.20
+CHANGE3_LIMIT_DOWN_FACTOR = 0.85  # slightly looser capping for 3d
+CHANGE3_LIMIT_UP_FACTOR = 1.15
+
+# --- Reliability weighting (down-weight disagreement) ---
+# weights are scaled by 1 / (EPS + absolute deviation)
+RELIABILITY_EPS = 0.05  # kWh; prevents division by zero and over-sensitivity
+RELIABILITY_SCALE_STRENGTH = 1.00  # 1.0 = full effect; lower to soften


### PR DESCRIPTION
This PR introduces a comprehensive improvement to the hourly energy consumption calculation logic for the HSEM integration. The changes focus on making the weighted average calculation more robust against spikes, short-term anomalies, and data noise while preserving configurability and backward compatibility.

**Key improvements:**
- **Spike-aware reweighting:**
  - Dynamic weight redistribution when 1d/3d/7d/14d readings deviate significantly from the baseline.
  - Supports different thresholds for each time window with tunable redistribution fractions.
  - Prevents short-term consumption spikes from dominating the final weighted average.
- **Baseline capping:**
  - 1d/3d values are capped relative to a mixed 7d/14d baseline before weighting.
  - Mild fail-safe capping between 7d and 14d to avoid long-term drift.
- **Reliability scaling:**
  - Weights are dynamically scaled down if a source shows strong disagreement with longer baselines.
  - Final weights are normalized back to the configured total sum.
**Fail-safes and guards:**
  - Skips calculation if weights sum to zero or entity data is missing.
  - Negative values are clamped to zero.
  - Renormalization ensures final weights always sum to 100%.
- **Configuration preserved:**
  - Default weights remain configurable (1d/3d/7d/14d).
  - All constants (spike thresholds, caps, scaling factors) documented and easy to tune.

**Benefits:**
- Reduces overreaction to single-day outliers.
- Improves forecast stability for tomorrow's expected hourly consumption.
- Maintains responsiveness to gradual changes in energy patterns.
- Provides debug information for tuning and analysis.

**Suggested default weights (sum=100):**
The following suggestions for default weights going forward will be:

- 1d: 25
- 3d: 30
- 7d: 30
- 14d: 15