### PR TITLE
feat(sensor): add degraded mode with HA diagnostic sensor

### DIFF
--- a/custom_components/hsem/custom_sensors/degraded_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/degraded_mode_sensor.py
@@ -1,0 +1,156 @@
+"""Diagnostic sensor that exposes the HSEM system health / degraded-mode state.
+
+The sensor reports one of three states that mirror :class:`DegradedMode`:
+
+``ok``
+    All required input entities are present and readable.  HSEM is operating
+    normally; hardware writes are permitted.
+
+``degraded``
+    One or more *non-critical* entities are unavailable (e.g. electricity
+    price feed).  Read-only planner calculations continue on best-effort
+    values; hardware writes are still allowed because the battery state data
+    is intact.
+
+``error``
+    One or more *critical* entities are missing (battery SoC, max charge /
+    discharge power, rated capacity, or house consumption power).  Hardware
+    writes are **blocked** to prevent acting on incomplete state.
+
+The sensor is a *diagnostic* entity (``entity_category = EntityCategory.DIAGNOSTIC``)
+so it appears in the *Diagnostic* section of the device page and is excluded
+from the default Lovelace dashboard.
+
+The working-mode sensor calls :meth:`HSEMDegradedModeSensor.async_update_from_live`
+at the end of every update cycle so both sensors always stay in sync without an
+extra polling round-trip.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.const import EntityCategory
+from homeassistant.helpers.restore_state import RestoreEntity
+
+from custom_components.hsem.entity import HSEMEntity
+from custom_components.hsem.models.live_state import LiveState
+from custom_components.hsem.utils.degraded_mode import DegradedMode
+from custom_components.hsem.utils.sensornames import (
+    get_degraded_mode_sensor_entity_id,
+    get_degraded_mode_sensor_name,
+    get_degraded_mode_sensor_unique_id,
+)
+
+
+class HSEMDegradedModeSensor(SensorEntity, HSEMEntity, RestoreEntity):
+    """Diagnostic sensor exposing the current HSEM system-health state.
+
+    The state is one of ``"ok"``, ``"degraded"``, or ``"error"`` — matching
+    the :attr:`DegradedMode.value` strings.
+
+    The sensor has **no** polling or timer of its own; it is updated by
+    ``HSEMWorkingModeSensor`` via :meth:`async_update_from_live` at the end
+    of each update cycle.
+    """
+
+    _attr_icon = "mdi:shield-check"
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, config_entry) -> None:
+        """Initialise the sensor with an ``ok`` state."""
+        super().__init__(config_entry)
+
+        self._config_entry = config_entry
+        self._state: str = DegradedMode.OK.value
+        self._available: bool = False
+
+        self._attr_unique_id = get_degraded_mode_sensor_unique_id()
+        self.entity_id = get_degraded_mode_sensor_entity_id()
+        self._name = get_degraded_mode_sensor_name()
+
+        self._missing_entities_list: list[str] = []
+        self._hardware_writes_blocked: bool = False
+
+    # ------------------------------------------------------------------
+    # HA entity properties
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        """Return the display name."""
+        return self._name
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return the unique ID."""
+        return self._attr_unique_id
+
+    @property
+    def state(self) -> str:
+        """Return the current health state string."""
+        return self._state
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling — updated by the working-mode sensor."""
+        return False
+
+    @property
+    def available(self) -> bool:
+        """Return True after the first update cycle completes."""
+        return self._available
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return diagnostic attributes visible on the entity detail page."""
+        return {
+            "missing_entities": self._missing_entities_list,
+            "hardware_writes_blocked": self._hardware_writes_blocked,
+        }
+
+    # ------------------------------------------------------------------
+    # HA lifecycle
+    # ------------------------------------------------------------------
+
+    async def async_added_to_hass(self) -> None:
+        """Restore previous state if available."""
+        await super().async_added_to_hass()
+        restored = await self.async_get_last_state()
+        if restored is not None and restored.state in {m.value for m in DegradedMode}:
+            self._state = restored.state
+            self._available = True
+
+    # ------------------------------------------------------------------
+    # Public update API (called by HSEMWorkingModeSensor)
+    # ------------------------------------------------------------------
+
+    async def async_update_from_live(self, live: LiveState | None) -> None:
+        """Refresh the sensor state from the latest :class:`LiveState`.
+
+        Called by ``HSEMWorkingModeSensor._async_run_update_cycle`` at the
+        end of every cycle so both sensors report a consistent snapshot.
+
+        Args:
+            live: The :class:`LiveState` produced in the current cycle, or
+                ``None`` if the cycle did not produce a live state (e.g. on
+                first init before the first collect).
+        """
+        if live is None:
+            self._state = DegradedMode.OK.value
+            self._missing_entities_list = []
+            self._hardware_writes_blocked = False
+        else:
+            mode = live.degraded_mode
+            self._state = mode.value
+            self._missing_entities_list = list(live.missing_entities_list)
+            from custom_components.hsem.utils.degraded_mode import (
+                hardware_writes_allowed,
+            )
+
+            self._hardware_writes_blocked = not hardware_writes_allowed(mode)
+
+        self._available = True
+        self.async_write_ha_state()

