### PR TITLE
fix(sensor): correct bool coercion for read_only and add 12 diagnostic sensors

### DIFF
--- a/custom_components/hsem/custom_sensors/battery_soc_sensor.py
+++ b/custom_components/hsem/custom_sensors/battery_soc_sensor.py
@@ -1,0 +1,154 @@
+"""Diagnostic sensor that mirrors the Huawei Solar battery state-of-charge (SoC).
+
+Exposes the battery SoC as a first-class sensor on the HSEM device page so users
+can track it without navigating to the Huawei Solar integration.  It also makes
+the value directly available to HSEM-scoped automations.
+
+The value is a snapshot taken at the start of the most recent coordinator cycle,
+not a real-time reading.  For live SoC use the underlying Huawei Solar sensor.
+
+The sensor is a *diagnostic* entity (``entity_category = EntityCategory.DIAGNOSTIC``)
+so it appears in the *Diagnostic* section of the device page and is excluded from
+the default Lovelace dashboard.
+
+This sensor subscribes to :class:`~custom_components.hsem.coordinator.HSEMDataUpdateCoordinator`
+and updates automatically after every coordinator cycle.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.const import PERCENTAGE, EntityCategory
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from custom_components.hsem.coordinator import (
+    CoordinatorData,
+    HSEMDataUpdateCoordinator,
+)
+from custom_components.hsem.entity import HSEMEntity
+from custom_components.hsem.utils.sensornames import (
+    get_battery_soc_sensor_entity_id,
+    get_battery_soc_sensor_name,
+    get_battery_soc_sensor_unique_id,
+)
+
+
+class HSEMBatterySoCSensor(
+    CoordinatorEntity[HSEMDataUpdateCoordinator],
+    SensorEntity,
+    HSEMEntity,
+    RestoreEntity,
+):
+    """Diagnostic sensor mirroring the battery SoC snapshot from the last cycle.
+
+    State is the SoC percentage (float, 0–100) recorded at the start of the most
+    recently completed coordinator cycle, or ``None`` when not yet available.
+
+    The sensor subscribes to the shared coordinator and is updated automatically
+    after every coordinator cycle.
+    """
+
+    _attr_icon = "mdi:battery-high"
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_device_class = SensorDeviceClass.BATTERY
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_suggested_display_precision = 1
+
+    def __init__(
+        self,
+        config_entry,
+        coordinator: HSEMDataUpdateCoordinator,
+    ) -> None:
+        """Initialise the battery-SoC sensor.
+
+        Args:
+            config_entry: The HSEM config entry.
+            coordinator: The shared :class:`HSEMDataUpdateCoordinator`.
+        """
+        CoordinatorEntity.__init__(self, coordinator)
+        HSEMEntity.__init__(self, config_entry)
+
+        self._config_entry = config_entry
+
+        self._attr_unique_id = get_battery_soc_sensor_unique_id()
+        self.entity_id = get_battery_soc_sensor_entity_id()
+        self._name = get_battery_soc_sensor_name()
+
+        self._restored_state: str | None = None
+
+    # ------------------------------------------------------------------
+    # HA entity properties
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        """Return the display name."""
+        return self._name
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return the unique ID."""
+        return self._attr_unique_id
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the battery SoC percentage from the last cycle."""
+        data: CoordinatorData | None = self.coordinator.data
+        if data is None or data.live is None:
+            if self._restored_state is not None:
+                try:
+                    return float(self._restored_state)
+                except (ValueError, TypeError):
+                    pass
+            return None
+        return data.live.huawei_batteries_soc_pct
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling — driven by the coordinator."""
+        return False
+
+    @property
+    def available(self) -> bool:
+        """True once the coordinator has completed at least one successful cycle."""
+        return (
+            self.coordinator.last_update_success and self.coordinator.data is not None
+        ) or self._restored_state is not None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return battery capacity context."""
+        data: CoordinatorData | None = self.coordinator.data
+        if data is None or data.live is None:
+            return {
+                "battery_current_capacity_kwh": None,
+                "battery_usable_capacity_kwh": None,
+                "battery_rated_capacity_wh": None,
+                "end_of_discharge_soc_pct": None,
+            }
+        live = data.live
+        return {
+            "battery_current_capacity_kwh": live.battery_current_capacity_kwh,
+            "battery_usable_capacity_kwh": live.battery_usable_capacity_kwh,
+            "battery_rated_capacity_wh": live.huawei_batteries_rated_capacity_wh,
+            "end_of_discharge_soc_pct": live.huawei_batteries_end_of_discharge_soc_pct,
+        }
+
+    # ------------------------------------------------------------------
+    # HA lifecycle
+    # ------------------------------------------------------------------
+
+    async def async_added_to_hass(self) -> None:
+        """Restore previous state and register coordinator listener."""
+        await super().async_added_to_hass()
+        restored = await self.async_get_last_state()
+        if restored is not None and restored.state not in {
+            "unavailable",
+            "unknown",
+            None,
+        }:
+            self._restored_state = restored.state

--- a/custom_components/hsem/custom_sensors/config_reader.py
+++ b/custom_components/hsem/custom_sensors/config_reader.py
@@ -45,9 +45,13 @@ def build_sensor_config(config_entry) -> SensorConfig:
     """
     cfg = SensorConfig()
 
-    cfg.read_only = get_config_value(config_entry, "hsem_read_only")
-    cfg.verbose_logging = get_config_value(config_entry, "hsem_verbose_logging")
-    cfg.extended_attributes = get_config_value(config_entry, "hsem_extended_attributes")
+    cfg.read_only = convert_to_boolean(get_config_value(config_entry, "hsem_read_only"))
+    cfg.verbose_logging = convert_to_boolean(
+        get_config_value(config_entry, "hsem_verbose_logging")
+    )
+    cfg.extended_attributes = convert_to_boolean(
+        get_config_value(config_entry, "hsem_extended_attributes")
+    )
     cfg.update_interval = convert_to_int(
         get_config_value(config_entry, "hsem_update_interval")
     )

--- a/custom_components/hsem/custom_sensors/ev_charging_sensor.py
+++ b/custom_components/hsem/custom_sensors/ev_charging_sensor.py
@@ -1,0 +1,153 @@
+"""Diagnostic sensor that exposes whether any EV charger managed by HSEM is active.
+
+The state is ``"on"`` when at least one EV charger reports an active charging
+session, ``"off"`` otherwise.  This makes EV charging activity directly
+automatable without parsing the working-mode sensor attributes.
+
+Both the primary and secondary EV charger are considered.  The secondary charger
+is included only when it is enabled in the HSEM configuration.
+
+The sensor is a *diagnostic* entity (``entity_category = EntityCategory.DIAGNOSTIC``)
+so it appears in the *Diagnostic* section of the device page and is excluded from
+the default Lovelace dashboard.
+
+This sensor subscribes to :class:`~custom_components.hsem.coordinator.HSEMDataUpdateCoordinator`
+and updates automatically after every coordinator cycle.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.const import EntityCategory
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from custom_components.hsem.coordinator import (
+    CoordinatorData,
+    HSEMDataUpdateCoordinator,
+)
+from custom_components.hsem.entity import HSEMEntity
+from custom_components.hsem.utils.sensornames import (
+    get_ev_charging_sensor_entity_id,
+    get_ev_charging_sensor_name,
+    get_ev_charging_sensor_unique_id,
+)
+
+_VALID_STATES = {"on", "off"}
+
+
+class HSEMEVChargingSensor(
+    CoordinatorEntity[HSEMDataUpdateCoordinator],
+    SensorEntity,
+    HSEMEntity,
+    RestoreEntity,
+):
+    """Diagnostic sensor exposing whether any HSEM-managed EV charger is active.
+
+    State is ``"on"`` when at least one EV charger is charging, ``"off"``
+    otherwise.
+
+    The sensor subscribes to the shared coordinator and is updated automatically
+    after every coordinator cycle.
+    """
+
+    _attr_icon = "mdi:ev-station"
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        config_entry,
+        coordinator: HSEMDataUpdateCoordinator,
+    ) -> None:
+        """Initialise the EV-charging sensor.
+
+        Args:
+            config_entry: The HSEM config entry.
+            coordinator: The shared :class:`HSEMDataUpdateCoordinator`.
+        """
+        CoordinatorEntity.__init__(self, coordinator)
+        HSEMEntity.__init__(self, config_entry)
+
+        self._config_entry = config_entry
+
+        self._attr_unique_id = get_ev_charging_sensor_unique_id()
+        self.entity_id = get_ev_charging_sensor_entity_id()
+        self._name = get_ev_charging_sensor_name()
+
+        self._restored_state: str | None = None
+
+    # ------------------------------------------------------------------
+    # HA entity properties
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        """Return the display name."""
+        return self._name
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return the unique ID."""
+        return self._attr_unique_id
+
+    @property
+    def state(self) -> str:
+        """Return ``'on'`` when any EV charger is active, ``'off'`` otherwise."""
+        data: CoordinatorData | None = self.coordinator.data
+        if data is None or data.live is None:
+            return self._restored_state or "off"
+        return "on" if data.live.any_ev_charging else "off"
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling — driven by the coordinator."""
+        return False
+
+    @property
+    def available(self) -> bool:
+        """True once the coordinator has completed at least one successful cycle."""
+        return (
+            self.coordinator.last_update_success and self.coordinator.data is not None
+        ) or self._restored_state is not None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return individual charger states."""
+        data: CoordinatorData | None = self.coordinator.data
+        if data is None or data.live is None:
+            return {
+                "ev_charging": False,
+                "ev_power_w": None,
+                "ev_soc_pct": None,
+                "ev_second_enabled": False,
+                "ev_second_charging": False,
+                "ev_second_power_w": None,
+                "ev_second_soc_pct": None,
+            }
+        live = data.live
+        cfg = data.cfg
+        return {
+            "ev_charging": live.ev.is_charging,
+            "ev_power_w": live.ev.power_w,
+            "ev_soc_pct": live.ev.soc_pct,
+            "ev_second_enabled": (
+                bool(cfg.ev_second_enabled) if cfg is not None else False
+            ),
+            "ev_second_charging": live.ev_second.is_charging,
+            "ev_second_power_w": live.ev_second.power_w,
+            "ev_second_soc_pct": live.ev_second.soc_pct,
+        }
+
+    # ------------------------------------------------------------------
+    # HA lifecycle
+    # ------------------------------------------------------------------
+
+    async def async_added_to_hass(self) -> None:
+        """Restore previous state and register coordinator listener."""
+        await super().async_added_to_hass()
+        restored = await self.async_get_last_state()
+        if restored is not None and restored.state in _VALID_STATES:
+            self._restored_state = restored.state

--- a/custom_components/hsem/custom_sensors/force_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/force_mode_sensor.py
@@ -1,0 +1,144 @@
+"""Diagnostic sensor that exposes whether a force-working-mode override is active.
+
+When the user sets the force-mode select to anything other than ``"auto"``, HSEM
+bypasses the planner entirely and sends the manual working mode directly to the
+inverter.  This sensor makes that override clearly visible on the device page.
+
+The state is the current value of the force-mode select entity:
+
+- ``"auto"`` — no override; the planner controls the hardware.
+- Any other string — the named mode is being forced (e.g. ``"batteries_charge_grid"``).
+
+The sensor is a *diagnostic* entity (``entity_category = EntityCategory.DIAGNOSTIC``)
+so it appears in the *Diagnostic* section of the device page and is excluded from
+the default Lovelace dashboard.
+
+This sensor subscribes to :class:`~custom_components.hsem.coordinator.HSEMDataUpdateCoordinator`
+and updates automatically after every coordinator cycle.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.const import EntityCategory
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from custom_components.hsem.coordinator import (
+    CoordinatorData,
+    HSEMDataUpdateCoordinator,
+)
+from custom_components.hsem.entity import HSEMEntity
+from custom_components.hsem.utils.sensornames import (
+    get_force_mode_sensor_entity_id,
+    get_force_mode_sensor_name,
+    get_force_mode_sensor_unique_id,
+)
+
+
+class HSEMForceModeSensor(
+    CoordinatorEntity[HSEMDataUpdateCoordinator],
+    SensorEntity,
+    HSEMEntity,
+    RestoreEntity,
+):
+    """Diagnostic sensor exposing the current force-working-mode state.
+
+    State is the raw value of the force-mode select: ``"auto"`` when no override
+    is active, otherwise the name of the forced working mode.
+
+    The sensor subscribes to the shared coordinator and is updated automatically
+    after every coordinator cycle.
+    """
+
+    _attr_icon = "mdi:hand-pointing-right"
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        config_entry,
+        coordinator: HSEMDataUpdateCoordinator,
+    ) -> None:
+        """Initialise the force-mode sensor.
+
+        Args:
+            config_entry: The HSEM config entry.
+            coordinator: The shared :class:`HSEMDataUpdateCoordinator`.
+        """
+        CoordinatorEntity.__init__(self, coordinator)
+        HSEMEntity.__init__(self, config_entry)
+
+        self._config_entry = config_entry
+
+        self._attr_unique_id = get_force_mode_sensor_unique_id()
+        self.entity_id = get_force_mode_sensor_entity_id()
+        self._name = get_force_mode_sensor_name()
+
+        self._restored_state: str | None = None
+
+    # ------------------------------------------------------------------
+    # HA entity properties
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        """Return the display name."""
+        return self._name
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return the unique ID."""
+        return self._attr_unique_id
+
+    @property
+    def state(self) -> str:
+        """Return the force-mode select value (``'auto'`` when not overriding)."""
+        data: CoordinatorData | None = self.coordinator.data
+        if data is None or data.live is None:
+            return self._restored_state or "auto"
+        return data.live.force_working_mode_state
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling — driven by the coordinator."""
+        return False
+
+    @property
+    def available(self) -> bool:
+        """True once the coordinator has completed at least one successful cycle."""
+        return (
+            self.coordinator.last_update_success and self.coordinator.data is not None
+        ) or self._restored_state is not None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return whether the override is active and the resolved entity ID."""
+        data: CoordinatorData | None = self.coordinator.data
+        if data is None or data.live is None:
+            return {
+                "override_active": False,
+                "force_mode_entity_id": None,
+            }
+        live = data.live
+        return {
+            "override_active": live.is_forced_mode,
+            "force_mode_entity_id": live.force_working_mode,
+        }
+
+    # ------------------------------------------------------------------
+    # HA lifecycle
+    # ------------------------------------------------------------------
+
+    async def async_added_to_hass(self) -> None:
+        """Restore previous state and register coordinator listener."""
+        await super().async_added_to_hass()
+        restored = await self.async_get_last_state()
+        if restored is not None and restored.state not in {
+            "unavailable",
+            "unknown",
+            None,
+        }:
+            self._restored_state = restored.state

