### PR TITLE
fix(planner,sensors,huawei): fix batteries_charged double-count, listener leaks, and Huawei service failures

### DIFF
--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -176,6 +176,9 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         # Entity resolution cache (persisted across cycles).
         self._force_working_mode_entity: str | None = None
         self._tracked_entities: set[str] = set()
+        # Unsubscribe callbacks for state-change listeners registered via
+        # state_collector._register_listeners.  Cancelled during async_teardown.
+        self._listener_unsubs: list = []
         self._avg_house_consumption_entity_id_cache: dict[str, str] = {}
 
     # ------------------------------------------------------------------
@@ -201,7 +204,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         )
 
     async def async_teardown(self) -> None:
-        """Cancel all registered timers.
+        """Cancel all registered timers and state-change listeners.
 
         Called from :func:`~custom_components.hsem.__init__.async_unload_entry`.
         """
@@ -211,6 +214,9 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         if self._interval_timer_unsub is not None:
             self._interval_timer_unsub()
             self._interval_timer_unsub = None
+        for unsub in self._listener_unsubs:
+            unsub()
+        self._listener_unsubs.clear()
 
     async def async_options_updated(self) -> None:
         """Re-run the pipeline when the user saves new options."""
@@ -252,12 +258,14 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             (
                 self._live,
                 self._force_working_mode_entity,
+                new_unsubs,
             ) = await async_collect_live_state(
                 self,
                 cfg,
                 self._force_working_mode_entity,
                 self._tracked_entities,
             )
+            self._listener_unsubs.extend(new_unsubs)
             live = self._live
 
             # 3. Reset and generate recommendation time-slots.

--- a/custom_components/hsem/custom_sensors/avg_sensor.py
+++ b/custom_components/hsem/custom_sensors/avg_sensor.py
@@ -54,6 +54,8 @@ class HSEMAvgSensor(SensorEntity, HSEMEntity, RestoreEntity):
         self._name = name
         self._measurements = None
         self._tracked_entities = set()
+        # Unsubscribe callbacks registered by async_track_* helpers.
+        self._unsub_callbacks: list = []
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -124,9 +126,11 @@ class HSEMAvgSensor(SensorEntity, HSEMEntity, RestoreEntity):
 
             self._last_updated = old_state.attributes.get("last_updated", None)
 
-        # Register new timer
-        async_track_time_interval(
-            self.hass, self._async_handle_update, timedelta(minutes=5)
+        # Register new timer — store unsub so it is cancelled on removal.
+        self._unsub_callbacks.append(
+            async_track_time_interval(
+                self.hass, self._async_handle_update, timedelta(minutes=5)
+            )
         )
 
         # Initial update
@@ -134,14 +138,22 @@ class HSEMAvgSensor(SensorEntity, HSEMEntity, RestoreEntity):
 
         await super().async_added_to_hass()
 
+    async def async_will_remove_from_hass(self) -> None:
+        """Cancel all tracked listeners when the entity is removed."""
+        for unsub in self._unsub_callbacks:
+            unsub()
+        self._unsub_callbacks.clear()
+        await super().async_will_remove_from_hass()
+
     async def _async_track_entities(self) -> None:
         if self._tracked_entity:
             if self._tracked_entity not in self._tracked_entities:
-                async_track_state_change_event(
+                unsub = async_track_state_change_event(
                     self.hass,
                     [self._tracked_entity],
                     self._async_handle_update,
                 )
+                self._unsub_callbacks.append(unsub)
                 self._tracked_entities.add(self._tracked_entity)
 
     async def _async_handle_update(self, event=None) -> None:

--- a/custom_components/hsem/custom_sensors/house_consumption_power_sensor.py
+++ b/custom_components/hsem/custom_sensors/house_consumption_power_sensor.py
@@ -119,6 +119,8 @@ class HSEMHouseConsumptionPowerSensor(SensorEntity, HSEMEntity, RestoreEntity):
         # Track which derived sensors have already been created to avoid duplicate adds.
         self._derived_sensors_created: set[str] = set()
         self._tracked_entities = set()
+        # Unsubscribe callbacks registered by async_track_* helpers.
+        self._unsub_callbacks: list = []
         self._async_add_entities = async_add_entities
         self._name = get_house_consumption_power_sensor_name(
             self._hour_start, self._hour_end
@@ -215,6 +217,13 @@ class HSEMHouseConsumptionPowerSensor(SensorEntity, HSEMEntity, RestoreEntity):
 
         await super().async_added_to_hass()
 
+    async def async_will_remove_from_hass(self) -> None:
+        """Cancel all tracked listeners when the entity is removed."""
+        for unsub in self._unsub_callbacks:
+            unsub()
+        self._unsub_callbacks.clear()
+        await super().async_will_remove_from_hass()
+
     def _update_settings(self) -> None:
         """Fetch updated settings from config_entry options."""
         self._hsem_house_consumption_power = get_config_value(
@@ -308,11 +317,12 @@ class HSEMHouseConsumptionPowerSensor(SensorEntity, HSEMEntity, RestoreEntity):
                 _LOGGER.debug(
                     f"Starting to track state changes for {self._hsem_house_consumption_power}"
                 )
-                async_track_state_change_event(
+                unsub = async_track_state_change_event(
                     self.hass,
                     [self._hsem_house_consumption_power],
                     self._async_handle_update,
                 )
+                self._unsub_callbacks.append(unsub)
                 self._tracked_entities.add(self._hsem_house_consumption_power)
 
         if self._hsem_ev_charger_power:
@@ -320,9 +330,10 @@ class HSEMHouseConsumptionPowerSensor(SensorEntity, HSEMEntity, RestoreEntity):
                 _LOGGER.debug(
                     f"Starting to track state changes for {self._hsem_ev_charger_power}"
                 )
-                async_track_state_change_event(
+                unsub = async_track_state_change_event(
                     self.hass, [self._hsem_ev_charger_power], self._async_handle_update
                 )
+                self._unsub_callbacks.append(unsub)
                 self._tracked_entities.add(self._hsem_ev_charger_power)
 
     async def _async_fetch_sensor_states(self) -> None:

--- a/custom_components/hsem/custom_sensors/state_collector.py
+++ b/custom_components/hsem/custom_sensors/state_collector.py
@@ -46,7 +46,7 @@ async def async_collect_live_state(
     cfg: SensorConfig,
     force_working_mode_cache: str | None,
     tracked_entities: set[str],
-) -> tuple[LiveState, str | None]:
+) -> tuple[LiveState, str | None, list]:
     """Read all HA entity states and return a populated :class:`LiveState`.
 
     This is the **only** function in the module that touches ``sensor.hass``.
