### PR TITLE
feat(sensor): write-and-verify inverter applier with status sensor

### DIFF
--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -63,6 +63,7 @@ from custom_components.hsem.models.planner_inputs import (
 )
 from custom_components.hsem.models.sensor_config import SensorConfig
 from custom_components.hsem.planner import run_planner
+from custom_components.hsem.utils.inverter_verify import CycleApplySummary
 from custom_components.hsem.utils.logger import async_logger
 from custom_components.hsem.utils.misc import convert_to_float, convert_to_int
 from custom_components.hsem.utils.recommendations import Recommendations
@@ -108,6 +109,9 @@ class CoordinatorData:
     state: str | None = None
     last_updated: str | None = None
     next_update: str | None = None
+    #: Aggregated write-and-verify results from the most recent hardware apply cycle.
+    #: ``None`` before the first hardware-write cycle completes.
+    apply_summary: CycleApplySummary | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/hsem/custom_sensors/applier.py
+++ b/custom_components/hsem/custom_sensors/applier.py
@@ -8,6 +8,25 @@ This is the **only** module in the sensor pipeline that is allowed to call
 ``async_set_*`` hardware functions.  All decision logic lives in the planner
 engine or the recommendation resolver; this module only executes the resulting
 action plan.
+
+Write-and-verify
+----------------
+Every hardware write is wrapped with :func:`~utils.inverter_verify.async_write_and_verify`:
+
+1. Write the desired value via a Huawei Solar service call.
+2. Wait :data:`~utils.inverter_verify.DEFAULT_SETTLE_SECONDS` for the inverter
+   to persist the new value.
+3. Read the entity state back from HA.
+4. Accept if the read-back value matches within
+   :data:`~utils.inverter_verify.DEFAULT_NUMERIC_TOLERANCE`.
+5. Retry up to :data:`~utils.inverter_verify.DEFAULT_MAX_RETRIES` times on
+   mismatch or transient read/write error.
+6. After all retries, mark the result ``FAILED`` and **block further writes for
+   this cycle** (the caller gates subsequent writes on the summary status).
+
+Each top-level apply function returns a :class:`~utils.inverter_verify.CycleApplySummary`
+that the :class:`~custom_sensors.applier_status_sensor.HSEMApplierStatusSensor` surfaces
+to Home Assistant.
 """
 
 from __future__ import annotations
@@ -27,6 +46,12 @@ from custom_components.hsem.utils.huawei import (
     async_set_grid_export_power_pct,
     async_set_tou_periods,
 )
+from custom_components.hsem.utils.inverter_verify import (
+    ApplyResult,
+    ApplyStatus,
+    CycleApplySummary,
+    async_write_and_verify,
+)
 from custom_components.hsem.utils.logger import async_logger
 from custom_components.hsem.utils.misc import (
     async_set_number_value,
@@ -43,7 +68,7 @@ async def async_apply_inverter_power_control(
     sensor,
     cfg: SensorConfig,
     live: LiveState,
-) -> None:
+) -> CycleApplySummary:
     """Set the grid-export power percentage on all inverters.
 
     Decides whether to allow full export (100%) or block export (0%) based on
