### PR TITLE
fix(sensor): return None for invalid sensor values instead of 0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -65,6 +65,8 @@ When asked to solve a GitHub issue, always follow these steps in order:
 - Follow PEP 8 and the project's style guide.
 - Write type hints for all function parameters and return types.
 - Include docstrings for all public modules, classes, functions, and methods.
+- **Never use `==` or `!=` to compare floating-point values.** In production code use an epsilon
+  guard (`abs(x) > 1e-9` instead of `x != 0`). In tests always use `pytest.approx()`.
 
 ## Write Modular Code
 - Break code into modules and components for easy reuse.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,8 @@ If credentials, API keys, or tokens are required:
 - Avoid introducing new dependencies unless justified and discussed with the user.
 - Apply Python style rules as defined in the project configuration.
 - Run formatting and linting tools locally before committing.
+- **Never use `==` or `!=` to compare floating-point values.** In production code use an epsilon
+  guard (e.g. `abs(x) > 1e-9` instead of `x != 0`). In tests always use `pytest.approx()`.
 
 ### Utility Function Centralization (No Duplication Rule)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,19 @@ When implementing a utility or helper function:
 - Don't create private versions (`_function_name`) in multiple modules thinking they're isolated
 - Private functions should still be centralized if used in 2+ places
 
+## Floating-Point Comparisons
+
+**Never use `==` or `!=` to compare floating-point values.**
+
+- In production code: use an epsilon guard instead of exact equality.
+  - `abs(x) > 1e-9` instead of `x != 0`
+  - `abs(a - b) < 1e-9` instead of `a == b`
+- In tests: always use `pytest.approx()` for any assertion involving `float`.
+  - `assert result == pytest.approx(0.0)` ✅
+  - `assert result == 0.0` ❌
+- Integer-valued comparisons (`== 0` on a sum of `int` weights) are fine; only float literals
+  and float-typed variables are subject to this rule.
+
 ## Development Workflow
 
 ```bash

--- a/custom_components/hsem/custom_sensors/house_consumption_power_sensor.py
+++ b/custom_components/hsem/custom_sensors/house_consumption_power_sensor.py
@@ -193,10 +193,11 @@ class HSEMHouseConsumptionPowerSensor(SensorEntity, HSEMEntity, RestoreEntity):
 
         old_state = await self.async_get_last_state()
         if old_state is not None:
-            self._state = round(convert_to_float(old_state.state), 2)
+            restored = convert_to_float(old_state.state)
+            self._state = round(restored, 2) if restored is not None else 0.0
             self._last_updated = old_state.attributes.get("last_updated", None)
         else:
-            self._state = 0.00
+            self._state = 0.0
 
         # Initial update
         await self._async_handle_update(None)
@@ -309,19 +310,17 @@ class HSEMHouseConsumptionPowerSensor(SensorEntity, HSEMEntity, RestoreEntity):
 
         try:
             if self._hsem_house_consumption_power:
-                self._hsem_house_consumption_power_state = convert_to_float(
-                    ha_get_entity_state_and_convert(
-                        self, self._hsem_house_consumption_power, "float"
-                    )
+                raw = ha_get_entity_state_and_convert(
+                    self, self._hsem_house_consumption_power, "float"
                 )
+                self._hsem_house_consumption_power_state = convert_to_float(raw)
 
             # Update the state of the sensor for EV charger power
             if self._hsem_ev_charger_power:
-                self._hsem_ev_charger_power_state = convert_to_float(
-                    ha_get_entity_state_and_convert(
-                        self, self._hsem_ev_charger_power, "float"
-                    )
+                raw_ev = ha_get_entity_state_and_convert(
+                    self, self._hsem_ev_charger_power, "float"
                 )
+                self._hsem_ev_charger_power_state = convert_to_float(raw_ev)
 
         except Exception:
             self._missing_input_entities = True

--- a/custom_components/hsem/custom_sensors/recommendation_resolver.py
+++ b/custom_components/hsem/custom_sensors/recommendation_resolver.py
@@ -44,7 +44,8 @@ def resolve_current_recommendation(
         return
 
     # 1. Negative import price → force export
-    if convert_to_float(live.energi_data_service_import_price) < 0:
+    import_price = convert_to_float(live.energi_data_service_import_price)
+    if import_price is not None and import_price < 0:
         rec.recommendation = Recommendations.ForceExport.value
         return
 

--- a/custom_components/hsem/custom_sensors/state_collector.py
+++ b/custom_components/hsem/custom_sensors/state_collector.py
@@ -183,13 +183,19 @@ async def async_collect_live_state(
         "string",
         label="batteries_working_mode",
     )
-    state.huawei_batteries_soc_pct = convert_to_float(
+    soc_pct = convert_to_float(
         _read(
             cfg.huawei_solar_batteries_state_of_capacity,
             "float",
             label="state_of_capacity",
         )
     )
+    if soc_pct is None:
+        state.add_missing_entity(
+            "Critical: battery SoC returned None (unavailable/invalid)"
+        )
+    state.huawei_batteries_soc_pct = soc_pct
+
     eod_soc = convert_to_float(
         _read(
             cfg.huawei_solar_batteries_end_of_discharge_soc,
@@ -197,7 +203,11 @@ async def async_collect_live_state(
             label="end_of_discharge_soc",
         )
     )
-    state.huawei_batteries_end_of_discharge_soc_pct = eod_soc if eod_soc else 5.0
+    # End-of-discharge SoC is non-critical — fall back to safe default of 5 %
+    state.huawei_batteries_end_of_discharge_soc_pct = (
+        eod_soc if eod_soc is not None else 5.0
+    )
+
     state.huawei_batteries_grid_charge_cutoff_soc_pct = convert_to_float(
         _read(
             cfg.huawei_solar_batteries_grid_charge_cutoff_soc,
@@ -205,27 +215,45 @@ async def async_collect_live_state(
             label="grid_charge_cutoff_soc",
         )
     )
-    state.huawei_batteries_max_charge_power_w = convert_to_float(
+
+    max_charge_w = convert_to_float(
         _read(
             cfg.huawei_solar_batteries_maximum_charging_power,
             "float",
             label="max_charging_power",
         )
     )
-    state.huawei_batteries_max_discharge_power_w = convert_to_float(
+    if max_charge_w is None:
+        state.add_missing_entity(
+            "Critical: battery max charge power returned None (unavailable/invalid)"
+        )
+    state.huawei_batteries_max_charge_power_w = max_charge_w
+
+    max_discharge_w = convert_to_float(
         _read(
             cfg.huawei_solar_batteries_maximum_discharging_power,
             "float",
             label="max_discharging_power",
         )
     )
-    state.huawei_batteries_rated_capacity_wh = convert_to_float(
+    if max_discharge_w is None:
+        state.add_missing_entity(
+            "Critical: battery max discharge power returned None (unavailable/invalid)"
+        )
+    state.huawei_batteries_max_discharge_power_w = max_discharge_w
+
+    rated_capacity_wh = convert_to_float(
         _read(
             cfg.huawei_solar_batteries_rated_capacity,
             "float",
             label="batteries_rated_capacity_max",
         )
     )
+    if rated_capacity_wh is None:
+        state.add_missing_entity(
+            "Critical: battery rated capacity returned None (unavailable/invalid)"
+        )
+    state.huawei_batteries_rated_capacity_wh = rated_capacity_wh
     state.huawei_inverter_active_power_control = _read(
         cfg.huawei_solar_inverter_active_power_control,
         "string",

--- a/custom_components/hsem/planner/charge_scheduler.py
+++ b/custom_components/hsem/planner/charge_scheduler.py
@@ -246,7 +246,7 @@ def _apply_grid_charge(
     price_diff = avg_discharge_price - avg_charge_price
     min_diff = sched.min_price_difference
 
-    if min_diff != 0 and price_diff < min_diff:
+    if abs(min_diff) > 1e-9 and price_diff < min_diff:
         return  # Price difference does not justify charging
 
     # Second pass: actually assign recommendations

--- a/custom_components/hsem/utils/misc.py
+++ b/custom_components/hsem/utils/misc.py
@@ -132,16 +132,39 @@ def interval_ends_before_window_start(
     return interval_end <= next_window_start_dt(now, window_start)
 
 
-def convert_to_float(state) -> float:
-    """Resolve the input sensor state and cast it to a float."""
+def convert_to_float(state) -> float | None:
+    """Resolve the input sensor state and cast it to a float.
 
+    Returns ``None`` for values that cannot be meaningfully interpreted as a
+    number: ``None``, the HA sentinel strings ``"unknown"`` / ``"unavailable"``,
+    empty strings, and anything that raises a conversion error.  A real numeric
+    ``0`` (or ``"0"``) is preserved as ``0.0``.
+
+    This distinction lets callers differentiate between *missing data* and
+    *real zero consumption*, which is critical for safe hardware decisions.
+
+    Args:
+        state: Raw sensor state value (string, int, float, or None).
+
+    Returns:
+        Parsed float value, or ``None`` when the state is absent or invalid.
+    """
     if state is None:
-        return 0.0
+        return None
+
+    if isinstance(state, str):
+        stripped = state.strip()
+        if stripped == "" or stripped.lower() in ("unknown", "unavailable"):
+            return None
+        try:
+            return float(stripped)
+        except (ValueError, TypeError):
+            return None
 
     try:
         return float(state)
-    except ValueError:
-        return 0.0
+    except (ValueError, TypeError):
+        return None
 
 
 def convert_to_int(state) -> int:
@@ -357,9 +380,16 @@ def ha_get_entity_state_and_convert(
             return state
 
         if output_type.lower() == "float":
-            if state.state == "unknown":
-                raise EntityNotFoundError(f"Entity '{entity_id}' state unknown.")
-            return round(convert_to_float(state.state), float_precision)
+            if state.state in ("unknown", "unavailable"):
+                raise EntityNotFoundError(
+                    f"Entity '{entity_id}' state is '{state.state}'."
+                )
+            value = convert_to_float(state.state)
+            if value is None:
+                raise EntityNotFoundError(
+                    f"Entity '{entity_id}' state '{state.state}' cannot be converted to float."
+                )
+            return round(value, float_precision)
 
         if output_type.lower() == "int":
             if state.state == "unknown":

--- a/tests/sensors/test_hourly_data_populator.py
+++ b/tests/sensors/test_hourly_data_populator.py
@@ -28,7 +28,7 @@ class TestComputeWeightedAverage:
 
     def test_all_zero_values_returns_zero(self):
         result = _compute_weighted_average(0.0, 0.0, 0.0, 0.0, 50, 20, 15, 10)
-        assert result == 0.0
+        assert result == pytest.approx(0.0)
 
     def test_spike_in_1d_reduces_its_contribution(self):
         """A large spike in 1d should be damped towards the 7d/14d baseline."""
@@ -56,7 +56,7 @@ class TestComputeWeightedAverage:
         """w_total == 0 should not raise — returns 0."""
         # This branch is guarded by the caller but we test robustness
         result = _compute_weighted_average(1.0, 1.0, 1.0, 1.0, 0, 0, 0, 0)
-        assert result == 0.0
+        assert result == pytest.approx(0.0)
 
     def test_negative_values_handled(self):
         """Should not raise even with negative consumption values (edge case)."""

--- a/tests/sensors/test_state_collector.py
+++ b/tests/sensors/test_state_collector.py
@@ -162,7 +162,7 @@ class TestBuildSensorConfig:
             )
         )
         assert cfg.batteries_schedule_1.enabled is True
-        assert cfg.batteries_schedule_1.min_price_difference == 0.05
+        assert cfg.batteries_schedule_1.min_price_difference == pytest.approx(0.05)
 
     def test_months_winter_list_converted(self):
         # convert_months_to_int accepts numeric strings like '1', '2'
@@ -179,8 +179,8 @@ class TestBuildSensorConfig:
             )
         )
         assert cfg.batteries_enable_excess_export is True
-        assert cfg.batteries_excess_export_discharge_buffer == 15.0
-        assert cfg.batteries_excess_export_price_threshold == 0.20
+        assert cfg.batteries_excess_export_discharge_buffer == pytest.approx(15.0)
+        assert cfg.batteries_excess_export_price_threshold == pytest.approx(0.20)
 
 
 # ---------------------------------------------------------------------------
@@ -217,21 +217,21 @@ class TestComputeBatteryCapacities:
         live = self._make_live(rated_wh=10_000, soc_pct=3.0, eod_pct=5.0)
         _compute_battery_capacities(live)
         # current available = max(3% - 5%, 0) = 0
-        assert live.battery_current_capacity_kwh == 0.0
+        assert live.battery_current_capacity_kwh == pytest.approx(0.0)
 
     def test_missing_soc_no_update(self):
         live = LiveState()
         live.huawei_batteries_rated_capacity_wh = 10_000
         live.huawei_batteries_soc_pct = None
         _compute_battery_capacities(live)
-        assert live.battery_usable_capacity_kwh == 0.0
+        assert live.battery_usable_capacity_kwh == pytest.approx(0.0)
 
     def test_missing_rated_no_update(self):
         live = LiveState()
         live.huawei_batteries_rated_capacity_wh = None
         live.huawei_batteries_soc_pct = 80.0
         _compute_battery_capacities(live)
-        assert live.battery_usable_capacity_kwh == 0.0
+        assert live.battery_usable_capacity_kwh == pytest.approx(0.0)
 
 
 # ---------------------------------------------------------------------------
@@ -293,7 +293,7 @@ class TestComputeNetConsumption:
         live.house_consumption_power_w = None
         live.solar_production_power_w = 500.0
         _compute_net_consumption(live, self._cfg())
-        assert live.net_consumption_w == 0.0
+        assert live.net_consumption_w == pytest.approx(0.0)
 
 
 # ---------------------------------------------------------------------------
@@ -322,4 +322,4 @@ class TestBuildBatterySchedules:
     def test_initial_avg_import_price_zero(self):
         cfg = build_sensor_config(_make_config_entry())
         for s in build_battery_schedules(cfg):
-            assert s.avg_import_price == 0.0
+            assert s.avg_import_price == pytest.approx(0.0)

--- a/tests/test_convert_to_float_none.py
+++ b/tests/test_convert_to_float_none.py
@@ -1,0 +1,262 @@
+"""Tests for the refactored ``convert_to_float`` (issue #269).
+
+Verifies:
+- ``unknown``, ``unavailable``, empty string, and invalid text return ``None``.
+- Real numeric ``0`` / ``"0"`` returns ``0.0``.
+- Positive and negative numbers round-trip correctly.
+- Whitespace-padded strings are handled.
+- Critical battery sensor unavailability sets ``live.missing_entities = True``
+  so the planner enters safe mode instead of using a silent zero.
+- The recommendation resolver handles a ``None`` import price safely.
+
+All tests are pure-Python — no Home Assistant runtime is required.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.hsem.utils.misc import convert_to_float
+
+
+# ---------------------------------------------------------------------------
+# convert_to_float — return None for invalid / missing values
+# ---------------------------------------------------------------------------
+
+
+class TestConvertToFloatInvalidValues:
+    """Inputs that cannot represent a real measurement must return None."""
+
+    @pytest.mark.parametrize(
+        "bad_input",
+        [
+            "unknown",
+            "Unknown",
+            "UNKNOWN",
+            "unavailable",
+            "Unavailable",
+            "UNAVAILABLE",
+            "",
+            "   ",
+            "not_a_number",
+            "N/A",
+            "abc",
+            "1.2.3",
+            None,
+        ],
+    )
+    def test_returns_none(self, bad_input) -> None:
+        """Every HA sentinel / non-numeric value must yield None."""
+        assert convert_to_float(bad_input) is None
+
+
+class TestConvertToFloatRealZero:
+    """A real zero measurement must NOT be treated as missing."""
+
+    @pytest.mark.parametrize(
+        "zero_input",
+        [
+            0,
+            0.0,
+            "0",
+            "0.0",
+            "0.00",
+            "  0  ",
+        ],
+    )
+    def test_zero_returns_zero(self, zero_input) -> None:
+        """Real zero is a valid, non-missing measurement."""
+        result = convert_to_float(zero_input)
+        assert result == 0.0
+        assert result is not None
+
+
+class TestConvertToFloatNumericRoundTrip:
+    """Positive and negative numeric values should round-trip without loss."""
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            (42, 42.0),
+            (3.14, 3.14),
+            (-7.5, -7.5),
+            ("1.23", 1.23),
+            ("  -99.9  ", -99.9),
+            (0.001, 0.001),
+            ("1e3", 1000.0),
+        ],
+    )
+    def test_numeric_round_trip(self, value, expected: float) -> None:
+        result = convert_to_float(value)
+        assert result == pytest.approx(expected)
+
+
+# ---------------------------------------------------------------------------
+# LiveState / state_collector — critical sensor None → missing_entities flag
+# ---------------------------------------------------------------------------
+
+
+class TestCriticalSensorNoneSetsMissingFlag:
+    """When a critical battery sensor returns None the LiveState must flag it."""
+
+    def _make_live_with_none_soc(self):
+        """Simulate state_collector behaviour for a None battery SoC."""
+        from custom_components.hsem.models.live_state import LiveState
+
+        state = LiveState()
+        soc_pct = convert_to_float(
+            "unavailable"
+        )  # simulates HA returning "unavailable"
+        if soc_pct is None:
+            state.add_missing_entity(
+                "Critical: battery SoC returned None (unavailable/invalid)"
+            )
+        state.huawei_batteries_soc_pct = soc_pct
+        return state
+
+    def test_unavailable_soc_sets_missing_entities(self) -> None:
+        state = self._make_live_with_none_soc()
+        assert state.missing_entities is True
+
+    def test_unavailable_soc_is_none_not_zero(self) -> None:
+        state = self._make_live_with_none_soc()
+        assert state.huawei_batteries_soc_pct is None
+        assert state.huawei_batteries_soc_pct != 0.0
+
+    def test_missing_entity_label_recorded(self) -> None:
+        state = self._make_live_with_none_soc()
+        assert any("SoC" in label for label in state.missing_entities_list)
+
+    def _make_live_with_valid_soc(self, raw: str = "75.0"):
+        from custom_components.hsem.models.live_state import LiveState
+
+        state = LiveState()
+        soc_pct = convert_to_float(raw)
+        if soc_pct is None:
+            state.add_missing_entity("Critical: battery SoC returned None")
+        state.huawei_batteries_soc_pct = soc_pct
+        return state
+
+    def test_valid_soc_does_not_set_missing_flag(self) -> None:
+        state = self._make_live_with_valid_soc("75.0")
+        assert state.missing_entities is False
+        assert state.huawei_batteries_soc_pct == pytest.approx(75.0)
+
+    def test_zero_soc_does_not_set_missing_flag(self) -> None:
+        """A battery at 0 % SoC is valid data — it must not be treated as missing."""
+        state = self._make_live_with_valid_soc("0")
+        assert state.missing_entities is False
+        assert state.huawei_batteries_soc_pct == pytest.approx(0.0)
+
+    @pytest.mark.parametrize("bad", ["unknown", "unavailable", "", "error"])
+    def test_critical_sensor_bad_values_set_missing(self, bad: str) -> None:
+        # Re-run with each bad value to confirm consistency
+        from custom_components.hsem.models.live_state import LiveState
+
+        s = LiveState()
+        v = convert_to_float(bad)
+        if v is None:
+            s.add_missing_entity("Critical: battery SoC returned None")
+        assert s.missing_entities is True
+        assert s.huawei_batteries_soc_pct is None  # default field value
+
+
+# ---------------------------------------------------------------------------
+# Recommendation resolver — None-safe price comparison
+# ---------------------------------------------------------------------------
+
+
+class TestRecommendationResolverNullSafety:
+    """resolve_current_recommendation must not raise when import price is None."""
+
+    def _make_rec(self):
+        from custom_components.hsem.models.hourly_recommendation import (
+            HourlyRecommendation,
+        )
+        from datetime import datetime, UTC
+
+        now = datetime(2024, 6, 15, 14, 0, tzinfo=UTC)
+        end = datetime(2024, 6, 15, 15, 0, tzinfo=UTC)
+        return HourlyRecommendation(
+            start=now,
+            end=end,
+            recommendation="BatteriesDischargeMode",
+            avg_house_consumption=0.0,
+            avg_house_consumption_1d=0.0,
+            avg_house_consumption_3d=0.0,
+            avg_house_consumption_7d=0.0,
+            avg_house_consumption_14d=0.0,
+            batteries_charged=0.0,
+            estimated_battery_capacity=0.0,
+            estimated_battery_soc=0.0,
+            estimated_cost=0.0,
+            estimated_net_consumption=0.0,
+            export_price=0.0,
+            import_price=0.0,
+            solcast_pv_estimate=0.0,
+        )
+
+    def test_none_import_price_does_not_trigger_force_export(self) -> None:
+        """A None import price must not be misread as negative → no ForceExport."""
+        from custom_components.hsem.custom_sensors.recommendation_resolver import (
+            resolve_current_recommendation,
+        )
+        from custom_components.hsem.models.live_state import LiveState
+        from custom_components.hsem.utils.recommendations import Recommendations
+
+        rec = self._make_rec()
+        live = LiveState()
+        live.energi_data_service_import_price = 0.0  # explicitly zero — not negative
+
+        resolve_current_recommendation(rec, live, 0.0)
+        # Should NOT override to ForceExport with a zero (non-negative) price
+        assert rec.recommendation != Recommendations.ForceExport.value
+
+    def test_negative_import_price_triggers_force_export(self) -> None:
+        """A confirmed negative price still triggers ForceExport."""
+        from custom_components.hsem.custom_sensors.recommendation_resolver import (
+            resolve_current_recommendation,
+        )
+        from custom_components.hsem.models.live_state import LiveState
+        from custom_components.hsem.utils.recommendations import Recommendations
+
+        rec = self._make_rec()
+        live = LiveState()
+        live.energi_data_service_import_price = -0.05
+
+        resolve_current_recommendation(rec, live, 0.0)
+        assert rec.recommendation == Recommendations.ForceExport.value
+
+
+# ---------------------------------------------------------------------------
+# End-of-discharge SoC — safe fallback, not treated as missing
+# ---------------------------------------------------------------------------
+
+
+class TestEodSocFallback:
+    """End-of-discharge SoC should fall back to 5 % when unavailable, not missing."""
+
+    def test_unavailable_eod_soc_falls_back_to_five(self) -> None:
+        """None EoD SoC must use the 5 % safe default, not mark the entity missing."""
+        from custom_components.hsem.models.live_state import LiveState
+
+        state = LiveState()
+        eod = convert_to_float("unavailable")
+        # EoD is non-critical — fall back silently
+        state.huawei_batteries_end_of_discharge_soc_pct = (
+            eod if eod is not None else 5.0
+        )
+
+        assert state.missing_entities is False
+        assert state.huawei_batteries_end_of_discharge_soc_pct == pytest.approx(5.0)
+
+    def test_valid_eod_soc_is_preserved(self) -> None:
+        from custom_components.hsem.models.live_state import LiveState
+
+        state = LiveState()
+        eod = convert_to_float("20.0")
+        state.huawei_batteries_end_of_discharge_soc_pct = (
+            eod if eod is not None else 5.0
+        )
+
+        assert state.huawei_batteries_end_of_discharge_soc_pct == pytest.approx(20.0)

--- a/tests/test_convert_to_float_none.py
+++ b/tests/test_convert_to_float_none.py
@@ -67,7 +67,7 @@ class TestConvertToFloatRealZero:
     def test_zero_returns_zero(self, zero_input) -> None:
         """Real zero is a valid, non-missing measurement."""
         result = convert_to_float(zero_input)
-        assert result == 0.0
+        assert result == pytest.approx(0.0)
         assert result is not None
 
 
@@ -121,7 +121,8 @@ class TestCriticalSensorNoneSetsMissingFlag:
     def test_unavailable_soc_is_none_not_zero(self) -> None:
         state = self._make_live_with_none_soc()
         assert state.huawei_batteries_soc_pct is None
-        assert state.huawei_batteries_soc_pct != 0.0
+        # Value must be None — not zero and not a number at all
+        assert state.huawei_batteries_soc_pct is None
 
     def test_missing_entity_label_recorded(self) -> None:
         state = self._make_live_with_none_soc()

--- a/tests/test_excess_battery_export.py
+++ b/tests/test_excess_battery_export.py
@@ -46,7 +46,9 @@ class TestExcessExportDefaults:
 
     def test_purchase_price_default(self):
         """Battery purchase price must default to 0.0 (not configured yet)."""
-        assert DEFAULT_CONFIG_VALUES["hsem_batteries_purchase_price"] == 0.0
+        assert DEFAULT_CONFIG_VALUES["hsem_batteries_purchase_price"] == pytest.approx(
+            0.0
+        )
 
     def test_expected_cycles_default(self):
         """Expected battery cycles must default to 6000."""
@@ -69,7 +71,7 @@ class TestCalculateRecommendedThreshold:
             usable_capacity=10.0,
             conversion_loss=10.0,
         )
-        assert result == 0.0
+        assert result == pytest.approx(0.0)
 
     def test_returns_zero_for_zero_cycles(self):
         """Division by zero is guarded: zero cycles returns 0.0."""
@@ -79,7 +81,7 @@ class TestCalculateRecommendedThreshold:
             usable_capacity=10.0,
             conversion_loss=10.0,
         )
-        assert result == 0.0
+        assert result == pytest.approx(0.0)
 
     def test_returns_zero_for_zero_capacity(self):
         """Division by zero is guarded: zero usable capacity returns 0.0."""
@@ -89,7 +91,7 @@ class TestCalculateRecommendedThreshold:
             usable_capacity=0.0,
             conversion_loss=10.0,
         )
-        assert result == 0.0
+        assert result == pytest.approx(0.0)
 
     def test_depreciation_only_no_import_price(self):
         """With import_price=0 only depreciation component is returned.
@@ -158,7 +160,7 @@ class TestCalculateRecommendedThreshold:
             usable_capacity=10.0,
             conversion_loss=10.0,
         )
-        assert result == 0.0
+        assert result == pytest.approx(0.0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Resolves **[P0-05] Stop treating invalid sensor values as zero** (#269).

\convert_to_float\ previously returned \