@@ -62,9 +62,10 @@ async def async_collect_live_state(
             state-change tracking.  Updated in-place when new entities are added.
 
     Returns:
-        A ``(LiveState, updated_force_working_mode_entity_id)`` tuple.  The second
-        element is the (possibly newly resolved) force working mode entity_id so
-        the caller can persist it between cycles.
+        A ``(LiveState, updated_force_working_mode_entity_id, new_unsub_callbacks)``
+        tuple.  The third element is a list of new unsubscribe callables for
+        listeners registered during this call; the caller is responsible for
+        storing and eventually cancelling them.
     """
     state = LiveState()
 
@@ -332,9 +333,9 @@ async def async_collect_live_state(
     _compute_net_consumption(state, cfg)
 
     # --- Register state-change listeners for reactive entities ---
-    await _register_listeners(sensor, cfg, state, tracked_entities)
+    new_unsubs = await _register_listeners(sensor, cfg, state, tracked_entities)
 
-    return state, fwm_entity
+    return state, fwm_entity, new_unsubs
 
 
 # ---------------------------------------------------------------------------
@@ -394,11 +395,16 @@ async def _register_listeners(
     cfg: SensorConfig,
     state: LiveState,
     tracked_entities: set[str],
-) -> None:
+) -> list:
     """Register ``async_track_state_change_event`` for reactive entities.
 
     Only entities that have not been tracked before are registered (idempotent).
+
+    Returns:
+        List of new unsubscribe callables for all listeners registered during
+        this call.  The caller should store these and cancel them on teardown.
     """
+    new_unsubs: list = []
     candidates = [
         cfg.ev.status_entity,
         cfg.ev.connected_entity,
@@ -413,7 +419,10 @@ async def _register_listeners(
                 sensor,
                 f"Starting to track state changes for {entity_id}",
             )
-            async_track_state_change_event(
+            unsub = async_track_state_change_event(
                 sensor.hass, [entity_id], sensor._async_handle_update
             )
+            new_unsubs.append(unsub)
             tracked_entities.add(entity_id)
+
+    return new_unsubs

--- a/custom_components/hsem/planner/charge_scheduler.py
+++ b/custom_components/hsem/planner/charge_scheduler.py
@@ -429,9 +429,14 @@ def apply_optimization_strategy(
         # v5.1.0 threshold: <= NEAR_ZERO_CONSUMPTION_THRESHOLD_KWH
         # (charge even near-zero-consumption slots)
         if rec.estimated_net_consumption <= NEAR_ZERO_CONSUMPTION_THRESHOLD_KWH:
-            charged += abs(rec.estimated_net_consumption)
+            # Per-slot energy: how much this individual slot contributes, capped at
+            # what is still needed.  Store the per-slot value so that summing across
+            # slots in engine.py / total_charged_energy_kwh() is not double-counted.
+            slot_solar = abs(rec.estimated_net_consumption)
+            slot_energy = min(slot_solar, batteries_needed_charge - charged)
+            charged += slot_energy
             rec.recommendation = Recommendations.BatteriesChargeSolar.value
-            rec.batteries_charged = round(charged, 3)
+            rec.batteries_charged = round(slot_energy, 3)
 
     # Seasonal fill for remaining unassigned slots
     for rec in slots:

--- a/custom_components/hsem/utils/huawei.py
+++ b/custom_components/hsem/utils/huawei.py
@@ -34,26 +34,31 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_set_grid_export_power_pct(self, device_id, power_percentage) -> None:
-    """Set the maximum grid export power percentage and handle errors."""
+    """Set the maximum grid export power percentage and handle errors.
 
-    # Check if the service exists
+    Raises:
+        ServiceNotFound: When the huawei_solar service is not registered in HA.
+        HomeAssistantError: On any other HA-level write failure.
+    """
+
+    # Raise explicitly so callers (write-and-verify) can record the failure.
     if not self.hass.services.has_service(
         "huawei_solar", "set_maximum_feed_grid_power_percent"
     ):
-        _LOGGER.error(
-            "Service huawei_solar.set_maximum_feed_grid_power_percent not found"
-        )
+        raise ServiceNotFound("huawei_solar", "set_maximum_feed_grid_power_percent")
 
     try:
-        # Send the service call to set the maximum grid export power percentage
+        # Send the service call to set the maximum grid export power percentage.
+        # blocking=True propagates service exceptions back to the caller so that
+        # write-and-verify can record the failure and retry.
         await self.hass.services.async_call(
-            "huawei_solar",  # Integration providing the service
-            "set_maximum_feed_grid_power_percent",  # The action to set grid export power
+            "huawei_solar",
+            "set_maximum_feed_grid_power_percent",
             {
-                "device_id": device_id,  # Device ID of the inverter
-                "power_percentage": power_percentage,  # The power percentage to set
+                "device_id": device_id,
+                "power_percentage": power_percentage,
             },
-            blocking=False,  # Non-blocking call to avoid performance issues
+            blocking=True,
         )
 
         # Log success message
@@ -85,26 +90,32 @@ async def async_set_grid_export_power_pct(self, device_id, power_percentage) -> 
 
 
 async def async_set_tou_periods(self, batteries_id, tou_modes) -> None:
-    """Set the TOU modes for the specified batteries."""
+    """Set the TOU modes for the specified batteries.
+
+    Raises:
+        ServiceNotFound: When the huawei_solar service is not registered in HA.
+        HomeAssistantError: On any other HA-level write failure.
+    """
 
     # Convert the list of TOU modes into the required format
     periods = "\n".join(tou_modes)  # Join TOU modes with newline
 
-    # Check if the service exists
+    # Raise explicitly so callers (write-and-verify) can record the failure.
     if not self.hass.services.has_service("huawei_solar", "set_tou_periods"):
-        _LOGGER.error("Service huawei_solar.set_tou_periods not found")
-        return  # Exit early if service is not found
+        raise ServiceNotFound("huawei_solar", "set_tou_periods")
 
     try:
-        # Send the service call to set the TOU periods
+        # Send the service call to set the TOU periods.
+        # blocking=True propagates service exceptions back to the caller so that
+        # write-and-verify can record the failure and retry.
         await self.hass.services.async_call(
             "huawei_solar",
             "set_tou_periods",
             {
-                "device_id": batteries_id,  # Device ID of the inverter
-                "periods": periods,  # TOU modes formatted as a string
+                "device_id": batteries_id,
+                "periods": periods,
             },
-            blocking=False,  # Non-blocking call to avoid performance issues
+            blocking=True,
         )
 
         # Log success message
@@ -151,22 +162,23 @@ async def async_set_forcible_discharge(
     if not isinstance(power, int) or power < 0:
         raise ValueError(f"power must be a non-negative integer, got {power}")
 
-    # Check if the service exists
+    # Raise explicitly so callers (write-and-verify) can record the failure.
     if not self.hass.services.has_service("huawei_solar", "set_forcible_discharge"):
-        _LOGGER.error("Service huawei_solar.set_forcible_discharge not found")
-        return
+        raise ServiceNotFound("huawei_solar", "set_forcible_discharge")
 
     try:
-        # Send the service call to set forcible discharge
+        # Send the service call to set forcible discharge.
+        # blocking=True propagates service exceptions back to the caller so that
+        # write-and-verify can record the failure and retry.
         await self.hass.services.async_call(
             "huawei_solar",
             "set_forcible_discharge",
             {
-                "device_id": device_id,  # Device ID of the battery
-                "target_soc": target_soc,  # Target SOC in percentage (0-100)
-                "power": power,  # Maximum discharge power in watts
+                "device_id": device_id,
+                "target_soc": target_soc,
+                "power": power,
             },
-            blocking=False,  # Non-blocking call to avoid performance issues
+            blocking=True,
         )
 
         # Log success message

--- a/tests/planner/test_solar_charge_no_double_count.py
+++ b/tests/planner/test_solar_charge_no_double_count.py
@@ -1,0 +1,281 @@
+"""Tests that solar charge energy is not double-counted across multiple slots.
+
+Regression suite for the bug where ``apply_optimization_strategy`` stored the
+running cumulative ``charged`` total in each slot's ``batteries_charged`` field
+instead of the per-slot energy delta.  Summing those values in
+``total_charged_energy_kwh()`` or ``engine._derive_windows()`` therefore
+over-reported how much energy was charged.
+
+Acceptance criteria
+-------------------
+1. Each BatteriesChargeSolar slot stores only the energy charged *in that slot*,
+   not the running cumulative total.
+2. Summing ``batteries_charged`` across all BatteriesChargeSolar slots equals
+   ``total_charged_energy_kwh()`` (no duplication).
+3. The sum never exceeds the battery's usable remaining capacity.
+4. ``total_charged_energy_kwh()`` matches a manual slot-by-slot sum.
+5. Multiple solar charge slots do not accumulate into a single incorrectly large
+   value on any individual slot.
+"""
+
+from __future__ import annotations
+
+from datetime import time
+
+import pytest
+
+from custom_components.hsem.models.planner_inputs import (
+    BatteryScheduleInput,
+    HourlyConsumptionAverage,
+    PlannerInput,
+    PricePoint,
+    SolcastSlot,
+)
+from custom_components.hsem.planner import run_planner
+from custom_components.hsem.utils.recommendations import Recommendations
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SOLAR_CHARGE_VALUE = Recommendations.BatteriesChargeSolar.value
+
+
+def _make_solar_only_input(
+    *,
+    battery_soc_pct: float = 0.0,
+    battery_rated_capacity_kwh: float = 10.0,
+    battery_end_of_discharge_soc_pct: float = 10.0,
+    battery_max_charge_power_w: float = 5000.0,
+    solar_per_hour: float = 3.0,
+    consumption_per_hour: float = 0.3,
+    now_iso: str = "2024-06-15T00:00:00+02:00",
+    schedules: list[BatteryScheduleInput] | None = None,
+) -> PlannerInput:
+    """Return a 24-hour summer input where solar > consumption in most mid-day hours.
+
+    All hours have a uniform price (no cheap-grid incentive), so the planner
+    should rely solely on solar surplus for charging.
+
+    Args:
+        battery_soc_pct: Initial SoC (0-100 %).
+        battery_rated_capacity_kwh: Nameplate capacity.
+        battery_end_of_discharge_soc_pct: End-of-discharge reserve.
+        battery_max_charge_power_w: Max charge power in Watts.
+        solar_per_hour: PV production per hour in kWh.
+        consumption_per_hour: House consumption per hour in kWh.
+        now_iso: Planning timestamp (timezone-aware ISO-8601).
+        schedules: Battery charge/discharge schedule overrides.
+    """
+    prices = [
+        PricePoint(hour=h, import_price=0.20, export_price=0.18) for h in range(24)
+    ]
+    # Solar only during hours 8-16; 0 otherwise
+    solar = [
+        SolcastSlot(hour=h, pv_estimate=solar_per_hour if 8 <= h < 16 else 0.0)
+        for h in range(24)
+    ]
+    consumption = [
+        HourlyConsumptionAverage(
+            hour=h,
+            avg_1d=consumption_per_hour,
+            avg_3d=consumption_per_hour,
+            avg_7d=consumption_per_hour,
+            avg_14d=consumption_per_hour,
+        )
+        for h in range(24)
+    ]
+    # Default: no discharge schedules so only solar-strategy charging runs
+    if schedules is None:
+        schedules = [
+            BatteryScheduleInput(enabled=False, start=time(7, 0), end=time(9, 0)),
+        ]
+    return PlannerInput(
+        now_iso=now_iso,
+        interval_minutes=60,
+        interval_length_hours=24,
+        battery_soc_pct=battery_soc_pct,
+        battery_rated_capacity_kwh=battery_rated_capacity_kwh,
+        battery_end_of_discharge_soc_pct=battery_end_of_discharge_soc_pct,
+        battery_max_charge_power_w=battery_max_charge_power_w,
+        battery_conversion_loss_pct=10.0,
+        battery_purchase_price=10_000.0,
+        battery_expected_cycles=6000,
+        weight_1d=25,
+        weight_3d=30,
+        weight_7d=30,
+        weight_14d=15,
+        consumption_averages=consumption,
+        price_points=prices,
+        solcast_slots=solar,
+        battery_schedules=schedules,
+        excess_export_enabled=False,
+        excess_export_discharge_buffer_pct=10.0,
+        excess_export_price_threshold=0.10,
+        months_winter=[1, 2, 3, 4, 10, 11, 12],
+        house_power_includes_ev=True,
+        is_read_only=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test classes
+# ---------------------------------------------------------------------------
+
+
+class TestSolarChargePerSlotSemantics:
+    """batteries_charged on each slot must store per-slot energy, not cumulative."""
+
+    def test_per_slot_value_does_not_exceed_slot_solar_surplus(self):
+        """Each solar-charge slot must not charge more than its own solar surplus."""
+        inp = _make_solar_only_input(battery_soc_pct=0.0, solar_per_hour=3.0)
+        result = run_planner(inp)
+
+        solar_slots = [
+            s for s in result.slots if s.recommendation == _SOLAR_CHARGE_VALUE
+        ]
+        assert solar_slots, "Expected at least one BatteriesChargeSolar slot"
+
+        for slot in solar_slots:
+            # Per-slot surplus: PV production - consumption (negative net consumption)
+            surplus = abs(slot.estimated_net_consumption)
+            assert slot.batteries_charged <= surplus + 1e-6, (
+                f"Slot {slot.start.isoformat()}: batteries_charged={slot.batteries_charged} "
+                f"exceeds available solar surplus={surplus}"
+            )
+
+    def test_sum_matches_total_charged_energy_kwh(self):
+        """Summing batteries_charged across all slots must equal total_charged_energy_kwh."""
+        inp = _make_solar_only_input(battery_soc_pct=0.0, solar_per_hour=3.0)
+        result = run_planner(inp)
+
+        manual_sum = round(sum(s.batteries_charged for s in result.slots), 3)
+        reported = result.total_charged_energy_kwh()
+
+        assert abs(manual_sum - reported) < 1e-6, (
+            f"Manual sum {manual_sum} != total_charged_energy_kwh {reported}"
+        )
+
+    def test_total_charged_does_not_exceed_usable_capacity(self):
+        """Total solar charge must not exceed the available battery headroom."""
+        rated = 10.0
+        eod_pct = 10.0
+        soc = 0.0
+        usable = rated * (1 - eod_pct / 100.0)  # 9 kWh
+        current_kwh = soc / 100.0 * rated
+        headroom = max(usable - current_kwh, 0.0)
+
+        inp = _make_solar_only_input(
+            battery_soc_pct=soc,
+            battery_rated_capacity_kwh=rated,
+            battery_end_of_discharge_soc_pct=eod_pct,
+            solar_per_hour=5.0,  # abundant solar
+        )
+        result = run_planner(inp)
+
+        total = result.total_charged_energy_kwh()
+        assert total <= headroom + 1e-3, (
+            f"Total charged {total} kWh exceeds battery headroom {headroom} kWh"
+        )
+
+    def test_no_single_slot_holds_entire_cumulative_sum(self):
+        """No individual slot may carry a batteries_charged value larger than its surplus.
+
+        Before the fix, the last solar slot would receive the running total instead
+        of its own per-slot contribution.
+        """
+        inp = _make_solar_only_input(
+            battery_soc_pct=0.0,
+            solar_per_hour=2.0,
+            consumption_per_hour=0.3,
+        )
+        result = run_planner(inp)
+
+        solar_slots = [
+            s for s in result.slots if s.recommendation == _SOLAR_CHARGE_VALUE
+        ]
+        assert len(solar_slots) >= 2, (
+            "Need multiple solar-charge slots to test double-count regression"
+        )
+
+        for slot in solar_slots:
+            per_slot_max = abs(slot.estimated_net_consumption)
+            assert slot.batteries_charged <= per_slot_max + 1e-6, (
+                f"Slot {slot.start.isoformat()}: batteries_charged={slot.batteries_charged} "
+                f"is larger than per-slot surplus={per_slot_max}. "
+                "Likely the cumulative total was stored in this slot (double-count bug)."
+            )
+
+    def test_multiple_solar_slots_distribute_charge_correctly(self):
+        """With many solar hours and an empty battery, charge is spread across slots."""
+        inp = _make_solar_only_input(
+            battery_soc_pct=0.0,
+            solar_per_hour=2.0,
+            battery_rated_capacity_kwh=10.0,
+            battery_end_of_discharge_soc_pct=10.0,
+        )
+        result = run_planner(inp)
+
+        solar_slots = [
+            s for s in result.slots if s.recommendation == _SOLAR_CHARGE_VALUE
+        ]
+        # Total across slots must equal reported total (no double-count)
+        manual_sum = round(sum(s.batteries_charged for s in solar_slots), 3)
+        reported = result.total_charged_energy_kwh()
+        assert abs(manual_sum - reported) < 1e-6
+
+        # Each individual slot must not exceed its per-slot surplus
+        for slot in solar_slots:
+            surplus = abs(slot.estimated_net_consumption)
+            assert slot.batteries_charged <= surplus + 1e-6, (
+                f"Slot {slot.start.isoformat()}: per_slot={slot.batteries_charged} "
+                f"> surplus={surplus}"
+            )
+
+    def test_partial_battery_fill_does_not_exceed_rated_capacity(self):
+        """With abundant solar, total charged energy must never exceed the rated capacity.
+
+        This verifies the key invariant: no matter how many solar-surplus slots the
+        optimizer processes, the per-slot accumulator never inflates individual slot
+        values beyond what was actually charged in that slot.
+        """
+        rated = 10.0
+        eod_pct = 10.0
+        soc = 0.0
+
+        inp = _make_solar_only_input(
+            battery_soc_pct=soc,
+            battery_rated_capacity_kwh=rated,
+            battery_end_of_discharge_soc_pct=eod_pct,
+            solar_per_hour=5.0,  # 8 h × 5 kWh = 40 kWh >> battery
+        )
+        result = run_planner(inp)
+
+        total = result.total_charged_energy_kwh()
+        # Total charged must not exceed rated capacity (usable + reserve) as an
+        # absolute upper bound — the planner may cap at usable but never above rated.
+        assert total <= rated + 1e-3, (
+            f"Total charged {total} kWh exceeds rated capacity {rated} kWh"
+        )
+
+        # Each individual solar slot must store a per-slot value ≤ its own surplus
+        for slot in result.slots:
+            if slot.recommendation == _SOLAR_CHARGE_VALUE:
+                surplus = abs(slot.estimated_net_consumption)
+                assert slot.batteries_charged <= surplus + 1e-6, (
+                    f"Slot {slot.start.isoformat()}: batteries_charged={slot.batteries_charged} "
+                    f"> slot surplus={surplus} (cumulative bug?)"
+                )
+
+    def test_fully_charged_battery_no_solar_charge(self):
+        """A 100 % SoC battery with no discharge schedules must not charge further."""
+        inp = _make_solar_only_input(
+            battery_soc_pct=100.0,
+            solar_per_hour=5.0,
+        )
+        result = run_planner(inp)
+
+        total = result.total_charged_energy_kwh()
+        assert total == pytest.approx(0.0), (
+            f"Expected 0 kWh charged for a full battery, got {total}"
+        )

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -55,6 +55,7 @@ def _make_bare_coordinator() -> HSEMDataUpdateCoordinator:
     coord._update_lock = asyncio.Lock()
     coord._interval_timer_unsub = None
     coord._hourly_timer_unsub = None
+    coord._listener_unsubs = []
     coord._timer_interval = None
     coord._next_update = None
     coord.data = None

--- a/tests/test_exception_handling.py
+++ b/tests/test_exception_handling.py
@@ -156,9 +156,10 @@ class TestStateCollectorReadMissingOnError:
                 "custom_components.hsem.custom_sensors.state_collector"
                 "._register_listeners",
                 new_callable=AsyncMock,
+                return_value=[],
             ),
         ):
-            live, _ = await async_collect_live_state(sensor, cfg, None, set())
+            live, _, _unsubs = await async_collect_live_state(sensor, cfg, None, set())
 
         assert live.missing_entities is True
 
@@ -196,9 +197,10 @@ class TestStateCollectorReadMissingOnError:
                 "custom_components.hsem.custom_sensors.state_collector"
                 "._register_listeners",
                 new_callable=AsyncMock,
+                return_value=[],
             ),
         ):
-            live, _ = await async_collect_live_state(sensor, cfg, None, set())
+            live, _, _unsubs = await async_collect_live_state(sensor, cfg, None, set())
 
         # Critical battery sensors are unavailable → missing_entities
         assert live.missing_entities is True
@@ -417,7 +419,13 @@ class TestAsyncSetTouPeriodsFailures:
 
     @pytest.mark.asyncio
     async def test_service_missing_exits_early(self):
-        """When the service does not exist, the function returns without calling it."""
+        """When the service does not exist, ServiceNotFound is raised immediately.
+
+        Previously the function logged an error and returned silently, which
+        caused write-and-verify to report success even though the write was never
+        performed.  The corrected behaviour raises ServiceNotFound so the caller
+        can record the failure.
+        """
         from custom_components.hsem.utils.huawei import async_set_tou_periods
 
         hass = MagicMock()
@@ -425,8 +433,8 @@ class TestAsyncSetTouPeriodsFailures:
         hass.services.async_call = AsyncMock()
         sensor = _make_inverter_sensor(hass)
 
-        # Should NOT raise — early return path
-        await async_set_tou_periods(sensor, "bat_device_2", ["00:00-06:00/100/1/0"])
+        with pytest.raises(ServiceNotFound):
+            await async_set_tou_periods(sensor, "bat_device_2", ["00:00-06:00/100/1/0"])
         hass.services.async_call.assert_not_called()
 
 
@@ -501,7 +509,13 @@ class TestAsyncSetForcibleDischargeFailures:
 
     @pytest.mark.asyncio
     async def test_service_missing_exits_early(self):
-        """When the service does not exist, the function returns without calling it."""
+        """When the service does not exist, ServiceNotFound is raised immediately.
+
+        Previously the function logged an error and returned silently, which
+        caused write-and-verify to report success even though the write was never
+        performed.  The corrected behaviour raises ServiceNotFound so the caller
+        can record the failure.
+        """
         from custom_components.hsem.utils.huawei import async_set_forcible_discharge
 
         hass = MagicMock()
@@ -509,7 +523,8 @@ class TestAsyncSetForcibleDischargeFailures:
         hass.services.async_call = AsyncMock()
         sensor = _make_inverter_sensor(hass)
 
-        await async_set_forcible_discharge(sensor, "bat_device_4", 20, 1000)
+        with pytest.raises(ServiceNotFound):
+            await async_set_forcible_discharge(sensor, "bat_device_4", 20, 1000)
         hass.services.async_call.assert_not_called()
 
 

--- a/tests/test_ha_mock_integration.py
+++ b/tests/test_ha_mock_integration.py
@@ -203,6 +203,7 @@ def make_bare_coordinator(
     coord._update_lock = asyncio.Lock()
     coord._interval_timer_unsub = None
     coord._hourly_timer_unsub = None
+    coord._listener_unsubs = []
     coord._timer_interval = None
     coord._next_update = None
     coord.data = None

--- a/tests/test_huawei_service_calls.py
+++ b/tests/test_huawei_service_calls.py
@@ -1,0 +1,259 @@
+"""Tests for utils/huawei.py service call behaviour (Tasks 3 & 4).
+
+Acceptance criteria
+-------------------
+1. When a Huawei service is NOT registered in HA, the function raises
+   ``ServiceNotFound`` immediately (instead of silently logging and continuing).
+2. Service calls are made with ``blocking=True`` so exceptions raised by the
+   service propagate back to the caller (write-and-verify can record them).
+3. ``HomeAssistantError`` and ``ServiceValidationError`` raised by the service
+   are re-raised so callers observe the failure.
+4. Validation errors (``voluptuous.Invalid``) are wrapped in ``HomeAssistantError``
+   and re-raised.
+5. The three functions covered: ``async_set_grid_export_power_pct``,
+   ``async_set_tou_periods``, ``async_set_forcible_discharge``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import voluptuous as vol
+from homeassistant.exceptions import (
+    HomeAssistantError,
+    ServiceNotFound,
+    ServiceValidationError,
+)
+
+from custom_components.hsem.utils.huawei import (
+    async_set_forcible_discharge,
+    async_set_grid_export_power_pct,
+    async_set_tou_periods,
+)
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_sensor(has_service: bool = True, service_exception=None):
+    """Return a minimal sensor mock whose ``hass`` object mimics HA services.
+
+    Args:
+        has_service: Whether ``hass.services.has_service`` returns True.
+        service_exception: If set, ``hass.services.async_call`` raises this.
+    """
+    hass = MagicMock()
+    hass.services.has_service.return_value = has_service
+
+    call_mock = AsyncMock()
+    if service_exception is not None:
+        call_mock.side_effect = service_exception
+    hass.services.async_call = call_mock
+
+    sensor = MagicMock()
+    sensor.hass = hass
+    return sensor
+
+
+# ---------------------------------------------------------------------------
+# async_set_grid_export_power_pct
+# ---------------------------------------------------------------------------
+
+
+class TestSetGridExportPowerPct:
+    """Tests for async_set_grid_export_power_pct."""
+
+    @pytest.mark.asyncio
+    async def test_missing_service_raises_service_not_found(self):
+        """Must raise ServiceNotFound when the service is absent — not silently continue."""
+        sensor = _make_sensor(has_service=False)
+        with pytest.raises(ServiceNotFound):
+            await async_set_grid_export_power_pct(sensor, "device1", 80)
+
+    @pytest.mark.asyncio
+    async def test_service_called_with_blocking_true(self):
+        """Service call must use blocking=True so exceptions propagate."""
+        sensor = _make_sensor(has_service=True)
+        await async_set_grid_export_power_pct(sensor, "device1", 80)
+        sensor.hass.services.async_call.assert_called_once()
+        _, kwargs = sensor.hass.services.async_call.call_args
+        assert kwargs.get("blocking") is True, "Expected blocking=True"
+
+    @pytest.mark.asyncio
+    async def test_home_assistant_error_is_reraised(self):
+        """HomeAssistantError from the service must propagate to the caller."""
+        sensor = _make_sensor(
+            has_service=True, service_exception=HomeAssistantError("fail")
+        )
+        with pytest.raises(HomeAssistantError):
+            await async_set_grid_export_power_pct(sensor, "device1", 80)
+
+    @pytest.mark.asyncio
+    async def test_service_validation_error_is_reraised(self):
+        """ServiceValidationError must propagate to the caller."""
+        sensor = _make_sensor(
+            has_service=True,
+            service_exception=ServiceValidationError(
+                "bad data", translation_domain="test", translation_key="bad"
+            ),
+        )
+        with pytest.raises(ServiceValidationError):
+            await async_set_grid_export_power_pct(sensor, "device1", 80)
+
+    @pytest.mark.asyncio
+    async def test_vol_invalid_wrapped_as_ha_error(self):
+        """voluptuous.Invalid must be wrapped in HomeAssistantError."""
+        sensor = _make_sensor(
+            has_service=True, service_exception=vol.Invalid("bad schema")
+        )
+        with pytest.raises(HomeAssistantError):
+            await async_set_grid_export_power_pct(sensor, "device1", -1)
+
+    @pytest.mark.asyncio
+    async def test_success_path_does_not_raise(self):
+        """Happy-path call completes without raising."""
+        sensor = _make_sensor(has_service=True)
+        # Should not raise
+        await async_set_grid_export_power_pct(sensor, "device1", 100)
+
+
+# ---------------------------------------------------------------------------
+# async_set_tou_periods
+# ---------------------------------------------------------------------------
+
+
+class TestSetTouPeriods:
+    """Tests for async_set_tou_periods."""
+
+    @pytest.mark.asyncio
+    async def test_missing_service_raises_service_not_found(self):
+        """Must raise ServiceNotFound when the service is absent."""
+        sensor = _make_sensor(has_service=False)
+        with pytest.raises(ServiceNotFound):
+            await async_set_tou_periods(sensor, "bat1", ["mode1"])
+
+    @pytest.mark.asyncio
+    async def test_service_called_with_blocking_true(self):
+        """Service call must use blocking=True."""
+        sensor = _make_sensor(has_service=True)
+        await async_set_tou_periods(sensor, "bat1", ["mode1", "mode2"])
+        sensor.hass.services.async_call.assert_called_once()
+        _, kwargs = sensor.hass.services.async_call.call_args
+        assert kwargs.get("blocking") is True
+
+    @pytest.mark.asyncio
+    async def test_home_assistant_error_is_reraised(self):
+        """HomeAssistantError must propagate."""
+        sensor = _make_sensor(
+            has_service=True, service_exception=HomeAssistantError("tou fail")
+        )
+        with pytest.raises(HomeAssistantError):
+            await async_set_tou_periods(sensor, "bat1", ["mode1"])
+
+    @pytest.mark.asyncio
+    async def test_service_validation_error_is_reraised(self):
+        """ServiceValidationError must propagate."""
+        sensor = _make_sensor(
+            has_service=True,
+            service_exception=ServiceValidationError(
+                "bad", translation_domain="test", translation_key="bad"
+            ),
+        )
+        with pytest.raises(ServiceValidationError):
+            await async_set_tou_periods(sensor, "bat1", ["mode1"])
+
+    @pytest.mark.asyncio
+    async def test_vol_invalid_wrapped_as_ha_error(self):
+        """voluptuous.Invalid must be wrapped in HomeAssistantError."""
+        sensor = _make_sensor(
+            has_service=True, service_exception=vol.Invalid("bad schema")
+        )
+        with pytest.raises(HomeAssistantError):
+            await async_set_tou_periods(sensor, "bat1", [])
+
+    @pytest.mark.asyncio
+    async def test_success_path_does_not_raise(self):
+        """Happy-path call completes without raising."""
+        sensor = _make_sensor(has_service=True)
+        await async_set_tou_periods(sensor, "bat1", ["TOU_MODE_1"])
+
+
+# ---------------------------------------------------------------------------
+# async_set_forcible_discharge
+# ---------------------------------------------------------------------------
+
+
+class TestSetForcibleDischarge:
+    """Tests for async_set_forcible_discharge."""
+
+    @pytest.mark.asyncio
+    async def test_missing_service_raises_service_not_found(self):
+        """Must raise ServiceNotFound when the service is absent."""
+        sensor = _make_sensor(has_service=False)
+        with pytest.raises(ServiceNotFound):
+            await async_set_forcible_discharge(sensor, "bat_dev", 20, 3000)
+
+    @pytest.mark.asyncio
+    async def test_service_called_with_blocking_true(self):
+        """Service call must use blocking=True."""
+        sensor = _make_sensor(has_service=True)
+        await async_set_forcible_discharge(sensor, "bat_dev", 20, 3000)
+        sensor.hass.services.async_call.assert_called_once()
+        _, kwargs = sensor.hass.services.async_call.call_args
+        assert kwargs.get("blocking") is True
+
+    @pytest.mark.asyncio
+    async def test_home_assistant_error_is_reraised(self):
+        """HomeAssistantError must propagate."""
+        sensor = _make_sensor(
+            has_service=True, service_exception=HomeAssistantError("discharge fail")
+        )
+        with pytest.raises(HomeAssistantError):
+            await async_set_forcible_discharge(sensor, "bat_dev", 20, 3000)
+
+    @pytest.mark.asyncio
+    async def test_service_validation_error_is_reraised(self):
+        """ServiceValidationError must propagate."""
+        sensor = _make_sensor(
+            has_service=True,
+            service_exception=ServiceValidationError(
+                "bad soc", translation_domain="test", translation_key="bad"
+            ),
+        )
+        with pytest.raises(ServiceValidationError):
+            await async_set_forcible_discharge(sensor, "bat_dev", 20, 3000)
+
+    @pytest.mark.asyncio
+    async def test_vol_invalid_wrapped_as_ha_error(self):
+        """voluptuous.Invalid must be wrapped in HomeAssistantError."""
+        sensor = _make_sensor(
+            has_service=True, service_exception=vol.Invalid("bad schema")
+        )
+        with pytest.raises(HomeAssistantError):
+            await async_set_forcible_discharge(sensor, "bat_dev", 20, 3000)
+
+    @pytest.mark.asyncio
+    async def test_invalid_target_soc_raises_value_error(self):
+        """Passing a non-integer or out-of-range target_soc must raise ValueError."""
+        sensor = _make_sensor(has_service=True)
+        with pytest.raises(ValueError):
+            await async_set_forcible_discharge(sensor, "bat_dev", 150, 3000)  # > 100
+        with pytest.raises(ValueError):
+            await async_set_forcible_discharge(sensor, "bat_dev", -1, 3000)  # < 0
+        with pytest.raises(ValueError):
+            await async_set_forcible_discharge(sensor, "bat_dev", 50.5, 3000)  # float
+
+    @pytest.mark.asyncio
+    async def test_invalid_power_raises_value_error(self):
+        """Negative power must raise ValueError."""
+        sensor = _make_sensor(has_service=True)
+        with pytest.raises(ValueError):
+            await async_set_forcible_discharge(sensor, "bat_dev", 20, -100)
+
+    @pytest.mark.asyncio
+    async def test_success_path_does_not_raise(self):
+        """Happy-path call completes without raising."""
+        sensor = _make_sensor(has_service=True)
+        await async_set_forcible_discharge(sensor, "bat_dev", 20, 3000)

--- a/tests/test_listener_cleanup.py
+++ b/tests/test_listener_cleanup.py
@@ -1,0 +1,335 @@
+"""Tests for async_will_remove_from_hass listener cleanup (Tasks 2 & 5).
+
+Acceptance criteria
+-------------------
+1. ``HSEMAvgSensor.async_will_remove_from_hass`` cancels all registered
+   ``async_track_*`` callbacks.
+2. ``HSEMHouseConsumptionPowerSensor.async_will_remove_from_hass`` cancels all
+   registered ``async_track_state_change_event`` callbacks.
+3. ``HSEMDataUpdateCoordinator.async_teardown`` cancels all state-change listener
+   callbacks collected from ``state_collector._register_listeners``.
+4. No duplicate callbacks are registered after a simulated reload cycle
+   (add → remove → add).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config_entry(**overrides) -> MagicMock:
+    """Minimal mock ConfigEntry used by HSEMAvgSensor and HSEMHouseConsumption."""
+    defaults = {
+        "entry_id": "test_entry_id",
+        "hsem_house_consumption_power": "sensor.house",
+        "hsem_ev_charger_power": "sensor.ev",
+        "hsem_house_power_includes_ev_charger_power": False,
+    }
+    defaults.update(overrides)
+
+    mock = MagicMock()
+    mock.entry_id = defaults["entry_id"]
+    mock.options = defaults
+    mock.data = {}
+    return mock
+
+
+def _make_hass() -> MagicMock:
+    hass = MagicMock()
+    hass.states.get.return_value = None
+    return hass
+
+
+# ---------------------------------------------------------------------------
+# HSEMAvgSensor
+# ---------------------------------------------------------------------------
+
+
+class TestAvgSensorListenerCleanup:
+    """HSEMAvgSensor must cancel all async_track_* callbacks on removal."""
+
+    @pytest.mark.asyncio
+    async def test_timer_unsub_called_on_removal(self):
+        """The interval-timer unsub returned by async_track_time_interval is called."""
+        from custom_components.hsem.custom_sensors.avg_sensor import HSEMAvgSensor
+
+        cfg = _make_config_entry()
+        sensor = HSEMAvgSensor(
+            config_entry=cfg,
+            hour_start=10,
+            hour_end=11,
+            avg=7,
+            tracked_entity="sensor.utility",
+            name="Test Avg",
+            unique_id="test_avg_uid",
+            entity_id="sensor.test_avg",
+        )
+        sensor.hass = _make_hass()
+
+        timer_unsub = MagicMock()
+        state_unsub = MagicMock()
+
+        async def _fake_handle_update(_event=None):
+            pass
+
+        sensor._async_handle_update = _fake_handle_update
+
+        with (
+            patch(
+                "custom_components.hsem.custom_sensors.avg_sensor"
+                ".async_track_time_interval",
+                return_value=timer_unsub,
+            ),
+            patch(
+                "custom_components.hsem.custom_sensors.avg_sensor"
+                ".async_track_state_change_event",
+                return_value=state_unsub,
+            ),
+            patch.object(
+                sensor,
+                "async_get_last_state",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch.object(sensor, "async_write_ha_state"),
+        ):
+            await sensor.async_added_to_hass()
+            # Simulate entity-tracking registration
+            await sensor._async_track_entities()
+
+        # Now remove — both callbacks must be cancelled
+        await sensor.async_will_remove_from_hass()
+
+        timer_unsub.assert_called_once()
+        state_unsub.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_unsub_list_cleared_after_removal(self):
+        """_unsub_callbacks must be empty after async_will_remove_from_hass."""
+        from custom_components.hsem.custom_sensors.avg_sensor import HSEMAvgSensor
+
+        cfg = _make_config_entry()
+        sensor = HSEMAvgSensor(
+            config_entry=cfg,
+            hour_start=12,
+            hour_end=13,
+            avg=7,
+            tracked_entity=None,
+            name="Avg Clear Test",
+            unique_id="avg_clear_uid",
+            entity_id="sensor.avg_clear",
+        )
+        sensor.hass = _make_hass()
+
+        fake_unsub = MagicMock()
+        sensor._unsub_callbacks.append(fake_unsub)
+
+        await sensor.async_will_remove_from_hass()
+
+        assert sensor._unsub_callbacks == []
+
+    @pytest.mark.asyncio
+    async def test_no_duplicate_state_listener_after_reload(self):
+        """Calling _async_track_entities twice must not register the entity twice.
+
+        The idempotency guard (_tracked_entities set) must prevent duplicate
+        registrations within a single lifecycle.
+        """
+        from custom_components.hsem.custom_sensors.avg_sensor import HSEMAvgSensor
+
+        cfg = _make_config_entry()
+        sensor = HSEMAvgSensor(
+            config_entry=cfg,
+            hour_start=8,
+            hour_end=9,
+            avg=7,
+            tracked_entity="sensor.utility",
+            name="Reload Test",
+            unique_id="reload_uid",
+            entity_id="sensor.reload_avg",
+        )
+        sensor.hass = _make_hass()
+
+        register_calls: list[int] = []
+
+        def _track_state(*args, **kwargs):
+            register_calls.append(1)
+            return MagicMock()
+
+        with patch(
+            "custom_components.hsem.custom_sensors.avg_sensor"
+            ".async_track_state_change_event",
+            side_effect=_track_state,
+        ):
+            # First call registers the entity
+            await sensor._async_track_entities()
+            # Second call within the same lifecycle — must be a no-op (idempotent)
+            await sensor._async_track_entities()
+
+        # Must register exactly once despite two calls
+        assert len(register_calls) == 1, (
+            f"Expected 1 registration (idempotent), got {len(register_calls)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# HSEMHouseConsumptionPowerSensor
+# ---------------------------------------------------------------------------
+
+
+class TestHouseConsumptionListenerCleanup:
+    """HSEMHouseConsumptionPowerSensor must cancel all async_track_* on removal."""
+
+    def _make_sensor(self, cfg=None):
+        from custom_components.hsem.custom_sensors.house_consumption_power_sensor import (
+            HSEMHouseConsumptionPowerSensor,
+        )
+
+        if cfg is None:
+            cfg = _make_config_entry()
+
+        with patch(
+            "custom_components.hsem.custom_sensors.house_consumption_power_sensor"
+            ".get_config_value",
+            side_effect=lambda entry, key: entry.options.get(key),
+        ):
+            sensor = HSEMHouseConsumptionPowerSensor(cfg, 10, 11, MagicMock())
+        sensor.hass = _make_hass()
+        return sensor
+
+    @pytest.mark.asyncio
+    async def test_state_unsubs_called_on_removal(self):
+        """All state-change unsubs must be called when entity is removed."""
+        sensor = self._make_sensor()
+
+        house_unsub = MagicMock()
+        ev_unsub = MagicMock()
+        call_order = []
+
+        def _track(hass, entities, callback):
+            if "house" in entities[0]:
+                call_order.append("house")
+                return house_unsub
+            call_order.append("ev")
+            return ev_unsub
+
+        with patch(
+            "custom_components.hsem.custom_sensors.house_consumption_power_sensor"
+            ".async_track_state_change_event",
+            side_effect=_track,
+        ):
+            await sensor._async_track_entities()
+
+        await sensor.async_will_remove_from_hass()
+
+        house_unsub.assert_called_once()
+        ev_unsub.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_unsub_list_cleared_after_removal(self):
+        """_unsub_callbacks is empty after async_will_remove_from_hass."""
+        sensor = self._make_sensor()
+        fake_unsub = MagicMock()
+        sensor._unsub_callbacks.append(fake_unsub)
+
+        await sensor.async_will_remove_from_hass()
+
+        assert sensor._unsub_callbacks == []
+
+    @pytest.mark.asyncio
+    async def test_no_duplicate_listener_after_reload(self):
+        """Calling _async_track_entities twice must not register the same entity twice."""
+        sensor = self._make_sensor()
+        register_count = {"house": 0}
+
+        def _track(hass, entities, callback):
+            if entities and "house" in entities[0]:
+                register_count["house"] += 1
+            return MagicMock()
+
+        with patch(
+            "custom_components.hsem.custom_sensors.house_consumption_power_sensor"
+            ".async_track_state_change_event",
+            side_effect=_track,
+        ):
+            await sensor._async_track_entities()
+            await sensor._async_track_entities()  # second call — already tracked
+
+        # Must have registered exactly once for house (idempotent)
+        assert register_count["house"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Coordinator state-change listener cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestCoordinatorListenerCleanup:
+    """HSEMDataUpdateCoordinator must cancel state-change unsubs on teardown."""
+
+    def _make_coordinator(self):
+        """Return a minimal coordinator with mocked HA internals."""
+        from custom_components.hsem.coordinator import HSEMDataUpdateCoordinator
+
+        hass = _make_hass()
+        hass.data = {}
+
+        coord = HSEMDataUpdateCoordinator.__new__(HSEMDataUpdateCoordinator)
+        coord.hass = hass
+        coord._listener_unsubs = []
+        coord._hourly_timer_unsub = None
+        coord._interval_timer_unsub = None
+
+        return coord
+
+    @pytest.mark.asyncio
+    async def test_teardown_cancels_listener_unsubs(self):
+        """async_teardown must call every unsub in _listener_unsubs."""
+        coord = self._make_coordinator()
+
+        unsub_a = MagicMock()
+        unsub_b = MagicMock()
+        coord._listener_unsubs = [unsub_a, unsub_b]
+
+        await coord.async_teardown()
+
+        unsub_a.assert_called_once()
+        unsub_b.assert_called_once()
+        assert coord._listener_unsubs == []
+
+    @pytest.mark.asyncio
+    async def test_teardown_also_cancels_timer_unsubs(self):
+        """Timers and state listeners are both cancelled during teardown."""
+        coord = self._make_coordinator()
+
+        timer_unsub = MagicMock()
+        interval_unsub = MagicMock()
+        listener_unsub = MagicMock()
+
+        coord._hourly_timer_unsub = timer_unsub
+        coord._interval_timer_unsub = interval_unsub
+        coord._listener_unsubs = [listener_unsub]
+
+        await coord.async_teardown()
+
+        timer_unsub.assert_called_once()
+        interval_unsub.assert_called_once()
+        listener_unsub.assert_called_once()
+        assert coord._hourly_timer_unsub is None
+        assert coord._interval_timer_unsub is None
+        assert coord._listener_unsubs == []
+
+    @pytest.mark.asyncio
+    async def test_teardown_safe_with_empty_lists(self):
+        """async_teardown must not raise when no listeners are registered."""
+        coord = self._make_coordinator()
+        coord._listener_unsubs = []
+
+        # Must not raise
+        await coord.async_teardown()


### PR DESCRIPTION
## Summary

This PR fixes four independent bugs across the planner, sensor lifecycle, and Huawei hardware write layer.

---

## Task 1 � atteries_charged double-count in charge_scheduler.py

**Bug:** pply_optimization_strategy stored the running cumulative charged total in each slot's atteries_charged field instead of the per-slot energy delta. Summing atteries_charged across slots in 	otal_charged_energy_kwh() and _derive_windows() therefore over-reported how much energy was charged.

**Fix** (custom_components/hsem/planner/charge_scheduler.py):
- Compute slot_energy = min(slot_solar, batteries_needed_charge - charged) per slot.
- Store slot_energy (per-slot) rather than charged (cumulative total).

**Tests added** (	ests/planner/test_solar_charge_no_double_count.py, 7 tests):
- Per-slot value never exceeds the slot's own solar surplus.
- Sum across all slots equals 	otal_charged_energy_kwh() (no duplication).
- Total never exceeds battery capacity / rated capacity.
- No single slot holds the entire cumulative sum (direct regression guard).

---

## Tasks 2 & 5 � sync_track_* listener leaks & sync_will_remove_from_hass

**Problem:** HSEMAvgSensor, HSEMHouseConsumptionPowerSensor, and state_collector._register_listeners registered sync_track_* callbacks but never stored or cancelled the returned unsubscribe callables, causing listener leaks on reload/removal.

**Fixes:**
- vg_sensor.py � added _unsub_callbacks list; stores timer + state-change unsubs; sync_will_remove_from_hass cancels all of them.
- house_consumption_power_sensor.py � same pattern for sync_track_state_change_event callbacks.
- state_collector.py � _register_listeners returns a list of new unsub callables; sync_collect_live_state returns a (state, fwm_entity, new_unsubs) 3-tuple.
- coordinator.py � added _listener_unsubs; extended on each cycle from sync_collect_live_state; all cancelled in sync_teardown.

**Tests added** (	ests/test_listener_cleanup.py, 9 tests):
- Timer and state-change unsubs called on entity removal.
- _unsub_callbacks list cleared after sync_will_remove_from_hass.
- Idempotency guard: duplicate registrations prevented by _tracked_entities set.
- Coordinator sync_teardown cancels all listener + timer unsubs.

---

## Tasks 3 & 4 � utils/huawei.py silent missing-service and non-blocking writes

**Problems:**
1. sync_set_grid_export_power_pct logged an error when the service was absent but continued � then tried to call the missing service (silent false-success path).
2. sync_set_tou_periods and sync_set_forcible_discharge silently returned None for missing services.
3. All three used locking=False � service exceptions were swallowed and never reached the write-and-verify retry loop, making failed writes appear as successes.

**Fixes** (custom_components/hsem/utils/huawei.py):
- Missing service ? raises ServiceNotFound immediately (explicit failure, visible to callers).
- All three service calls use locking=True so exceptions propagate back through the write-and-verify loop.

**Tests added** (	ests/test_huawei_service_calls.py, 18 tests):
- Missing service raises ServiceNotFound for all three functions.
- locking=True verified on all three service calls.
- HomeAssistantError, ServiceValidationError, ol.Invalid all propagate correctly.
- ValueError for invalid 	arget_soc / power in sync_set_forcible_discharge.

---

## Existing tests updated

| File | Change |
|------|--------|
| 	ests/test_exception_handling.py | Two 	est_service_missing_exits_early tests updated to expect ServiceNotFound instead of silent return. sync_collect_live_state unpacking updated to handle new 3-tuple. |
| 	ests/test_coordinator.py | _make_bare_coordinator helper sets _listener_unsubs = []. |
| 	ests/test_ha_mock_integration.py | make_bare_coordinator helper sets _listener_unsubs = []. |

---

## Test results

`
804 passed, 0 failures
`

Lint: ? 	ox -e lint � all checks passed
