### PR TITLE
fix(applier): add defense-in-depth safety gates for inverter/battery writes

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -103,6 +103,7 @@ jobs:
         uses: codecov/codecov-action@v6
         if: matrix.python-version == '3.13'
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           flags: unittests
           name: codecov-umbrella

--- a/custom_components/hsem/custom_sensors/applier.py
+++ b/custom_components/hsem/custom_sensors/applier.py
@@ -41,6 +41,7 @@ from custom_components.hsem.const import (
 from custom_components.hsem.models.hourly_recommendation import HourlyRecommendation
 from custom_components.hsem.models.live_state import LiveState
 from custom_components.hsem.models.sensor_config import SensorConfig
+from custom_components.hsem.utils.degraded_mode import hardware_writes_allowed
 from custom_components.hsem.utils.huawei import (
     async_set_forcible_discharge,
     async_set_grid_export_power_pct,
@@ -81,6 +82,11 @@ async def async_apply_inverter_power_control(
     within tolerance.  If any write fails all retries, further writes within this
     cycle are blocked and the failure is recorded in the returned summary.
 
+    This function includes its own safety gate as defense-in-depth.  Callers
+    (``working_mode_sensor``) are expected to gate writes too, but this
+    secondary check ensures no write ever reaches the inverter when
+    ``cfg.read_only`` is ``True`` or the degraded mode is ``Error``.
+
     Args:
         sensor: ``HSEMWorkingModeSensor`` instance for HA access and logging.
         cfg: Current sensor configuration.
@@ -88,9 +94,24 @@ async def async_apply_inverter_power_control(
 
     Returns:
         :class:`CycleApplySummary` with one :class:`ApplyResult` per inverter
-        write attempted.
+        write attempted.  Returns an empty summary immediately when blocked.
     """
     summary = CycleApplySummary()
+
+    # Defense-in-depth: block writes if read_only or degraded mode is Error.
+    if cfg.read_only:
+        await async_logger(
+            sensor,
+            "async_apply_inverter_power_control: skipped — read_only=True",
+        )
+        return summary
+    if not hardware_writes_allowed(live.degraded_mode):
+        await async_logger(
+            sensor,
+            f"async_apply_inverter_power_control: skipped — degraded mode: {live.degraded_mode.value}",
+            "warning",
+        )
+        return summary
 
     export_price = live.energi_data_service_export_price
     min_price = cfg.energi_data_service_export_min_price
@@ -208,9 +229,25 @@ async def async_apply_battery_settings(
 
     Returns:
         :class:`CycleApplySummary` with one :class:`ApplyResult` per write
-        attempted.
+        attempted.  Returns an empty summary immediately when blocked.
     """
     summary = CycleApplySummary()
+
+    # Defense-in-depth: block writes if read_only or degraded mode is Error.
+    if cfg.read_only:
+        await async_logger(
+            sensor,
+            "async_apply_battery_settings: skipped — read_only=True",
+        )
+        return summary
+    if not hardware_writes_allowed(live.degraded_mode):
+        await async_logger(
+            sensor,
+            f"async_apply_battery_settings: skipped — degraded mode: {live.degraded_mode.value}",
+            "warning",
+        )
+        return summary
+
     tou_modes = None
     working_mode = None
 

--- a/custom_components/hsem/custom_sensors/working_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/working_mode_sensor.py
@@ -345,7 +345,19 @@ class HSEMWorkingModeSensor(
         # Gate hardware writes on read_only and degraded mode.
         writes_safe = hardware_writes_allowed(live.degraded_mode)
         combined_summary = CycleApplySummary()
-        if not cfg.read_only and writes_safe:
+        if cfg.read_only:
+            await async_logger(
+                self,
+                "Hardware writes SKIPPED — read_only=True",
+                "warning",
+            )
+        elif not writes_safe:
+            await async_logger(
+                self,
+                f"Hardware writes BLOCKED — degraded mode: {live.degraded_mode.value}. Missing: {live.missing_entities_list}",
+                "warning",
+            )
+        else:
             inv_summary = await async_apply_inverter_power_control(self, cfg, live)
             combined_summary.results.extend(inv_summary.results)
 
@@ -362,12 +374,6 @@ class HSEMWorkingModeSensor(
                     data.current_required_battery,
                 )
                 combined_summary.results.extend(bat_summary.results)
-        elif not cfg.read_only and not writes_safe:
-            await async_logger(
-                self,
-                f"Hardware writes BLOCKED — degraded mode: {live.degraded_mode.value}. Missing: {live.missing_entities_list}",
-                "warning",
-            )
 
         # Persist the apply summary onto the coordinator data so the status
         # sensor and extra_state_attributes can surface it to HA.

--- a/tests/test_ha_mock_integration.py
+++ b/tests/test_ha_mock_integration.py
@@ -640,6 +640,10 @@ class TestMockServiceCalls:
 
         with (
             patch(
+                "custom_components.hsem.custom_sensors.working_mode_sensor.async_logger",
+                new_callable=AsyncMock,
+            ),
+            patch(
                 "custom_components.hsem.custom_sensors.applier.async_set_select_option",
                 new_callable=AsyncMock,
             ) as mock_select,

--- a/tests/test_safety_gates.py
+++ b/tests/test_safety_gates.py
@@ -1,0 +1,552 @@
+"""Safety gate tests for inverter/battery hardware write paths (issue P0).
+
+These tests prove that every combination of blocking mode prevents writes from
+reaching the Huawei Solar service layer, and that normal mode still allows
+them when valid data is present.
+
+Covered scenarios
+-----------------
+- ``read_only=True`` blocks both :func:`async_apply_inverter_power_control` and
+  :func:`async_apply_battery_settings`.
+- ``DegradedMode.Error`` blocks both applier functions.
+- ``DegradedMode.Degraded`` (non-critical entities missing) still allows writes.
+- Normal mode (``read_only=False``, ``DegradedMode.OK``) allows writes.
+- The top-level gate in ``_async_apply_hardware_writes`` (working_mode_sensor)
+  logs the correct message for each blocking scenario.
+
+All tests are pure-Python and require no running Home Assistant instance.
+
+Note on ``async_logger``
+------------------------
+The real :func:`async_logger` uses ``loop.run_in_executor`` with a
+``ThreadPoolExecutor``, which spawns background threads that are caught by the
+pytest-homeassistant-custom-component teardown thread-leak check.  We therefore
+patch ``async_logger`` with a no-op coroutine in every test that calls an
+applier function so that no threads are leaked and teardown stays clean.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.hsem.custom_sensors.applier import (
+    async_apply_battery_settings,
+    async_apply_inverter_power_control,
+)
+from custom_components.hsem.models.hourly_recommendation import HourlyRecommendation
+from custom_components.hsem.models.live_state import LiveState
+from custom_components.hsem.models.sensor_config import SensorConfig
+from custom_components.hsem.utils.degraded_mode import DegradedMode
+from custom_components.hsem.utils.inverter_verify import ApplyStatus
+
+# ---------------------------------------------------------------------------
+# Module-level patch targets (reused across all test classes)
+# ---------------------------------------------------------------------------
+
+# The applier module imports async_logger under this name.
+_APPLIER_LOGGER = "custom_components.hsem.custom_sensors.applier.async_logger"
+_SENSOR_LOGGER = (
+    "custom_components.hsem.custom_sensors.working_mode_sensor.async_logger"
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_sensor():
+    """Return a minimal mock sensor that satisfies async_logger requirements."""
+    sensor = MagicMock()
+    sensor.hass = MagicMock()
+    return sensor
+
+
+def _make_cfg(*, read_only: bool = False) -> SensorConfig:
+    """Return a minimal :class:`SensorConfig` with the given read_only flag."""
+    cfg = SensorConfig()
+    cfg.read_only = read_only
+    cfg.energi_data_service_export_min_price = 0.0
+    return cfg
+
+
+def _make_live(*, degraded_mode: DegradedMode = DegradedMode.OK) -> LiveState:
+    """Return a :class:`LiveState` with the chosen degraded mode forced."""
+    live = LiveState()
+    # Override the lazily-computed cached value directly so no entities need
+    # to be set up just to drive the mode.
+    live._degraded_mode = degraded_mode
+    live.energi_data_service_export_price = 1.0
+    return live
+
+
+def _make_rec(recommendation: str = "batteries_discharge_mode") -> HourlyRecommendation:
+    """Return a minimal :class:`HourlyRecommendation` for testing."""
+    rec = HourlyRecommendation.__new__(HourlyRecommendation)
+    object.__setattr__(rec, "recommendation", recommendation)
+    return rec
+
+
+# ---------------------------------------------------------------------------
+# async_apply_inverter_power_control — safety gate
+# ---------------------------------------------------------------------------
+
+
+class TestInverterPowerControlSafetyGate:
+    """Defense-in-depth gate inside async_apply_inverter_power_control."""
+
+    @pytest.mark.asyncio
+    async def test_read_only_blocks_inverter_writes(self):
+        """read_only=True must return an empty summary without any service call."""
+        sensor = _make_sensor()
+        cfg = _make_cfg(read_only=True)
+        live = _make_live(degraded_mode=DegradedMode.OK)
+
+        with (
+            patch(_APPLIER_LOGGER, new_callable=AsyncMock),
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_set_grid_export_power_pct"
+            ) as mock_write,
+        ):
+            summary = await async_apply_inverter_power_control(sensor, cfg, live)
+
+        mock_write.assert_not_called()
+        assert len(summary.results) == 0
+
+    @pytest.mark.asyncio
+    async def test_error_mode_blocks_inverter_writes(self):
+        """DegradedMode.Error must block all inverter writes."""
+        sensor = _make_sensor()
+        cfg = _make_cfg(read_only=False)
+        live = _make_live(degraded_mode=DegradedMode.Error)
+
+        with (
+            patch(_APPLIER_LOGGER, new_callable=AsyncMock),
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_set_grid_export_power_pct"
+            ) as mock_write,
+        ):
+            summary = await async_apply_inverter_power_control(sensor, cfg, live)
+
+        mock_write.assert_not_called()
+        assert len(summary.results) == 0
+
+    @pytest.mark.asyncio
+    async def test_degraded_mode_allows_inverter_writes(self):
+        """DegradedMode.Degraded must NOT block writes (non-critical data only)."""
+        sensor = _make_sensor()
+        cfg = _make_cfg(read_only=False)
+        # Degraded: price entity missing, but battery data present.
+        live = _make_live(degraded_mode=DegradedMode.Degraded)
+        # Set a numeric export price so the function can compute export_pct.
+        live.energi_data_service_export_price = 0.5
+        # Set current inverter state to force a write (100 → 0 would write).
+        live.huawei_inverter_active_power_control = "Unlimited"
+
+        # Set up an inverter device ID so the write loop has something to call.
+        cfg.huawei_solar_device_id_inverter_1 = "device_123"
+        cfg.huawei_solar_inverter_active_power_control = (
+            "sensor.inverter_active_power_control"
+        )
+        cfg.energi_data_service_export_min_price = 1.0
+
+        # Make the HA state read return an entity indicating "Unlimited" (100 %).
+        mock_state = MagicMock()
+        mock_state.state = "Unlimited"
+        sensor.hass.states.get.return_value = mock_state
+
+        with (
+            patch(_APPLIER_LOGGER, new_callable=AsyncMock),
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_write_and_verify",
+                new_callable=AsyncMock,
+            ) as mock_wv,
+        ):
+            from custom_components.hsem.utils.inverter_verify import ApplyResult
+
+            mock_wv.return_value = ApplyResult(
+                entity_id="sensor.inverter_active_power_control",
+                desired=0,
+                actual=0,
+                status=ApplyStatus.OK,
+                attempts=1,
+            )
+            _summary = await async_apply_inverter_power_control(sensor, cfg, live)
+
+        # The write-and-verify function should have been reached (not blocked).
+        mock_wv.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_normal_mode_allows_inverter_writes(self):
+        """OK mode with read_only=False must reach the write path."""
+        sensor = _make_sensor()
+        cfg = _make_cfg(read_only=False)
+        cfg.huawei_solar_device_id_inverter_1 = "device_abc"
+        cfg.huawei_solar_inverter_active_power_control = (
+            "sensor.inverter_active_power_control"
+        )
+        cfg.energi_data_service_export_min_price = 1.0
+
+        live = _make_live(degraded_mode=DegradedMode.OK)
+        live.energi_data_service_export_price = 0.5
+        live.huawei_inverter_active_power_control = "Unlimited"
+
+        mock_state = MagicMock()
+        mock_state.state = "Unlimited"
+        sensor.hass.states.get.return_value = mock_state
+
+        with (
+            patch(_APPLIER_LOGGER, new_callable=AsyncMock),
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_write_and_verify",
+                new_callable=AsyncMock,
+            ) as mock_wv,
+        ):
+            from custom_components.hsem.utils.inverter_verify import ApplyResult
+
+            mock_wv.return_value = ApplyResult(
+                entity_id="sensor.inverter_active_power_control",
+                desired=0,
+                actual=0,
+                status=ApplyStatus.OK,
+                attempts=1,
+            )
+            _summary = await async_apply_inverter_power_control(sensor, cfg, live)
+
+        mock_wv.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# async_apply_battery_settings — safety gate
+# ---------------------------------------------------------------------------
+
+
+class TestBatterySettingsSafetyGate:
+    """Defense-in-depth gate inside async_apply_battery_settings."""
+
+    def _make_rec(self) -> HourlyRecommendation:
+        from custom_components.hsem.utils.recommendations import Recommendations
+
+        return _make_rec(Recommendations.BatteriesDischargeMode.value)
+
+    @pytest.mark.asyncio
+    async def test_read_only_blocks_battery_writes(self):
+        """read_only=True must return an empty summary without any service call."""
+        sensor = _make_sensor()
+        cfg = _make_cfg(read_only=True)
+        live = _make_live(degraded_mode=DegradedMode.OK)
+        rec = self._make_rec()
+
+        with (
+            patch(_APPLIER_LOGGER, new_callable=AsyncMock),
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_write_and_verify",
+                new_callable=AsyncMock,
+            ) as mock_wv,
+        ):
+            summary = await async_apply_battery_settings(sensor, cfg, live, rec, 5.0)
+
+        mock_wv.assert_not_called()
+        assert len(summary.results) == 0
+
+    @pytest.mark.asyncio
+    async def test_error_mode_blocks_battery_writes(self):
+        """DegradedMode.Error must block all battery writes."""
+        sensor = _make_sensor()
+        cfg = _make_cfg(read_only=False)
+        live = _make_live(degraded_mode=DegradedMode.Error)
+        rec = self._make_rec()
+
+        with (
+            patch(_APPLIER_LOGGER, new_callable=AsyncMock),
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_write_and_verify",
+                new_callable=AsyncMock,
+            ) as mock_wv,
+        ):
+            summary = await async_apply_battery_settings(sensor, cfg, live, rec, 5.0)
+
+        mock_wv.assert_not_called()
+        assert len(summary.results) == 0
+
+    @pytest.mark.asyncio
+    async def test_degraded_mode_allows_battery_writes(self):
+        """DegradedMode.Degraded must NOT block battery writes."""
+        sensor = _make_sensor()
+        cfg = _make_cfg(read_only=False)
+        cfg.huawei_solar_batteries_working_mode = "select.batteries_working_mode"
+        cfg.huawei_solar_batteries_maximum_discharging_power = (
+            "number.batteries_max_discharge"
+        )
+        cfg.huawei_solar_batteries_excess_pv_energy_use_in_tou = (
+            "select.batteries_excess_pv"
+        )
+
+        live = _make_live(degraded_mode=DegradedMode.Degraded)
+        live.huawei_batteries_max_discharge_power_w = 3000.0
+        live.huawei_batteries_rated_capacity_wh = 10000.0
+        live.huawei_batteries_working_mode = "TimeOfUse"
+        live.huawei_batteries_excess_pv_use_in_tou = "charge"
+
+        from custom_components.hsem.utils.recommendations import Recommendations
+
+        rec = _make_rec(Recommendations.BatteriesDischargeMode.value)
+
+        with (
+            patch(_APPLIER_LOGGER, new_callable=AsyncMock),
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_write_and_verify",
+                new_callable=AsyncMock,
+            ) as mock_wv,
+        ):
+            from custom_components.hsem.utils.inverter_verify import ApplyResult
+
+            mock_wv.return_value = ApplyResult(
+                entity_id="select.batteries_working_mode",
+                desired="MaximizeSelfConsumption",
+                actual="MaximizeSelfConsumption",
+                status=ApplyStatus.OK,
+                attempts=1,
+            )
+            _summary = await async_apply_battery_settings(sensor, cfg, live, rec, 5.0)
+
+        # At least one write was attempted (not blocked).
+        mock_wv.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_normal_mode_allows_battery_writes(self):
+        """OK mode with read_only=False must reach the write path."""
+        sensor = _make_sensor()
+        cfg = _make_cfg(read_only=False)
+        cfg.huawei_solar_batteries_working_mode = "select.batteries_working_mode"
+        cfg.huawei_solar_batteries_maximum_discharging_power = (
+            "number.batteries_max_discharge"
+        )
+        cfg.huawei_solar_batteries_excess_pv_energy_use_in_tou = (
+            "select.batteries_excess_pv"
+        )
+
+        live = _make_live(degraded_mode=DegradedMode.OK)
+        live.huawei_batteries_max_discharge_power_w = 3000.0
+        live.huawei_batteries_rated_capacity_wh = 10000.0
+        live.huawei_batteries_working_mode = "TimeOfUse"
+        live.huawei_batteries_excess_pv_use_in_tou = "charge"
+
+        from custom_components.hsem.utils.recommendations import Recommendations
+
+        rec = _make_rec(Recommendations.BatteriesDischargeMode.value)
+
+        with (
+            patch(_APPLIER_LOGGER, new_callable=AsyncMock),
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_write_and_verify",
+                new_callable=AsyncMock,
+            ) as mock_wv,
+        ):
+            from custom_components.hsem.utils.inverter_verify import ApplyResult
+
+            mock_wv.return_value = ApplyResult(
+                entity_id="select.batteries_working_mode",
+                desired="MaximizeSelfConsumption",
+                actual="MaximizeSelfConsumption",
+                status=ApplyStatus.OK,
+                attempts=1,
+            )
+            _summary = await async_apply_battery_settings(sensor, cfg, live, rec, 5.0)
+
+        mock_wv.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# Working-mode sensor top-level gate (_async_apply_hardware_writes)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkingModeSensorTopLevelGate:
+    """Prove the outer gate in HSEMWorkingModeSensor._async_apply_hardware_writes.
+
+    We import the gate function directly via the applier module to verify
+    the plumbing without a full HA setup.
+    """
+
+    def _make_coordinator_data(
+        self,
+        *,
+        read_only: bool = False,
+        degraded_mode: DegradedMode = DegradedMode.OK,
+    ):
+        """Build a minimal CoordinatorData-like object for gate testing."""
+        cfg = _make_cfg(read_only=read_only)
+        live = _make_live(degraded_mode=degraded_mode)
+        live.energi_data_service_export_price = 1.0
+
+        data = MagicMock()
+        data.cfg = cfg
+        data.live = live
+        data.hourly_recommendation = None
+        data.batteries_schedules_remaining_capacity_needed = 0.0
+        data.current_required_battery = 0.0
+        data.apply_summary = None
+        return data
+
+    @pytest.mark.asyncio
+    async def test_read_only_skips_both_appliers(self):
+        """When read_only=True the applier functions must not be called at all."""
+        data = self._make_coordinator_data(read_only=True)
+
+        with (
+            patch(_SENSOR_LOGGER, new_callable=AsyncMock),
+            patch(
+                "custom_components.hsem.custom_sensors.working_mode_sensor.async_apply_inverter_power_control",
+                new_callable=AsyncMock,
+            ) as mock_inv,
+            patch(
+                "custom_components.hsem.custom_sensors.working_mode_sensor.async_apply_battery_settings",
+                new_callable=AsyncMock,
+            ) as mock_bat,
+        ):
+            # Import here to avoid circular import issues in test collection.
+            from custom_components.hsem.custom_sensors.working_mode_sensor import (
+                HSEMWorkingModeSensor,
+            )
+
+            sensor = MagicMock(spec=HSEMWorkingModeSensor)
+            sensor.hass = MagicMock()
+
+            await HSEMWorkingModeSensor._async_apply_hardware_writes(sensor, data)
+
+        mock_inv.assert_not_called()
+        mock_bat.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_error_mode_skips_both_appliers(self):
+        """DegradedMode.Error must prevent both applier calls."""
+        data = self._make_coordinator_data(
+            read_only=False, degraded_mode=DegradedMode.Error
+        )
+
+        with (
+            patch(_SENSOR_LOGGER, new_callable=AsyncMock),
+            patch(
+                "custom_components.hsem.custom_sensors.working_mode_sensor.async_apply_inverter_power_control",
+                new_callable=AsyncMock,
+            ) as mock_inv,
+            patch(
+                "custom_components.hsem.custom_sensors.working_mode_sensor.async_apply_battery_settings",
+                new_callable=AsyncMock,
+            ) as mock_bat,
+        ):
+            from custom_components.hsem.custom_sensors.working_mode_sensor import (
+                HSEMWorkingModeSensor,
+            )
+
+            sensor = MagicMock(spec=HSEMWorkingModeSensor)
+            sensor.hass = MagicMock()
+
+            await HSEMWorkingModeSensor._async_apply_hardware_writes(sensor, data)
+
+        mock_inv.assert_not_called()
+        mock_bat.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_degraded_mode_calls_inverter_applier(self):
+        """DegradedMode.Degraded must still call the inverter applier."""
+        data = self._make_coordinator_data(
+            read_only=False, degraded_mode=DegradedMode.Degraded
+        )
+
+        from custom_components.hsem.utils.inverter_verify import CycleApplySummary
+
+        with (
+            patch(_SENSOR_LOGGER, new_callable=AsyncMock),
+            patch(
+                "custom_components.hsem.custom_sensors.working_mode_sensor.async_apply_inverter_power_control",
+                new_callable=AsyncMock,
+                return_value=CycleApplySummary(),
+            ) as mock_inv,
+            patch(
+                "custom_components.hsem.custom_sensors.working_mode_sensor.async_apply_battery_settings",
+                new_callable=AsyncMock,
+                return_value=CycleApplySummary(),
+            ) as mock_bat,
+        ):
+            from custom_components.hsem.custom_sensors.working_mode_sensor import (
+                HSEMWorkingModeSensor,
+            )
+
+            sensor = MagicMock(spec=HSEMWorkingModeSensor)
+            sensor.hass = MagicMock()
+
+            await HSEMWorkingModeSensor._async_apply_hardware_writes(sensor, data)
+
+        mock_inv.assert_called_once()
+        # Battery applier not called because hourly_rec is None.
+        mock_bat.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_normal_mode_calls_both_appliers(self):
+        """OK mode with read_only=False must call both appliers when a rec exists."""
+        data = self._make_coordinator_data(
+            read_only=False, degraded_mode=DegradedMode.OK
+        )
+        # Provide a dummy hourly_recommendation so the battery applier gets called.
+        data.hourly_recommendation = MagicMock()
+
+        from custom_components.hsem.utils.inverter_verify import CycleApplySummary
+
+        inv_summary = CycleApplySummary()
+        # overall_status of an empty CycleApplySummary is SKIPPED, not FAILED,
+        # so the battery gate passes.
+
+        with (
+            patch(_SENSOR_LOGGER, new_callable=AsyncMock),
+            patch(
+                "custom_components.hsem.custom_sensors.working_mode_sensor.async_apply_inverter_power_control",
+                new_callable=AsyncMock,
+                return_value=inv_summary,
+            ) as mock_inv,
+            patch(
+                "custom_components.hsem.custom_sensors.working_mode_sensor.async_apply_battery_settings",
+                new_callable=AsyncMock,
+                return_value=CycleApplySummary(),
+            ) as mock_bat,
+            patch(
+                "custom_components.hsem.custom_sensors.working_mode_sensor.resolve_current_recommendation"
+            ),
+        ):
+            from custom_components.hsem.custom_sensors.working_mode_sensor import (
+                HSEMWorkingModeSensor,
+            )
+
+            sensor = MagicMock(spec=HSEMWorkingModeSensor)
+            sensor.hass = MagicMock()
+
+            await HSEMWorkingModeSensor._async_apply_hardware_writes(sensor, data)
+
+        mock_inv.assert_called_once()
+        mock_bat.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# hardware_writes_allowed — unit tests (full coverage)
+# ---------------------------------------------------------------------------
+
+
+class TestHardwareWritesAllowedDirectly:
+    """Direct unit tests for :func:`hardware_writes_allowed` covering every mode."""
+
+    def test_ok_mode_allows(self):
+        from custom_components.hsem.utils.degraded_mode import hardware_writes_allowed
+
+        assert hardware_writes_allowed(DegradedMode.OK) is True
+
+    def test_degraded_mode_allows(self):
+        from custom_components.hsem.utils.degraded_mode import hardware_writes_allowed
+
+        assert hardware_writes_allowed(DegradedMode.Degraded) is True
+
+    def test_error_mode_blocks(self):
+        from custom_components.hsem.utils.degraded_mode import hardware_writes_allowed
+
+        assert hardware_writes_allowed(DegradedMode.Error) is False


### PR DESCRIPTION
## Summary

Audit and tighten the safety gates that block Huawei Solar inverter and battery writes when the system is in a protected state.

## Problem

The outer gate in `_async_apply_hardware_writes` (working mode sensor) correctly blocked writes for `read_only=True` and `DegradedMode.Error`, but:

1. **No defense-in-depth inside the applier functions** — `async_apply_inverter_power_control` and `async_apply_battery_settings` had no safety check of their own. Any future caller that bypasses the sensor gate would reach real hardware writes unchecked.
2. **Silent `read_only` skip** — when `read_only=True` caused writes to be skipped, no log message was emitted, making it impossible to confirm from logs that the gate had fired.

## Changes

### `custom_components/hsem/custom_sensors/applier.py`
- Added `read_only` and `hardware_writes_allowed(live.degraded_mode)` safety gates at the **start** of both `async_apply_inverter_power_control` and `async_apply_battery_settings`.
- These are **defense-in-depth**: the outer gate in `working_mode_sensor` still exists; these inner gates block writes even if the outer gate is ever bypassed.
- Each blocked path logs a debug or warning message so operators can confirm gate activation.

### `custom_components/hsem/custom_sensors/working_mode_sensor.py`
- Added an explicit `warning` log when `read_only=True` causes writes to be skipped (was previously silent).
- Restructured the `if/elif/else` branching to be clearer: `read_only` → `degraded Error` → `allowed` (previously mixed the `read_only` and `not writes_safe` checks in a way that could obscure intent).

### `tests/test_safety_gates.py` (new file)
15 new tests covering all safety gate scenarios:

| Test class | Scenarios covered |
|---|---|
| `TestInverterPowerControlSafetyGate` | `read_only` blocks, Error blocks, Degraded allows, OK allows |
| `TestBatterySettingsSafetyGate` | `read_only` blocks, Error blocks, Degraded allows, OK allows |
| `TestWorkingModeSensorTopLevelGate` | Outer gate: `read_only` skips both appliers, Error skips both, Degraded calls inverter, OK calls both |
| `TestHardwareWritesAllowedDirectly` | All three `DegradedMode` values |

### `tests/test_ha_mock_integration.py`
- Patched `async_logger` in `test_no_service_calls_in_read_only_mode` to prevent a `ThreadPoolExecutor` thread-leak during test teardown (the new `read_only` warning log now calls `async_logger`, which uses `run_in_executor`).

## Safety Gate Matrix (after this PR)

| Condition | Outer gate (`working_mode_sensor`) | Inner gate (`applier`) | Result |
|---|---|---|---|
| `read_only=True` | ✅ Blocks + logs warning | ✅ Blocks | No writes |
| `DegradedMode.Error` | ✅ Blocks + logs warning | ✅ Blocks | No writes |
| `DegradedMode.Degraded` | ✅ Allows | ✅ Allows | Writes proceed |
| Normal (`OK`, `read_only=False`) | ✅ Allows | ✅ Allows | Writes proceed |

## Remaining Risks

- `DegradedMode.Degraded` intentionally **still allows** writes (per the existing design: non-critical entities missing — battery SoC and capacity are still available so safe decisions can be made). This is the correct documented behaviour.
- `huawei.py` helper functions (`async_set_grid_export_power_pct`, `async_set_tou_periods`, `async_set_forcible_discharge`) have no gate of their own by design — they are primitives. The `applier.py` layer is the correct place to enforce the gate.

## Test Results

```
768 passed, 770 warnings in 26.40s
```

Lint: `tox -e lint` → All checks passed ✓

## Checklist

- [x] Safety gate present at outer level (`working_mode_sensor`)
- [x] Defense-in-depth gate added at inner level (`applier.py`)
- [x] `read_only` path now logs a warning (no longer silent)
- [x] Tests: `read_only` blocks writes
- [x] Tests: `DegradedMode.Error` blocks writes
- [x] Tests: `DegradedMode.Degraded` allows writes
- [x] Tests: normal (`OK`) mode allows writes
- [x] `tox -e lint` passes
- [x] All 768 tests pass
- [x] No planner logic changed
- [x] No forecast logic changed
- [x] No unrelated formatting changed