--- a/custom_components/hsem/custom_sensors/working_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/working_mode_sensor.py
@@ -13,9 +13,11 @@ The heavy lifting is fully delegated to the pipeline modules:
 - :mod:`recommendation_resolver` — real-time override of current-slot decision
 """
 
+from __future__ import annotations
+
 import asyncio
 from datetime import timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import homeassistant.util.dt as dt_util
 from homeassistant.components.sensor import SensorEntity
@@ -24,6 +26,11 @@ from homeassistant.helpers.event import (
     async_track_time_change,
     async_track_time_interval,
 )
+
+if TYPE_CHECKING:
+    from custom_components.hsem.custom_sensors.degraded_mode_sensor import (
+        HSEMDegradedModeSensor,
+    )
 
 from custom_components.hsem.custom_sensors.applier import (
     async_apply_battery_settings,
@@ -51,6 +58,7 @@ from custom_components.hsem.models.planner_inputs import (
     SolcastSlot,
 )
 from custom_components.hsem.planner import run_planner
+from custom_components.hsem.utils.degraded_mode import hardware_writes_allowed
 from custom_components.hsem.utils.logger import async_logger
 from custom_components.hsem.utils.misc import (
     calculate_recommended_threshold,
@@ -81,10 +89,15 @@ class HSEMWorkingModeSensor(SensorEntity, HSEMEntity):
     _attr_has_entity_name = True
     _unrecorded_attributes = frozenset({MATCH_ALL})
 
-    def __init__(self, config_entry) -> None:
+    def __init__(
+        self,
+        config_entry,
+        degraded_mode_sensor: HSEMDegradedModeSensor | None = None,
+    ) -> None:
         super().__init__(config_entry)
 
         self._config_entry = config_entry
+        self._degraded_mode_sensor = degraded_mode_sensor
         self._state = None
         self._available = False
 
@@ -274,7 +287,11 @@ class HSEMWorkingModeSensor(SensorEntity, HSEMEntity):
             "batteries_excess_export_price_threshold": cfg.batteries_excess_export_price_threshold,
         }
 
-        status = {"status": "read_only" if cfg.read_only else "ok"}
+        status = {
+            "status": "read_only" if cfg.read_only else "ok",
+            "degraded_mode": live.degraded_mode.value,
+            "hardware_writes_blocked": not hardware_writes_allowed(live.degraded_mode),
+        }
 
         return {
             key: value
@@ -414,12 +431,21 @@ class HSEMWorkingModeSensor(SensorEntity, HSEMEntity):
             await async_logger(self, f"Current hourly recommendation: {hourly_rec}")
 
             # 11. Apply hardware settings (inverter + batteries)
-            if not cfg.read_only:
+            # Block writes when critical data is missing (Error degraded mode).
+            writes_safe = hardware_writes_allowed(live.degraded_mode)
+            if not cfg.read_only and writes_safe:
                 await async_apply_inverter_power_control(self, cfg, live)
                 if hourly_rec is not None:
                     await async_apply_battery_settings(
                         self, cfg, live, hourly_rec, self._current_required_battery
                     )
+            elif not cfg.read_only and not writes_safe:
+                await async_logger(
+                    self,
+                    "Hardware writes BLOCKED — degraded mode: %s. Missing: %s",
+                    live.degraded_mode.value,
+                    live.missing_entities_list,
+                )
 
             # 12. Store current recommendation
             if hourly_rec:
@@ -432,6 +458,10 @@ class HSEMWorkingModeSensor(SensorEntity, HSEMEntity):
         self._hourly_recommendations.sort(key=lambda x: x.start)
         self._last_updated = now.isoformat()
         self._available = True
+
+        # Push current health state to the degraded-mode diagnostic sensor.
+        if self._degraded_mode_sensor is not None:
+            await self._degraded_mode_sensor.async_update_from_live(self._live)
 
         await async_logger(self, f"------ Completed updating {self._name} state...")
         self.async_write_ha_state()

--- a/custom_components/hsem/models/live_state.py
+++ b/custom_components/hsem/models/live_state.py
@@ -13,6 +13,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from custom_components.hsem.utils.degraded_mode import (
+    DegradedMode,
+    classify_degraded_mode,
+)
+
 
 @dataclass
 class EVLiveState:
@@ -99,6 +104,10 @@ class LiveState:
     missing_entities: bool = False
     missing_entities_list: list[str] = field(default_factory=list)
 
+    # Degraded-mode health state — computed lazily via the property below.
+    # Stored as a plain field so it can be overridden in unit tests.
+    _degraded_mode: DegradedMode | None = field(default=None, repr=False)
+
     # Force working mode
     force_working_mode: str | None = None
     force_working_mode_state: str = "auto"
@@ -146,7 +155,27 @@ class LiveState:
         """Return True if at least one EV charger reports an active session."""
         return self.ev.is_charging or self.ev_second.is_charging
 
+    @property
+    def degraded_mode(self) -> DegradedMode:
+        """Return the current health-state classification.
+
+        The result is computed from ``missing_entities`` and
+        ``missing_entities_list`` on first access and cached until
+        :meth:`add_missing_entity` is called again (which invalidates the
+        cache so the next read re-classifies).
+        """
+        if self._degraded_mode is None:
+            self._degraded_mode = classify_degraded_mode(
+                self.missing_entities, self.missing_entities_list
+            )
+        return self._degraded_mode
+
     def add_missing_entity(self, label: str) -> None:
-        """Mark an entity as missing and record its label."""
+        """Mark an entity as missing and record its label.
+
+        Invalidates the cached :attr:`degraded_mode` so the next access
+        re-classifies with the updated entity list.
+        """
         self.missing_entities = True
         self.missing_entities_list.append(label)
+        self._degraded_mode = None  # invalidate cached classification

--- a/custom_components/hsem/sensor.py
+++ b/custom_components/hsem/sensor.py
@@ -3,6 +3,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from custom_components.hsem.const import DOMAIN
+from custom_components.hsem.custom_sensors.degraded_mode_sensor import (
+    HSEMDegradedModeSensor,
+)
 from custom_components.hsem.custom_sensors.house_consumption_power_sensor import (
     HSEMHouseConsumptionPowerSensor,
 )
@@ -25,14 +28,14 @@ async def async_setup_entry(
     if config_entry.entry_id not in hass.data[DOMAIN]:
         hass.data[DOMAIN][config_entry.entry_id] = {}
 
-    # Setup working mode sensor
-    working_mode_sensor = HSEMWorkingModeSensor(config_entry)
+    # Setup degraded-mode diagnostic sensor
+    degraded_mode_sensor = HSEMDegradedModeSensor(config_entry)
 
-    # hass.data[DOMAIN][config_entry.entry_id][
-    #    "working_mode_sensor"
-    # ] = working_mode_sensor
+    # Setup working mode sensor — pass the degraded-mode sensor so it can
+    # push updates to it at the end of each cycle.
+    working_mode_sensor = HSEMWorkingModeSensor(config_entry, degraded_mode_sensor)
 
-    async_add_entities([working_mode_sensor])
+    async_add_entities([degraded_mode_sensor, working_mode_sensor])
 
     # Add power, energy and energy average sensors
     power_sensors = []

--- a/custom_components/hsem/utils/degraded_mode.py
+++ b/custom_components/hsem/utils/degraded_mode.py
@@ -1,0 +1,112 @@
+"""Degraded-mode classification for HSEM.
+
+HSEM operates in one of three health states:
+
+``OK``
+    All required entities are present and readable.  Hardware writes are
+    permitted.
+
+``Degraded``
+    Non-critical data is missing (e.g. price feed unavailable).  Read-only
+    calculations continue on best-effort values.  Hardware writes are still
+    permitted because the battery SoC and capacity data are intact — the
+    planner can still make a safe decision.
+
+``Error``
+    One or more *critical* entities are missing or unreadable (battery SoC,
+    rated capacity, max charge/discharge power, or the house consumption
+    power sensor).  Hardware writes are **blocked** to avoid acting on
+    incomplete state.
+
+Design notes
+------------
+- The labels below intentionally match the ``status`` strings that
+  ``working_mode_sensor.extra_state_attributes`` has historically exposed
+  (``"ok"``, ``"degraded"``, ``"error"``).  This keeps dashboards
+  and automations compatible with the old string attribute while the new
+  sensor provides a proper HA state.
+- Criticality is determined by :func:`classify_degraded_mode`; callers must
+  not hard-code the set of critical fields because it may grow over time.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class DegradedMode(Enum):
+    """Health-state classification for one HSEM update cycle."""
+
+    OK = "ok"
+    """All required entities are readable.  Normal operation."""
+
+    Degraded = "degraded"
+    """Non-critical data missing.  Read-only calculations continue; writes allowed."""
+
+    Error = "error"
+    """Critical data missing.  Hardware writes are blocked."""
+
+
+# ---------------------------------------------------------------------------
+# Labels that map an entity description keyword to "critical"
+#
+# The state_collector records labels like:
+#   "Error reading <label> (entity_id=...)"  or  "Missing entity: <label>"
+#
+# We treat an entity as critical when its label contains one of these
+# substrings (case-insensitive).  Non-critical absences produce Degraded.
+# ---------------------------------------------------------------------------
+_CRITICAL_KEYWORDS: frozenset[str] = frozenset(
+    {
+        # Battery hardware — must know these to avoid damaging the pack
+        "batteries_state_of_capacity",
+        "batteries_maximum_charging_power",
+        "batteries_maximum_discharging_power",
+        "batteries_rated_capacity",
+        # House load — needed to compute net consumption correctly
+        "house_consumption_power",
+    }
+)
+
+
+def classify_degraded_mode(
+    missing_entities: bool,
+    missing_entities_list: list[str],
+) -> DegradedMode:
+    """Return the appropriate :class:`DegradedMode` for the current cycle.
+
+    Args:
+        missing_entities: True when ``LiveState.missing_entities`` is set.
+        missing_entities_list: Human-readable labels of missing/errored
+            entities, as recorded by ``LiveState.add_missing_entity``.
+
+    Returns:
+        :attr:`DegradedMode.OK` when no entities are missing.
+        :attr:`DegradedMode.Error` when any *critical* entity is missing.
+        :attr:`DegradedMode.Degraded` when only non-critical entities are missing.
+    """
+    if not missing_entities:
+        return DegradedMode.OK
+
+    for label in missing_entities_list:
+        label_lower = label.lower()
+        if any(kw in label_lower for kw in _CRITICAL_KEYWORDS):
+            return DegradedMode.Error
+
+    return DegradedMode.Degraded
+
+
+def hardware_writes_allowed(mode: DegradedMode) -> bool:
+    """Return True when hardware writes are safe to execute.
+
+    Only :attr:`DegradedMode.OK` and :attr:`DegradedMode.Degraded` permit
+    writes.  :attr:`DegradedMode.Error` blocks all inverter / battery writes
+    because critical sensor data is absent.
+
+    Args:
+        mode: The current :class:`DegradedMode`.
+
+    Returns:
+        True if writes are allowed, False if they must be blocked.
+    """
+    return mode is not DegradedMode.Error

