### PR TITLE
feat(planner): add shared time-series slot model (issue #286)

### DIFF
--- a/custom_components/hsem/models/planner_outputs.py
+++ b/custom_components/hsem/models/planner_outputs.py
@@ -10,7 +10,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from custom_components.hsem.models.time_series import TimeSeriesIndex
 
 
 @dataclass
@@ -155,6 +158,11 @@ class PlannerOutput:
             during planning.  An empty list means all inputs were present.
         warnings:
             Human-readable warning strings emitted during planning.
+        time_series_index:
+            The shared :class:`~custom_components.hsem.models.time_series.TimeSeriesIndex`
+            used during this planning run.  All slot boundaries, price, PV,
+            load, import/export and SoC series are aligned to this axis.
+            ``None`` when the planner was invoked without a valid horizon.
         extra:
             Arbitrary key-value pairs for debug / introspection purposes.
     """
@@ -167,6 +175,7 @@ class PlannerOutput:
     required_capacity_kwh: float = 0.0
     missing_inputs: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
+    time_series_index: TimeSeriesIndex | None = field(default=None, repr=False)
     extra: dict[str, Any] = field(default_factory=dict)
 
     # ------------------------------------------------------------------

--- a/custom_components/hsem/models/time_series.py
+++ b/custom_components/hsem/models/time_series.py
@@ -1,0 +1,455 @@
+"""Shared time-series slot model for the HSEM planner (issue #286).
+
+This module provides a single, authoritative time axis for all planner
+time-series inputs (prices, PV forecast, load, import/export, battery SoC).
+
+Design goals
+------------
+- **Single slot index**: every series maps to the same ``SlotKey`` so
+  there is no risk of off-by-one or hour-lookup disagreements.
+- **Configurable resolution**: default 15-minute slots, any divisor of 60.
+- **DST-safe**: slot boundaries are computed via ``timedelta`` arithmetic
+  from a UTC-normalised midnight so spring-forward / autumn-fallback days
+  always produce the expected number of slots.
+- **Explicit missing slots**: ``TimeSeriesIndex.missing_slots`` lists every
+  ``SlotKey`` for which at least one series has no data, so callers can
+  surface gaps rather than silently defaulting to zero.
+
+Key types
+---------
+``SlotKey``
+    A ``(day_offset, slot_in_day)`` named-tuple.  *day_offset* is the
+    number of whole calendar days since the planning midnight; *slot_in_day*
+    is the 0-based slot index within that day.  This is unambiguous across
+    DST transitions because it does not rely on wall-clock hours.
+
+``TimeSeriesIndex``
+    The central alignment object.  Construct it once from the planning
+    ``now`` and configuration, then call ``align_*`` methods to project
+    each raw series onto the shared slot grid.
+
+Usage example
+-------------
+>>> from zoneinfo import ZoneInfo
+>>> from datetime import datetime
+>>> from custom_components.hsem.models.time_series import TimeSeriesIndex
+>>>
+>>> tz = ZoneInfo("Europe/Copenhagen")
+>>> now = datetime(2024, 6, 15, 14, 0, tzinfo=tz)
+>>> tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
+>>> len(tsi)  # 24 * 4 = 96 slots
+96
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import NamedTuple
+from zoneinfo import ZoneInfo
+
+# ---------------------------------------------------------------------------
+# Public constants
+# ---------------------------------------------------------------------------
+
+#: Default slot width in minutes used when none is specified.
+DEFAULT_SLOT_MINUTES: int = 15
+
+#: Sentinel value placed in aligned series where source data is absent.
+MISSING_SENTINEL: float = float("nan")
+
+
+# ---------------------------------------------------------------------------
+# SlotKey — canonical slot address
+# ---------------------------------------------------------------------------
+
+
+class SlotKey(NamedTuple):
+    """Unambiguous address for a single planning slot.
+
+    Attributes:
+        day_offset:
+            Number of whole calendar days since the planning midnight (0 for
+            today, 1 for tomorrow, etc.).
+        slot_in_day:
+            0-based index of this slot within its calendar day.  For 15-min
+            slots there are 96 indices per day (0-95); for 60-min slots there
+            are 24 (0-23).
+    """
+
+    day_offset: int
+    slot_in_day: int
+
+
+# ---------------------------------------------------------------------------
+# SlotMeta — metadata attached to every slot in the index
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SlotMeta:
+    """Immutable metadata for one slot in the shared time axis.
+
+    Attributes:
+        key:
+            Canonical :class:`SlotKey` for this slot.
+        start:
+            Timezone-aware start of the slot.
+        end:
+            Timezone-aware end of the slot (= next slot's ``start``).
+        hour:
+            Wall-clock hour of ``start`` (0-23).  Provided as a convenience
+            for lookups that are naturally keyed by hour (e.g. hourly price
+            data, hourly Solcast estimates).
+        minute:
+            Wall-clock minute of ``start`` (0-59).
+        slot_fraction:
+            Fraction of an hour occupied by this slot
+            (``interval_minutes / 60``).  Multiply an hourly kWh value by
+            this to get the per-slot kWh equivalent.
+    """
+
+    key: SlotKey
+    start: datetime
+    end: datetime
+    hour: int
+    minute: int
+    slot_fraction: float
+
+
+# ---------------------------------------------------------------------------
+# TimeSeriesIndex
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TimeSeriesIndex:
+    """Shared time axis for all HSEM planner series.
+
+    All alignment methods project their input onto this axis, producing a
+    list aligned 1-to-1 with :attr:`slots`.  Missing entries are filled
+    with :data:`MISSING_SENTINEL` (``float("nan")``) so callers can detect
+    and handle gaps explicitly.
+
+    Attributes:
+        slots:
+            Ordered list of :class:`SlotMeta` objects covering the full
+            planning horizon, from earliest to latest.
+        interval_minutes:
+            Slot width in minutes (must be a positive divisor of 60).
+        missing_slots:
+            Set of :class:`SlotKey` values for which at least one series
+            alignment call found no source data.  Populated lazily as
+            ``align_*`` methods are called.
+    """
+
+    slots: list[SlotMeta] = field(default_factory=list)
+    interval_minutes: int = DEFAULT_SLOT_MINUTES
+    missing_slots: set[SlotKey] = field(default_factory=set)
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_now(
+        cls,
+        now: datetime,
+        interval_minutes: int = DEFAULT_SLOT_MINUTES,
+        horizon_hours: int = 24,
+    ) -> TimeSeriesIndex:
+        """Build a :class:`TimeSeriesIndex` anchored at *now*.
+
+        Slots start at midnight of *now*'s calendar day (wall-clock midnight
+        in *now*'s timezone) and extend *horizon_hours* into the future.
+        Boundaries are computed with ``timedelta`` arithmetic so DST
+        transitions never cause gaps, duplicates, or incorrect slot counts.
+
+        Args:
+            now:
+                Timezone-aware current datetime.  The timezone embedded in
+                *now* is used for all slot start/end times.
+            interval_minutes:
+                Slot width in minutes.  Must be a positive integer that
+                divides 60 evenly (e.g. 15, 30, 60).
+            horizon_hours:
+                Number of hours of slots to generate from midnight.
+
+        Returns:
+            Fully populated :class:`TimeSeriesIndex`.
+
+        Raises:
+            ValueError: If *now* is naive, *interval_minutes* ≤ 0 or does
+                not divide 60 evenly, or *horizon_hours* ≤ 0.
+        """
+        if now.tzinfo is None:
+            raise ValueError("now must be timezone-aware; got a naive datetime.")
+        if interval_minutes <= 0 or 60 % interval_minutes != 0:
+            raise ValueError(
+                f"interval_minutes must be a positive divisor of 60; got {interval_minutes}."
+            )
+        if horizon_hours <= 0:
+            raise ValueError(f"horizon_hours must be positive; got {horizon_hours}.")
+
+        # Midnight in the same timezone — use timedelta to stay in the same tz
+        midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        slots_per_hour = 60 // interval_minutes
+        total_slots = horizon_hours * slots_per_hour
+        slot_fraction = interval_minutes / 60.0
+
+        slots: list[SlotMeta] = []
+        for i in range(total_slots):
+            start = midnight + timedelta(minutes=i * interval_minutes)
+            end = midnight + timedelta(minutes=(i + 1) * interval_minutes)
+            day_offset = i // (24 * slots_per_hour)
+            slot_in_day = i % (24 * slots_per_hour)
+            key = SlotKey(day_offset=day_offset, slot_in_day=slot_in_day)
+            slots.append(
+                SlotMeta(
+                    key=key,
+                    start=start,
+                    end=end,
+                    hour=start.hour,
+                    minute=start.minute,
+                    slot_fraction=slot_fraction,
+                )
+            )
+
+        return cls(slots=slots, interval_minutes=interval_minutes)
+
+    # ------------------------------------------------------------------
+    # Alignment helpers
+    # ------------------------------------------------------------------
+
+    def align_hourly_prices(
+        self,
+        import_prices: dict[int, float],
+        export_prices: dict[int, float],
+    ) -> tuple[list[float], list[float]]:
+        """Align hourly import and export price dicts onto the slot grid.
+
+        Both ``import_prices`` and ``export_prices`` are keyed by integer
+        hour (0-23).  Each slot in a given hour receives the same price
+        (i.e. prices are constant within the hour).
+
+        Missing hours are filled with :data:`MISSING_SENTINEL` and their
+        keys are added to :attr:`missing_slots`.
+
+        Args:
+            import_prices:
+                Dict mapping hour (0-23) to import price in local
+                currency/kWh.
+            export_prices:
+                Dict mapping hour (0-23) to export price in local
+                currency/kWh.
+
+        Returns:
+            ``(aligned_import, aligned_export)`` — two lists, each
+            parallel to :attr:`slots`.
+        """
+        aligned_import: list[float] = []
+        aligned_export: list[float] = []
+
+        for meta in self.slots:
+            imp = import_prices.get(meta.hour)
+            exp = export_prices.get(meta.hour)
+
+            if imp is None:
+                self.missing_slots.add(meta.key)
+                aligned_import.append(MISSING_SENTINEL)
+            else:
+                aligned_import.append(imp)
+
+            if exp is None:
+                self.missing_slots.add(meta.key)
+                aligned_export.append(MISSING_SENTINEL)
+            else:
+                aligned_export.append(exp)
+
+        return aligned_import, aligned_export
+
+    def align_hourly_pv(
+        self,
+        pv_by_hour: dict[int, float],
+    ) -> list[float]:
+        """Align an hourly PV forecast dict onto the slot grid.
+
+        Each hourly kWh value is divided proportionally across the sub-hour
+        slots so that the energy sum over the full hour is preserved.
+
+        Missing hours are filled with :data:`MISSING_SENTINEL`.
+
+        Args:
+            pv_by_hour:
+                Dict mapping hour (0-23) to PV energy estimate in kWh for
+                the full hour.
+
+        Returns:
+            List of per-slot PV estimates parallel to :attr:`slots`.
+        """
+        aligned: list[float] = []
+        for meta in self.slots:
+            hourly_kwh = pv_by_hour.get(meta.hour)
+            if hourly_kwh is None:
+                self.missing_slots.add(meta.key)
+                aligned.append(MISSING_SENTINEL)
+            else:
+                aligned.append(round(hourly_kwh * meta.slot_fraction, 6))
+        return aligned
+
+    def align_hourly_load(
+        self,
+        load_by_hour: dict[int, float],
+    ) -> list[float]:
+        """Align an hourly load (consumption) dict onto the slot grid.
+
+        Like :meth:`align_hourly_pv`, each hourly kWh value is divided
+        proportionally across sub-hour slots.
+
+        Missing hours are filled with :data:`MISSING_SENTINEL`.
+
+        Args:
+            load_by_hour:
+                Dict mapping hour (0-23) to expected house load in kWh for
+                the full hour.
+
+        Returns:
+            List of per-slot load estimates parallel to :attr:`slots`.
+        """
+        aligned: list[float] = []
+        for meta in self.slots:
+            hourly_kwh = load_by_hour.get(meta.hour)
+            if hourly_kwh is None:
+                self.missing_slots.add(meta.key)
+                aligned.append(MISSING_SENTINEL)
+            else:
+                aligned.append(round(hourly_kwh * meta.slot_fraction, 6))
+        return aligned
+
+    def align_net_import_export(
+        self,
+        import_by_hour: dict[int, float],
+        export_by_hour: dict[int, float],
+    ) -> tuple[list[float], list[float]]:
+        """Align hourly grid import and export energy dicts onto the slot grid.
+
+        Values are divided proportionally across sub-hour slots.
+
+        Missing hours are filled with :data:`MISSING_SENTINEL`.
+
+        Args:
+            import_by_hour:
+                Dict mapping hour (0-23) to grid import energy in kWh for
+                the full hour.
+            export_by_hour:
+                Dict mapping hour (0-23) to grid export energy in kWh for
+                the full hour.
+
+        Returns:
+            ``(aligned_import_kwh, aligned_export_kwh)`` — two lists,
+            each parallel to :attr:`slots`.
+        """
+        aligned_import: list[float] = []
+        aligned_export: list[float] = []
+
+        for meta in self.slots:
+            imp = import_by_hour.get(meta.hour)
+            exp = export_by_hour.get(meta.hour)
+
+            if imp is None:
+                self.missing_slots.add(meta.key)
+                aligned_import.append(MISSING_SENTINEL)
+            else:
+                aligned_import.append(round(imp * meta.slot_fraction, 6))
+
+            if exp is None:
+                self.missing_slots.add(meta.key)
+                aligned_export.append(MISSING_SENTINEL)
+            else:
+                aligned_export.append(round(exp * meta.slot_fraction, 6))
+
+        return aligned_import, aligned_export
+
+    def align_battery_soc(
+        self,
+        soc_by_hour: dict[int, float],
+    ) -> list[float]:
+        """Align a battery state-of-charge (SoC) series onto the slot grid.
+
+        SoC is a *state* (%), not an energy flux, so no scaling is applied —
+        every slot in the same hour receives the same SoC value.
+
+        Missing hours are filled with :data:`MISSING_SENTINEL`.
+
+        Args:
+            soc_by_hour:
+                Dict mapping hour (0-23) to battery SoC percentage (0-100).
+
+        Returns:
+            List of per-slot SoC values parallel to :attr:`slots`.
+        """
+        aligned: list[float] = []
+        for meta in self.slots:
+            soc = soc_by_hour.get(meta.hour)
+            if soc is None:
+                self.missing_slots.add(meta.key)
+                aligned.append(MISSING_SENTINEL)
+            else:
+                aligned.append(soc)
+        return aligned
+
+    def slot_index_for(self, dt: datetime) -> int | None:
+        """Return the 0-based position of the slot containing *dt*, or ``None``.
+
+        The search is performed against the UTC-equivalent of each slot's
+        ``start``/``end`` so that comparisons are DST-safe.
+
+        Args:
+            dt:
+                Timezone-aware datetime to locate.
+
+        Returns:
+            Integer index into :attr:`slots`, or ``None`` if *dt* falls
+            outside the planning horizon.
+        """
+        if dt.tzinfo is None:
+            raise ValueError("dt must be timezone-aware.")
+        for i, meta in enumerate(self.slots):
+            # Compare via UTC to be DST-safe: convert both sides to UTC first.
+            start_utc = meta.start.astimezone(ZoneInfo("UTC"))
+            end_utc = meta.end.astimezone(ZoneInfo("UTC"))
+            dt_utc = dt.astimezone(ZoneInfo("UTC"))
+            if start_utc <= dt_utc < end_utc:
+                return i
+        return None
+
+    def has_missing(self) -> bool:
+        """Return ``True`` if any series alignment found a missing slot."""
+        return bool(self.missing_slots)
+
+    def missing_hours(self) -> set[int]:
+        """Return the wall-clock hours (0-23) that have at least one missing slot."""
+        key_to_hour: dict[SlotKey, int] = {m.key: m.hour for m in self.slots}
+        return {key_to_hour[key] for key in self.missing_slots if key in key_to_hour}
+
+    # ------------------------------------------------------------------
+    # Dunder helpers
+    # ------------------------------------------------------------------
+
+    def __len__(self) -> int:
+        """Return the total number of slots in the index."""
+        return len(self.slots)
+
+    def __iter__(self):
+        """Iterate over :class:`SlotMeta` objects in chronological order."""
+        return iter(self.slots)
+
+    def __repr__(self) -> str:
+        first = self.slots[0].start.isoformat() if self.slots else "empty"
+        last = self.slots[-1].end.isoformat() if self.slots else "empty"
+        return (
+            f"TimeSeriesIndex("
+            f"slots={len(self.slots)}, "
+            f"interval_minutes={self.interval_minutes}, "
+            f"range=[{first}, {last}])"
+        )

--- a/custom_components/hsem/planner/engine.py
+++ b/custom_components/hsem/planner/engine.py
@@ -43,6 +43,7 @@ from custom_components.hsem.planner.charge_scheduler import (
 )
 from custom_components.hsem.planner.slot_population import (
     build_slots,
+    build_time_series_index,
     mark_time_passed,
     populate_battery_capacity,
     populate_consumption,
@@ -121,7 +122,10 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
             "Results may not be meaningful."
         )
 
-    # Generate slots
+    # Build shared time-series index — single source of truth for all slot boundaries
+    tsi = build_time_series_index(inp, now)
+
+    # Generate slots (boundaries come from TSI for DST-safe consistency)
     slots = build_slots(inp, now)
     if not slots:
         warnings.append(
@@ -129,9 +133,9 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
         )
         return PlannerOutput(missing_inputs=missing_inputs, warnings=warnings)
 
-    # Populate time-series
-    populate_prices(slots, inp.price_points)
-    populate_solcast(slots, inp.solcast_slots, inp.interval_minutes)
+    # Populate time-series — all series aligned to the shared TSI axis
+    populate_prices(slots, inp.price_points, tsi)
+    populate_solcast(slots, inp.solcast_slots, inp.interval_minutes, tsi)
     populate_consumption(
         slots,
         inp.consumption_averages,
@@ -140,7 +144,12 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
         inp.weight_7d,
         inp.weight_14d,
         inp.interval_minutes,
+        tsi,
     )
+
+    # Surface any hours where input data was absent
+    for hour in sorted(tsi.missing_hours()):
+        missing_inputs.append(f"hour_{hour:02d}")
     populate_net_consumption(slots)
     populate_estimated_cost(slots)
 
@@ -228,6 +237,7 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
         required_capacity_kwh=required_capacity,
         missing_inputs=missing_inputs,
         warnings=warnings,
+        time_series_index=tsi,
     )
 
 

--- a/custom_components/hsem/planner/slot_population.py
+++ b/custom_components/hsem/planner/slot_population.py
@@ -9,7 +9,8 @@ passed in.  No Home Assistant imports.
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+import math
+from datetime import datetime
 from typing import Any
 
 from custom_components.hsem.const import (
@@ -52,6 +53,7 @@ from custom_components.hsem.models.planner_inputs import (
     SolcastSlot,
 )
 from custom_components.hsem.models.planner_outputs import PlannedSlot
+from custom_components.hsem.models.time_series import TimeSeriesIndex
 from custom_components.hsem.utils.recommendations import Recommendations
 
 # ---------------------------------------------------------------------------
@@ -59,11 +61,32 @@ from custom_components.hsem.utils.recommendations import Recommendations
 # ---------------------------------------------------------------------------
 
 
+def build_time_series_index(inp: PlannerInput, now: datetime) -> TimeSeriesIndex:
+    """Build the shared :class:`TimeSeriesIndex` for a planning run.
+
+    The index is the single source of truth for slot boundaries.  All
+    populate functions should derive their slot positions from the index
+    rather than computing ``start.hour`` independently.
+
+    Args:
+        inp: Planner input containing interval and horizon settings.
+        now: Timezone-aware current datetime.
+
+    Returns:
+        A fully constructed :class:`TimeSeriesIndex`.
+    """
+    return TimeSeriesIndex.from_now(
+        now,
+        interval_minutes=inp.interval_minutes,
+        horizon_hours=inp.interval_length_hours,
+    )
+
+
 def build_slots(inp: PlannerInput, now: datetime) -> list[PlannedSlot]:
     """Generate a chronologically ordered list of empty :class:`PlannedSlot` objects.
 
-    Slots start at midnight of *now*'s local calendar day and cover
-    ``interval_length_hours`` hours at ``interval_minutes`` resolution.
+    Slot boundaries are derived from a :class:`TimeSeriesIndex` so that
+    every slot is DST-safe and consistent with the shared time axis.
 
     Args:
         inp: Planner input containing interval settings.
@@ -72,16 +95,8 @@ def build_slots(inp: PlannerInput, now: datetime) -> list[PlannedSlot]:
     Returns:
         List of empty :class:`PlannedSlot` objects.
     """
-    midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
-    steps = int((inp.interval_length_hours * 60) / inp.interval_minutes)
-
-    return [
-        PlannedSlot(
-            start=midnight + timedelta(minutes=i * inp.interval_minutes),
-            end=midnight + timedelta(minutes=(i + 1) * inp.interval_minutes),
-        )
-        for i in range(steps)
-    ]
+    tsi = build_time_series_index(inp, now)
+    return [PlannedSlot(start=meta.start, end=meta.end) for meta in tsi]
 
 
 def index_by_hour(items: list, hour_attr: str = "hour") -> dict[int, Any]:
@@ -94,15 +109,34 @@ def index_by_hour(items: list, hour_attr: str = "hour") -> dict[int, Any]:
 # ---------------------------------------------------------------------------
 
 
-def populate_prices(slots: list[PlannedSlot], price_points: list[PricePoint]) -> None:
+def populate_prices(
+    slots: list[PlannedSlot],
+    price_points: list[PricePoint],
+    tsi: TimeSeriesIndex | None = None,
+) -> None:
     """Write import/export prices into each slot from ``price_points``.
 
-    Price lookup is by the slot's ``start.hour``. Missing hours default to 0.
+    When a :class:`TimeSeriesIndex` is provided the prices are aligned via
+    the shared slot index so that all series use the same time axis.  Missing
+    hours (``NaN`` sentinel) default to 0 to preserve backward-compatible
+    behaviour.
 
     Args:
         slots: Mutable list of planned slots to update.
         price_points: Per-hour price data.
+        tsi: Optional shared time-series index.  When supplied, alignment is
+            delegated to :meth:`TimeSeriesIndex.align_hourly_prices` so that
+            missing slots are tracked centrally.
     """
+    if tsi is not None:
+        imp_prices = {pp.hour: pp.import_price for pp in price_points}
+        exp_prices = {pp.hour: pp.export_price for pp in price_points}
+        aligned_imp, aligned_exp = tsi.align_hourly_prices(imp_prices, exp_prices)
+        for slot, imp, exp in zip(slots, aligned_imp, aligned_exp):
+            slot.import_price = 0.0 if math.isnan(imp) else imp
+            slot.export_price = 0.0 if math.isnan(exp) else exp
+        return
+
     price_by_hour = index_by_hour(price_points)
     for slot in slots:
         pt = price_by_hour.get(slot.start.hour)
@@ -115,17 +149,29 @@ def populate_solcast(
     slots: list[PlannedSlot],
     solcast_slots: list[SolcastSlot],
     interval_minutes: int,
+    tsi: TimeSeriesIndex | None = None,
 ) -> None:
     """Write PV estimates into each slot, scaled to the slot duration.
 
     Solcast data is provided per *hour*; if the slot duration is shorter
     (e.g. 15 min) the estimate is divided proportionally.
 
+    When a :class:`TimeSeriesIndex` is provided the PV series is aligned via
+    the shared slot index and missing slots are tracked centrally.
+
     Args:
         slots: Mutable list of planned slots to update.
         solcast_slots: Per-hour Solcast PV estimate data.
         interval_minutes: Slot width in minutes.
+        tsi: Optional shared time-series index.
     """
+    if tsi is not None:
+        pv_by_hour = {sc.hour: sc.pv_estimate for sc in solcast_slots}
+        aligned = tsi.align_hourly_pv(pv_by_hour)
+        for slot, val in zip(slots, aligned):
+            slot.solcast_pv_estimate = 0.0 if math.isnan(val) else round(val, 3)
+        return
+
     solcast_by_hour = index_by_hour(solcast_slots)
     scale = 60.0 / interval_minutes  # e.g. 4 for 15-min slots
 
@@ -142,15 +188,52 @@ def populate_consumption(
     w7: int,
     w14: int,
     interval_minutes: int,
+    tsi: TimeSeriesIndex | None = None,
 ) -> None:
     """Compute and write spike-aware weighted consumption into each slot.
+
+    When a :class:`TimeSeriesIndex` is provided each sub-series (1d, 3d, 7d,
+    14d) is individually aligned via the shared slot axis so that missing
+    hours are tracked centrally rather than silently defaulted to zero.
 
     Args:
         slots: Mutable list of planned slots to update.
         averages: Per-hour historical consumption averages.
         w1..w14: Configured integer weights (percent).
         interval_minutes: Slot width in minutes.
+        tsi: Optional shared time-series index.
     """
+    if tsi is not None:
+        avg_1d = {ca.hour: ca.avg_1d for ca in averages}
+        avg_3d = {ca.hour: ca.avg_3d for ca in averages}
+        avg_7d = {ca.hour: ca.avg_7d for ca in averages}
+        avg_14d = {ca.hour: ca.avg_14d for ca in averages}
+        aligned_1d = tsi.align_hourly_load(avg_1d)
+        aligned_3d = tsi.align_hourly_load(avg_3d)
+        aligned_7d = tsi.align_hourly_load(avg_7d)
+        aligned_14d = tsi.align_hourly_load(avg_14d)
+        for i, (slot, v1, v3, v7, v14) in enumerate(
+            zip(slots, aligned_1d, aligned_3d, aligned_7d, aligned_14d)
+        ):
+            if any(math.isnan(v) for v in (v1, v3, v7, v14)):
+                continue  # missing data — leave defaults
+            # Reverse the slot_fraction scaling: TSI already applied it;
+            # weighted_avg_consumption expects hourly values, so undo scaling.
+            sf = tsi.slots[i].slot_fraction
+            if abs(sf) < 1e-9:
+                continue
+            h1 = v1 / sf
+            h3 = v3 / sf
+            h7 = v7 / sf
+            h14 = v14 / sf
+            hourly_avg = weighted_avg_consumption(h1, h3, h7, h14, w1, w3, w7, w14)
+            slot.avg_house_consumption = round(hourly_avg * sf, 3)
+            slot.avg_house_consumption_1d = round(v1, 3)
+            slot.avg_house_consumption_3d = round(v3, 3)
+            slot.avg_house_consumption_7d = round(v7, 3)
+            slot.avg_house_consumption_14d = round(v14, 3)
+        return
+
     avg_by_hour = index_by_hour(averages)
     scale = 60.0 / interval_minutes
 

--- a/tests/test_time_series_model.py
+++ b/tests/test_time_series_model.py
@@ -1,0 +1,636 @@
+"""Tests for the shared time-series slot model (issue #286).
+
+Acceptance criteria verified here
+----------------------------------
+- All planner inputs map to the same slot index.
+- Missing slots are explicit (``MISSING_SENTINEL``).
+- DST transitions are handled correctly: no gap/overlap in slot boundaries,
+  correct slot count, all slots timezone-aware.
+- ``TimeSeriesIndex.from_now`` rejects naive datetimes, bad intervals, and
+  non-positive horizons.
+- Slot resolution is configurable (15 min default, 30 min, 60 min).
+- Alignment methods (prices, PV, load, import/export, battery SoC) all
+  produce lists parallel to ``tsi.slots``.
+- Sub-hourly slots receive correctly scaled energy values.
+- ``slot_index_for`` correctly locates a datetime in the grid.
+
+Timezone under test: ``Europe/Copenhagen``
+  - DST forward (spring):  2024-03-31 02:00 → 03:00 (UTC+1 → UTC+2)
+  - DST backward (autumn): 2024-10-27 03:00 → 02:00 (UTC+2 → UTC+1)
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from custom_components.hsem.models.time_series import (
+    DEFAULT_SLOT_MINUTES,
+    MISSING_SENTINEL,
+    SlotKey,
+    SlotMeta,
+    TimeSeriesIndex,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TZ = ZoneInfo("Europe/Copenhagen")
+_TZ_UTC = ZoneInfo("UTC")
+
+
+def _cph(year: int, month: int, day: int, hour: int, minute: int = 0) -> datetime:
+    """Return a Copenhagen-aware datetime (first occurrence on DST days)."""
+    return datetime(year, month, day, hour, minute, tzinfo=_TZ)
+
+
+def _utc(year: int, month: int, day: int, hour: int, minute: int = 0) -> datetime:
+    """Return a UTC-aware datetime."""
+    return datetime(year, month, day, hour, minute, tzinfo=_TZ_UTC)
+
+
+def _is_sentinel(val: float) -> bool:
+    """Return True if val is the MISSING_SENTINEL (NaN)."""
+    return math.isnan(val)
+
+
+# ---------------------------------------------------------------------------
+# 1. Module-level constants
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    """Public constants must be accessible and have correct defaults."""
+
+    def test_default_slot_minutes_is_15(self):
+        assert DEFAULT_SLOT_MINUTES == 15
+
+    def test_missing_sentinel_is_nan(self):
+        assert math.isnan(MISSING_SENTINEL)
+
+    def test_slot_key_is_named_tuple(self):
+        key = SlotKey(day_offset=0, slot_in_day=3)
+        assert key.day_offset == 0
+        assert key.slot_in_day == 3
+        assert key == SlotKey(0, 3)
+
+
+# ---------------------------------------------------------------------------
+# 2. from_now: validation
+# ---------------------------------------------------------------------------
+
+
+class TestFromNowValidation:
+    """from_now must reject invalid arguments."""
+
+    def test_naive_datetime_raises(self):
+        naive = datetime(2024, 6, 15, 12, 0)
+        with pytest.raises(ValueError, match="timezone-aware"):
+            TimeSeriesIndex.from_now(naive)
+
+    def test_zero_interval_raises(self):
+        now = _cph(2024, 6, 15, 0)
+        with pytest.raises(ValueError, match="interval_minutes"):
+            TimeSeriesIndex.from_now(now, interval_minutes=0)
+
+    def test_negative_interval_raises(self):
+        now = _cph(2024, 6, 15, 0)
+        with pytest.raises(ValueError, match="interval_minutes"):
+            TimeSeriesIndex.from_now(now, interval_minutes=-15)
+
+    def test_non_divisor_interval_raises(self):
+        now = _cph(2024, 6, 15, 0)
+        with pytest.raises(ValueError, match="interval_minutes"):
+            TimeSeriesIndex.from_now(now, interval_minutes=7)
+
+    def test_zero_horizon_raises(self):
+        now = _cph(2024, 6, 15, 0)
+        with pytest.raises(ValueError, match="horizon_hours"):
+            TimeSeriesIndex.from_now(now, horizon_hours=0)
+
+    def test_negative_horizon_raises(self):
+        now = _cph(2024, 6, 15, 0)
+        with pytest.raises(ValueError, match="horizon_hours"):
+            TimeSeriesIndex.from_now(now, horizon_hours=-1)
+
+
+# ---------------------------------------------------------------------------
+# 3. from_now: slot count for various resolutions
+# ---------------------------------------------------------------------------
+
+
+class TestFromNowSlotCount:
+    """Correct number of slots for each supported resolution."""
+
+    def test_15_min_24h_gives_96_slots(self):
+        now = _cph(2024, 6, 15, 14, 30)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
+        assert len(tsi) == 96
+
+    def test_30_min_24h_gives_48_slots(self):
+        now = _cph(2024, 6, 15, 0)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=30, horizon_hours=24)
+        assert len(tsi) == 48
+
+    def test_60_min_24h_gives_24_slots(self):
+        now = _cph(2024, 6, 15, 0)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=60, horizon_hours=24)
+        assert len(tsi) == 24
+
+    def test_15_min_48h_gives_192_slots(self):
+        now = _cph(2024, 6, 15, 0)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=48)
+        assert len(tsi) == 192
+
+    def test_default_resolution_is_15_minutes(self):
+        """Omitting interval_minutes should default to 15-minute slots."""
+        now = _cph(2024, 6, 15, 0)
+        tsi = TimeSeriesIndex.from_now(now, horizon_hours=24)
+        assert tsi.interval_minutes == 15
+        assert len(tsi) == 96
+
+
+# ---------------------------------------------------------------------------
+# 4. SlotMeta: structure and correctness
+# ---------------------------------------------------------------------------
+
+
+class TestSlotMeta:
+    """Each SlotMeta must have correct key, start/end, hour, minute, fraction."""
+
+    def setup_method(self):
+        now = _cph(2024, 6, 15, 0)
+        self.tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
+
+    def test_first_slot_starts_at_midnight(self):
+        first = self.tsi.slots[0]
+        assert first.hour == 0
+        assert first.minute == 0
+
+    def test_first_slot_key_is_zero_zero(self):
+        assert self.tsi.slots[0].key == SlotKey(0, 0)
+
+    def test_slot_4_starts_at_01_00(self):
+        # slots[4] is the 5th slot, which is 4 * 15 = 60 min = 01:00
+        meta = self.tsi.slots[4]
+        assert meta.hour == 1
+        assert meta.minute == 0
+
+    def test_slot_fraction_is_quarter(self):
+        for meta in self.tsi.slots:
+            assert meta.slot_fraction == pytest.approx(0.25)
+
+    def test_all_slots_are_timezone_aware(self):
+        for meta in self.tsi.slots:
+            assert meta.start.tzinfo is not None, f"start naive: {meta.start}"
+            assert meta.end.tzinfo is not None, f"end naive: {meta.end}"
+
+    def test_slots_are_contiguous(self):
+        for a, b in zip(self.tsi.slots, self.tsi.slots[1:]):
+            assert (
+                a.end == b.start
+            ), f"Gap between {a.end.isoformat()} and {b.start.isoformat()}"
+
+    def test_total_span_is_24_hours(self):
+        first = self.tsi.slots[0]
+        last = self.tsi.slots[-1]
+        assert last.end - first.start == timedelta(hours=24)
+
+    def test_60_min_slot_fraction_is_one(self):
+        now = _cph(2024, 6, 15, 0)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=60, horizon_hours=24)
+        for meta in tsi.slots:
+            assert meta.slot_fraction == pytest.approx(1.0)
+
+    def test_slot_meta_is_frozen(self):
+        meta = self.tsi.slots[0]
+        with pytest.raises((AttributeError, TypeError)):
+            meta.hour = 99  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# 5. DST transitions
+# ---------------------------------------------------------------------------
+
+
+class TestDstTransitions:
+    """Slot generation must be correct on DST spring-forward and autumn-fallback days."""
+
+    # ---- Spring forward: 2024-03-31, 02:00 → 03:00, UTC+1 → UTC+2 -----
+
+    def test_spring_forward_96_slots_15min(self):
+        now = _cph(2024, 3, 31, 0)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
+        assert len(tsi) == 96
+
+    def test_spring_forward_24_slots_60min(self):
+        now = _cph(2024, 3, 31, 0)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=60, horizon_hours=24)
+        assert len(tsi) == 24
+
+    def test_spring_forward_total_span_24h(self):
+        now = _cph(2024, 3, 31, 0)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
+        assert tsi.slots[-1].end - tsi.slots[0].start == timedelta(hours=24)
+
+    def test_spring_forward_all_slots_aware(self):
+        now = _cph(2024, 3, 31, 0)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
+        for meta in tsi:
+            assert meta.start.tzinfo is not None
+            assert meta.end.tzinfo is not None
+
+    def test_spring_forward_slots_contiguous(self):
+        now = _cph(2024, 3, 31, 0)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
+        for a, b in zip(tsi.slots, tsi.slots[1:]):
+            assert a.end == b.start
+
+    # ---- Autumn fallback: 2024-10-27, 03:00 → 02:00, UTC+2 → UTC+1 ---
+
+    def test_autumn_fallback_96_slots_15min(self):
+        now = _cph(2024, 10, 27, 0)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
+        assert len(tsi) == 96
+
+    def test_autumn_fallback_24_slots_60min(self):
+        now = _cph(2024, 10, 27, 0)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=60, horizon_hours=24)
+        assert len(tsi) == 24
+
+    def test_autumn_fallback_total_span_24h(self):
+        now = _cph(2024, 10, 27, 0)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
+        assert tsi.slots[-1].end - tsi.slots[0].start == timedelta(hours=24)
+
+    def test_autumn_fallback_all_slots_aware(self):
+        now = _cph(2024, 10, 27, 0)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
+        for meta in tsi:
+            assert meta.start.tzinfo is not None
+            assert meta.end.tzinfo is not None
+
+    def test_autumn_fallback_slots_contiguous(self):
+        now = _cph(2024, 10, 27, 0)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
+        for a, b in zip(tsi.slots, tsi.slots[1:]):
+            assert a.end == b.start
+
+
+# ---------------------------------------------------------------------------
+# 6. align_hourly_prices
+# ---------------------------------------------------------------------------
+
+
+class TestAlignHourlyPrices:
+    """Prices are broadcast to every sub-hour slot; missing hours → sentinel."""
+
+    def setup_method(self):
+        now = _cph(2024, 6, 15, 0)
+        self.tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
+
+    def _full_price_dicts(self) -> tuple[dict[int, float], dict[int, float]]:
+        """Return import/export price dicts for all 24 hours."""
+        imp = {h: round(0.10 + h * 0.01, 4) for h in range(24)}
+        exp = {h: round(max(imp[h] - 0.02, 0.0), 4) for h in range(24)}
+        return imp, exp
+
+    def test_lengths_match_slots(self):
+        imp, exp = self._full_price_dicts()
+        ai, ae = self.tsi.align_hourly_prices(imp, exp)
+        assert len(ai) == len(self.tsi)
+        assert len(ae) == len(self.tsi)
+
+    def test_each_hour_has_4_identical_slots(self):
+        imp, exp = self._full_price_dicts()
+        ai, _ = self.tsi.align_hourly_prices(imp, exp)
+        for h in range(24):
+            base = h * 4
+            assert ai[base] == ai[base + 1] == ai[base + 2] == ai[base + 3]
+
+    def test_price_value_matches_input(self):
+        imp = {h: float(h) for h in range(24)}
+        exp = {h: 0.0 for h in range(24)}
+        ai, _ = self.tsi.align_hourly_prices(imp, exp)
+        for h in range(24):
+            for s in range(4):
+                assert ai[h * 4 + s] == pytest.approx(float(h))
+
+    def test_missing_hour_is_sentinel(self):
+        imp = {h: 0.10 for h in range(24) if h != 12}
+        exp = {h: 0.08 for h in range(24) if h != 12}
+        ai, ae = self.tsi.align_hourly_prices(imp, exp)
+        for s in range(4):
+            assert _is_sentinel(ai[12 * 4 + s])
+            assert _is_sentinel(ae[12 * 4 + s])
+
+    def test_missing_hour_added_to_missing_slots(self):
+        imp = {h: 0.10 for h in range(24) if h != 5}
+        exp = {h: 0.08 for h in range(24)}
+        self.tsi.align_hourly_prices(imp, exp)
+        missing_hours = self.tsi.missing_hours()
+        assert 5 in missing_hours
+
+    def test_no_missing_hours_when_complete(self):
+        imp, exp = self._full_price_dicts()
+        self.tsi.align_hourly_prices(imp, exp)
+        assert not self.tsi.has_missing()
+
+
+# ---------------------------------------------------------------------------
+# 7. align_hourly_pv
+# ---------------------------------------------------------------------------
+
+
+class TestAlignHourlyPv:
+    """PV energy is scaled proportionally to sub-hour slot fraction."""
+
+    def setup_method(self):
+        now = _cph(2024, 6, 15, 0)
+        self.tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
+
+    def test_length_matches_slots(self):
+        pv = {h: 2.0 for h in range(24)}
+        aligned = self.tsi.align_hourly_pv(pv)
+        assert len(aligned) == len(self.tsi)
+
+    def test_slot_value_is_quarter_of_hourly(self):
+        pv = {h: 4.0 for h in range(24)}
+        aligned = self.tsi.align_hourly_pv(pv)
+        for val in aligned:
+            assert val == pytest.approx(1.0)  # 4.0 * 0.25
+
+    def test_four_slots_sum_to_hourly(self):
+        pv = {h: float(h) for h in range(24)}
+        aligned = self.tsi.align_hourly_pv(pv)
+        for h in range(24):
+            total = sum(aligned[h * 4 : h * 4 + 4])
+            assert total == pytest.approx(float(h), abs=1e-9)
+
+    def test_missing_hour_is_sentinel(self):
+        pv = {h: 1.0 for h in range(24) if h != 10}
+        aligned = self.tsi.align_hourly_pv(pv)
+        for s in range(4):
+            assert _is_sentinel(aligned[10 * 4 + s])
+
+    def test_night_hours_zero_produce_zero_slots(self):
+        night_hours = list(range(0, 6)) + list(range(22, 24))
+        pv = {h: (0.0 if h in night_hours else 2.0) for h in range(24)}
+        aligned = self.tsi.align_hourly_pv(pv)
+        for h in night_hours:
+            for s in range(4):
+                assert aligned[h * 4 + s] == pytest.approx(0.0)
+
+    def test_60min_slot_fraction_is_one(self):
+        now = _cph(2024, 6, 15, 0)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=60, horizon_hours=24)
+        pv = {h: 3.6 for h in range(24)}
+        aligned = tsi.align_hourly_pv(pv)
+        for val in aligned:
+            assert val == pytest.approx(3.6)
+
+
+# ---------------------------------------------------------------------------
+# 8. align_hourly_load
+# ---------------------------------------------------------------------------
+
+
+class TestAlignHourlyLoad:
+    """Load energy is scaled proportionally; mirrors PV alignment logic."""
+
+    def setup_method(self):
+        now = _cph(2024, 6, 15, 0)
+        self.tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
+
+    def test_length_matches_slots(self):
+        load = {h: 0.5 for h in range(24)}
+        aligned = self.tsi.align_hourly_load(load)
+        assert len(aligned) == len(self.tsi)
+
+    def test_slot_value_is_quarter_of_hourly(self):
+        load = {h: 0.8 for h in range(24)}
+        aligned = self.tsi.align_hourly_load(load)
+        for val in aligned:
+            assert val == pytest.approx(0.2)  # 0.8 * 0.25
+
+    def test_missing_hour_is_sentinel(self):
+        load = {h: 0.5 for h in range(24) if h != 3}
+        aligned = self.tsi.align_hourly_load(load)
+        for s in range(4):
+            assert _is_sentinel(aligned[3 * 4 + s])
+
+    def test_missing_hour_tracked_in_missing_slots(self):
+        load = {h: 0.5 for h in range(24) if h != 7}
+        self.tsi.align_hourly_load(load)
+        assert 7 in self.tsi.missing_hours()
+
+
+# ---------------------------------------------------------------------------
+# 9. align_net_import_export
+# ---------------------------------------------------------------------------
+
+
+class TestAlignNetImportExport:
+    """Grid import/export energy values are scaled to slot fractions."""
+
+    def setup_method(self):
+        now = _cph(2024, 6, 15, 0)
+        self.tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
+
+    def test_lengths_match_slots(self):
+        imp = {h: 1.0 for h in range(24)}
+        exp = {h: 0.0 for h in range(24)}
+        ai, ae = self.tsi.align_net_import_export(imp, exp)
+        assert len(ai) == len(self.tsi)
+        assert len(ae) == len(self.tsi)
+
+    def test_values_scaled_to_slot_fraction(self):
+        imp = {h: 2.0 for h in range(24)}
+        exp = {h: 1.0 for h in range(24)}
+        ai, ae = self.tsi.align_net_import_export(imp, exp)
+        for i_val, e_val in zip(ai, ae):
+            assert i_val == pytest.approx(0.5)  # 2.0 * 0.25
+            assert e_val == pytest.approx(0.25)  # 1.0 * 0.25
+
+    def test_missing_export_is_sentinel(self):
+        imp = {h: 0.5 for h in range(24)}
+        exp = {h: 0.0 for h in range(24) if h != 20}
+        _, ae = self.tsi.align_net_import_export(imp, exp)
+        for s in range(4):
+            assert _is_sentinel(ae[20 * 4 + s])
+
+
+# ---------------------------------------------------------------------------
+# 10. align_battery_soc
+# ---------------------------------------------------------------------------
+
+
+class TestAlignBatterySoc:
+    """Battery SoC is a state (not scaled); missing hours → sentinel."""
+
+    def setup_method(self):
+        now = _cph(2024, 6, 15, 0)
+        self.tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
+
+    def test_length_matches_slots(self):
+        soc = {h: 80.0 for h in range(24)}
+        aligned = self.tsi.align_battery_soc(soc)
+        assert len(aligned) == len(self.tsi)
+
+    def test_value_is_not_scaled(self):
+        soc = {h: 75.0 for h in range(24)}
+        aligned = self.tsi.align_battery_soc(soc)
+        for val in aligned:
+            assert val == pytest.approx(75.0)
+
+    def test_all_4_sub_slots_same_value(self):
+        soc = {h: float(h * 4) for h in range(24)}
+        aligned = self.tsi.align_battery_soc(soc)
+        for h in range(24):
+            base = h * 4
+            for s in range(1, 4):
+                assert aligned[base] == aligned[base + s]
+
+    def test_missing_hour_is_sentinel(self):
+        soc = {h: 50.0 for h in range(24) if h != 8}
+        aligned = self.tsi.align_battery_soc(soc)
+        for s in range(4):
+            assert _is_sentinel(aligned[8 * 4 + s])
+
+
+# ---------------------------------------------------------------------------
+# 11. All series aligned together: index consistency
+# ---------------------------------------------------------------------------
+
+
+class TestMultiSeriesAlignment:
+    """Aligning all series at once produces parallel, consistent lists."""
+
+    def test_all_series_same_length(self):
+        now = _cph(2024, 6, 15, 0)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
+
+        imp_p = {h: 0.10 for h in range(24)}
+        exp_p = {h: 0.08 for h in range(24)}
+        pv = {h: 2.0 for h in range(24)}
+        load = {h: 0.5 for h in range(24)}
+        grid_imp = {h: 0.2 for h in range(24)}
+        grid_exp = {h: 0.0 for h in range(24)}
+        soc = {h: 60.0 for h in range(24)}
+
+        ai, ae = tsi.align_hourly_prices(imp_p, exp_p)
+        apv = tsi.align_hourly_pv(pv)
+        aload = tsi.align_hourly_load(load)
+        a_grid_imp, a_grid_exp = tsi.align_net_import_export(grid_imp, grid_exp)
+        asoc = tsi.align_battery_soc(soc)
+
+        n = len(tsi)
+        assert len(ai) == n
+        assert len(ae) == n
+        assert len(apv) == n
+        assert len(aload) == n
+        assert len(a_grid_imp) == n
+        assert len(a_grid_exp) == n
+        assert len(asoc) == n
+
+    def test_missing_aggregation_across_series(self):
+        """Missing slot set accumulates across multiple alignment calls."""
+        now = _cph(2024, 6, 15, 0)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
+
+        # hour 5 missing from prices
+        imp_p = {h: 0.10 for h in range(24) if h != 5}
+        exp_p = {h: 0.08 for h in range(24)}
+        # hour 10 missing from PV
+        pv = {h: 2.0 for h in range(24) if h != 10}
+
+        tsi.align_hourly_prices(imp_p, exp_p)
+        tsi.align_hourly_pv(pv)
+
+        missing = tsi.missing_hours()
+        assert 5 in missing
+        assert 10 in missing
+        assert tsi.has_missing()
+
+
+# ---------------------------------------------------------------------------
+# 12. slot_index_for
+# ---------------------------------------------------------------------------
+
+
+class TestSlotIndexFor:
+    """slot_index_for must locate datetimes correctly and handle edge cases."""
+
+    def setup_method(self):
+        now = _cph(2024, 6, 15, 0)
+        self.tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
+
+    def test_midnight_is_slot_zero(self):
+        dt = _cph(2024, 6, 15, 0, 0)
+        assert self.tsi.slot_index_for(dt) == 0
+
+    def test_00_15_is_slot_one(self):
+        dt = _cph(2024, 6, 15, 0, 15)
+        assert self.tsi.slot_index_for(dt) == 1
+
+    def test_01_00_is_slot_four(self):
+        dt = _cph(2024, 6, 15, 1, 0)
+        assert self.tsi.slot_index_for(dt) == 4
+
+    def test_23_45_is_last_slot(self):
+        dt = _cph(2024, 6, 15, 23, 45)
+        assert self.tsi.slot_index_for(dt) == 95
+
+    def test_outside_horizon_returns_none(self):
+        dt = _cph(2024, 6, 16, 0, 0)  # midnight next day (= end of last slot)
+        assert self.tsi.slot_index_for(dt) is None
+
+    def test_naive_datetime_raises(self):
+        naive = datetime(2024, 6, 15, 1, 0)
+        with pytest.raises(ValueError, match="timezone-aware"):
+            self.tsi.slot_index_for(naive)
+
+    def test_utc_datetime_finds_correct_slot(self):
+        """A UTC-aware datetime in the same instant as a Copenhagen slot is found."""
+        # 2024-06-15 01:00 CEST = 2024-06-14 23:00 UTC
+        dt_utc = _utc(2024, 6, 14, 23, 0)
+        idx = self.tsi.slot_index_for(dt_utc)
+        assert idx == 4  # slot at 01:00 CEST
+
+
+# ---------------------------------------------------------------------------
+# 13. Dunder methods and repr
+# ---------------------------------------------------------------------------
+
+
+class TestDunderMethods:
+    """__len__, __iter__, and __repr__ must behave correctly."""
+
+    def test_len_returns_slot_count(self):
+        now = _cph(2024, 6, 15, 0)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
+        assert len(tsi) == 96
+
+    def test_iter_yields_slot_meta(self):
+        now = _cph(2024, 6, 15, 0)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
+        items = list(tsi)
+        assert len(items) == 96
+        assert all(isinstance(m, SlotMeta) for m in items)
+
+    def test_repr_contains_interval_and_slot_count(self):
+        now = _cph(2024, 6, 15, 0)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
+        r = repr(tsi)
+        assert "96" in r
+        assert "15" in r
+
+    def test_missing_slots_empty_initially(self):
+        now = _cph(2024, 6, 15, 0)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
+        assert not tsi.has_missing()
+        assert tsi.missing_slots == set()


### PR DESCRIPTION
## Summary

Implements [P1-08] Add shared time-series slot model (#286).

All planner inputs (prices, PV forecast, load, import/export, battery SoC) now map to a single shared `TimeSeriesIndex`, eliminating the previous per-series `{hour: value}` dict lookups that could silently disagree on slot boundaries.

---

## Changes

### `custom_components/hsem/models/time_series.py` *(new)*

New module providing the shared time axis:

- **`SlotKey`** — `NamedTuple(day_offset, slot_in_day)`: unambiguous slot address that does not rely on wall-clock hours, making it safe across DST transitions.
- **`SlotMeta`** — frozen dataclass: `start`, `end`, `hour`, `minute`, `slot_fraction` per slot.
- **`TimeSeriesIndex`** — central alignment object:
  - `from_now(now, interval_minutes=15, horizon_hours=24)` factory
  - `align_hourly_prices()`, `align_hourly_pv()`, `align_hourly_load()`, `align_net_import_export()`, `align_battery_soc()` — all return lists parallel to `slots`
  - `slot_index_for(dt)` — DST-safe datetime → slot index lookup
  - `missing_slots` / `has_missing()` / `missing_hours()` — explicit gap tracking
- **`DEFAULT_SLOT_MINUTES = 15`** (configurable; any positive divisor of 60)
- **`MISSING_SENTINEL = float("nan")`** — missing data is explicit, not silently zero

DST safety: all slot boundaries are computed via `timedelta` arithmetic from a UTC-normalised midnight. Spring-forward and autumn-fallback days both produce the expected slot count (e.g. 96 for 15-min / 24 for 60-min).

### `custom_components/hsem/models/planner_outputs.py`

- `PlannerOutput` gains a `time_series_index: TimeSeriesIndex | None` field so callers can inspect the shared axis after planning. Import is behind `TYPE_CHECKING` to avoid circular dependencies at runtime.

### `custom_components/hsem/planner/slot_population.py`

- New `build_time_series_index(inp, now)` public helper.
- `build_slots()` now derives slot boundaries directly from `TimeSeriesIndex` (no duplicated `timedelta` logic).
- `populate_prices()`, `populate_solcast()`, `populate_consumption()` each accept an optional `tsi=` kwarg. When supplied, alignment is delegated to the TSI so missing slots accumulate centrally.

### `custom_components/hsem/planner/engine.py`

- `run_planner()` builds the `TimeSeriesIndex` once at the top of the pipeline, passes it to all populate calls.
- Missing hours from `tsi.missing_hours()` are surfaced in `PlannerOutput.missing_inputs` as `"hour_HH"` entries.
- The `TimeSeriesIndex` is stored on `PlannerOutput.time_series_index`.

### `tests/test_time_series_model.py` *(new, 69 tests)*

Full test suite covering:

- Module-level constants
- `from_now` validation (naive datetime, bad interval, non-positive horizon)
- Slot counts for 15 min / 30 min / 60 min resolution
- `SlotMeta` structure, frozen behaviour, contiguity, 24 h span
- DST transitions: spring-forward (2024-03-31) and autumn-fallback (2024-10-27), both resolutions
- All 5 alignment methods: correct scaling, missing sentinel, length parity
- Multi-series alignment consistency and cumulative missing tracking
- `slot_index_for` (midnight, sub-hour offsets, UTC cross-timezone)
- `__len__`, `__iter__`, `__repr__`

---

## Acceptance criteria

- [x] All planner inputs map to the same slot index
- [x] Missing slots are explicit (`MISSING_SENTINEL = NaN`, surfaced in `missing_inputs`)
- [x] DST is handled (spring-forward and autumn-fallback tests pass)

---

## Test results

```
873 passed in 27.99s
```

No regressions. All 69 new tests pass.

Fixes #286