### PR TITLE
fix(version): replace string comparison with packaging.version.Version

### DIFF
--- a/custom_components/hsem/__init__.py
+++ b/custom_components/hsem/__init__.py
@@ -4,6 +4,8 @@ import inspect
 import logging
 from importlib.metadata import PackageNotFoundError, version
 
+from packaging.version import InvalidVersion, Version
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -15,6 +17,23 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS = [Platform.SENSOR, Platform.SWITCH, Platform.TIME, Platform.SELECT]
 
 
+def _parse_version(version_str: str) -> Version | None:
+    """Parse a version string into a packaging Version object.
+
+    Args:
+        version_str: The version string to parse (e.g. "1.10.0", "1.5.0a1").
+
+    Returns:
+        A ``packaging.version.Version`` instance, or ``None`` if the string is
+        not a valid PEP 440 version.
+    """
+    try:
+        return Version(version_str)
+    except InvalidVersion:
+        _LOGGER.warning("Invalid version string encountered: '%s'", version_str)
+        return None
+
+
 async def check_huawei_solar_version(hass: HomeAssistant) -> bool:
     """Check the version of the Huawei Solar integration asynchronously."""
 
@@ -24,16 +43,35 @@ async def check_huawei_solar_version(hass: HomeAssistant) -> bool:
         except PackageNotFoundError:
             return None
 
-    installed_version = await hass.async_add_executor_job(_get_version)
+    installed_version_str = await hass.async_add_executor_job(_get_version)
 
-    if installed_version is None:
+    if installed_version_str is None:
         _LOGGER.error("Huawei Solar integration is not installed.")
         return False
 
-    if installed_version < MIN_HUAWEI_SOLAR_VERSION:
+    installed_version = _parse_version(installed_version_str)
+    required_version = _parse_version(MIN_HUAWEI_SOLAR_VERSION)
+
+    if installed_version is None:
         _LOGGER.error(
-            f"Huawei Solar version {installed_version} is installed, "
-            f"but version {MIN_HUAWEI_SOLAR_VERSION} or higher is required."
+            "Could not parse installed Huawei Solar version: '%s'.",
+            installed_version_str,
+        )
+        return False
+
+    if required_version is None:
+        _LOGGER.error(
+            "Could not parse required Huawei Solar version constant: '%s'.",
+            MIN_HUAWEI_SOLAR_VERSION,
+        )
+        return False
+
+    if installed_version < required_version:
+        _LOGGER.error(
+            "Huawei Solar version %s is installed, "
+            "but version %s or higher is required.",
+            installed_version_str,
+            MIN_HUAWEI_SOLAR_VERSION,
         )
         return False
 