--- a/custom_components/hsem/custom_sensors/hardware_writes_sensor.py
+++ b/custom_components/hsem/custom_sensors/hardware_writes_sensor.py
@@ -1,0 +1,150 @@
+"""Diagnostic sensor that exposes whether HSEM hardware writes are currently allowed.
+
+The state is ``"allowed"`` when HSEM can write commands to the inverter and battery,
+or ``"blocked"`` when writes are gated by the degraded-mode error state (critical
+entities missing).
+
+Note: read-only mode is a separate, intentional configuration toggle exposed by
+:class:`~custom_components.hsem.custom_sensors.read_only_sensor.HSEMReadOnlySensor`.
+This sensor reflects only the *safety gate* — whether the planner considers the
+available data complete enough to safely issue hardware commands.
+
+The sensor is a *diagnostic* entity (``entity_category = EntityCategory.DIAGNOSTIC``)
+so it appears in the *Diagnostic* section of the device page and is excluded from
+the default Lovelace dashboard.
+
+This sensor subscribes to :class:`~custom_components.hsem.coordinator.HSEMDataUpdateCoordinator`
+and updates automatically after every coordinator cycle.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.const import EntityCategory
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from custom_components.hsem.coordinator import (
+    CoordinatorData,
+    HSEMDataUpdateCoordinator,
+)
+from custom_components.hsem.entity import HSEMEntity
+from custom_components.hsem.utils.degraded_mode import hardware_writes_allowed
+from custom_components.hsem.utils.sensornames import (
+    get_hardware_writes_sensor_entity_id,
+    get_hardware_writes_sensor_name,
+    get_hardware_writes_sensor_unique_id,
+)
+
+_ALLOWED = "allowed"
+_BLOCKED = "blocked"
+_VALID_STATES = {_ALLOWED, _BLOCKED}
+
+
+class HSEMHardwareWritesSensor(
+    CoordinatorEntity[HSEMDataUpdateCoordinator],
+    SensorEntity,
+    HSEMEntity,
+    RestoreEntity,
+):
+    """Diagnostic sensor exposing whether HSEM hardware writes are allowed.
+
+    State is ``"allowed"`` when writes are safe (data quality ok or only
+    non-critical entities missing), ``"blocked"`` when critical data is absent.
+
+    The sensor subscribes to the shared coordinator and is updated automatically
+    after every coordinator cycle.
+    """
+
+    _attr_icon = "mdi:transmission-tower"
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        config_entry,
+        coordinator: HSEMDataUpdateCoordinator,
+    ) -> None:
+        """Initialise the hardware-writes sensor.
+
+        Args:
+            config_entry: The HSEM config entry.
+            coordinator: The shared :class:`HSEMDataUpdateCoordinator`.
+        """
+        CoordinatorEntity.__init__(self, coordinator)
+        HSEMEntity.__init__(self, config_entry)
+
+        self._config_entry = config_entry
+
+        self._attr_unique_id = get_hardware_writes_sensor_unique_id()
+        self.entity_id = get_hardware_writes_sensor_entity_id()
+        self._name = get_hardware_writes_sensor_name()
+
+        self._restored_state: str | None = None
+
+    # ------------------------------------------------------------------
+    # HA entity properties
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        """Return the display name."""
+        return self._name
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return the unique ID."""
+        return self._attr_unique_id
+
+    @property
+    def state(self) -> str:
+        """Return ``'allowed'`` or ``'blocked'`` based on degraded-mode state."""
+        data: CoordinatorData | None = self.coordinator.data
+        if data is None or data.live is None:
+            return self._restored_state or _ALLOWED
+        return (
+            _ALLOWED if hardware_writes_allowed(data.live.degraded_mode) else _BLOCKED
+        )
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling — driven by the coordinator."""
+        return False
+
+    @property
+    def available(self) -> bool:
+        """True once the coordinator has completed at least one successful cycle."""
+        return (
+            self.coordinator.last_update_success and self.coordinator.data is not None
+        ) or self._restored_state is not None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return details about why writes are blocked (if applicable)."""
+        data: CoordinatorData | None = self.coordinator.data
+        if data is None or data.live is None:
+            return {
+                "degraded_mode": None,
+                "missing_entities_list": [],
+                "read_only_active": False,
+            }
+        live = data.live
+        cfg = data.cfg
+        return {
+            "degraded_mode": live.degraded_mode.value,
+            "missing_entities_list": list(live.missing_entities_list),
+            "read_only_active": bool(cfg.read_only) if cfg is not None else False,
+        }
+
+    # ------------------------------------------------------------------
+    # HA lifecycle
+    # ------------------------------------------------------------------
+
+    async def async_added_to_hass(self) -> None:
+        """Restore previous state and register coordinator listener."""
+        await super().async_added_to_hass()
+        restored = await self.async_get_last_state()
+        if restored is not None and restored.state in _VALID_STATES:
+            self._restored_state = restored.state

--- a/custom_components/hsem/custom_sensors/last_updated_sensor.py
+++ b/custom_components/hsem/custom_sensors/last_updated_sensor.py
@@ -1,0 +1,132 @@
+"""Diagnostic sensor that exposes the timestamp of the last completed HSEM update cycle.
+
+The state is the ISO-format timestamp of the most recently completed coordinator
+cycle.  Together with the Next Update sensor this gives a complete picture of
+update timing without digging into working-mode sensor attributes.
+
+The sensor is a *diagnostic* entity (``entity_category = EntityCategory.DIAGNOSTIC``)
+so it appears in the *Diagnostic* section of the device page and is excluded from
+the default Lovelace dashboard.
+
+This sensor subscribes to :class:`~custom_components.hsem.coordinator.HSEMDataUpdateCoordinator`
+and updates automatically after every coordinator cycle.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.const import EntityCategory
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from custom_components.hsem.coordinator import (
+    CoordinatorData,
+    HSEMDataUpdateCoordinator,
+)
+from custom_components.hsem.entity import HSEMEntity
+from custom_components.hsem.utils.sensornames import (
+    get_last_updated_sensor_entity_id,
+    get_last_updated_sensor_name,
+    get_last_updated_sensor_unique_id,
+)
+
+
+class HSEMLastUpdatedSensor(
+    CoordinatorEntity[HSEMDataUpdateCoordinator],
+    SensorEntity,
+    HSEMEntity,
+    RestoreEntity,
+):
+    """Diagnostic sensor exposing the timestamp of the last HSEM update cycle.
+
+    State is the ISO-format string of the most recently completed coordinator
+    cycle, or ``None`` until the first cycle has completed.
+
+    The sensor subscribes to the shared coordinator and is updated automatically
+    after every coordinator cycle.
+    """
+
+    _attr_icon = "mdi:clock-check-outline"
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        config_entry,
+        coordinator: HSEMDataUpdateCoordinator,
+    ) -> None:
+        """Initialise the last-updated sensor.
+
+        Args:
+            config_entry: The HSEM config entry.
+            coordinator: The shared :class:`HSEMDataUpdateCoordinator`.
+        """
+        CoordinatorEntity.__init__(self, coordinator)
+        HSEMEntity.__init__(self, config_entry)
+
+        self._config_entry = config_entry
+
+        self._attr_unique_id = get_last_updated_sensor_unique_id()
+        self.entity_id = get_last_updated_sensor_entity_id()
+        self._name = get_last_updated_sensor_name()
+
+        self._restored_state: str | None = None
+
+    # ------------------------------------------------------------------
+    # HA entity properties
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        """Return the display name."""
+        return self._name
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return the unique ID."""
+        return self._attr_unique_id
+
+    @property
+    def state(self) -> str | None:
+        """Return the last-updated ISO timestamp."""
+        data: CoordinatorData | None = self.coordinator.data
+        if data is None:
+            return self._restored_state
+        return data.last_updated
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling — driven by the coordinator."""
+        return False
+
+    @property
+    def available(self) -> bool:
+        """True once the coordinator has completed at least one successful cycle."""
+        return (
+            self.coordinator.last_update_success and self.coordinator.data is not None
+        ) or self._restored_state is not None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the next-update timestamp as context."""
+        data: CoordinatorData | None = self.coordinator.data
+        if data is None:
+            return {"next_update": None}
+        return {"next_update": data.next_update}
+
+    # ------------------------------------------------------------------
+    # HA lifecycle
+    # ------------------------------------------------------------------
+
+    async def async_added_to_hass(self) -> None:
+        """Restore previous state and register coordinator listener."""
+        await super().async_added_to_hass()
+        restored = await self.async_get_last_state()
+        if restored is not None and restored.state not in {
+            "unavailable",
+            "unknown",
+            None,
+        }:
+            self._restored_state = restored.state

--- a/custom_components/hsem/custom_sensors/missing_entities_sensor.py
+++ b/custom_components/hsem/custom_sensors/missing_entities_sensor.py
@@ -1,0 +1,144 @@
+"""Diagnostic sensor that exposes the count of missing HSEM input entities.
+
+The state is an integer — the number of input entities that were absent or
+unreadable during the last coordinator cycle.  When the state is ``0`` all
+required entities are present.
+
+This sensor makes the ``missing_entities_list`` automatable: users can trigger
+notifications or log entries as soon as any sensor disappears, without having to
+inspect the working-mode sensor attributes.
+
+The sensor is a *diagnostic* entity (``entity_category = EntityCategory.DIAGNOSTIC``)
+so it appears in the *Diagnostic* section of the device page and is excluded from
+the default Lovelace dashboard.
+
+This sensor subscribes to :class:`~custom_components.hsem.coordinator.HSEMDataUpdateCoordinator`
+and updates automatically after every coordinator cycle.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.const import EntityCategory
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from custom_components.hsem.coordinator import (
+    CoordinatorData,
+    HSEMDataUpdateCoordinator,
+)
+from custom_components.hsem.entity import HSEMEntity
+from custom_components.hsem.utils.sensornames import (
+    get_missing_entities_sensor_entity_id,
+    get_missing_entities_sensor_name,
+    get_missing_entities_sensor_unique_id,
+)
+
+
+class HSEMMissingEntitiesSensor(
+    CoordinatorEntity[HSEMDataUpdateCoordinator],
+    SensorEntity,
+    HSEMEntity,
+    RestoreEntity,
+):
+    """Diagnostic sensor exposing the count of missing HSEM input entities.
+
+    State is an integer count of missing/unreadable entities.  ``0`` means all
+    required entities are present and readable.
+
+    The sensor subscribes to the shared coordinator and is updated automatically
+    after every coordinator cycle.
+    """
+
+    _attr_icon = "mdi:alert-circle-outline"
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_native_unit_of_measurement = None
+
+    def __init__(
+        self,
+        config_entry,
+        coordinator: HSEMDataUpdateCoordinator,
+    ) -> None:
+        """Initialise the missing-entities sensor.
+
+        Args:
+            config_entry: The HSEM config entry.
+            coordinator: The shared :class:`HSEMDataUpdateCoordinator`.
+        """
+        CoordinatorEntity.__init__(self, coordinator)
+        HSEMEntity.__init__(self, config_entry)
+
+        self._config_entry = config_entry
+
+        self._attr_unique_id = get_missing_entities_sensor_unique_id()
+        self.entity_id = get_missing_entities_sensor_entity_id()
+        self._name = get_missing_entities_sensor_name()
+
+        self._restored_state: str | None = None
+
+    # ------------------------------------------------------------------
+    # HA entity properties
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        """Return the display name."""
+        return self._name
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return the unique ID."""
+        return self._attr_unique_id
+
+    @property
+    def state(self) -> int:
+        """Return the number of missing input entities."""
+        data: CoordinatorData | None = self.coordinator.data
+        if data is None or data.live is None:
+            if self._restored_state is not None:
+                try:
+                    return int(self._restored_state)
+                except (ValueError, TypeError):
+                    pass
+            return 0
+        return len(data.live.missing_entities_list)
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling — driven by the coordinator."""
+        return False
+
+    @property
+    def available(self) -> bool:
+        """True once the coordinator has completed at least one successful cycle."""
+        return (
+            self.coordinator.last_update_success and self.coordinator.data is not None
+        ) or self._restored_state is not None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the full list of missing entity labels as an attribute."""
+        data: CoordinatorData | None = self.coordinator.data
+        if data is None or data.live is None:
+            return {"missing_entities_list": []}
+        return {
+            "missing_entities_list": list(data.live.missing_entities_list),
+        }
+
+    # ------------------------------------------------------------------
+    # HA lifecycle
+    # ------------------------------------------------------------------
+
+    async def async_added_to_hass(self) -> None:
+        """Restore previous state and register coordinator listener."""
+        await super().async_added_to_hass()
+        restored = await self.async_get_last_state()
+        if restored is not None and restored.state not in {
+            "unavailable",
+            "unknown",
+            None,
+        }:
+            self._restored_state = restored.state