@@ -51,18 +76,29 @@ async def async_apply_inverter_power_control(
     state.  Only issues a hardware write when the value differs from the current
     inverter state.
 
+    Each write is wrapped with :func:`~utils.inverter_verify.async_write_and_verify`
+    so that the inverter is polled after the write and the result is verified
+    within tolerance.  If any write fails all retries, further writes within this
+    cycle are blocked and the failure is recorded in the returned summary.
+
     Args:
         sensor: ``HSEMWorkingModeSensor`` instance for HA access and logging.
         cfg: Current sensor configuration.
         live: Live state snapshot (prices, EV states, inverter control state).
+
+    Returns:
+        :class:`CycleApplySummary` with one :class:`ApplyResult` per inverter
+        write attempted.
     """
+    summary = CycleApplySummary()
+
     export_price = live.energi_data_service_export_price
     min_price = cfg.energi_data_service_export_min_price
 
     if not isinstance(export_price, (int, float)):
-        return
+        return summary
     if not isinstance(min_price, (int, float)):
-        return
+        return summary
 
     export_pct = 100 if export_price >= min_price else 0
 
@@ -113,8 +149,35 @@ async def async_apply_inverter_power_control(
             cfg.huawei_solar_device_id_inverter_1,
             cfg.huawei_solar_device_id_inverter_2,
         ]:
-            if inv_id is not None:
-                await async_set_grid_export_power_pct(sensor, inv_id, export_pct)
+            if inv_id is None:
+                continue
+
+            inv_entity = cfg.huawei_solar_inverter_active_power_control
+
+            result = await async_write_and_verify(
+                entity_id=inv_entity or f"inverter:{inv_id}",
+                desired=export_pct,
+                writer=lambda _id=inv_id, _pct=export_pct: (
+                    async_set_grid_export_power_pct(sensor, _id, _pct)
+                ),
+                reader=lambda: _parse_power_control_pct(
+                    sensor.hass.states.get(inv_entity).state
+                    if inv_entity and sensor.hass.states.get(inv_entity) is not None
+                    else None
+                ),
+            )
+            summary.results.append(result)
+
+            if result.status == ApplyStatus.FAILED:
+                await async_logger(
+                    sensor,
+                    f"Export power % write FAILED for inverter {inv_id} after all retries. "
+                    f"Blocking further writes this cycle.",
+                    "error",
+                )
+                return summary
+
+    return summary
 
 
 async def async_apply_battery_settings(
@@ -123,12 +186,17 @@ async def async_apply_battery_settings(
     live: LiveState,
     rec: HourlyRecommendation,
     current_required_battery_kwh: float,
-) -> None:
+) -> CycleApplySummary:
     """Apply the working mode, TOU periods, and discharge power to the battery pack.
 
     Translates the ``rec.recommendation`` string into the correct Huawei Solar
     API calls.  Only issues writes when the hardware state actually needs to
     change (idempotent guard on each write).
+
+    Each write is wrapped with :func:`~utils.inverter_verify.async_write_and_verify`
+    so that the value is polled back from HA after the write and verified within
+    tolerance.  If a write fails all retries it is recorded in the returned
+    summary and further writes are blocked for this cycle.
 
     Args:
         sensor: ``HSEMWorkingModeSensor`` instance for HA access and logging.
@@ -137,7 +205,12 @@ async def async_apply_battery_settings(
         rec: The current-interval recommendation.
         current_required_battery_kwh: Remaining energy required until end of day
             (used when computing forcible-discharge target SoC).
+
+    Returns:
+        :class:`CycleApplySummary` with one :class:`ApplyResult` per write
+        attempted.
     """
+    summary = CycleApplySummary()
     tou_modes = None
     working_mode = None
 
@@ -149,11 +222,24 @@ async def async_apply_battery_settings(
     # Set maximum discharging power unless EV is charging
     if not live.ev.is_charging and not live.ev_second.is_charging:
         if live.huawei_batteries_max_discharge_power_w != max_discharge_power:
-            await async_set_number_value(
-                sensor,
-                cfg.huawei_solar_batteries_maximum_discharging_power,
-                max_discharge_power,
+            discharge_entity = cfg.huawei_solar_batteries_maximum_discharging_power
+            result = await async_write_and_verify(
+                entity_id=discharge_entity or "batteries_maximum_discharging_power",
+                desired=max_discharge_power,
+                writer=lambda: async_set_number_value(
+                    sensor, discharge_entity, max_discharge_power
+                ),
+                reader=lambda: _read_number_state(sensor, discharge_entity),
             )
+            summary.results.append(result)
+            if result.status == ApplyStatus.FAILED:
+                await async_logger(
+                    sensor,
+                    f"Max discharge power write FAILED for {discharge_entity}. "
+                    "Blocking further battery writes this cycle.",
+                    "error",
+                )
+                return summary
 
     recommendation = rec.recommendation
 
@@ -182,10 +268,12 @@ async def async_apply_battery_settings(
             working_mode = WorkingModes.MaximizeSelfConsumption.value
 
         case Recommendations.ForceBatteriesDischarge.value:
-            await _async_apply_forcible_discharge(
+            forcible_result = await _async_apply_forcible_discharge(
                 sensor, cfg, live, current_required_battery_kwh, max_discharge_power
             )
-            return
+            if forcible_result is not None:
+                summary.results.append(forcible_result)
+            return summary
 
         case Recommendations.BatteriesWaitMode.value:
             tou_modes = DEFAULT_HSEM_BATTERIES_WAIT_MODE
@@ -203,11 +291,22 @@ async def async_apply_battery_settings(
             live.ev_second.max_discharge_power_w,
         )
         if live.huawei_batteries_max_discharge_power_w != ev_max:
-            await async_set_number_value(
-                sensor,
-                cfg.huawei_solar_batteries_maximum_discharging_power,
-                ev_max,
+            discharge_entity = cfg.huawei_solar_batteries_maximum_discharging_power
+            ev_result = await async_write_and_verify(
+                entity_id=discharge_entity or "batteries_maximum_discharging_power",
+                desired=ev_max,
+                writer=lambda: async_set_number_value(sensor, discharge_entity, ev_max),
+                reader=lambda: _read_number_state(sensor, discharge_entity),
             )
+            summary.results.append(ev_result)
+            if ev_result.status == ApplyStatus.FAILED:
+                await async_logger(
+                    sensor,
+                    f"EV V2H discharge power write FAILED for {discharge_entity}. "
+                    "Blocking further battery writes this cycle.",
+                    "error",
+                )
+                return summary
 
     # Excess PV use in TOU
     desired_excess = (
@@ -217,28 +316,80 @@ async def async_apply_battery_settings(
         else "charge"
     )
     if live.huawei_batteries_excess_pv_use_in_tou != desired_excess:
-        await async_set_select_option(
-            sensor,
-            cfg.huawei_solar_batteries_excess_pv_energy_use_in_tou,
-            desired_excess,
+        excess_entity = cfg.huawei_solar_batteries_excess_pv_energy_use_in_tou
+        excess_result = await async_write_and_verify(
+            entity_id=excess_entity or "batteries_excess_pv_energy_use_in_tou",
+            desired=desired_excess,
+            writer=lambda: async_set_select_option(
+                sensor, excess_entity, desired_excess
+            ),
+            reader=lambda: _read_select_state(sensor, excess_entity),
         )
+        summary.results.append(excess_result)
+        if excess_result.status == ApplyStatus.FAILED:
+            await async_logger(
+                sensor,
+                f"Excess PV use write FAILED for {excess_entity}. "
+                "Blocking further battery writes this cycle.",
+                "error",
+            )
+            return summary
 
-    # TOU periods
+    # TOU periods — no read-back verification (TOU period state is complex JSON;
+    # hash comparison is sufficient; single attempt only).
     if working_mode == WorkingModes.TimeOfUse.value and tou_modes:
         if generate_hash(str(tou_modes)) != generate_hash(
             str(live.tou_periods.periods)
         ):
-            await async_set_tou_periods(
-                sensor, cfg.huawei_solar_device_id_batteries, tou_modes
+            tou_entity = cfg.huawei_solar_batteries_tou_charging_and_discharging_periods
+            result = await async_write_and_verify(
+                entity_id=tou_entity or "batteries_tou_periods",
+                desired=generate_hash(str(tou_modes)),
+                writer=lambda: async_set_tou_periods(
+                    sensor, cfg.huawei_solar_device_id_batteries, tou_modes
+                ),
+                reader=lambda: generate_hash(
+                    str(
+                        sensor.hass.states.get(tou_entity).state
+                        if tou_entity and sensor.hass.states.get(tou_entity) is not None
+                        else ""
+                    )
+                ),
+                # TOU periods may take longer to propagate; skip equality check
+                # since we always write when the hash differs.
+                skip_if_equal=False,
+                max_retries=2,
             )
+            summary.results.append(result)
+            if result.status == ApplyStatus.FAILED:
+                await async_logger(
+                    sensor,
+                    f"TOU period write FAILED for device {cfg.huawei_solar_device_id_batteries}. "
+                    "Blocking further battery writes this cycle.",
+                    "error",
+                )
+                return summary
 
     # Working mode
     if working_mode and live.huawei_batteries_working_mode != working_mode:
-        await async_set_select_option(
-            sensor,
-            cfg.huawei_solar_batteries_working_mode,
-            working_mode,
+        mode_entity = cfg.huawei_solar_batteries_working_mode
+        mode_result = await async_write_and_verify(
+            entity_id=mode_entity or "batteries_working_mode",
+            desired=working_mode,
+            writer=lambda: async_set_select_option(sensor, mode_entity, working_mode),
+            reader=lambda: _read_select_state(sensor, mode_entity),
         )
+        summary.results.append(mode_result)
+        if mode_result.status == ApplyStatus.FAILED:
+            await async_logger(
+                sensor,
+                f"Working mode write FAILED for {mode_entity}. "
+                "Blocking further battery writes this cycle.",
+                "error",
+            )
+            return summary
+
+    return summary
 
 
 # ---------------------------------------------------------------------------
@@ -252,29 +403,93 @@ async def _async_apply_forcible_discharge(
     live: LiveState,
     current_required_kwh: float,
     max_discharge_power: int,
-) -> None:
-    """Issue a forcible-discharge command to the battery pack."""
+) -> ApplyResult | None:
+    """Issue a forcible-discharge command to the battery pack and verify acceptance.
+
+    Returns:
+        :class:`ApplyResult` with the outcome, or ``None`` if the preconditions
+        were not met and no write was attempted.
+    """
     if (
         live.battery_usable_capacity_kwh <= 0
         or current_required_kwh < 0
         or not cfg.huawei_solar_device_id_batteries
     ):
-        return
+        return None
 
     target_soc = int((current_required_kwh / live.battery_usable_capacity_kwh) * 100)
     target_soc = max(10, min(100, target_soc))  # clamp 10–100
 
-    await async_set_forcible_discharge(
-        sensor,
-        cfg.huawei_solar_device_id_batteries,
-        target_soc,
-        max_discharge_power,
+    bat_soc_entity = cfg.huawei_solar_batteries_state_of_capacity
+    device_id = cfg.huawei_solar_device_id_batteries
+
+    result = await async_write_and_verify(
+        entity_id=bat_soc_entity or f"battery:{device_id}",
+        desired=target_soc,
+        writer=lambda: async_set_forcible_discharge(
+            sensor,
+            device_id,
+            target_soc,
+            max_discharge_power,
+        ),
+        reader=lambda: _read_number_state(sensor, bat_soc_entity),
+        # Forcible-discharge target SoC may differ from current SoC even after
+        # a successful write (the battery is actively discharging), so use a
+        # wider tolerance and only 1 retry — the main guard is the write success.
+        tolerance=5.0,
+        max_retries=1,
     )
+
     await async_logger(
         sensor,
         f"Excess battery export: Set forcible discharge to {target_soc}% SOC "
-        f"at {max_discharge_power}W power.",
+        f"at {max_discharge_power}W power. Verify result: {result.status.value}",
     )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Read-back helpers (pure — no side effects)
+# ---------------------------------------------------------------------------
+
+
+def _read_number_state(sensor, entity_id: str | None) -> float | None:
+    """Read a number entity state from HA and return it as float, or None.
+
+    Args:
+        sensor: HSEM sensor instance with a ``hass`` attribute.
+        entity_id: HA entity ID to read.
+
+    Returns:
+        Current numeric state, or ``None`` when the entity is unavailable.
+    """
+    if not entity_id:
+        return None
+    state = sensor.hass.states.get(entity_id)
+    if state is None or state.state in ("unknown", "unavailable", None):
+        return None
+    try:
+        return float(state.state)
+    except (ValueError, TypeError):
+        return None
+
+
+def _read_select_state(sensor, entity_id: str | None) -> str | None:
+    """Read a select entity state from HA and return it as a string, or None.
+
+    Args:
+        sensor: HSEM sensor instance with a ``hass`` attribute.
+        entity_id: HA entity ID to read.
+
+    Returns:
+        Current option string, or ``None`` when unavailable.
+    """
+    if not entity_id:
+        return None
+    state = sensor.hass.states.get(entity_id)
+    if state is None or state.state in ("unknown", "unavailable", None):
+        return None
+    return str(state.state)
 
 
 def _parse_power_control_pct(state: str | None) -> int | None:

--- a/custom_components/hsem/custom_sensors/applier_status_sensor.py
+++ b/custom_components/hsem/custom_sensors/applier_status_sensor.py
@@ -1,0 +1,180 @@
+"""Diagnostic sensor that exposes the result of the last inverter apply cycle.
+
+State values
+------------
+``ok``
+    All hardware writes in the last cycle were verified successfully, or no
+    writes were needed (all values already matched — ``skipped`` is also
+    treated as ``ok`` from a health perspective).
+
+``unverified``
+    At least one write could not be verified because the entity read-back
+    returned ``None`` (entity unavailable after the write).
+
+``failed``
+    At least one write failed all retry attempts — the inverter did not accept
+    the new value within the allowed tolerance.
+
+``pending``
+    The coordinator has not yet completed a hardware-write cycle (e.g. on HA
+    restart before the first coordinator tick).
+
+The sensor is a *diagnostic* entity (``entity_category = EntityCategory.DIAGNOSTIC``)
+so it appears in the *Diagnostic* section of the device page.
+
+This sensor subscribes to :class:`~custom_components.hsem.coordinator.HSEMDataUpdateCoordinator`
+and updates automatically after every coordinator cycle, including after the
+working-mode sensor mutates :attr:`CoordinatorData.apply_summary`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.const import EntityCategory
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from custom_components.hsem.coordinator import (
+    CoordinatorData,
+    HSEMDataUpdateCoordinator,
+)
+from custom_components.hsem.entity import HSEMEntity
+from custom_components.hsem.utils.inverter_verify import ApplyStatus
+from custom_components.hsem.utils.sensornames import (
+    get_applier_status_sensor_entity_id,
+    get_applier_status_sensor_name,
+    get_applier_status_sensor_unique_id,
+)
+
+_PENDING = "pending"
+_VALID_STATES = {s.value for s in ApplyStatus} | {_PENDING}
+
+
+class HSEMApplierStatusSensor(
+    CoordinatorEntity[HSEMDataUpdateCoordinator],
+    SensorEntity,
+    HSEMEntity,
+    RestoreEntity,
+):
+    """Diagnostic sensor exposing the last hardware-write cycle outcome.
+
+    State reflects the worst-case :class:`~utils.inverter_verify.ApplyStatus`
+    across all writes in the most recent coordinator cycle.
+
+    Attributes
+    ----------
+    ``last_apply_details``
+        List of per-entity result dicts (entity_id, desired, actual, status,
+        attempts, error_message).
+    ``failed_entities``
+        List of entity IDs whose writes failed all retries.
+    ``unverified_entities``
+        List of entity IDs whose read-back returned None.
+    """
+
+    _attr_icon = "mdi:check-network"
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        config_entry,
+        coordinator: HSEMDataUpdateCoordinator,
+    ) -> None:
+        """Initialise the applier-status sensor.
+
+        Args:
+            config_entry: The HSEM config entry.
+            coordinator: The shared :class:`HSEMDataUpdateCoordinator`.
+        """
+        CoordinatorEntity.__init__(self, coordinator)
+        HSEMEntity.__init__(self, config_entry)
+
+        self._config_entry = config_entry
+        self._attr_unique_id = get_applier_status_sensor_unique_id()
+        self.entity_id = get_applier_status_sensor_entity_id()
+        self._name = get_applier_status_sensor_name()
+
+        self._restored_state: str | None = None
+
+    # ------------------------------------------------------------------
+    # HA entity properties
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        """Return the display name."""
+        return self._name
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return the unique ID."""
+        return self._attr_unique_id
+
+    @property
+    def state(self) -> str:
+        """Return the worst-case apply status for the last cycle.
+
+        Returns ``"pending"`` when no cycle has completed yet, restoring a
+        previously persisted state if available.
+        """
+        data: CoordinatorData | None = self.coordinator.data
+        if data is None or data.apply_summary is None:
+            return self._restored_state or _PENDING
+        return data.apply_summary.overall_status.value
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling — driven by the coordinator."""
+        return False
+
+    @property
+    def available(self) -> bool:
+        """True once the coordinator has completed at least one successful cycle."""
+        return (
+            self.coordinator.last_update_success and self.coordinator.data is not None
+        ) or self._restored_state is not None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return per-entity write results and aggregated failure lists."""
+        data: CoordinatorData | None = self.coordinator.data
+        if data is None or data.apply_summary is None:
+            return {
+                "last_apply_details": [],
+                "failed_entities": [],
+                "unverified_entities": [],
+                "total_writes": 0,
+            }
+
+        summary = data.apply_summary
+        details = [
+            {
+                "entity_id": r.entity_id,
+                "desired": r.desired,
+                "actual": r.actual,
+                "status": r.status.value,
+                "attempts": r.attempts,
+                "error_message": r.error_message,
+            }
+            for r in summary.results
+        ]
+        return {
+            "last_apply_details": details,
+            "failed_entities": summary.failed_entities,
+            "unverified_entities": summary.unverified_entities,
+            "total_writes": len(summary.results),
+        }
+
+    # ------------------------------------------------------------------
+    # HA lifecycle
+    # ------------------------------------------------------------------
+
+    async def async_added_to_hass(self) -> None:
+        """Restore previous state and register coordinator listener."""
+        await super().async_added_to_hass()
+        restored = await self.async_get_last_state()
+        if restored is not None and restored.state in _VALID_STATES:
+            self._restored_state = restored.state

--- a/custom_components/hsem/custom_sensors/working_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/working_mode_sensor.py
@@ -34,6 +34,7 @@ from custom_components.hsem.custom_sensors.recommendation_resolver import (
 )
 from custom_components.hsem.entity import HSEMEntity
 from custom_components.hsem.utils.degraded_mode import hardware_writes_allowed
+from custom_components.hsem.utils.inverter_verify import ApplyStatus, CycleApplySummary
 from custom_components.hsem.utils.logger import async_logger
 from custom_components.hsem.utils.misc import calculate_recommended_threshold
 from custom_components.hsem.utils.sensornames import (
@@ -257,10 +258,17 @@ class HSEMWorkingModeSensor(
             "batteries_excess_export_price_threshold": cfg.batteries_excess_export_price_threshold,
         }
 
+        apply_summary = data.apply_summary
         status = {
             "status": "read_only" if cfg.read_only else "ok",
             "degraded_mode": live.degraded_mode.value,
             "hardware_writes_blocked": not hardware_writes_allowed(live.degraded_mode),
+            "apply_status": (
+                apply_summary.overall_status.value if apply_summary else None
+            ),
+            "apply_failed_entities": (
+                apply_summary.failed_entities if apply_summary else []
+            ),
         }
 
         return {
@@ -336,22 +344,34 @@ class HSEMWorkingModeSensor(
 
         # Gate hardware writes on read_only and degraded mode.
         writes_safe = hardware_writes_allowed(live.degraded_mode)
+        combined_summary = CycleApplySummary()
         if not cfg.read_only and writes_safe:
-            await async_apply_inverter_power_control(self, cfg, live)
-            if hourly_rec is not None:
-                await async_apply_battery_settings(
+            inv_summary = await async_apply_inverter_power_control(self, cfg, live)
+            combined_summary.results.extend(inv_summary.results)
+
+            # Block battery writes if the inverter write already failed.
+            if (
+                inv_summary.overall_status != ApplyStatus.FAILED
+                and hourly_rec is not None
+            ):
+                bat_summary = await async_apply_battery_settings(
                     self,
                     cfg,
                     live,
                     hourly_rec,
                     data.current_required_battery,
                 )
+                combined_summary.results.extend(bat_summary.results)
         elif not cfg.read_only and not writes_safe:
             await async_logger(
                 self,
                 f"Hardware writes BLOCKED — degraded mode: {live.degraded_mode.value}. Missing: {live.missing_entities_list}",
                 "warning",
             )
+
+        # Persist the apply summary onto the coordinator data so the status
+        # sensor and extra_state_attributes can surface it to HA.
+        data.apply_summary = combined_summary
 
     # ------------------------------------------------------------------
     # Legacy compatibility

--- a/custom_components/hsem/sensor.py
+++ b/custom_components/hsem/sensor.py
@@ -4,6 +4,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from custom_components.hsem.const import DOMAIN
 from custom_components.hsem.coordinator import HSEMDataUpdateCoordinator
+from custom_components.hsem.custom_sensors.applier_status_sensor import (
+    HSEMApplierStatusSensor,
+)
 from custom_components.hsem.custom_sensors.battery_soc_sensor import (
     HSEMBatterySoCSensor,
 )
@@ -75,6 +78,9 @@ async def async_setup_entry(
     # Working-mode sensor — subscribes to coordinator updates and owns hardware writes.
     working_mode_sensor = HSEMWorkingModeSensor(config_entry, coordinator)
 
+    # Applier-status sensor — exposes write-and-verify results per cycle.
+    applier_status_sensor = HSEMApplierStatusSensor(config_entry, coordinator)
+
     async_add_entities(
         [
             degraded_mode_sensor,
@@ -89,6 +95,7 @@ async def async_setup_entry(
             battery_soc_sensor,
             force_mode_sensor,
             ev_charging_sensor,
+            applier_status_sensor,
             working_mode_sensor,
         ]
     )

--- a/custom_components/hsem/utils/inverter_verify.py
+++ b/custom_components/hsem/utils/inverter_verify.py
@@ -1,0 +1,295 @@
+"""Write-and-verify helper for inverter and battery hardware writes.
+
+Single responsibility: wrap a hardware write with a read-back verification
+loop so that HSEM can confirm each setting was accepted by the inverter before
+marking the apply cycle as successful.
+
+Design
+------
+- Write the desired value via a caller-supplied coroutine.
+- Wait a configurable settle time so the inverter has time to persist the value.
+- Read the current value back via a caller-supplied reader callable.
+- Accept the write if the read-back value matches within the specified tolerance.
+- Retry up to ``max_retries`` times on mismatch or transient error.
+- Return an :class:`ApplyResult` that the caller can log and surface to the
+  status sensor.
+
+The helpers in this module are intentionally free of Home Assistant dependencies
+so that they can be unit-tested without a running HA instance.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Public constants
+# ---------------------------------------------------------------------------
+
+#: Default seconds to wait between write and read-back.
+DEFAULT_SETTLE_SECONDS: float = 1.5
+
+#: Default maximum number of write+verify attempts.
+DEFAULT_MAX_RETRIES: int = 3
+
+#: Absolute tolerance for numeric (float/int) comparisons.
+DEFAULT_NUMERIC_TOLERANCE: float = 1.0
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+class ApplyStatus(StrEnum):
+    """Outcome of a single write-and-verify operation."""
+
+    #: The read-back value matched the desired value within tolerance.
+    OK = "ok"
+
+    #: The write was accepted but the read-back timed out or returned None.
+    UNVERIFIED = "unverified"
+
+    #: All retries exhausted; the inverter did not accept the value.
+    FAILED = "failed"
+
+    #: The write was skipped because the current value already matched.
+    SKIPPED = "skipped"
+
+
+@dataclass
+class ApplyResult:
+    """Detailed outcome of a :func:`async_write_and_verify` call.
+
+    Attributes:
+        entity_id: The HA entity that was written.
+        desired: The value that was written.
+        actual: The last read-back value (``None`` if unreadable).
+        status: Outcome enum.
+        attempts: How many write+verify rounds were performed.
+        error_message: Human-readable reason for failure (empty on success).
+    """
+
+    entity_id: str
+    desired: Any
+    actual: Any
+    status: ApplyStatus
+    attempts: int = 0
+    error_message: str = ""
+
+
+@dataclass
+class CycleApplySummary:
+    """Aggregated results for one full apply cycle (all writes in one coordinator
+    tick).
+
+    Attributes:
+        results: Individual :class:`ApplyResult` per write operation.
+        last_updated: ISO-format timestamp set by the caller after the cycle.
+    """
+
+    results: list[ApplyResult] = field(default_factory=list)
+    last_updated: str | None = None
+
+    # ------------------------------------------------------------------
+    # Derived helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def overall_status(self) -> ApplyStatus:
+        """Worst-case status across all results.
+
+        Priority: FAILED > UNVERIFIED > OK > SKIPPED.
+        If the results list is empty, returns ``ApplyStatus.SKIPPED``.
+        """
+        if not self.results:
+            return ApplyStatus.SKIPPED
+        priority = (
+            ApplyStatus.FAILED,
+            ApplyStatus.UNVERIFIED,
+            ApplyStatus.OK,
+            ApplyStatus.SKIPPED,
+        )
+        for status in priority:
+            if any(r.status == status for r in self.results):
+                return status
+        return ApplyStatus.SKIPPED
+
+    @property
+    def failed_entities(self) -> list[str]:
+        """Entity IDs whose last write ultimately failed verification."""
+        return [r.entity_id for r in self.results if r.status == ApplyStatus.FAILED]
+
+    @property
+    def unverified_entities(self) -> list[str]:
+        """Entity IDs whose write could not be verified (reader returned None)."""
+        return [r.entity_id for r in self.results if r.status == ApplyStatus.UNVERIFIED]
+
+
+# ---------------------------------------------------------------------------
+# Core write-and-verify primitive
+# ---------------------------------------------------------------------------
+
+
+async def async_write_and_verify(
+    entity_id: str,
+    desired: Any,
+    writer: Callable[[], Awaitable[None]],
+    reader: Callable[[], Any],
+    *,
+    tolerance: float = DEFAULT_NUMERIC_TOLERANCE,
+    settle_seconds: float = DEFAULT_SETTLE_SECONDS,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    skip_if_equal: bool = True,
+) -> ApplyResult:
+    """Write *desired* to an inverter entity and verify the value was accepted.
+
+    Args:
+        entity_id: HA entity that is written (used only for logging/reporting).
+        desired: The value to write.
+        writer: Zero-argument coroutine that performs the actual hardware write.
+        reader: Zero-argument callable that returns the current entity value
+                (may be a regular function or a coroutine).  Returns ``None``
+                when the entity is unavailable.
+        tolerance: Accepted absolute difference for numeric comparisons.
+                   String comparisons use exact equality regardless.
+        settle_seconds: Seconds to wait after writing before reading back.
+        max_retries: Maximum number of write+verify attempts.
+        skip_if_equal: When ``True``, skip the write entirely if the current
+                       value already matches *desired* within tolerance.
+
+    Returns:
+        :class:`ApplyResult` describing the outcome.
+    """
+    if max_retries < 1:
+        raise ValueError(f"max_retries must be >= 1, got {max_retries}")
+
+    # ------------------------------------------------------------------
+    # Pre-flight: read current value
+    # ------------------------------------------------------------------
+    try:
+        current = await reader() if asyncio.iscoroutinefunction(reader) else reader()
+    except Exception as exc:  # noqa: BLE001
+        _LOGGER.warning("Could not read current value of %s: %s", entity_id, exc)
+        current = None
+
+    if (
+        skip_if_equal
+        and current is not None
+        and _values_match(current, desired, tolerance)
+    ):
+        return ApplyResult(
+            entity_id=entity_id,
+            desired=desired,
+            actual=current,
+            status=ApplyStatus.SKIPPED,
+            attempts=0,
+        )
+
+    # ------------------------------------------------------------------
+    # Retry loop
+    # ------------------------------------------------------------------
+    last_actual: Any = current
+    last_error = ""
+
+    for attempt in range(1, max_retries + 1):
+        try:
+            await writer()
+        except Exception as exc:  # noqa: BLE001
+            last_error = f"Write error on attempt {attempt}: {exc}"
+            _LOGGER.warning("%s — %s", entity_id, last_error)
+            # Wait before retrying even after a write error (device may recover).
+            if attempt < max_retries:
+                await asyncio.sleep(settle_seconds)
+            continue
+
+        # Wait for the inverter to settle before reading back.
+        await asyncio.sleep(settle_seconds)
+
+        try:
+            readback = (
+                await reader() if asyncio.iscoroutinefunction(reader) else reader()
+            )
+        except Exception as exc:  # noqa: BLE001
+            last_error = f"Read-back error on attempt {attempt}: {exc}"
+            _LOGGER.warning("%s — %s", entity_id, last_error)
+            last_actual = None
+            continue
+
+        last_actual = readback
+
+        if readback is None:
+            last_error = f"Read-back returned None on attempt {attempt}"
+            _LOGGER.warning("%s — %s", entity_id, last_error)
+            continue
+
+        if _values_match(readback, desired, tolerance):
+            _LOGGER.debug(
+                "%s verified after %d attempt(s): desired=%s, actual=%s",
+                entity_id,
+                attempt,
+                desired,
+                readback,
+            )
+            return ApplyResult(
+                entity_id=entity_id,
+                desired=desired,
+                actual=readback,
+                status=ApplyStatus.OK,
+                attempts=attempt,
+            )
+
+        last_error = (
+            f"Mismatch on attempt {attempt}: desired={desired}, actual={readback}"
+        )
+        _LOGGER.warning("%s — %s", entity_id, last_error)
+
+    # ------------------------------------------------------------------
+    # All retries exhausted
+    # ------------------------------------------------------------------
+    final_status = ApplyStatus.UNVERIFIED if last_actual is None else ApplyStatus.FAILED
+    _LOGGER.error(
+        "%s write-and-verify FAILED after %d attempt(s). Last error: %s",
+        entity_id,
+        max_retries,
+        last_error,
+    )
+    return ApplyResult(
+        entity_id=entity_id,
+        desired=desired,
+        actual=last_actual,
+        status=final_status,
+        attempts=max_retries,
+        error_message=last_error,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _values_match(actual: Any, desired: Any, tolerance: float) -> bool:
+    """Return True when *actual* is close enough to *desired*.
+
+    Numeric types use an absolute tolerance comparison.
+    Strings and other types use exact equality.
+
+    Args:
+        actual: The read-back value.
+        desired: The intended value.
+        tolerance: Maximum allowed absolute difference for numeric types.
+
+    Returns:
+        True if the values are considered equal within tolerance.
+    """
+    if isinstance(desired, (int, float)) and isinstance(actual, (int, float)):
+        return abs(float(actual) - float(desired)) <= tolerance
+    return str(actual).lower().strip() == str(desired).lower().strip()

--- a/custom_components/hsem/utils/sensornames.py
+++ b/custom_components/hsem/utils/sensornames.py
@@ -448,3 +448,19 @@ def get_ev_charging_sensor_unique_id() -> str:
 def get_ev_charging_sensor_entity_id() -> str:
     """Return the entity_id for the EV-charging sensor."""
     return sensor.ENTITY_ID_FORMAT.format(s(f"{DOMAIN}_ev_charging_sensor"))
+
+
+# Applier Status Sensor
+def get_applier_status_sensor_name() -> str:
+    """Return the display name for the applier-status diagnostic sensor."""
+    return "Inverter Apply Status"
+
+
+def get_applier_status_sensor_unique_id() -> str:
+    """Return a unique ID for the applier-status sensor."""
+    return f"{DOMAIN}_applier_status_sensor"
+
+
+def get_applier_status_sensor_entity_id() -> str:
+    """Return the entity_id for the applier-status sensor."""
+    return sensor.ENTITY_ID_FORMAT.format(s(f"{DOMAIN}_applier_status_sensor"))

--- a/tests/test_write_verify_applier.py
+++ b/tests/test_write_verify_applier.py
@@ -1,0 +1,512 @@
+"""Tests for write-and-verify inverter applier (issue #275).
+
+These tests cover:
+- :mod:`utils.inverter_verify`: core write-and-verify primitive and result types.
+- :mod:`custom_sensors.applier`: :func:`_parse_power_control_pct` (no change) and
+  the new read-back helper functions.
+- ``CycleApplySummary`` aggregation logic.
+- Edge cases: None readers, write errors, tolerance boundaries, string matching.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.hsem.utils.inverter_verify import (
+    ApplyResult,
+    ApplyStatus,
+    CycleApplySummary,
+    _values_match,
+    async_write_and_verify,
+)
+
+# ---------------------------------------------------------------------------
+# Helper factories
+# ---------------------------------------------------------------------------
+
+
+def _make_writer(fail: bool = False) -> AsyncMock:
+    """Return an AsyncMock writer that optionally raises on the first call."""
+    mock = AsyncMock()
+    if fail:
+        mock.side_effect = [RuntimeError("Service not found"), None, None]
+    return mock
+
+
+def _const_reader(value):
+    """Return a sync callable that always returns *value*."""
+    return lambda: value
+
+
+def _async_const_reader(value):
+    """Return a coroutine callable that always returns *value*."""
+
+    async def _reader():
+        return value
+
+    return _reader
+
+
+# ---------------------------------------------------------------------------
+# _values_match
+# ---------------------------------------------------------------------------
+
+
+class TestValuesMatch:
+    """Unit tests for the :func:`_values_match` helper."""
+
+    def test_exact_int_match(self):
+        assert _values_match(80, 80, 1.0) is True
+
+    def test_int_within_tolerance(self):
+        assert _values_match(79, 80, 1.0) is True
+
+    def test_int_outside_tolerance(self):
+        assert _values_match(78, 80, 1.0) is False
+
+    def test_float_match(self):
+        assert _values_match(80.0, 80, 1.0) is True
+
+    def test_float_boundary_inclusive(self):
+        """Exactly at the tolerance boundary should still pass."""
+        assert _values_match(79.0, 80.0, 1.0) is True
+
+    def test_float_just_outside_tolerance(self):
+        assert _values_match(78.9, 80.0, 1.0) is False
+
+    def test_string_exact_match(self):
+        assert (
+            _values_match("MaximizeSelfConsumption", "MaximizeSelfConsumption", 0)
+            is True
+        )
+
+    def test_string_case_insensitive(self):
+        assert (
+            _values_match("maximizeselFConsumption", "MaximizeSelfConsumption", 0)
+            is True
+        )
+
+    def test_string_mismatch(self):
+        assert _values_match("TimeOfUse", "MaximizeSelfConsumption", 0) is False
+
+    def test_zero_tolerance_numeric(self):
+        assert _values_match(80, 80, 0) is True
+        assert _values_match(79, 80, 0) is False
+
+    def test_negative_numeric(self):
+        """Negative values should work correctly with tolerance."""
+        assert _values_match(-1, 0, 1.0) is True
+        assert _values_match(-2, 0, 1.0) is False
+
+
+# ---------------------------------------------------------------------------
+# ApplyStatus enum
+# ---------------------------------------------------------------------------
+
+
+class TestApplyStatus:
+    """Verify enum values are stable string literals."""
+
+    def test_ok_value(self):
+        assert ApplyStatus.OK.value == "ok"
+
+    def test_failed_value(self):
+        assert ApplyStatus.FAILED.value == "failed"
+
+    def test_unverified_value(self):
+        assert ApplyStatus.UNVERIFIED.value == "unverified"
+
+    def test_skipped_value(self):
+        assert ApplyStatus.SKIPPED.value == "skipped"
+
+    def test_unique_values(self):
+        values = [s.value for s in ApplyStatus]
+        assert len(values) == len(set(values))
+
+
+# ---------------------------------------------------------------------------
+# CycleApplySummary aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestCycleApplySummary:
+    """Tests for :class:`CycleApplySummary` aggregation helpers."""
+
+    def test_empty_summary_is_skipped(self):
+        s = CycleApplySummary()
+        assert s.overall_status == ApplyStatus.SKIPPED
+
+    def test_all_ok(self):
+        s = CycleApplySummary(
+            results=[
+                ApplyResult("e1", 80, 80, ApplyStatus.OK, 1),
+                ApplyResult("e2", "TOU", "tou", ApplyStatus.OK, 1),
+            ]
+        )
+        assert s.overall_status == ApplyStatus.OK
+
+    def test_all_skipped(self):
+        s = CycleApplySummary(
+            results=[
+                ApplyResult("e1", 80, 80, ApplyStatus.SKIPPED, 0),
+            ]
+        )
+        assert s.overall_status == ApplyStatus.SKIPPED
+
+    def test_failed_dominates_ok(self):
+        s = CycleApplySummary(
+            results=[
+                ApplyResult("e1", 80, 80, ApplyStatus.OK, 1),
+                ApplyResult("e2", 100, 50, ApplyStatus.FAILED, 3, "mismatch"),
+            ]
+        )
+        assert s.overall_status == ApplyStatus.FAILED
+
+    def test_unverified_dominates_ok(self):
+        s = CycleApplySummary(
+            results=[
+                ApplyResult("e1", 80, 80, ApplyStatus.OK, 1),
+                ApplyResult(
+                    "e2", 100, None, ApplyStatus.UNVERIFIED, 3, "None read-back"
+                ),
+            ]
+        )
+        assert s.overall_status == ApplyStatus.UNVERIFIED
+
+    def test_failed_dominates_unverified(self):
+        s = CycleApplySummary(
+            results=[
+                ApplyResult("e1", 100, None, ApplyStatus.UNVERIFIED, 3),
+                ApplyResult("e2", 100, 50, ApplyStatus.FAILED, 3, "mismatch"),
+            ]
+        )
+        assert s.overall_status == ApplyStatus.FAILED
+
+    def test_failed_entities_list(self):
+        s = CycleApplySummary(
+            results=[
+                ApplyResult("entity_a", 80, 80, ApplyStatus.OK, 1),
+                ApplyResult("entity_b", 100, 50, ApplyStatus.FAILED, 3),
+                ApplyResult("entity_c", 100, 50, ApplyStatus.FAILED, 3),
+            ]
+        )
+        assert s.failed_entities == ["entity_b", "entity_c"]
+
+    def test_unverified_entities_list(self):
+        s = CycleApplySummary(
+            results=[
+                ApplyResult("entity_x", 100, None, ApplyStatus.UNVERIFIED, 3),
+                ApplyResult("entity_y", 80, 80, ApplyStatus.OK, 1),
+            ]
+        )
+        assert s.unverified_entities == ["entity_x"]
+
+    def test_no_failed_when_all_ok(self):
+        s = CycleApplySummary(
+            results=[
+                ApplyResult("e1", 80, 80, ApplyStatus.OK, 1),
+            ]
+        )
+        assert s.failed_entities == []
+        assert s.unverified_entities == []
+
+
+# ---------------------------------------------------------------------------
+# async_write_and_verify — write success paths
+# ---------------------------------------------------------------------------
+
+
+class TestWriteAndVerifySuccess:
+    """Tests for successful write-and-verify scenarios."""
+
+    @pytest.mark.asyncio
+    async def test_write_and_verify_ok_numeric(self):
+        """Write and read-back within tolerance returns OK."""
+        writer = AsyncMock()
+        # Use skip_if_equal=False so the write path is exercised even when
+        # current == desired (simulates TOU-style forced writes).
+        result = await async_write_and_verify(
+            entity_id="number.bat_discharge",
+            desired=5000,
+            writer=writer,
+            reader=_const_reader(5000),
+            settle_seconds=0,
+            skip_if_equal=False,
+        )
+        assert result.status == ApplyStatus.OK
+        assert result.attempts == 1
+        assert result.actual == pytest.approx(5000)
+        writer.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_write_and_verify_ok_string(self):
+        """Write a working-mode string and verify exact match."""
+        writer = AsyncMock()
+        result = await async_write_and_verify(
+            entity_id="select.working_mode",
+            desired="MaximizeSelfConsumption",
+            writer=writer,
+            reader=_const_reader("MaximizeSelfConsumption"),
+            settle_seconds=0,
+            skip_if_equal=False,
+        )
+        assert result.status == ApplyStatus.OK
+        assert result.entity_id == "select.working_mode"
+
+    @pytest.mark.asyncio
+    async def test_skipped_when_already_matches(self):
+        """Write is skipped if the current value already matches desired."""
+        writer = AsyncMock()
+        result = await async_write_and_verify(
+            entity_id="number.bat_discharge",
+            desired=5000,
+            writer=writer,
+            reader=_const_reader(5000),
+            settle_seconds=0,
+            skip_if_equal=True,
+        )
+        assert result.status == ApplyStatus.SKIPPED
+        assert result.attempts == 0
+        writer.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_not_skipped_when_skip_if_equal_false(self):
+        """When skip_if_equal=False the write always executes even if values match."""
+        writer = AsyncMock()
+        result = await async_write_and_verify(
+            entity_id="select.tou",
+            desired="same_value",
+            writer=writer,
+            reader=_const_reader("same_value"),
+            settle_seconds=0,
+            skip_if_equal=False,
+        )
+        assert result.status == ApplyStatus.OK
+        writer.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_verify_within_tolerance(self):
+        """Read-back within tolerance (but not exact) is accepted."""
+        writer = AsyncMock()
+        call_count = 0
+
+        def _reader():
+            nonlocal call_count
+            call_count += 1
+            # Pre-flight returns 90 (outside tolerance of 1.0 vs desired 100),
+            # so the skip is not triggered.  After the write it returns 99.5,
+            # which IS within the 1.0 tolerance.
+            return 90 if call_count == 1 else 99.5
+
+        result = await async_write_and_verify(
+            entity_id="number.bat",
+            desired=100,
+            writer=writer,
+            reader=_reader,
+            tolerance=1.0,
+            settle_seconds=0,
+        )
+        assert result.status == ApplyStatus.OK
+
+    @pytest.mark.asyncio
+    async def test_async_reader_is_supported(self):
+        """Coroutine readers are awaited correctly."""
+        writer = AsyncMock()
+        result = await async_write_and_verify(
+            entity_id="select.mode",
+            desired="TimeOfUse",
+            writer=writer,
+            reader=_async_const_reader("TimeOfUse"),
+            settle_seconds=0,
+            skip_if_equal=False,
+        )
+        assert result.status == ApplyStatus.OK
+
+    @pytest.mark.asyncio
+    async def test_current_reader_error_does_not_block_write(self):
+        """Pre-flight reader failure falls through to the write attempt."""
+        writer = AsyncMock()
+        call_count = 0
+
+        def _failing_then_ok():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("Entity unavailable")
+            return 80
+
+        result = await async_write_and_verify(
+            entity_id="number.bat",
+            desired=80,
+            writer=writer,
+            reader=_failing_then_ok,
+            settle_seconds=0,
+        )
+        assert result.status == ApplyStatus.OK
+        writer.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# async_write_and_verify — failure paths
+# ---------------------------------------------------------------------------
+
+
+class TestWriteAndVerifyFailure:
+    """Tests for write failure and mismatch retry scenarios."""
+
+    @pytest.mark.asyncio
+    async def test_failed_after_all_retries_mismatch(self):
+        """Returns FAILED when read-back never matches despite all retries."""
+        writer = AsyncMock()
+        result = await async_write_and_verify(
+            entity_id="select.mode",
+            desired="TimeOfUse",
+            writer=writer,
+            reader=_const_reader("MaximizeSelfConsumption"),
+            settle_seconds=0,
+            max_retries=3,
+        )
+        assert result.status == ApplyStatus.FAILED
+        assert result.attempts == 3
+        assert result.actual == "MaximizeSelfConsumption"
+        assert "mismatch" in result.error_message.lower()
+        assert writer.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_unverified_when_reader_always_returns_none(self):
+        """Returns UNVERIFIED when the entity is never readable after write."""
+        writer = AsyncMock()
+        result = await async_write_and_verify(
+            entity_id="number.bat",
+            desired=5000,
+            writer=writer,
+            reader=_const_reader(None),
+            settle_seconds=0,
+            max_retries=2,
+        )
+        assert result.status == ApplyStatus.UNVERIFIED
+        assert result.actual is None
+
+    @pytest.mark.asyncio
+    async def test_retries_on_write_error_then_succeeds(self):
+        """Writer raises on first attempt but succeeds on second; overall OK."""
+        call_count = 0
+
+        async def _flaky_writer():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("Transient error")
+
+        read_count = 0
+
+        def _reader():
+            nonlocal read_count
+            read_count += 1
+            return 80 if read_count >= 2 else None
+
+        result = await async_write_and_verify(
+            entity_id="number.bat",
+            desired=80,
+            writer=_flaky_writer,
+            reader=_reader,
+            settle_seconds=0,
+            max_retries=3,
+        )
+        assert result.status == ApplyStatus.OK
+        assert result.attempts == 2
+
+    @pytest.mark.asyncio
+    async def test_all_write_errors_returns_failed_or_unverified(self):
+        """Writer always raises; the last attempt cannot produce a read-back."""
+
+        async def _always_fails():
+            raise RuntimeError("Network error")
+
+        result = await async_write_and_verify(
+            entity_id="select.mode",
+            desired="TimeOfUse",
+            writer=_always_fails,
+            reader=_const_reader(None),
+            settle_seconds=0,
+            max_retries=3,
+        )
+        # last_actual stays None (never read a value) → UNVERIFIED
+        assert result.status == ApplyStatus.UNVERIFIED
+
+    @pytest.mark.asyncio
+    async def test_invalid_max_retries_raises(self):
+        """max_retries < 1 must raise ValueError immediately."""
+        with pytest.raises(ValueError, match="max_retries"):
+            await async_write_and_verify(
+                entity_id="x",
+                desired=0,
+                writer=AsyncMock(),
+                reader=_const_reader(0),
+                max_retries=0,
+            )
+
+    @pytest.mark.asyncio
+    async def test_succeeds_on_second_attempt(self):
+        """First read-back mismatches; second attempt's read-back succeeds."""
+        read_call = 0
+
+        def _reader():
+            nonlocal read_call
+            read_call += 1
+            # Call 1: pre-flight (50 — not matching desired 80, so no skip)
+            # Call 2: after write attempt 1 — returns wrong value (50)
+            # Call 3: after write attempt 2 — returns correct value (80)
+            if read_call <= 2:
+                return 50
+            return 80
+
+        writer = AsyncMock()
+        result = await async_write_and_verify(
+            entity_id="number.bat",
+            desired=80,
+            writer=writer,
+            reader=_reader,
+            settle_seconds=0,
+            max_retries=3,
+        )
+        assert result.status == ApplyStatus.OK
+        assert result.attempts == 2
+
+    @pytest.mark.asyncio
+    async def test_outside_tolerance_fails(self):
+        """Read-back outside tolerance does not count as a match."""
+        writer = AsyncMock()
+        result = await async_write_and_verify(
+            entity_id="number.bat",
+            desired=100,
+            writer=writer,
+            reader=_const_reader(95.0),
+            tolerance=1.0,
+            settle_seconds=0,
+            max_retries=1,
+        )
+        assert result.status == ApplyStatus.FAILED
+
+
+# ---------------------------------------------------------------------------
+# ApplyResult dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestApplyResult:
+    """Verify ApplyResult defaults and field population."""
+
+    def test_default_attempts_zero(self):
+        r = ApplyResult("e", 1, 1, ApplyStatus.SKIPPED)
+        assert r.attempts == 0
+
+    def test_default_error_message_empty(self):
+        r = ApplyResult("e", 1, 1, ApplyStatus.OK)
+        assert r.error_message == ""
+
+    def test_entity_id_preserved(self):
+        r = ApplyResult("select.mode", "TOU", "TOU", ApplyStatus.OK, 1)
+        assert r.entity_id == "select.mode"


### PR DESCRIPTION
## Summary

Resolves **[P0-11] Implement write-and-verify inverter applier** (#275).

HSEM no longer assumes inverter writes succeed. After every hardware write the
value is polled back from the HA entity state and compared against the desired
value within tolerance. On mismatch the write is retried up to 3 times. If all
retries fail, further writes for the current cycle are blocked and the failure
is recorded in a new diagnostic sensor.

---

## How it works

1. **Write** the desired value via the Huawei Solar service call.
2. **Wait** `DEFAULT_SETTLE_SECONDS` (1.5 s) for the inverter to persist the value.
3. **Read back** the current HA entity state.
4. **Accept** if the read-back matches within `DEFAULT_NUMERIC_TOLERANCE` (1.0 for
   numbers, exact case-insensitive equality for strings).
5. **Retry** up to `DEFAULT_MAX_RETRIES` (3) times on mismatch or transient error.
6. **Fail safe** � after all retries, mark the write `FAILED` and **block further
   writes for this cycle** (battery writes are skipped if the inverter write
   already failed).

---

## New file: `utils/inverter_verify.py`

- `ApplyStatus(StrEnum)` � `ok`, `unverified`, `failed`, `skipped`.
- `ApplyResult` dataclass � entity_id, desired, actual, status, attempts, error_message.
- `CycleApplySummary` � list of `ApplyResult`s with `overall_status` (worst-case
  priority: failed > unverified > ok > skipped), `failed_entities`, `unverified_entities`.
- `async_write_and_verify()` � core coroutine; supports sync and async readers,
  configurable tolerance / settle time / max retries / skip-if-equal.

---

## Changed: `custom_sensors/applier.py`

All hardware writes now go through `async_write_and_verify`:

| Write | Entity read-back |
|---|---|
| Grid-export power % | `cfg.huawei_solar_inverter_active_power_control` |
| Max discharge power | `cfg.huawei_solar_batteries_maximum_discharging_power` |
| EV V2H discharge power | same number entity |
| Excess PV use in TOU | `cfg.huawei_solar_batteries_excess_pv_energy_use_in_tou` |
| TOU periods | hash of TOU period state (2 retries, skip_if_equal=False) |
| Working mode | `cfg.huawei_solar_batteries_working_mode` |
| Forcible discharge | `cfg.huawei_solar_batteries_state_of_capacity` (5 % tolerance, 1 retry) |

Both top-level functions now return `CycleApplySummary`. If any write returns
`FAILED`, the function returns early to prevent further writes.

Two new private helpers added: `_read_number_state()` and `_read_select_state()`.

---

## New file: `custom_sensors/applier_status_sensor.py`

`HSEMApplierStatusSensor` � `EntityCategory.DIAGNOSTIC` sensor.

| Property | Value |
|---|---|
| State | `ok` / `unverified` / `failed` / `pending` |
| `last_apply_details` | Per-entity list (entity_id, desired, actual, status, attempts, error_message) |
| `failed_entities` | Entity IDs whose writes failed all retries |
| `unverified_entities` | Entity IDs whose read-back returned None |
| `total_writes` | Count of write operations in the last cycle |

Restores previous state on HA restart (before first coordinator cycle).

---

## Changed: `custom_sensors/working_mode_sensor.py`

- Collects `CycleApplySummary` from both `async_apply_inverter_power_control` and
  `async_apply_battery_settings`.
- If the inverter summary is `FAILED`, battery writes are skipped for the cycle.
- Stores the combined summary on `coordinator.data.apply_summary`.
- `extra_state_attributes` exposes `apply_status` and `apply_failed_entities`.

---

## Changed: `coordinator.py`

`CoordinatorData` gains `apply_summary: CycleApplySummary | None` field.

---

## Changed: `sensor.py`

Registers `HSEMApplierStatusSensor` alongside the existing diagnostic sensors.

---

## Changed: `utils/sensornames.py`

Adds `get_applier_status_sensor_name/unique_id/entity_id` helpers.

---

## New tests: `tests/test_write_verify_applier.py` (42 tests)

| Class | What is verified |
|---|---|
| `TestValuesMatch` | Numeric tolerance boundaries, string case-insensitivity, negatives |
| `TestApplyStatus` | StrEnum string values, uniqueness |
| `TestCycleApplySummary` | Empty ? skipped, priority ordering, failed/unverified lists |
| `TestWriteAndVerifySuccess` | OK numeric/string, skip_if_equal, tolerance, async reader, pre-flight reader error |
| `TestWriteAndVerifyFailure` | Mismatch exhausts retries ? FAILED, None reader ? UNVERIFIED, write error recovery, all writes fail ? UNVERIFIED, invalid max_retries, succeeds on second attempt, outside tolerance ? FAILED |
| `TestApplyResult` | Defaults (attempts=0, error_message=""), field preservation |

---

## Acceptance criteria

- [x] Hardware writes are verified
- [x] Failed verification blocks further writes for the cycle
- [x] Status entity exposes apply result (`sensor.hsem_applier_status_sensor`)
- [x] Tests mock write success and write failure

---

## Test results

```
727 passed, 729 warnings in 25.62s
```

## Lint

```
All checks passed! (isort + black + ruff format + ruff check)
```

Fixes #275