--- a/tests/test_version_comparison.py
+++ b/tests/test_version_comparison.py
@@ -1,0 +1,93 @@
+"""Tests for version comparison logic in the HSEM __init__ module.
+
+Covers:
+- Correct numeric ordering (1.10 > 1.9)
+- Pre-release version ordering (1.5.0a1 < 1.5.0)
+- Patch version ordering (1.10.0 < 1.10.1)
+- Invalid version strings are handled without raising
+"""
+
+from packaging.version import Version
+
+from custom_components.hsem import _parse_version
+
+
+class TestParseVersion:
+    """Tests for the _parse_version helper."""
+
+    def test_returns_version_object_for_valid_string(self):
+        """A valid version string should return a packaging.version.Version."""
+        result = _parse_version("1.9.0")
+        assert isinstance(result, Version)
+
+    def test_returns_none_for_invalid_version(self):
+        """An invalid version string should return None instead of raising."""
+        result = _parse_version("not-a-version")
+        assert result is None
+
+    def test_returns_none_for_empty_string(self):
+        """An empty string is not a valid version and should return None."""
+        result = _parse_version("")
+        assert result is None
+
+    def test_returns_none_for_bare_text(self):
+        """Arbitrary text without digits should return None."""
+        result = _parse_version("release-candidate")
+        assert result is None
+
+    def test_parses_pre_release_version(self):
+        """Pre-release versions (PEP 440) must be parsed successfully."""
+        result = _parse_version("1.5.0a1")
+        assert result is not None
+        assert result == Version("1.5.0a1")
+
+
+class TestVersionOrdering:
+    """Tests for numeric version ordering correctness.
+
+    String comparison produces wrong results, e.g. "1.10" < "1.9" because
+    "1" == "1" and then "." == "." and then "1" < "9" lexicographically.
+    packaging.version.Version must produce the correct numeric result.
+    """
+
+    def test_1_10_greater_than_1_9(self):
+        """1.10 must compare as greater than 1.9 (not less, as string comparison gives)."""
+        assert _parse_version("1.10") > _parse_version("1.9")
+
+    def test_1_9_less_than_1_10(self):
+        """1.9 must compare as less than 1.10."""
+        assert _parse_version("1.9") < _parse_version("1.10")
+
+    def test_1_10_1_greater_than_1_10(self):
+        """1.10.1 must compare as greater than 1.10."""
+        assert _parse_version("1.10.1") > _parse_version("1.10")
+
+    def test_1_10_less_than_1_10_1(self):
+        """1.10 must compare as less than 1.10.1."""
+        assert _parse_version("1.10") < _parse_version("1.10.1")
+
+    def test_equal_versions(self):
+        """Two identical version strings must compare as equal."""
+        assert _parse_version("1.10") == _parse_version("1.10")
+
+    def test_pre_release_less_than_release(self):
+        """A pre-release version (1.5.0a1) must compare as less than the release (1.5.0)."""
+        assert _parse_version("1.5.0a1") < _parse_version("1.5.0")
+
+    def test_min_huawei_version_accepted(self):
+        """Installed version equal to the minimum required version must be accepted."""
+        installed = _parse_version("1.5.0a1")
+        required = _parse_version("1.5.0a1")
+        assert installed >= required
+
+    def test_version_above_minimum_accepted(self):
+        """A version higher than the minimum required must be accepted."""
+        installed = _parse_version("1.10.0")
+        required = _parse_version("1.5.0a1")
+        assert installed >= required
+
+    def test_version_below_minimum_rejected(self):
+        """A version lower than the minimum required must be rejected."""
+        installed = _parse_version("1.4.9")
+        required = _parse_version("1.5.0a1")
+        assert installed < required


### PR DESCRIPTION
## Summary

Replaces the string-based version comparison in `check_huawei_solar_version` with `packaging.version.Version`, fixing cases where string ordering produces wrong results (e.g. `"1.10" < "1.9"` lexicographically but `1.10 > 1.9` numerically).

Fixes #271

## Changes

### `custom_components/hsem/__init__.py`
- Added `from packaging.version import InvalidVersion, Version`
- Extracted a `_parse_version(version_str)` helper that returns a `Version` object or `None` on invalid input (logs a warning)
- Updated `check_huawei_solar_version` to parse both the installed and required version strings before comparing, and handle invalid version strings gracefully
- Converted f-string log calls to `%`-style placeholders (ruff auto-fix, consistent with project logging rules)

### `tests/test_version_comparison.py` *(new)*
- `TestParseVersion` — verifies valid strings return `Version`, invalid strings return `None`, pre-release strings parse correctly
- `TestVersionOrdering` — verifies `1.10 > 1.9`, `1.10.1 > 1.10`, `1.5.0a1 < 1.5.0`, equality, and boundary checks against `MIN_HUAWEI_SOLAR_VERSION`

## Test Results

```
62 passed, 64 warnings in 2.71s
```

All 14 new version tests pass. No regressions.

## Lint / Format

```
ruff check . --fix   → Found 1 error (1 fixed, 0 remaining)
ruff format .        → 45 files left unchanged
```
