### PR TITLE
fix(sensor): correct async_logger call with too many positional args

### DIFF
--- a/custom_components/hsem/custom_sensors/working_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/working_mode_sensor.py
@@ -349,9 +349,8 @@ class HSEMWorkingModeSensor(
         elif not cfg.read_only and not writes_safe:
             await async_logger(
                 self,
-                "Hardware writes BLOCKED — degraded mode: %s. Missing: %s",
-                live.degraded_mode.value,
-                live.missing_entities_list,
+                f"Hardware writes BLOCKED — degraded mode: {live.degraded_mode.value}. Missing: {live.missing_entities_list}",
+                "warning",
             )
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes a `TypeError` crash in `working_mode_sensor.py` that caused every hardware-writes-blocked
cycle to silently swallow the update with an unhandled exception.

```
TypeError: async_logger() takes from 2 to 3 positional arguments but 4 were given
```

---

## Root cause

`async_logger(self, msg, level="debug")` accepts exactly 2�3 positional arguments.
The blocked-writes log call was written using `%s` placeholder syntax as if `async_logger`
were a standard `logging.*` call:

```python
# Before � crashes at runtime
await async_logger(
    self,
    "Hardware writes BLOCKED � degraded mode: %s. Missing: %s",
    live.degraded_mode.value,      # 3rd positional arg
    live.missing_entities_list,    # 4th positional arg
)
```

`async_logger` has no variadic `*args` parameter, so the two extra values are rejected.

---

## Fix

Pre-format the message as an f-string (matching every other `async_logger` call in the
codebase) and pass `"warning"` as the log level, which is appropriate for a blocked-write
condition:

```python
# After � correct
await async_logger(
    self,
    f"Hardware writes BLOCKED � degraded mode: {live.degraded_mode.value}. Missing: {live.missing_entities_list}",
    "warning",
)
```

---

## Changed files

| File | Change |
|---|---|
| `custom_sensors/working_mode_sensor.py` | Replace `%s` format + extra args with f-string; add `"warning"` level |

---

## Test results

No new tests needed � the fix is a one-line call-site correction with no logic change.
Existing test suite confirms no regressions.

## Lint

```
All checks passed! (isort + black + ruff format + ruff check)
```

Fixes the `TypeError: async_logger() takes from 2 to 3 positional arguments but 4 were given` runtime error.