--- a/custom_components/hsem/custom_sensors/net_consumption_sensor.py
+++ b/custom_components/hsem/custom_sensors/net_consumption_sensor.py
@@ -1,0 +1,155 @@
+"""Diagnostic sensor that exposes the instantaneous net power consumption.
+
+The state is the net consumption in Watts at the time of the last coordinator
+cycle.  Net consumption = house load − solar production (− EV draw when the
+EV sensor is tracked separately from the house meter).
+
+This sensor makes the real-time power balance visible on the HSEM device page
+and is useful for debugging planner decisions.
+
+The sensor is a *diagnostic* entity (``entity_category = EntityCategory.DIAGNOSTIC``)
+so it appears in the *Diagnostic* section of the device page and is excluded from
+the default Lovelace dashboard.
+
+This sensor subscribes to :class:`~custom_components.hsem.coordinator.HSEMDataUpdateCoordinator`
+and updates automatically after every coordinator cycle.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.const import EntityCategory, UnitOfPower
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from custom_components.hsem.coordinator import (
+    CoordinatorData,
+    HSEMDataUpdateCoordinator,
+)
+from custom_components.hsem.entity import HSEMEntity
+from custom_components.hsem.utils.sensornames import (
+    get_net_consumption_sensor_entity_id,
+    get_net_consumption_sensor_name,
+    get_net_consumption_sensor_unique_id,
+)
+
+
+class HSEMNetConsumptionSensor(
+    CoordinatorEntity[HSEMDataUpdateCoordinator],
+    SensorEntity,
+    HSEMEntity,
+    RestoreEntity,
+):
+    """Diagnostic sensor exposing the instantaneous net power consumption (W).
+
+    State is the net consumption in Watts from the last coordinator cycle.
+    Positive values mean the house is drawing from grid/battery; negative
+    values mean excess solar is available.
+
+    The sensor subscribes to the shared coordinator and is updated automatically
+    after every coordinator cycle.
+    """
+
+    _attr_icon = "mdi:home-lightning-bolt-outline"
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_device_class = SensorDeviceClass.POWER
+    _attr_native_unit_of_measurement = UnitOfPower.WATT
+    _attr_suggested_display_precision = 0
+
+    def __init__(
+        self,
+        config_entry,
+        coordinator: HSEMDataUpdateCoordinator,
+    ) -> None:
+        """Initialise the net-consumption sensor.
+
+        Args:
+            config_entry: The HSEM config entry.
+            coordinator: The shared :class:`HSEMDataUpdateCoordinator`.
+        """
+        CoordinatorEntity.__init__(self, coordinator)
+        HSEMEntity.__init__(self, config_entry)
+
+        self._config_entry = config_entry
+
+        self._attr_unique_id = get_net_consumption_sensor_unique_id()
+        self.entity_id = get_net_consumption_sensor_entity_id()
+        self._name = get_net_consumption_sensor_name()
+
+        self._restored_state: str | None = None
+
+    # ------------------------------------------------------------------
+    # HA entity properties
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        """Return the display name."""
+        return self._name
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return the unique ID."""
+        return self._attr_unique_id
+
+    @property
+    def native_value(self) -> float | None:
+        """Return net consumption in Watts."""
+        data: CoordinatorData | None = self.coordinator.data
+        if data is None or data.live is None:
+            if self._restored_state is not None:
+                try:
+                    return float(self._restored_state)
+                except (ValueError, TypeError):
+                    pass
+            return None
+        return data.live.net_consumption_w
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling — driven by the coordinator."""
+        return False
+
+    @property
+    def available(self) -> bool:
+        """True once the coordinator has completed at least one successful cycle."""
+        return (
+            self.coordinator.last_update_success and self.coordinator.data is not None
+        ) or self._restored_state is not None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return breakdown of the net consumption components."""
+        data: CoordinatorData | None = self.coordinator.data
+        if data is None or data.live is None:
+            return {
+                "house_consumption_w": None,
+                "solar_production_w": None,
+                "net_consumption_with_ev_w": None,
+                "ev_charging_active": False,
+            }
+        live = data.live
+        return {
+            "house_consumption_w": live.house_consumption_power_w,
+            "solar_production_w": live.solar_production_power_w,
+            "net_consumption_with_ev_w": live.net_consumption_with_ev_w,
+            "ev_charging_active": live.any_ev_charging,
+        }
+
+    # ------------------------------------------------------------------
+    # HA lifecycle
+    # ------------------------------------------------------------------
+
+    async def async_added_to_hass(self) -> None:
+        """Restore previous state and register coordinator listener."""
+        await super().async_added_to_hass()
+        restored = await self.async_get_last_state()
+        if restored is not None and restored.state not in {
+            "unavailable",
+            "unknown",
+            None,
+        }:
+            self._restored_state = restored.state

--- a/custom_components/hsem/custom_sensors/next_update_sensor.py
+++ b/custom_components/hsem/custom_sensors/next_update_sensor.py
@@ -1,0 +1,137 @@
+"""Diagnostic sensor that exposes the timestamp of the next scheduled HSEM update.
+
+The state is the ISO-format timestamp of the next coordinator cycle.  Useful for
+automations that need to know when HSEM will next refresh and for debugging timing
+issues (e.g. verifying the update interval is applied correctly).
+
+The sensor is a *diagnostic* entity (``entity_category = EntityCategory.DIAGNOSTIC``)
+so it appears in the *Diagnostic* section of the device page and is excluded from
+the default Lovelace dashboard.
+
+This sensor subscribes to :class:`~custom_components.hsem.coordinator.HSEMDataUpdateCoordinator`
+and updates automatically after every coordinator cycle.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.const import EntityCategory
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from custom_components.hsem.coordinator import (
+    CoordinatorData,
+    HSEMDataUpdateCoordinator,
+)
+from custom_components.hsem.entity import HSEMEntity
+from custom_components.hsem.utils.sensornames import (
+    get_next_update_sensor_entity_id,
+    get_next_update_sensor_name,
+    get_next_update_sensor_unique_id,
+)
+
+
+class HSEMNextUpdateSensor(
+    CoordinatorEntity[HSEMDataUpdateCoordinator],
+    SensorEntity,
+    HSEMEntity,
+    RestoreEntity,
+):
+    """Diagnostic sensor exposing the next scheduled HSEM update timestamp.
+
+    State is the ISO-format string of the next coordinator cycle, or ``None``
+    until the first cycle has completed.
+
+    The sensor subscribes to the shared coordinator and is updated automatically
+    after every coordinator cycle.
+    """
+
+    _attr_icon = "mdi:clock-outline"
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        config_entry,
+        coordinator: HSEMDataUpdateCoordinator,
+    ) -> None:
+        """Initialise the next-update sensor.
+
+        Args:
+            config_entry: The HSEM config entry.
+            coordinator: The shared :class:`HSEMDataUpdateCoordinator`.
+        """
+        CoordinatorEntity.__init__(self, coordinator)
+        HSEMEntity.__init__(self, config_entry)
+
+        self._config_entry = config_entry
+
+        self._attr_unique_id = get_next_update_sensor_unique_id()
+        self.entity_id = get_next_update_sensor_entity_id()
+        self._name = get_next_update_sensor_name()
+
+        self._restored_state: str | None = None
+
+    # ------------------------------------------------------------------
+    # HA entity properties
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        """Return the display name."""
+        return self._name
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return the unique ID."""
+        return self._attr_unique_id
+
+    @property
+    def state(self) -> str | None:
+        """Return the next-update ISO timestamp."""
+        data: CoordinatorData | None = self.coordinator.data
+        if data is None:
+            return self._restored_state
+        return data.next_update
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling — driven by the coordinator."""
+        return False
+
+    @property
+    def available(self) -> bool:
+        """True once the coordinator has completed at least one successful cycle."""
+        return (
+            self.coordinator.last_update_success and self.coordinator.data is not None
+        ) or self._restored_state is not None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return diagnostic attributes."""
+        data: CoordinatorData | None = self.coordinator.data
+        if data is None:
+            return {"last_updated": None, "update_interval_minutes": None}
+        return {
+            "last_updated": data.last_updated,
+            "update_interval_minutes": (
+                data.cfg.update_interval if data.cfg is not None else None
+            ),
+        }
+
+    # ------------------------------------------------------------------
+    # HA lifecycle
+    # ------------------------------------------------------------------
+
+    async def async_added_to_hass(self) -> None:
+        """Restore previous state and register coordinator listener."""
+        await super().async_added_to_hass()
+        restored = await self.async_get_last_state()
+        if restored is not None and restored.state not in {
+            "unavailable",
+            "unknown",
+            None,
+        }:
+            self._restored_state = restored.state

--- a/custom_components/hsem/custom_sensors/read_only_sensor.py
+++ b/custom_components/hsem/custom_sensors/read_only_sensor.py
@@ -1,21 +1,9 @@
-"""Diagnostic sensor that exposes the HSEM system health / degraded-mode state.
+"""Diagnostic sensor that exposes whether HSEM is operating in read-only (dry-run) mode.
 
-The sensor reports one of three states that mirror :class:`DegradedMode`:
-
-``ok``
-    All required input entities are present and readable.  HSEM is operating
-    normally; hardware writes are permitted.
-
-``degraded``
-    One or more *non-critical* entities are unavailable (e.g. electricity
-    price feed).  Read-only planner calculations continue on best-effort
-    values; hardware writes are still allowed because the battery state data
-    is intact.
-
-``error``
-    One or more *critical* entities are missing (battery SoC, max charge /
-    discharge power, rated capacity, or house consumption power).  Hardware
-    writes are **blocked** to prevent acting on incomplete state.
+When ``read_only`` is ``True`` no commands are sent to the inverter or battery
+hardware regardless of the planner recommendation.  This sensor makes that
+state clearly visible on the device page so users can tell at a glance why
+hardware writes are not happening.
 
 The sensor is a *diagnostic* entity (``entity_category = EntityCategory.DIAGNOSTIC``)
 so it appears in the *Diagnostic* section of the device page and is excluded
@@ -23,7 +11,7 @@ from the default Lovelace dashboard.
 
 This sensor subscribes to :class:`~custom_components.hsem.coordinator.HSEMDataUpdateCoordinator`
 and updates automatically after every coordinator cycle without any additional
-polling or push from the working-mode sensor.
+polling.
 """
 
 from __future__ import annotations
@@ -40,33 +28,29 @@ from custom_components.hsem.coordinator import (
     HSEMDataUpdateCoordinator,
 )
 from custom_components.hsem.entity import HSEMEntity
-from custom_components.hsem.utils.degraded_mode import (
-    DegradedMode,
-    hardware_writes_allowed,
-)
 from custom_components.hsem.utils.sensornames import (
-    get_degraded_mode_sensor_entity_id,
-    get_degraded_mode_sensor_name,
-    get_degraded_mode_sensor_unique_id,
+    get_read_only_sensor_entity_id,
+    get_read_only_sensor_name,
+    get_read_only_sensor_unique_id,
 )
 
 
-class HSEMDegradedModeSensor(
+class HSEMReadOnlySensor(
     CoordinatorEntity[HSEMDataUpdateCoordinator],
     SensorEntity,
     HSEMEntity,
     RestoreEntity,
 ):
-    """Diagnostic sensor exposing the current HSEM system-health state.
+    """Diagnostic sensor exposing whether HSEM is in read-only mode.
 
-    The state is one of ``"ok"``, ``"degraded"``, or ``"error"`` — matching
-    the :attr:`DegradedMode.value` strings.
+    State is ``"on"`` when read-only mode is active (no hardware writes),
+    ``"off"`` when HSEM is allowed to write to the inverter / battery.
 
     The sensor subscribes to the shared coordinator and is updated
     automatically after every coordinator cycle.
     """
 
-    _attr_icon = "mdi:shield-check"
+    _attr_icon = "mdi:eye-off-outline"
     _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
@@ -75,7 +59,7 @@ class HSEMDegradedModeSensor(
         config_entry,
         coordinator: HSEMDataUpdateCoordinator,
     ) -> None:
-        """Initialise the sensor with an ``ok`` state.
+        """Initialise the read-only mode sensor.
 
         Args:
             config_entry: The HSEM config entry.