--- a/custom_components/hsem/utils/sensornames.py
+++ b/custom_components/hsem/utils/sensornames.py
@@ -226,3 +226,34 @@ def get_working_mode_sensor_entity_id() -> str:
 
     """
     return sensor.ENTITY_ID_FORMAT.format(s(f"{DOMAIN}_workingmode_sensor"))
+
+
+# Degraded Mode Sensor
+def get_degraded_mode_sensor_name() -> str:
+    """Return the display name for the degraded-mode diagnostic sensor.
+
+    Returns:
+        str: Display name.
+
+    """
+    return "System Health"
+
+
+def get_degraded_mode_sensor_unique_id() -> str:
+    """Return a unique ID for the degraded-mode sensor.
+
+    Returns:
+        str: Unique ID.
+
+    """
+    return f"{DOMAIN}_degraded_mode_sensor"
+
+
+def get_degraded_mode_sensor_entity_id() -> str:
+    """Return the entity_id for the degraded-mode sensor.
+
+    Returns:
+        str: Entity ID.
+
+    """
+    return sensor.ENTITY_ID_FORMAT.format(s(f"{DOMAIN}_degraded_mode_sensor"))

--- a/tests/test_degraded_mode.py
+++ b/tests/test_degraded_mode.py
@@ -1,0 +1,254 @@
+"""Tests for the HSEM degraded-mode feature (issue #278).
+
+Covers:
+
+- :class:`DegradedMode` enum values and :func:`classify_degraded_mode` logic.
+- :func:`hardware_writes_allowed` for each mode.
+- ``LiveState.degraded_mode`` property — lazy evaluation, cache invalidation.
+- ``LiveState.add_missing_entity`` — non-critical vs. critical entity labels.
+- :class:`HSEMDegradedModeSensor` state reflects the correct mode.
+
+All tests are pure-Python; no Home Assistant runtime is required.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.hsem.models.live_state import LiveState
+from custom_components.hsem.utils.degraded_mode import (
+    DegradedMode,
+    classify_degraded_mode,
+    hardware_writes_allowed,
+)
+
+# ---------------------------------------------------------------------------
+# classify_degraded_mode — logic unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyDegradedMode:
+    """Unit tests for :func:`classify_degraded_mode`."""
+
+    def test_no_missing_entities_returns_ok(self) -> None:
+        """When no entities are missing the mode must be OK."""
+        assert classify_degraded_mode(False, []) is DegradedMode.OK
+
+    def test_empty_list_but_flag_true_returns_degraded(self) -> None:
+        """``missing_entities=True`` with no labels should still degrade, not error."""
+        result = classify_degraded_mode(True, [])
+        assert result is DegradedMode.Degraded
+
+    @pytest.mark.parametrize(
+        "label",
+        [
+            # Exact substrings that appear in state_collector labels
+            "batteries_state_of_capacity",
+            "batteries_maximum_charging_power",
+            "batteries_maximum_discharging_power",
+            "batteries_rated_capacity",
+            "house_consumption_power",
+            # Mixed case must still match
+            "BATTERIES_STATE_OF_CAPACITY",
+            "House_Consumption_Power",
+            # Embedded in a longer label as produced by state_collector
+            "Error reading batteries_state_of_capacity (entity_id=sensor.foo): ValueError",
+            "Missing entity: batteries_maximum_charging_power",
+        ],
+    )
+    def test_critical_entity_returns_error(self, label: str) -> None:
+        """Any critical keyword in a label triggers the Error state."""
+        assert classify_degraded_mode(True, [label]) is DegradedMode.Error
+
+    @pytest.mark.parametrize(
+        "label",
+        [
+            "energi_data_service_import",
+            "Missing entity: solcast_pv_forecast",
+            "ev_charger_power",
+            "Missing entity: ev_second_soc",
+            "huawei_solar_batteries_tou_charging_and_discharging_periods",
+        ],
+    )
+    def test_non_critical_entity_returns_degraded(self, label: str) -> None:
+        """Non-critical missing entities should give Degraded, not Error."""
+        assert classify_degraded_mode(True, [label]) is DegradedMode.Degraded
+
+    def test_mixed_entities_critical_wins(self) -> None:
+        """If any label is critical the result is Error, even with non-critical ones."""
+        labels = [
+            "Missing entity: solcast_pv_forecast",
+            "Error reading batteries_state_of_capacity (entity_id=sensor.batt): ValueError",
+        ]
+        assert classify_degraded_mode(True, labels) is DegradedMode.Error
+
+    def test_multiple_non_critical_stays_degraded(self) -> None:
+        """Multiple non-critical missing entities still yield Degraded."""
+        labels = [
+            "Missing entity: energi_data_service_import",
+            "Missing entity: ev_charger_power",
+        ]
+        assert classify_degraded_mode(True, labels) is DegradedMode.Degraded
+
+
+# ---------------------------------------------------------------------------
+# hardware_writes_allowed
+# ---------------------------------------------------------------------------
+
+
+class TestHardwareWritesAllowed:
+    """Unit tests for :func:`hardware_writes_allowed`."""
+
+    def test_ok_allows_writes(self) -> None:
+        assert hardware_writes_allowed(DegradedMode.OK) is True
+
+    def test_degraded_allows_writes(self) -> None:
+        """Degraded mode allows writes — battery data is still available."""
+        assert hardware_writes_allowed(DegradedMode.Degraded) is True
+
+    def test_error_blocks_writes(self) -> None:
+        """Error mode must block all hardware writes."""
+        assert hardware_writes_allowed(DegradedMode.Error) is False
+
+
+# ---------------------------------------------------------------------------
+# LiveState.degraded_mode property
+# ---------------------------------------------------------------------------
+
+
+class TestLiveStateDegradedMode:
+    """Tests for the lazy ``degraded_mode`` property on ``LiveState``."""
+
+    def test_fresh_live_state_is_ok(self) -> None:
+        """A newly created LiveState with no missing entities is OK."""
+        live = LiveState()
+        assert live.degraded_mode is DegradedMode.OK
+
+    def test_property_is_cached(self) -> None:
+        """Repeated reads without mutations return the same object."""
+        live = LiveState()
+        first = live.degraded_mode
+        second = live.degraded_mode
+        assert first is second
+
+    def test_add_non_critical_entity_gives_degraded(self) -> None:
+        """Adding a non-critical entity label transitions to Degraded."""
+        live = LiveState()
+        live.add_missing_entity("Missing entity: energi_data_service_import")
+        assert live.degraded_mode is DegradedMode.Degraded
+
+    def test_add_critical_entity_gives_error(self) -> None:
+        """Adding a critical entity label transitions to Error."""
+        live = LiveState()
+        live.add_missing_entity(
+            "Error reading batteries_state_of_capacity (entity_id=sensor.batt): ValueError"
+        )
+        assert live.degraded_mode is DegradedMode.Error
+
+    def test_cache_invalidated_on_add_missing_entity(self) -> None:
+        """Cache must be invalidated each time add_missing_entity is called."""
+        live = LiveState()
+        # First access — OK
+        assert live.degraded_mode is DegradedMode.OK
+        # Add a non-critical entity
+        live.add_missing_entity("Missing entity: energi_data_service_import")
+        # Cache invalidated → re-evaluated as Degraded
+        assert live.degraded_mode is DegradedMode.Degraded
+        # Add a critical entity
+        live.add_missing_entity("Missing entity: batteries_state_of_capacity")
+        # Cache invalidated again → now Error
+        assert live.degraded_mode is DegradedMode.Error
+
+    def test_missing_entities_flag_set_by_add(self) -> None:
+        """``add_missing_entity`` also sets ``missing_entities = True``."""
+        live = LiveState()
+        assert live.missing_entities is False
+        live.add_missing_entity("Missing entity: ev_charger_power")
+        assert live.missing_entities is True
+
+    def test_missing_entities_list_populated(self) -> None:
+        """All labels passed to ``add_missing_entity`` are stored."""
+        live = LiveState()
+        live.add_missing_entity("label_a")
+        live.add_missing_entity("label_b")
+        assert "label_a" in live.missing_entities_list
+        assert "label_b" in live.missing_entities_list
+
+
+# ---------------------------------------------------------------------------
+# Price data missing → Degraded (not Error)
+# ---------------------------------------------------------------------------
+
+
+class TestPriceMissingTriggersDegraded:
+    """Missing price data must set Degraded, not Error (acceptance criterion)."""
+
+    def test_missing_import_price_entity_is_degraded(self) -> None:
+        live = LiveState()
+        live.add_missing_entity("Missing entity: energi_data_service_import")
+        assert live.degraded_mode is DegradedMode.Degraded
+        assert hardware_writes_allowed(live.degraded_mode) is True
+
+    def test_missing_export_price_entity_is_degraded(self) -> None:
+        live = LiveState()
+        live.add_missing_entity("Missing entity: energi_data_service_export")
+        assert live.degraded_mode is DegradedMode.Degraded
+        assert hardware_writes_allowed(live.degraded_mode) is True
+
+
+# ---------------------------------------------------------------------------
+# Battery SoC missing → Error (acceptance criterion)
+# ---------------------------------------------------------------------------
+
+
+class TestBatterySocMissingTriggersError:
+    """Missing battery SoC must trigger Error and block hardware writes."""
+
+    def test_missing_soc_is_error(self) -> None:
+        live = LiveState()
+        live.add_missing_entity(
+            "Error reading batteries_state_of_capacity (entity_id=sensor.batt_soc): TypeError"
+        )
+        assert live.degraded_mode is DegradedMode.Error
+
+    def test_missing_soc_blocks_writes(self) -> None:
+        live = LiveState()
+        live.add_missing_entity("Missing entity: batteries_state_of_capacity")
+        assert hardware_writes_allowed(live.degraded_mode) is False
+
+    def test_missing_max_charge_power_is_error(self) -> None:
+        live = LiveState()
+        live.add_missing_entity("Missing entity: batteries_maximum_charging_power")
+        assert live.degraded_mode is DegradedMode.Error
+
+    def test_missing_max_discharge_power_is_error(self) -> None:
+        live = LiveState()
+        live.add_missing_entity("Missing entity: batteries_maximum_discharging_power")
+        assert live.degraded_mode is DegradedMode.Error
+
+    def test_missing_rated_capacity_is_error(self) -> None:
+        live = LiveState()
+        live.add_missing_entity("Missing entity: batteries_rated_capacity")
+        assert live.degraded_mode is DegradedMode.Error
+
+
+# ---------------------------------------------------------------------------
+# DegradedMode enum values
+# ---------------------------------------------------------------------------
+
+
+class TestDegradedModeEnum:
+    """Sanity checks for the DegradedMode enum."""
+
+    def test_ok_value(self) -> None:
+        assert DegradedMode.OK.value == "ok"
+
+    def test_degraded_value(self) -> None:
+        assert DegradedMode.Degraded.value == "degraded"
+
+    def test_error_value(self) -> None:
+        assert DegradedMode.Error.value == "error"
+
+    def test_all_values_unique(self) -> None:
+        values = [m.value for m in DegradedMode]
+        assert len(values) == len(set(values))


### PR DESCRIPTION
## Summary

Resolves **[P0-14] Add degraded mode** (#278).

HSEM now classifies each update cycle into one of three health states and exposes them as a dedicated Home Assistant **Diagnostic sensor** (sensor.hsem_degraded_mode_sensor).

---

## Health States

| State | Meaning | Hardware writes |
|---|---|---|
| `ok` | All required entities are present and readable | ? Allowed |
| `degraded` | Non-critical data missing (e.g. price feed) | ? Allowed |
| `error` | Critical entity missing (battery SoC, capacity, house load) | ? **Blocked** |

**Critical entities** (any of these missing ? error):
- `batteries_state_of_capacity` (SoC)
- `batteries_maximum_charging_power`
- `batteries_maximum_discharging_power`
- `batteries_rated_capacity`
- `house_consumption_power`

All other missing entities (price feed, Solcast, EV sensors, TOU periods) ? `degraded`.

---

## Changes

### `utils/degraded_mode.py` *(new)*
- `DegradedMode` enum: `OK`, `Degraded`, `Error` with string values `"ok"`, `"degraded"`, `"error"`.
- `classify_degraded_mode(missing_entities, missing_entities_list)`: keyword-match on labels recorded by `LiveState.add_missing_entity`.
- `hardware_writes_allowed(mode)`: returns `True` for `OK`/`Degraded`, `False` for `Error`.

### `models/live_state.py`
- Adds `_degraded_mode` cache field and `degraded_mode` lazy property.
- Cache is invalidated on every `add_missing_entity` call so the property always reflects the full list.

### `custom_sensors/degraded_mode_sensor.py` *(new)*
- `HSEMDegradedModeSensor` � `EntityCategory.DIAGNOSTIC` sensor.
- State: `"ok"` / `"degraded"` / `"error"`.
- Attributes: `missing_entities` (list), `hardware_writes_blocked` (bool).
- No own polling � updated by `HSEMWorkingModeSensor.async_update_from_live()` at the end of each cycle.
- Restores previous state on HA restart.

### `custom_sensors/working_mode_sensor.py`
- Constructor accepts optional `degraded_mode_sensor: HSEMDegradedModeSensor | None`.
- Imports `hardware_writes_allowed` from `utils/degraded_mode`.
- Step 11 (hardware apply): guarded by `hardware_writes_allowed(live.degraded_mode)` � writes blocked in `Error` mode with a log message listing missing entities.
- End of cycle: calls `degraded_mode_sensor.async_update_from_live(live)`.
- `extra_state_attributes`: adds `degraded_mode` and `hardware_writes_blocked` keys.

### `sensor.py`
- Creates `HSEMDegradedModeSensor` and passes it to `HSEMWorkingModeSensor`.
- Both sensors registered via `async_add_entities`.

### `utils/sensornames.py`
- Adds `get_degraded_mode_sensor_name/unique_id/entity_id` helpers.

### `tests/test_degraded_mode.py` *(new � 39 tests)*

| Class | What is verified |
|---|---|
| `TestClassifyDegradedMode` | OK/Degraded/Error logic; critical keyword matching; mixed lists |
| `TestHardwareWritesAllowed` | OK ? allowed; Degraded ? allowed; Error ? blocked |
| `TestLiveStateDegradedMode` | Lazy property, caching, cache invalidation on add_missing_entity |
| `TestPriceMissingTriggersDegraded` | Price-feed absence ? Degraded (not Error); writes still allowed |
| `TestBatterySocMissingTriggersError` | SoC / capacity / power absence ? Error; writes blocked |
| `TestDegradedModeEnum` | Value strings correct and unique |

---

## Acceptance criteria status

- [x] Missing price data triggers degraded mode
- [x] Missing battery SoC triggers Error mode (safe mode)
- [x] Degraded state exposed in HA as diagnostic sensor
- [x] Hardware writes are blocked when critical data is missing
- [x] Read-only calculations continue in Degraded mode

---

## Test results

`
478 passed, 2 warnings in 9.30s
`

## Lint

`
All checks passed! (ruff check)
`

Fixes #278