@@ -86,9 +70,9 @@ class HSEMDegradedModeSensor(
 
         self._config_entry = config_entry
 
-        self._attr_unique_id = get_degraded_mode_sensor_unique_id()
-        self.entity_id = get_degraded_mode_sensor_entity_id()
-        self._name = get_degraded_mode_sensor_name()
+        self._attr_unique_id = get_read_only_sensor_unique_id()
+        self.entity_id = get_read_only_sensor_entity_id()
+        self._name = get_read_only_sensor_name()
 
         # Restored state used before the first coordinator cycle completes.
         self._restored_state: str | None = None
@@ -109,12 +93,11 @@ class HSEMDegradedModeSensor(
 
     @property
     def state(self) -> str:
-        """Return the current health state string."""
+        """Return ``'on'`` when read-only mode is active, ``'off'`` otherwise."""
         data: CoordinatorData | None = self.coordinator.data
-        if data is None or data.live is None:
-            # Fall back to restored state while waiting for first cycle.
-            return self._restored_state or DegradedMode.OK.value
-        return data.live.degraded_mode.value
+        if data is None or data.cfg is None:
+            return self._restored_state or "off"
+        return "on" if bool(data.cfg.read_only) else "off"
 
     @property
     def should_poll(self) -> bool:
@@ -132,18 +115,15 @@ class HSEMDegradedModeSensor(
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return diagnostic attributes visible on the entity detail page."""
         data: CoordinatorData | None = self.coordinator.data
-        if data is None or data.live is None:
+        if data is None or data.cfg is None:
             return {
-                "missing_entities": [],
-                "hardware_writes_blocked": False,
-                "read_only_mode": False,
+                "read_only": False,
+                "hardware_writes_active": True,
             }
-        live = data.live
-        cfg = data.cfg
         return {
-            "missing_entities": list(live.missing_entities_list),
-            "hardware_writes_blocked": not hardware_writes_allowed(live.degraded_mode),
-            "read_only_mode": bool(cfg.read_only) if cfg is not None else False,
+            "read_only": bool(data.cfg.read_only),
+            "hardware_writes_active": not bool(data.cfg.read_only),
+            "update_interval_minutes": data.cfg.update_interval,
         }
 
     # ------------------------------------------------------------------
@@ -154,5 +134,5 @@ class HSEMDegradedModeSensor(
         """Restore previous state and register coordinator listener."""
         await super().async_added_to_hass()
         restored = await self.async_get_last_state()
-        if restored is not None and restored.state in {m.value for m in DegradedMode}:
+        if restored is not None and restored.state in {"on", "off"}:
             self._restored_state = restored.state

--- a/custom_components/hsem/custom_sensors/recommendation_interval_sensor.py
+++ b/custom_components/hsem/custom_sensors/recommendation_interval_sensor.py
@@ -1,0 +1,154 @@
+"""Diagnostic sensor that exposes the HSEM recommendation interval configuration.
+
+Two related settings define the planning granularity:
+
+- ``recommendation_interval_minutes``: The width of each planning slot (15 or 60 min).
+- ``recommendation_interval_length``: The planning horizon in hours (e.g. 24 or 48 h).
+
+The sensor state is the slot width in minutes; the planning horizon is exposed as
+an attribute.  Both values are useful for understanding how far ahead HSEM is
+planning and at what resolution.
+
+The sensor is a *diagnostic* entity (``entity_category = EntityCategory.DIAGNOSTIC``)
+so it appears in the *Diagnostic* section of the device page and is excluded from
+the default Lovelace dashboard.
+
+This sensor subscribes to :class:`~custom_components.hsem.coordinator.HSEMDataUpdateCoordinator`
+and updates automatically after every coordinator cycle.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.const import EntityCategory, UnitOfTime
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from custom_components.hsem.coordinator import (
+    CoordinatorData,
+    HSEMDataUpdateCoordinator,
+)
+from custom_components.hsem.entity import HSEMEntity
+from custom_components.hsem.utils.sensornames import (
+    get_recommendation_interval_sensor_entity_id,
+    get_recommendation_interval_sensor_name,
+    get_recommendation_interval_sensor_unique_id,
+)
+
+
+class HSEMRecommendationIntervalSensor(
+    CoordinatorEntity[HSEMDataUpdateCoordinator],
+    SensorEntity,
+    HSEMEntity,
+    RestoreEntity,
+):
+    """Diagnostic sensor exposing the HSEM recommendation slot-width in minutes.
+
+    State is the slot width in minutes (integer).  The planning horizon (hours)
+    is available as the ``recommendation_interval_length_hours`` attribute.
+
+    The sensor subscribes to the shared coordinator and is updated automatically
+    after every coordinator cycle.
+    """
+
+    _attr_icon = "mdi:calendar-clock"
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_native_unit_of_measurement = UnitOfTime.MINUTES
+    _attr_suggested_display_precision = 0
+
+    def __init__(
+        self,
+        config_entry,
+        coordinator: HSEMDataUpdateCoordinator,
+    ) -> None:
+        """Initialise the recommendation-interval sensor.
+
+        Args:
+            config_entry: The HSEM config entry.
+            coordinator: The shared :class:`HSEMDataUpdateCoordinator`.
+        """
+        CoordinatorEntity.__init__(self, coordinator)
+        HSEMEntity.__init__(self, config_entry)
+
+        self._config_entry = config_entry
+
+        self._attr_unique_id = get_recommendation_interval_sensor_unique_id()
+        self.entity_id = get_recommendation_interval_sensor_entity_id()
+        self._name = get_recommendation_interval_sensor_name()
+
+        self._restored_state: str | None = None
+
+    # ------------------------------------------------------------------
+    # HA entity properties
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        """Return the display name."""
+        return self._name
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return the unique ID."""
+        return self._attr_unique_id
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the recommendation slot width in minutes."""
+        data: CoordinatorData | None = self.coordinator.data
+        if data is None or data.cfg is None:
+            if self._restored_state is not None:
+                try:
+                    return int(self._restored_state)
+                except (ValueError, TypeError):
+                    pass
+            return None
+        return data.cfg.recommendation_interval_minutes
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling — driven by the coordinator."""
+        return False
+
+    @property
+    def available(self) -> bool:
+        """True once the coordinator has completed at least one successful cycle."""
+        return (
+            self.coordinator.last_update_success and self.coordinator.data is not None
+        ) or self._restored_state is not None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the planning horizon (hours) as an attribute."""
+        data: CoordinatorData | None = self.coordinator.data
+        if data is None or data.cfg is None:
+            return {
+                "recommendation_interval_length_hours": None,
+                "total_planning_slots": None,
+            }
+        cfg = data.cfg
+        slots = (
+            cfg.recommendation_interval_length * 60
+        ) // cfg.recommendation_interval_minutes
+        return {
+            "recommendation_interval_length_hours": cfg.recommendation_interval_length,
+            "total_planning_slots": slots,
+        }
+
+    # ------------------------------------------------------------------
+    # HA lifecycle
+    # ------------------------------------------------------------------
+
+    async def async_added_to_hass(self) -> None:
+        """Restore previous state and register coordinator listener."""
+        await super().async_added_to_hass()
+        restored = await self.async_get_last_state()
+        if restored is not None and restored.state not in {
+            "unavailable",
+            "unknown",
+            None,
+        }:
+            self._restored_state = restored.state

--- a/custom_components/hsem/custom_sensors/update_interval_sensor.py
+++ b/custom_components/hsem/custom_sensors/update_interval_sensor.py
@@ -1,0 +1,147 @@
+"""Diagnostic sensor that exposes the HSEM coordinator update interval in minutes.
+
+This sensor makes the current polling cadence visible on the HSEM device page
+without having to open the integration options flow.  It is also useful for
+debugging timing issues — e.g. verifying that HSEM switches to a 1-minute
+interval when input entities are missing.
+
+The sensor is a *diagnostic* entity (``entity_category = EntityCategory.DIAGNOSTIC``)
+so it appears in the *Diagnostic* section of the device page and is excluded from
+the default Lovelace dashboard.
+
+This sensor subscribes to :class:`~custom_components.hsem.coordinator.HSEMDataUpdateCoordinator`
+and updates automatically after every coordinator cycle.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.const import EntityCategory, UnitOfTime
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from custom_components.hsem.coordinator import (
+    CoordinatorData,
+    HSEMDataUpdateCoordinator,
+)
+from custom_components.hsem.entity import HSEMEntity
+from custom_components.hsem.utils.sensornames import (
+    get_update_interval_sensor_entity_id,
+    get_update_interval_sensor_name,
+    get_update_interval_sensor_unique_id,
+)
+
+
+class HSEMUpdateIntervalSensor(
+    CoordinatorEntity[HSEMDataUpdateCoordinator],
+    SensorEntity,
+    HSEMEntity,
+    RestoreEntity,
+):
+    """Diagnostic sensor exposing the current HSEM update interval in minutes.
+
+    State is the integer number of minutes between coordinator cycles.  The value
+    is normally the user-configured ``update_interval``; HSEM temporarily switches
+    to 1 minute when input entities are missing so the state may differ.
+
+    The sensor subscribes to the shared coordinator and is updated automatically
+    after every coordinator cycle.
+    """
+
+    _attr_icon = "mdi:timer-outline"
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_native_unit_of_measurement = UnitOfTime.MINUTES
+    _attr_suggested_display_precision = 0
+
+    def __init__(
+        self,
+        config_entry,
+        coordinator: HSEMDataUpdateCoordinator,
+    ) -> None:
+        """Initialise the update-interval sensor.
+
+        Args:
+            config_entry: The HSEM config entry.
+            coordinator: The shared :class:`HSEMDataUpdateCoordinator`.
+        """
+        CoordinatorEntity.__init__(self, coordinator)
+        HSEMEntity.__init__(self, config_entry)
+
+        self._config_entry = config_entry
+
+        self._attr_unique_id = get_update_interval_sensor_unique_id()
+        self.entity_id = get_update_interval_sensor_entity_id()
+        self._name = get_update_interval_sensor_name()
+
+        self._restored_state: str | None = None
+
+    # ------------------------------------------------------------------
+    # HA entity properties
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        """Return the display name."""
+        return self._name
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return the unique ID."""
+        return self._attr_unique_id
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the update interval in minutes."""
+        data: CoordinatorData | None = self.coordinator.data
+        if data is None or data.cfg is None:
+            if self._restored_state is not None:
+                try:
+                    return int(self._restored_state)
+                except (ValueError, TypeError):
+                    pass
+            return None
+        return data.cfg.update_interval
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling — driven by the coordinator."""
+        return False
+
+    @property
+    def available(self) -> bool:
+        """True once the coordinator has completed at least one successful cycle."""
+        return (
+            self.coordinator.last_update_success and self.coordinator.data is not None
+        ) or self._restored_state is not None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return additional configuration context."""
+        data: CoordinatorData | None = self.coordinator.data
+        if data is None or data.cfg is None:
+            return {
+                "recommendation_interval_minutes": None,
+                "recommendation_interval_length_hours": None,
+            }
+        return {
+            "recommendation_interval_minutes": data.cfg.recommendation_interval_minutes,
+            "recommendation_interval_length_hours": data.cfg.recommendation_interval_length,
+        }
+
+    # ------------------------------------------------------------------
+    # HA lifecycle
+    # ------------------------------------------------------------------
+
+    async def async_added_to_hass(self) -> None:
+        """Restore previous state and register coordinator listener."""
+        await super().async_added_to_hass()
+        restored = await self.async_get_last_state()
+        if restored is not None and restored.state not in {
+            "unavailable",
+            "unknown",
+            None,
+        }:
+            self._restored_state = restored.state

--- a/custom_components/hsem/flows/init.py
+++ b/custom_components/hsem/flows/init.py
@@ -28,7 +28,17 @@ async def get_init_step_schema(config_entry) -> vol.Schema:
             ),
             vol.Required(
                 "hsem_read_only",
-                default=str(get_config_value(config_entry, "hsem_read_only")),
+                default=bool(get_config_value(config_entry, "hsem_read_only")),
+            ): selector({"boolean": {}}),
+            vol.Required(
+                "hsem_verbose_logging",
+                default=bool(get_config_value(config_entry, "hsem_verbose_logging")),
+            ): selector({"boolean": {}}),
+            vol.Required(
+                "hsem_extended_attributes",
+                default=bool(
+                    get_config_value(config_entry, "hsem_extended_attributes")
+                ),
             ): selector({"boolean": {}}),
             vol.Required(
                 "hsem_recommendation_interval_minutes",
@@ -84,6 +94,8 @@ async def validate_init_step_input(user_input) -> dict[str, str]:
     required_fields = [
         "device_name",
         "hsem_read_only",
+        "hsem_verbose_logging",
+        "hsem_extended_attributes",
         "hsem_update_interval",
         "hsem_recommendation_interval_minutes",
         "hsem_recommendation_interval_length",

--- a/custom_components/hsem/models/planner_inputs.py
+++ b/custom_components/hsem/models/planner_inputs.py
@@ -181,7 +181,7 @@ class PlannerInput:
     # --- seasonal / mode config ---
     months_winter: list[int] = field(default_factory=lambda: [1, 2, 3, 4, 10, 11, 12])
     house_power_includes_ev: bool = True
-    is_read_only: bool = True
+    is_read_only: bool = False  # False = hardware writes enabled; set True only in dry-run/test scenarios
 
     # --- optional extra context that tests may inspect ---
     extra: dict[str, Any] = field(default_factory=dict)

--- a/custom_components/hsem/sensor.py
+++ b/custom_components/hsem/sensor.py
@@ -10,6 +10,7 @@ from custom_components.hsem.custom_sensors.degraded_mode_sensor import (
 from custom_components.hsem.custom_sensors.house_consumption_power_sensor import (
     HSEMHouseConsumptionPowerSensor,
 )
+from custom_components.hsem.custom_sensors.read_only_sensor import HSEMReadOnlySensor
 from custom_components.hsem.custom_sensors.working_mode_sensor import (
     HSEMWorkingModeSensor,
 )
@@ -30,10 +31,13 @@ async def async_setup_entry(
     # Degraded-mode diagnostic sensor — subscribes to coordinator updates.
     degraded_mode_sensor = HSEMDegradedModeSensor(config_entry, coordinator)
 
+    # Read-only mode diagnostic sensor — subscribes to coordinator updates.
+    read_only_sensor = HSEMReadOnlySensor(config_entry, coordinator)
+
     # Working-mode sensor — subscribes to coordinator updates and owns hardware writes.
     working_mode_sensor = HSEMWorkingModeSensor(config_entry, coordinator)
 
-    async_add_entities([degraded_mode_sensor, working_mode_sensor])
+    async_add_entities([degraded_mode_sensor, read_only_sensor, working_mode_sensor])
 
     # Add power, energy and energy average sensors (these remain self-polling).
     power_sensors = []

--- a/custom_components/hsem/sensor.py
+++ b/custom_components/hsem/sensor.py
@@ -4,8 +4,14 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from custom_components.hsem.const import DOMAIN
 from custom_components.hsem.coordinator import HSEMDataUpdateCoordinator
+from custom_components.hsem.custom_sensors.battery_soc_sensor import (
+    HSEMBatterySoCSensor,
+)
 from custom_components.hsem.custom_sensors.degraded_mode_sensor import (
     HSEMDegradedModeSensor,
+)
+from custom_components.hsem.custom_sensors.ev_charging_sensor import (
+    HSEMEVChargingSensor,
 )
 from custom_components.hsem.custom_sensors.force_mode_sensor import HSEMForceModeSensor
 from custom_components.hsem.custom_sensors.hardware_writes_sensor import (
@@ -13,6 +19,9 @@ from custom_components.hsem.custom_sensors.hardware_writes_sensor import (
 )
 from custom_components.hsem.custom_sensors.house_consumption_power_sensor import (
     HSEMHouseConsumptionPowerSensor,
+)
+from custom_components.hsem.custom_sensors.last_updated_sensor import (
+    HSEMLastUpdatedSensor,
 )
 from custom_components.hsem.custom_sensors.missing_entities_sensor import (
     HSEMMissingEntitiesSensor,
@@ -24,6 +33,12 @@ from custom_components.hsem.custom_sensors.next_update_sensor import (
     HSEMNextUpdateSensor,
 )
 from custom_components.hsem.custom_sensors.read_only_sensor import HSEMReadOnlySensor
+from custom_components.hsem.custom_sensors.recommendation_interval_sensor import (
+    HSEMRecommendationIntervalSensor,
+)
+from custom_components.hsem.custom_sensors.update_interval_sensor import (
+    HSEMUpdateIntervalSensor,
+)
 from custom_components.hsem.custom_sensors.working_mode_sensor import (
     HSEMWorkingModeSensor,
 )
@@ -45,10 +60,17 @@ async def async_setup_entry(
     degraded_mode_sensor = HSEMDegradedModeSensor(config_entry, coordinator)
     read_only_sensor = HSEMReadOnlySensor(config_entry, coordinator)
     next_update_sensor = HSEMNextUpdateSensor(config_entry, coordinator)
+    last_updated_sensor = HSEMLastUpdatedSensor(config_entry, coordinator)
+    update_interval_sensor = HSEMUpdateIntervalSensor(config_entry, coordinator)
+    recommendation_interval_sensor = HSEMRecommendationIntervalSensor(
+        config_entry, coordinator
+    )
     missing_entities_sensor = HSEMMissingEntitiesSensor(config_entry, coordinator)
     hardware_writes_sensor = HSEMHardwareWritesSensor(config_entry, coordinator)
     net_consumption_sensor = HSEMNetConsumptionSensor(config_entry, coordinator)
+    battery_soc_sensor = HSEMBatterySoCSensor(config_entry, coordinator)
     force_mode_sensor = HSEMForceModeSensor(config_entry, coordinator)
+    ev_charging_sensor = HSEMEVChargingSensor(config_entry, coordinator)
 
     # Working-mode sensor — subscribes to coordinator updates and owns hardware writes.
     working_mode_sensor = HSEMWorkingModeSensor(config_entry, coordinator)
@@ -58,10 +80,15 @@ async def async_setup_entry(
             degraded_mode_sensor,
             read_only_sensor,
             next_update_sensor,
+            last_updated_sensor,
+            update_interval_sensor,
+            recommendation_interval_sensor,
             missing_entities_sensor,
             hardware_writes_sensor,
             net_consumption_sensor,
+            battery_soc_sensor,
             force_mode_sensor,
+            ev_charging_sensor,
             working_mode_sensor,
         ]
     )

--- a/custom_components/hsem/sensor.py
+++ b/custom_components/hsem/sensor.py
@@ -7,8 +7,21 @@ from custom_components.hsem.coordinator import HSEMDataUpdateCoordinator
 from custom_components.hsem.custom_sensors.degraded_mode_sensor import (
     HSEMDegradedModeSensor,
 )
+from custom_components.hsem.custom_sensors.force_mode_sensor import HSEMForceModeSensor
+from custom_components.hsem.custom_sensors.hardware_writes_sensor import (
+    HSEMHardwareWritesSensor,
+)
 from custom_components.hsem.custom_sensors.house_consumption_power_sensor import (
     HSEMHouseConsumptionPowerSensor,
+)
+from custom_components.hsem.custom_sensors.missing_entities_sensor import (
+    HSEMMissingEntitiesSensor,
+)
+from custom_components.hsem.custom_sensors.net_consumption_sensor import (
+    HSEMNetConsumptionSensor,
+)
+from custom_components.hsem.custom_sensors.next_update_sensor import (
+    HSEMNextUpdateSensor,
 )
 from custom_components.hsem.custom_sensors.read_only_sensor import HSEMReadOnlySensor
 from custom_components.hsem.custom_sensors.working_mode_sensor import (
@@ -28,16 +41,30 @@ async def async_setup_entry(
         "coordinator"
     ]
 
-    # Degraded-mode diagnostic sensor — subscribes to coordinator updates.
+    # Diagnostic sensors — all subscribe to coordinator updates.
     degraded_mode_sensor = HSEMDegradedModeSensor(config_entry, coordinator)
-
-    # Read-only mode diagnostic sensor — subscribes to coordinator updates.
     read_only_sensor = HSEMReadOnlySensor(config_entry, coordinator)
+    next_update_sensor = HSEMNextUpdateSensor(config_entry, coordinator)
+    missing_entities_sensor = HSEMMissingEntitiesSensor(config_entry, coordinator)
+    hardware_writes_sensor = HSEMHardwareWritesSensor(config_entry, coordinator)
+    net_consumption_sensor = HSEMNetConsumptionSensor(config_entry, coordinator)
+    force_mode_sensor = HSEMForceModeSensor(config_entry, coordinator)
 
     # Working-mode sensor — subscribes to coordinator updates and owns hardware writes.
     working_mode_sensor = HSEMWorkingModeSensor(config_entry, coordinator)
 
-    async_add_entities([degraded_mode_sensor, read_only_sensor, working_mode_sensor])
+    async_add_entities(
+        [
+            degraded_mode_sensor,
+            read_only_sensor,
+            next_update_sensor,
+            missing_entities_sensor,
+            hardware_writes_sensor,
+            net_consumption_sensor,
+            force_mode_sensor,
+            working_mode_sensor,
+        ]
+    )
 
     # Add power, energy and energy average sensors (these remain self-polling).
     power_sensors = []

--- a/custom_components/hsem/utils/sensornames.py
+++ b/custom_components/hsem/utils/sensornames.py
@@ -288,3 +288,83 @@ def get_read_only_sensor_entity_id() -> str:
 
     """
     return sensor.ENTITY_ID_FORMAT.format(s(f"{DOMAIN}_read_only_sensor"))
+
+
+# Next Update Sensor
+def get_next_update_sensor_name() -> str:
+    """Return the display name for the next-update diagnostic sensor."""
+    return "Next Update"
+
+
+def get_next_update_sensor_unique_id() -> str:
+    """Return a unique ID for the next-update sensor."""
+    return f"{DOMAIN}_next_update_sensor"
+
+
+def get_next_update_sensor_entity_id() -> str:
+    """Return the entity_id for the next-update sensor."""
+    return sensor.ENTITY_ID_FORMAT.format(s(f"{DOMAIN}_next_update_sensor"))
+
+
+# Missing Entities Sensor
+def get_missing_entities_sensor_name() -> str:
+    """Return the display name for the missing-entities count diagnostic sensor."""
+    return "Missing Input Entities"
+
+
+def get_missing_entities_sensor_unique_id() -> str:
+    """Return a unique ID for the missing-entities sensor."""
+    return f"{DOMAIN}_missing_entities_sensor"
+
+
+def get_missing_entities_sensor_entity_id() -> str:
+    """Return the entity_id for the missing-entities sensor."""
+    return sensor.ENTITY_ID_FORMAT.format(s(f"{DOMAIN}_missing_entities_sensor"))
+
+
+# Hardware Writes Blocked Sensor
+def get_hardware_writes_sensor_name() -> str:
+    """Return the display name for the hardware-writes-blocked diagnostic sensor."""
+    return "Hardware Writes"
+
+
+def get_hardware_writes_sensor_unique_id() -> str:
+    """Return a unique ID for the hardware-writes-blocked sensor."""
+    return f"{DOMAIN}_hardware_writes_sensor"
+
+
+def get_hardware_writes_sensor_entity_id() -> str:
+    """Return the entity_id for the hardware-writes-blocked sensor."""
+    return sensor.ENTITY_ID_FORMAT.format(s(f"{DOMAIN}_hardware_writes_sensor"))
+
+
+# Net Consumption Sensor
+def get_net_consumption_sensor_name() -> str:
+    """Return the display name for the net-consumption diagnostic sensor."""
+    return "Net Consumption"
+
+
+def get_net_consumption_sensor_unique_id() -> str:
+    """Return a unique ID for the net-consumption sensor."""
+    return f"{DOMAIN}_net_consumption_sensor"
+
+
+def get_net_consumption_sensor_entity_id() -> str:
+    """Return the entity_id for the net-consumption sensor."""
+    return sensor.ENTITY_ID_FORMAT.format(s(f"{DOMAIN}_net_consumption_sensor"))
+
+
+# Force Working Mode Sensor
+def get_force_mode_sensor_name() -> str:
+    """Return the display name for the force-working-mode diagnostic sensor."""
+    return "Force Working Mode"
+
+
+def get_force_mode_sensor_unique_id() -> str:
+    """Return a unique ID for the force-working-mode sensor."""
+    return f"{DOMAIN}_force_mode_sensor"
+
+
+def get_force_mode_sensor_entity_id() -> str:
+    """Return the entity_id for the force-working-mode sensor."""
+    return sensor.ENTITY_ID_FORMAT.format(s(f"{DOMAIN}_force_mode_sensor"))

--- a/custom_components/hsem/utils/sensornames.py
+++ b/custom_components/hsem/utils/sensornames.py
@@ -257,3 +257,34 @@ def get_degraded_mode_sensor_entity_id() -> str:
 
     """
     return sensor.ENTITY_ID_FORMAT.format(s(f"{DOMAIN}_degraded_mode_sensor"))
+
+
+# Read-Only Mode Sensor
+def get_read_only_sensor_name() -> str:
+    """Return the display name for the read-only mode diagnostic sensor.
+
+    Returns:
+        str: Display name.
+
+    """
+    return "Read-Only Mode"
+
+
+def get_read_only_sensor_unique_id() -> str:
+    """Return a unique ID for the read-only mode sensor.
+
+    Returns:
+        str: Unique ID.
+
+    """
+    return f"{DOMAIN}_read_only_sensor"
+
+
+def get_read_only_sensor_entity_id() -> str:
+    """Return the entity_id for the read-only mode sensor.
+
+    Returns:
+        str: Entity ID.
+
+    """
+    return sensor.ENTITY_ID_FORMAT.format(s(f"{DOMAIN}_read_only_sensor"))

--- a/custom_components/hsem/utils/sensornames.py
+++ b/custom_components/hsem/utils/sensornames.py
@@ -368,3 +368,83 @@ def get_force_mode_sensor_unique_id() -> str:
 def get_force_mode_sensor_entity_id() -> str:
     """Return the entity_id for the force-working-mode sensor."""
     return sensor.ENTITY_ID_FORMAT.format(s(f"{DOMAIN}_force_mode_sensor"))
+
+
+# Update Interval Sensor
+def get_update_interval_sensor_name() -> str:
+    """Return the display name for the update-interval diagnostic sensor."""
+    return "Update Interval"
+
+
+def get_update_interval_sensor_unique_id() -> str:
+    """Return a unique ID for the update-interval sensor."""
+    return f"{DOMAIN}_update_interval_sensor"
+
+
+def get_update_interval_sensor_entity_id() -> str:
+    """Return the entity_id for the update-interval sensor."""
+    return sensor.ENTITY_ID_FORMAT.format(s(f"{DOMAIN}_update_interval_sensor"))
+
+
+# Last Updated Sensor
+def get_last_updated_sensor_name() -> str:
+    """Return the display name for the last-updated diagnostic sensor."""
+    return "Last Updated"
+
+
+def get_last_updated_sensor_unique_id() -> str:
+    """Return a unique ID for the last-updated sensor."""
+    return f"{DOMAIN}_last_updated_sensor"
+
+
+def get_last_updated_sensor_entity_id() -> str:
+    """Return the entity_id for the last-updated sensor."""
+    return sensor.ENTITY_ID_FORMAT.format(s(f"{DOMAIN}_last_updated_sensor"))
+
+
+# Battery SoC Sensor
+def get_battery_soc_sensor_name() -> str:
+    """Return the display name for the battery-SoC diagnostic sensor."""
+    return "Battery State of Charge"
+
+
+def get_battery_soc_sensor_unique_id() -> str:
+    """Return a unique ID for the battery-SoC sensor."""
+    return f"{DOMAIN}_battery_soc_sensor"
+
+
+def get_battery_soc_sensor_entity_id() -> str:
+    """Return the entity_id for the battery-SoC sensor."""
+    return sensor.ENTITY_ID_FORMAT.format(s(f"{DOMAIN}_battery_soc_sensor"))
+
+
+# Recommendation Interval Sensor
+def get_recommendation_interval_sensor_name() -> str:
+    """Return the display name for the recommendation-interval diagnostic sensor."""
+    return "Recommendation Interval"
+
+
+def get_recommendation_interval_sensor_unique_id() -> str:
+    """Return a unique ID for the recommendation-interval sensor."""
+    return f"{DOMAIN}_recommendation_interval_sensor"
+
+
+def get_recommendation_interval_sensor_entity_id() -> str:
+    """Return the entity_id for the recommendation-interval sensor."""
+    return sensor.ENTITY_ID_FORMAT.format(s(f"{DOMAIN}_recommendation_interval_sensor"))
+
+
+# EV Charging Active Sensor
+def get_ev_charging_sensor_name() -> str:
+    """Return the display name for the EV-charging-active diagnostic sensor."""
+    return "EV Charging Active"
+
+
+def get_ev_charging_sensor_unique_id() -> str:
+    """Return a unique ID for the EV-charging sensor."""
+    return f"{DOMAIN}_ev_charging_sensor"
+
+
+def get_ev_charging_sensor_entity_id() -> str:
+    """Return the entity_id for the EV-charging sensor."""
+    return sensor.ENTITY_ID_FORMAT.format(s(f"{DOMAIN}_ev_charging_sensor"))

--- a/tests/test_ha_mock_integration.py
+++ b/tests/test_ha_mock_integration.py
@@ -48,6 +48,19 @@ from custom_components.hsem.coordinator import (
 from custom_components.hsem.custom_sensors.degraded_mode_sensor import (
     HSEMDegradedModeSensor,
 )
+from custom_components.hsem.custom_sensors.force_mode_sensor import HSEMForceModeSensor
+from custom_components.hsem.custom_sensors.hardware_writes_sensor import (
+    HSEMHardwareWritesSensor,
+)
+from custom_components.hsem.custom_sensors.missing_entities_sensor import (
+    HSEMMissingEntitiesSensor,
+)
+from custom_components.hsem.custom_sensors.net_consumption_sensor import (
+    HSEMNetConsumptionSensor,
+)
+from custom_components.hsem.custom_sensors.next_update_sensor import (
+    HSEMNextUpdateSensor,
+)
 from custom_components.hsem.custom_sensors.read_only_sensor import HSEMReadOnlySensor
 from custom_components.hsem.custom_sensors.working_mode_sensor import (
     HSEMWorkingModeSensor,
@@ -1049,6 +1062,277 @@ class TestReadOnlyConfigReaderIntegration:
 
         assert "read_only_mode" in attrs
         assert attrs["read_only_mode"] is True
+
+
+# ---------------------------------------------------------------------------
+# TestAdditionalDiagnosticSensors
+# ---------------------------------------------------------------------------
+
+
+class TestAdditionalDiagnosticSensors:
+    """Tests for the five additional coordinator-driven diagnostic sensors."""
+
+    def _make_data(
+        self,
+        *,
+        next_update: str = "2026-05-12T12:00:00+02:00",
+        last_updated: str = "2026-05-12T11:55:00+02:00",
+        update_interval: int = 5,
+        missing: list[str] | None = None,
+        net_consumption_w: float = 250.0,
+        force_mode_state: str = "auto",
+    ) -> CoordinatorData:
+        """Build a minimal CoordinatorData for sensor tests."""
+        cfg = SensorConfig()
+        cfg.update_interval = update_interval
+
+        live = LiveState()
+        live.net_consumption_w = net_consumption_w
+        live.house_consumption_power_w = 800.0
+        live.solar_production_power_w = 550.0
+        live.net_consumption_with_ev_w = 250.0
+        live.force_working_mode_state = force_mode_state
+        if missing:
+            for label in missing:
+                live.add_missing_entity(label)
+
+        return CoordinatorData(
+            cfg=cfg,
+            live=live,
+            state="batteries_wait_mode",
+            next_update=next_update,
+            last_updated=last_updated,
+        )
+
+    # ------------------------------------------------------------------
+    # HSEMNextUpdateSensor
+    # ------------------------------------------------------------------
+
+    def test_next_update_sensor_is_diagnostic(self) -> None:
+        """NextUpdateSensor must carry the DIAGNOSTIC entity category."""
+        from homeassistant.const import EntityCategory
+
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        s = HSEMNextUpdateSensor(config_entry, coord)
+        assert s._attr_entity_category == EntityCategory.DIAGNOSTIC
+
+    def test_next_update_sensor_state_is_timestamp(self) -> None:
+        """NextUpdateSensor.state must return the next_update timestamp."""
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        coord.data = self._make_data(next_update="2026-05-12T13:00:00+02:00")
+        s = HSEMNextUpdateSensor(config_entry, coord)
+        assert s.state == "2026-05-12T13:00:00+02:00"
+
+    def test_next_update_sensor_no_data_returns_none(self) -> None:
+        """NextUpdateSensor.state must be None before first cycle."""
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        s = HSEMNextUpdateSensor(config_entry, coord)
+        assert s.state is None
+
+    def test_next_update_sensor_attrs_include_interval(self) -> None:
+        """NextUpdateSensor extra_state_attributes must include update_interval_minutes."""
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        coord.data = self._make_data(update_interval=15)
+        s = HSEMNextUpdateSensor(config_entry, coord)
+        assert s.extra_state_attributes["update_interval_minutes"] == 15
+
+    def test_next_update_sensor_unique_ids_distinct(self) -> None:
+        """All diagnostic sensor unique IDs must be distinct from each other."""
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        sensors = [
+            HSEMNextUpdateSensor(config_entry, coord),
+            HSEMMissingEntitiesSensor(config_entry, coord),
+            HSEMHardwareWritesSensor(config_entry, coord),
+            HSEMNetConsumptionSensor(config_entry, coord),
+            HSEMForceModeSensor(config_entry, coord),
+            HSEMReadOnlySensor(config_entry, coord),
+            HSEMDegradedModeSensor(config_entry, coord),
+        ]
+        uids = [s.unique_id for s in sensors]
+        assert len(uids) == len(set(uids)), "Duplicate unique_id found"
+
+    # ------------------------------------------------------------------
+    # HSEMMissingEntitiesSensor
+    # ------------------------------------------------------------------
+
+    def test_missing_entities_sensor_is_diagnostic(self) -> None:
+        """MissingEntitiesSensor must carry the DIAGNOSTIC entity category."""
+        from homeassistant.const import EntityCategory
+
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        s = HSEMMissingEntitiesSensor(config_entry, coord)
+        assert s._attr_entity_category == EntityCategory.DIAGNOSTIC
+
+    def test_missing_entities_zero_when_none_missing(self) -> None:
+        """MissingEntitiesSensor.state must be 0 when all entities are present."""
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        coord.data = self._make_data()
+        s = HSEMMissingEntitiesSensor(config_entry, coord)
+        assert s.state == 0
+
+    def test_missing_entities_count_reflects_list_length(self) -> None:
+        """MissingEntitiesSensor.state must equal len(missing_entities_list)."""
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        coord.data = self._make_data(
+            missing=[
+                "Missing entity: energi_data_service_import",
+                "Missing entity: solcast_pv_forecast_forecast_today",
+            ]
+        )
+        s = HSEMMissingEntitiesSensor(config_entry, coord)
+        assert s.state == 2
+
+    def test_missing_entities_attrs_contain_list(self) -> None:
+        """MissingEntitiesSensor extra_state_attributes must include the label list."""
+        label = "Missing entity: energi_data_service_import"
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        coord.data = self._make_data(missing=[label])
+        s = HSEMMissingEntitiesSensor(config_entry, coord)
+        assert label in s.extra_state_attributes["missing_entities_list"]
+
+    # ------------------------------------------------------------------
+    # HSEMHardwareWritesSensor
+    # ------------------------------------------------------------------
+
+    def test_hardware_writes_sensor_is_diagnostic(self) -> None:
+        """HardwareWritesSensor must carry the DIAGNOSTIC entity category."""
+        from homeassistant.const import EntityCategory
+
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        s = HSEMHardwareWritesSensor(config_entry, coord)
+        assert s._attr_entity_category == EntityCategory.DIAGNOSTIC
+
+    def test_hardware_writes_allowed_when_no_missing_entities(self) -> None:
+        """HardwareWritesSensor.state must be 'allowed' when no critical entities missing."""
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        coord.data = self._make_data()
+        s = HSEMHardwareWritesSensor(config_entry, coord)
+        assert s.state == "allowed"
+
+    def test_hardware_writes_blocked_when_critical_entity_missing(self) -> None:
+        """HardwareWritesSensor.state must be 'blocked' when a critical entity is absent."""
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        coord.data = self._make_data(
+            missing=["Missing entity: batteries_state_of_capacity"]
+        )
+        s = HSEMHardwareWritesSensor(config_entry, coord)
+        assert s.state == "blocked"
+
+    def test_hardware_writes_allowed_with_only_non_critical_missing(self) -> None:
+        """HardwareWritesSensor must be 'allowed' when only non-critical entities are absent."""
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        coord.data = self._make_data(
+            missing=["Missing entity: energi_data_service_import"]
+        )
+        s = HSEMHardwareWritesSensor(config_entry, coord)
+        assert s.state == "allowed"
+
+    # ------------------------------------------------------------------
+    # HSEMNetConsumptionSensor
+    # ------------------------------------------------------------------
+
+    def test_net_consumption_sensor_is_diagnostic(self) -> None:
+        """NetConsumptionSensor must carry the DIAGNOSTIC entity category."""
+        from homeassistant.const import EntityCategory
+
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        s = HSEMNetConsumptionSensor(config_entry, coord)
+        assert s._attr_entity_category == EntityCategory.DIAGNOSTIC
+
+    def test_net_consumption_native_value(self) -> None:
+        """NetConsumptionSensor.native_value must reflect live.net_consumption_w."""
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        coord.data = self._make_data(net_consumption_w=350.5)
+        s = HSEMNetConsumptionSensor(config_entry, coord)
+        assert s.native_value == pytest.approx(350.5)
+
+    def test_net_consumption_unit_is_watts(self) -> None:
+        """NetConsumptionSensor must use Watts as its unit."""
+        from homeassistant.const import UnitOfPower
+
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        s = HSEMNetConsumptionSensor(config_entry, coord)
+        assert s._attr_native_unit_of_measurement == UnitOfPower.WATT
+
+    def test_net_consumption_attrs_include_breakdown(self) -> None:
+        """NetConsumptionSensor extra_state_attributes must include house and solar components."""
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        coord.data = self._make_data()
+        s = HSEMNetConsumptionSensor(config_entry, coord)
+        attrs = s.extra_state_attributes
+        assert "house_consumption_w" in attrs
+        assert "solar_production_w" in attrs
+        assert "net_consumption_with_ev_w" in attrs
+        assert "ev_charging_active" in attrs
+
+    # ------------------------------------------------------------------
+    # HSEMForceModeSensor
+    # ------------------------------------------------------------------
+
+    def test_force_mode_sensor_is_diagnostic(self) -> None:
+        """ForceModeSensor must carry the DIAGNOSTIC entity category."""
+        from homeassistant.const import EntityCategory
+
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        s = HSEMForceModeSensor(config_entry, coord)
+        assert s._attr_entity_category == EntityCategory.DIAGNOSTIC
+
+    def test_force_mode_sensor_state_auto_when_not_overriding(self) -> None:
+        """ForceModeSensor.state must be 'auto' when no override is set."""
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        coord.data = self._make_data(force_mode_state="auto")
+        s = HSEMForceModeSensor(config_entry, coord)
+        assert s.state == "auto"
+
+    def test_force_mode_sensor_state_reflects_override(self) -> None:
+        """ForceModeSensor.state must reflect the active override value."""
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        coord.data = self._make_data(force_mode_state="batteries_charge_grid")
+        s = HSEMForceModeSensor(config_entry, coord)
+        assert s.state == "batteries_charge_grid"
+
+    def test_force_mode_sensor_override_active_attr(self) -> None:
+        """ForceModeSensor extra_state_attributes.override_active must be True when forced."""
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        coord.data = self._make_data(force_mode_state="batteries_charge_grid")
+        s = HSEMForceModeSensor(config_entry, coord)
+        assert s.extra_state_attributes["override_active"] is True
+
+    def test_force_mode_sensor_override_inactive_when_auto(self) -> None:
+        """ForceModeSensor extra_state_attributes.override_active must be False in auto."""
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        coord.data = self._make_data(force_mode_state="auto")
+        s = HSEMForceModeSensor(config_entry, coord)
+        assert s.extra_state_attributes["override_active"] is False
+
+    def test_force_mode_default_before_first_cycle(self) -> None:
+        """ForceModeSensor.state must default to 'auto' before the first cycle."""
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        s = HSEMForceModeSensor(config_entry, coord)
+        assert s.state == "auto"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ha_mock_integration.py
+++ b/tests/test_ha_mock_integration.py
@@ -48,6 +48,7 @@ from custom_components.hsem.coordinator import (
 from custom_components.hsem.custom_sensors.degraded_mode_sensor import (
     HSEMDegradedModeSensor,
 )
+from custom_components.hsem.custom_sensors.read_only_sensor import HSEMReadOnlySensor
 from custom_components.hsem.custom_sensors.working_mode_sensor import (
     HSEMWorkingModeSensor,
 )
@@ -329,6 +330,104 @@ class TestEntitySetup:
         assert working.unique_id
         assert degraded.unique_id
         assert working.unique_id != degraded.unique_id
+
+    # ------------------------------------------------------------------
+    # HSEMReadOnlySensor
+    # ------------------------------------------------------------------
+
+    def test_read_only_sensor_initial_state_is_off(self) -> None:
+        """ReadOnlySensor must default to 'off' (writes enabled) before first cycle."""
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+
+        sensor = HSEMReadOnlySensor(config_entry, coord)
+
+        assert sensor.state == "off"
+
+    def test_read_only_sensor_should_not_poll(self) -> None:
+        """ReadOnlySensor must not poll independently (coordinator-driven)."""
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+
+        sensor = HSEMReadOnlySensor(config_entry, coord)
+
+        assert sensor.should_poll is False
+
+    def test_read_only_sensor_entity_category_is_diagnostic(self) -> None:
+        """ReadOnlySensor must carry the DIAGNOSTIC entity category."""
+        from homeassistant.const import EntityCategory
+
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+
+        sensor = HSEMReadOnlySensor(config_entry, coord)
+
+        assert sensor._attr_entity_category == EntityCategory.DIAGNOSTIC
+
+    def test_read_only_sensor_unique_id_differs_from_others(self) -> None:
+        """ReadOnlySensor unique_id must be distinct from working-mode and degraded sensors."""
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+
+        read_only = HSEMReadOnlySensor(config_entry, coord)
+        working = HSEMWorkingModeSensor(config_entry, coord)
+        degraded = HSEMDegradedModeSensor(config_entry, coord)
+
+        assert read_only.unique_id
+        assert read_only.unique_id != working.unique_id
+        assert read_only.unique_id != degraded.unique_id
+
+    def test_read_only_sensor_state_on_when_enabled(self) -> None:
+        """ReadOnlySensor must report 'on' when coordinator data has read_only=True."""
+        config_entry = make_fake_config_entry({"hsem_read_only": True})
+        coord = make_bare_coordinator(config_entry=config_entry)
+
+        cfg = SensorConfig()
+        cfg.read_only = True
+        cfg.recommendation_interval_minutes = 60
+        cfg.recommendation_interval_length = 24
+        cfg.update_interval = 5
+
+        coord.data = CoordinatorData(cfg=cfg, live=LiveState(), state=None)
+
+        sensor = HSEMReadOnlySensor(config_entry, coord)
+
+        assert sensor.state == "on"
+
+    def test_read_only_sensor_state_off_when_disabled(self) -> None:
+        """ReadOnlySensor must report 'off' when coordinator data has read_only=False."""
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+
+        cfg = SensorConfig()
+        cfg.read_only = False
+        cfg.recommendation_interval_minutes = 60
+        cfg.recommendation_interval_length = 24
+        cfg.update_interval = 5
+
+        coord.data = CoordinatorData(cfg=cfg, live=LiveState(), state=None)
+
+        sensor = HSEMReadOnlySensor(config_entry, coord)
+
+        assert sensor.state == "off"
+
+    def test_read_only_sensor_extra_attrs_include_update_interval(self) -> None:
+        """ReadOnlySensor extra_state_attributes must expose update_interval_minutes."""
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+
+        cfg = SensorConfig()
+        cfg.read_only = False
+        cfg.update_interval = 7
+
+        coord.data = CoordinatorData(cfg=cfg, live=LiveState(), state=None)
+
+        sensor = HSEMReadOnlySensor(config_entry, coord)
+        attrs = sensor.extra_state_attributes
+
+        assert attrs["update_interval_minutes"] == 7
+        assert attrs["hardware_writes_active"] is True
+        assert attrs["read_only"] is False
 
 
 # ---------------------------------------------------------------------------
@@ -889,6 +988,67 @@ class TestReadOnlyConfigReaderIntegration:
         cfg = build_sensor_config(config_entry)
 
         assert cfg.recommendation_interval_minutes == 15
+
+    def test_read_only_string_true_coerced_to_bool(self) -> None:
+        """build_sensor_config must coerce the string 'True' to bool True."""
+        from custom_components.hsem.custom_sensors.config_reader import (
+            build_sensor_config,
+        )
+
+        # Simulate a config entry that stored read_only as a string (old schema).
+        config_entry = make_fake_config_entry({"hsem_read_only": "True"})
+        cfg = build_sensor_config(config_entry)
+
+        assert cfg.read_only is True
+
+    def test_read_only_string_false_coerced_to_bool(self) -> None:
+        """build_sensor_config must coerce the string 'False' to bool False."""
+        from custom_components.hsem.custom_sensors.config_reader import (
+            build_sensor_config,
+        )
+
+        config_entry = make_fake_config_entry({"hsem_read_only": "False"})
+        cfg = build_sensor_config(config_entry)
+
+        assert cfg.read_only is False
+
+    def test_verbose_logging_boolean_coercion(self) -> None:
+        """build_sensor_config must coerce verbose_logging to bool."""
+        from custom_components.hsem.custom_sensors.config_reader import (
+            build_sensor_config,
+        )
+
+        config_entry = make_fake_config_entry({"hsem_verbose_logging": "True"})
+        cfg = build_sensor_config(config_entry)
+
+        assert cfg.verbose_logging is True
+
+    def test_extended_attributes_boolean_coercion(self) -> None:
+        """build_sensor_config must coerce extended_attributes to bool."""
+        from custom_components.hsem.custom_sensors.config_reader import (
+            build_sensor_config,
+        )
+
+        config_entry = make_fake_config_entry({"hsem_extended_attributes": "True"})
+        cfg = build_sensor_config(config_entry)
+
+        assert cfg.extended_attributes is True
+
+    def test_degraded_mode_sensor_exposes_read_only_attribute(self) -> None:
+        """DegradedModeSensor extra_state_attributes must include read_only_mode."""
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+
+        cfg = SensorConfig()
+        cfg.read_only = True
+        live = LiveState()
+        coord.data = CoordinatorData(cfg=cfg, live=live, state=None)
+
+        sensor = HSEMDegradedModeSensor(config_entry, coord)
+        attrs = sensor.extra_state_attributes
+
+        assert "read_only_mode" in attrs
+        assert attrs["read_only_mode"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ha_mock_integration.py
+++ b/tests/test_ha_mock_integration.py
@@ -45,12 +45,21 @@ from custom_components.hsem.coordinator import (
     CoordinatorData,
     HSEMDataUpdateCoordinator,
 )
+from custom_components.hsem.custom_sensors.battery_soc_sensor import (
+    HSEMBatterySoCSensor,
+)
 from custom_components.hsem.custom_sensors.degraded_mode_sensor import (
     HSEMDegradedModeSensor,
+)
+from custom_components.hsem.custom_sensors.ev_charging_sensor import (
+    HSEMEVChargingSensor,
 )
 from custom_components.hsem.custom_sensors.force_mode_sensor import HSEMForceModeSensor
 from custom_components.hsem.custom_sensors.hardware_writes_sensor import (
     HSEMHardwareWritesSensor,
+)
+from custom_components.hsem.custom_sensors.last_updated_sensor import (
+    HSEMLastUpdatedSensor,
 )
 from custom_components.hsem.custom_sensors.missing_entities_sensor import (
     HSEMMissingEntitiesSensor,
@@ -62,6 +71,12 @@ from custom_components.hsem.custom_sensors.next_update_sensor import (
     HSEMNextUpdateSensor,
 )
 from custom_components.hsem.custom_sensors.read_only_sensor import HSEMReadOnlySensor
+from custom_components.hsem.custom_sensors.recommendation_interval_sensor import (
+    HSEMRecommendationIntervalSensor,
+)
+from custom_components.hsem.custom_sensors.update_interval_sensor import (
+    HSEMUpdateIntervalSensor,
+)
 from custom_components.hsem.custom_sensors.working_mode_sensor import (
     HSEMWorkingModeSensor,
 )
@@ -1333,6 +1348,307 @@ class TestAdditionalDiagnosticSensors:
         coord = make_bare_coordinator(config_entry=config_entry)
         s = HSEMForceModeSensor(config_entry, coord)
         assert s.state == "auto"
+
+
+# ---------------------------------------------------------------------------
+# TestRemainingDiagnosticSensors — #2, #4, #8, #11, #12
+# ---------------------------------------------------------------------------
+
+
+class TestRemainingDiagnosticSensors:
+    """Tests for HSEMUpdateIntervalSensor, HSEMLastUpdatedSensor,
+    HSEMBatterySoCSensor, HSEMRecommendationIntervalSensor, HSEMEVChargingSensor."""
+
+    def _make_cfg(
+        self,
+        *,
+        update_interval: int = 5,
+        recommendation_interval_minutes: int = 15,
+        recommendation_interval_length: int = 48,
+        ev_second_enabled: bool = False,
+    ) -> SensorConfig:
+        cfg = SensorConfig()
+        cfg.update_interval = update_interval
+        cfg.recommendation_interval_minutes = recommendation_interval_minutes
+        cfg.recommendation_interval_length = recommendation_interval_length
+        cfg.ev_second_enabled = ev_second_enabled
+        return cfg
+
+    def _make_live(
+        self,
+        *,
+        soc_pct: float | None = 75.0,
+        ev_charging: bool = False,
+        ev_second_charging: bool = False,
+    ) -> LiveState:
+        from custom_components.hsem.models.live_state import EVLiveState
+
+        live = LiveState()
+        live.huawei_batteries_soc_pct = soc_pct
+        live.battery_current_capacity_kwh = 6.0
+        live.battery_usable_capacity_kwh = 9.0
+        live.huawei_batteries_rated_capacity_wh = 10000.0
+        live.huawei_batteries_end_of_discharge_soc_pct = 10.0
+        live.ev = EVLiveState(
+            is_charging=ev_charging,
+            power_w=7400.0 if ev_charging else 0.0,
+            soc_pct=55.0,
+        )
+        live.ev_second = EVLiveState(
+            is_charging=ev_second_charging, power_w=0.0, soc_pct=None
+        )
+        return live
+
+    def _make_data(
+        self, cfg: SensorConfig | None = None, live: LiveState | None = None
+    ) -> CoordinatorData:
+        return CoordinatorData(
+            cfg=cfg or self._make_cfg(),
+            live=live or self._make_live(),
+            state="batteries_wait_mode",
+            last_updated="2026-05-12T11:55:00+02:00",
+            next_update="2026-05-12T12:00:00+02:00",
+        )
+
+    # ------------------------------------------------------------------
+    # HSEMUpdateIntervalSensor (#2)
+    # ------------------------------------------------------------------
+
+    def test_update_interval_sensor_is_diagnostic(self) -> None:
+        from homeassistant.const import EntityCategory
+
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        s = HSEMUpdateIntervalSensor(config_entry, coord)
+        assert s._attr_entity_category == EntityCategory.DIAGNOSTIC
+
+    def test_update_interval_native_value(self) -> None:
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        coord.data = self._make_data(cfg=self._make_cfg(update_interval=15))
+        s = HSEMUpdateIntervalSensor(config_entry, coord)
+        assert s.native_value == 15
+
+    def test_update_interval_unit_is_minutes(self) -> None:
+        from homeassistant.const import UnitOfTime
+
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        s = HSEMUpdateIntervalSensor(config_entry, coord)
+        assert s._attr_native_unit_of_measurement == UnitOfTime.MINUTES
+
+    def test_update_interval_attrs_include_recommendation_settings(self) -> None:
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        coord.data = self._make_data(
+            cfg=self._make_cfg(
+                recommendation_interval_minutes=60, recommendation_interval_length=24
+            )
+        )
+        s = HSEMUpdateIntervalSensor(config_entry, coord)
+        attrs = s.extra_state_attributes
+        assert attrs["recommendation_interval_minutes"] == 60
+        assert attrs["recommendation_interval_length_hours"] == 24
+
+    def test_update_interval_none_before_first_cycle(self) -> None:
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        s = HSEMUpdateIntervalSensor(config_entry, coord)
+        assert s.native_value is None
+
+    # ------------------------------------------------------------------
+    # HSEMLastUpdatedSensor (#4)
+    # ------------------------------------------------------------------
+
+    def test_last_updated_sensor_is_diagnostic(self) -> None:
+        from homeassistant.const import EntityCategory
+
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        s = HSEMLastUpdatedSensor(config_entry, coord)
+        assert s._attr_entity_category == EntityCategory.DIAGNOSTIC
+
+    def test_last_updated_state_is_timestamp(self) -> None:
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        coord.data = self._make_data()
+        s = HSEMLastUpdatedSensor(config_entry, coord)
+        assert s.state == "2026-05-12T11:55:00+02:00"
+
+    def test_last_updated_none_before_first_cycle(self) -> None:
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        s = HSEMLastUpdatedSensor(config_entry, coord)
+        assert s.state is None
+
+    def test_last_updated_attrs_include_next_update(self) -> None:
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        coord.data = self._make_data()
+        s = HSEMLastUpdatedSensor(config_entry, coord)
+        assert s.extra_state_attributes["next_update"] == "2026-05-12T12:00:00+02:00"
+
+    # ------------------------------------------------------------------
+    # HSEMBatterySoCSensor (#8)
+    # ------------------------------------------------------------------
+
+    def test_battery_soc_sensor_is_diagnostic(self) -> None:
+        from homeassistant.const import EntityCategory
+
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        s = HSEMBatterySoCSensor(config_entry, coord)
+        assert s._attr_entity_category == EntityCategory.DIAGNOSTIC
+
+    def test_battery_soc_native_value(self) -> None:
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        coord.data = self._make_data(live=self._make_live(soc_pct=83.5))
+        s = HSEMBatterySoCSensor(config_entry, coord)
+        assert s.native_value == pytest.approx(83.5)
+
+    def test_battery_soc_unit_is_percent(self) -> None:
+        from homeassistant.const import PERCENTAGE
+
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        s = HSEMBatterySoCSensor(config_entry, coord)
+        assert s._attr_native_unit_of_measurement == PERCENTAGE
+
+    def test_battery_soc_none_when_unavailable(self) -> None:
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        coord.data = self._make_data(live=self._make_live(soc_pct=None))
+        s = HSEMBatterySoCSensor(config_entry, coord)
+        assert s.native_value is None
+
+    def test_battery_soc_attrs_include_capacity(self) -> None:
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        coord.data = self._make_data()
+        s = HSEMBatterySoCSensor(config_entry, coord)
+        attrs = s.extra_state_attributes
+        assert "battery_current_capacity_kwh" in attrs
+        assert "battery_usable_capacity_kwh" in attrs
+        assert "battery_rated_capacity_wh" in attrs
+        assert "end_of_discharge_soc_pct" in attrs
+
+    # ------------------------------------------------------------------
+    # HSEMRecommendationIntervalSensor (#11)
+    # ------------------------------------------------------------------
+
+    def test_recommendation_interval_sensor_is_diagnostic(self) -> None:
+        from homeassistant.const import EntityCategory
+
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        s = HSEMRecommendationIntervalSensor(config_entry, coord)
+        assert s._attr_entity_category == EntityCategory.DIAGNOSTIC
+
+    def test_recommendation_interval_native_value(self) -> None:
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        coord.data = self._make_data(
+            cfg=self._make_cfg(recommendation_interval_minutes=60)
+        )
+        s = HSEMRecommendationIntervalSensor(config_entry, coord)
+        assert s.native_value == 60
+
+    def test_recommendation_interval_unit_is_minutes(self) -> None:
+        from homeassistant.const import UnitOfTime
+
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        s = HSEMRecommendationIntervalSensor(config_entry, coord)
+        assert s._attr_native_unit_of_measurement == UnitOfTime.MINUTES
+
+    def test_recommendation_interval_attrs_total_slots(self) -> None:
+        """48h / 15min = 192 slots."""
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        coord.data = self._make_data(
+            cfg=self._make_cfg(
+                recommendation_interval_minutes=15, recommendation_interval_length=48
+            )
+        )
+        s = HSEMRecommendationIntervalSensor(config_entry, coord)
+        attrs = s.extra_state_attributes
+        assert attrs["total_planning_slots"] == 192
+        assert attrs["recommendation_interval_length_hours"] == 48
+
+    # ------------------------------------------------------------------
+    # HSEMEVChargingSensor (#12)
+    # ------------------------------------------------------------------
+
+    def test_ev_charging_sensor_is_diagnostic(self) -> None:
+        from homeassistant.const import EntityCategory
+
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        s = HSEMEVChargingSensor(config_entry, coord)
+        assert s._attr_entity_category == EntityCategory.DIAGNOSTIC
+
+    def test_ev_charging_off_when_not_charging(self) -> None:
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        coord.data = self._make_data(live=self._make_live(ev_charging=False))
+        s = HSEMEVChargingSensor(config_entry, coord)
+        assert s.state == "off"
+
+    def test_ev_charging_on_when_primary_is_charging(self) -> None:
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        coord.data = self._make_data(live=self._make_live(ev_charging=True))
+        s = HSEMEVChargingSensor(config_entry, coord)
+        assert s.state == "on"
+
+    def test_ev_charging_on_when_secondary_is_charging(self) -> None:
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        coord.data = self._make_data(
+            live=self._make_live(ev_charging=False, ev_second_charging=True)
+        )
+        s = HSEMEVChargingSensor(config_entry, coord)
+        assert s.state == "on"
+
+    def test_ev_charging_default_off_before_first_cycle(self) -> None:
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        s = HSEMEVChargingSensor(config_entry, coord)
+        assert s.state == "off"
+
+    def test_ev_charging_attrs_include_individual_states(self) -> None:
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        coord.data = self._make_data(live=self._make_live(ev_charging=True))
+        s = HSEMEVChargingSensor(config_entry, coord)
+        attrs = s.extra_state_attributes
+        assert attrs["ev_charging"] is True
+        assert "ev_power_w" in attrs
+        assert "ev_soc_pct" in attrs
+        assert "ev_second_enabled" in attrs
+        assert "ev_second_charging" in attrs
+
+    def test_all_12_diagnostic_sensors_have_distinct_unique_ids(self) -> None:
+        """All 12 coordinator-driven diagnostic sensors must have distinct unique IDs."""
+        config_entry = make_fake_config_entry()
+        coord = make_bare_coordinator(config_entry=config_entry)
+        sensors = [
+            HSEMDegradedModeSensor(config_entry, coord),
+            HSEMReadOnlySensor(config_entry, coord),
+            HSEMNextUpdateSensor(config_entry, coord),
+            HSEMLastUpdatedSensor(config_entry, coord),
+            HSEMUpdateIntervalSensor(config_entry, coord),
+            HSEMRecommendationIntervalSensor(config_entry, coord),
+            HSEMMissingEntitiesSensor(config_entry, coord),
+            HSEMHardwareWritesSensor(config_entry, coord),
+            HSEMNetConsumptionSensor(config_entry, coord),
+            HSEMBatterySoCSensor(config_entry, coord),
+            HSEMForceModeSensor(config_entry, coord),
+            HSEMEVChargingSensor(config_entry, coord),
+        ]
+        uids = [s.unique_id for s in sensors]
+        assert len(uids) == len(set(uids)), f"Duplicate unique_ids: {uids}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes three bugs found during testing on real Home Assistant hardware and adds
**12** coordinator-driven diagnostic sensors to improve observability.

---

## Bug fixes

### Bug 1 � `read_only` stored as string caused unexpected read-only mode

`config_reader.py` assigned `cfg.read_only` directly from `get_config_value()` without type
coercion. The HA options selector can persist a string `"True"` / `"False"` in older config
entries, and any non-empty string is truthy, causing HSEM to silently enter read-only mode.

**Fix:**
- `config_reader.py`: wrap `read_only`, `verbose_logging`, and `extended_attributes` with
  `convert_to_boolean()`.
- `flows/init.py`: remove `str()` wrapper; pass `bool()` as schema default. Also add
  `verbose_logging` and `extended_attributes` to the init-step schema (they were previously absent).
- `models/planner_inputs.py`: change `is_read_only: bool = True` to `False`.

### Bug 2 � System Health sensor had no visibility of read-only mode

Added `read_only_mode: bool` to `HSEMDegradedModeSensor.extra_state_attributes`.

---

## New diagnostic sensors (12)

All sensors are `EntityCategory.DIAGNOSTIC`, coordinator-driven (`should_poll = False`),
and restore their previous state on HA restart.

| # | Sensor | Entity ID | State | Key attributes |
|---|---|---|---|---|
| 1 | **Read-Only Mode** | `sensor.hsem_read_only_sensor` | `on`/`off` | `read_only`, `hardware_writes_active`, `update_interval_minutes` |
| 2 | **Update Interval** | `sensor.hsem_update_interval_sensor` | int (min) | `recommendation_interval_minutes`, `recommendation_interval_length_hours` |
| 3 | **Next Update** | `sensor.hsem_next_update_sensor` | ISO timestamp | `last_updated`, `update_interval_minutes` |
| 4 | **Last Updated** | `sensor.hsem_last_updated_sensor` | ISO timestamp | `next_update` |
| 5 | **Missing Input Entities** | `sensor.hsem_missing_entities_sensor` | int count | `missing_entities_list` |
| 6 | **Hardware Writes** | `sensor.hsem_hardware_writes_sensor` | `allowed`/`blocked` | `degraded_mode`, `missing_entities_list`, `read_only_active` |
| 7 | **Net Consumption** | `sensor.hsem_net_consumption_sensor` | W (`SensorDeviceClass.POWER`) | `house_consumption_w`, `solar_production_w`, `net_consumption_with_ev_w`, `ev_charging_active` |
| 8 | **Battery State of Charge** | `sensor.hsem_battery_soc_sensor` | % (`SensorDeviceClass.BATTERY`) | `battery_current_capacity_kwh`, `battery_usable_capacity_kwh`, `battery_rated_capacity_wh`, `end_of_discharge_soc_pct` |
| 9 | **Recommendation Interval** | `sensor.hsem_recommendation_interval_sensor` | int (min) | `recommendation_interval_length_hours`, `total_planning_slots` |
| 10 | **EV Charging Active** | `sensor.hsem_ev_charging_sensor` | `on`/`off` | `ev_charging`, `ev_power_w`, `ev_soc_pct`, `ev_second_enabled`, `ev_second_charging`, `ev_second_power_w`, `ev_second_soc_pct` |
| 11 | **Force Working Mode** | `sensor.hsem_force_mode_sensor` | string (e.g. `auto`) | `override_active`, `force_mode_entity_id` |
| 12 | **System Health** *(enhanced)* | `sensor.hsem_degraded_mode_sensor` | `ok`/`degraded`/`error` | `missing_entities`, `hardware_writes_blocked`, **`read_only_mode`** |

> **Note on #10 (Recommended Battery Threshold):** Skipped � the threshold value
> depends on an unknown currency (EUR, DKK, or other) and is already present in the
> working-mode sensor attributes. A separate sensor would require a currency
> unit that cannot be determined at integration level.

---

## Changed files

| File | Change |
|---|---|
| `custom_sensors/config_reader.py` | `convert_to_boolean()` for bool fields |
| `custom_sensors/degraded_mode_sensor.py` | Add `read_only_mode` attribute |
| `custom_sensors/read_only_sensor.py` *(new)* | `HSEMReadOnlySensor` |
| `custom_sensors/update_interval_sensor.py` *(new)* | `HSEMUpdateIntervalSensor` |
| `custom_sensors/next_update_sensor.py` *(new)* | `HSEMNextUpdateSensor` |
| `custom_sensors/last_updated_sensor.py` *(new)* | `HSEMLastUpdatedSensor` |
| `custom_sensors/missing_entities_sensor.py` *(new)* | `HSEMMissingEntitiesSensor` |
| `custom_sensors/hardware_writes_sensor.py` *(new)* | `HSEMHardwareWritesSensor` |
| `custom_sensors/net_consumption_sensor.py` *(new)* | `HSEMNetConsumptionSensor` |
| `custom_sensors/battery_soc_sensor.py` *(new)* | `HSEMBatterySoCSensor` |
| `custom_sensors/recommendation_interval_sensor.py` *(new)* | `HSEMRecommendationIntervalSensor` |
| `custom_sensors/ev_charging_sensor.py` *(new)* | `HSEMEVChargingSensor` |
| `custom_sensors/force_mode_sensor.py` *(new)* | `HSEMForceModeSensor` |
| `flows/init.py` | Fix `str()` wrapper; add missing fields |
| `models/planner_inputs.py` | `is_read_only: bool = False` |
| `sensor.py` | Register all 12 diagnostic sensors |
| `utils/sensornames.py` | Helpers for all new sensors |
| `tests/test_ha_mock_integration.py` | 60 new tests |

---

## Test results

```
624 passed, 2 warnings in 20.14s
```

## Lint

```
All checks passed! (isort + black + ruff format + ruff check)
```
