### PR TITLE
fix(planner): apply discharge+charge schedules for every occurrence in 48h horizon

### DIFF
--- a/custom_components/hsem/planner/charge_scheduler.py
+++ b/custom_components/hsem/planner/charge_scheduler.py
@@ -17,10 +17,7 @@ from custom_components.hsem.const import (
 )
 from custom_components.hsem.models.planner_inputs import BatteryScheduleInput
 from custom_components.hsem.models.planner_outputs import PlannedSlot
-from custom_components.hsem.utils.misc import (
-    interval_ends_before_window_start,
-    next_window_start_dt,
-)
+from custom_components.hsem.utils.misc import next_window_start_dt
 from custom_components.hsem.utils.recommendations import Recommendations
 
 # ---------------------------------------------------------------------------
@@ -48,35 +45,78 @@ def apply_discharge_schedules(
         if not sched.enabled:
             continue
 
+        # Determine the last slot end in the planning horizon so we know how
+        # many days to cover.  We apply the discharge window once per calendar
+        # day that falls within [now, horizon_end].
+        future_slots = [s for s in slots if s.end.astimezone(now.tzinfo) > now]
+        if not future_slots:
+            continue
+        horizon_end = future_slots[-1].end.astimezone(now.tzinfo)
+
+        # Collect all occurrences of this schedule window within the horizon.
+        # Start from the first upcoming occurrence and advance one day at a time.
+        # Each occurrence is stored so apply_charge_schedules can schedule
+        # pre-charge independently per window occurrence.
         window_start_abs = next_window_start_dt(now, sched.start)
-        if sched.end > sched.start:
-            window_end_abs = datetime.combine(
-                window_start_abs.date(), sched.end
-            ).replace(tzinfo=now.tzinfo)
-        else:
-            # Cross-midnight discharge window
-            window_end_abs = datetime.combine(
-                (window_start_abs + timedelta(days=1)).date(), sched.end
-            ).replace(tzinfo=now.tzinfo)
+        occurrences: list[tuple[datetime, datetime, float, float]] = []
+        sched_total_net = 0.0
 
-        for slot in slots:
-            slot_start = slot.start.astimezone(now.tzinfo)
-            slot_end = slot.end.astimezone(now.tzinfo)
-            if slot_end <= now:
-                continue
-            if slot_start >= window_start_abs and slot_end <= window_end_abs:
-                slot.recommendation = Recommendations.BatteriesDischargeMode.value
+        while window_start_abs < horizon_end:
+            if sched.end > sched.start:
+                window_end_abs = datetime.combine(
+                    window_start_abs.date(), sched.end
+                ).replace(tzinfo=now.tzinfo)
+            else:
+                # Cross-midnight discharge window
+                window_end_abs = datetime.combine(
+                    (window_start_abs + timedelta(days=1)).date(), sched.end
+                ).replace(tzinfo=now.tzinfo)
 
-        total_net = sum(
-            s.estimated_net_consumption
-            for s in slots
-            if s.recommendation == Recommendations.BatteriesDischargeMode.value
-            and s.start.astimezone(now.tzinfo) >= window_start_abs
-            and s.end.astimezone(now.tzinfo) <= window_end_abs
-        )
-        sched._needed_capacity = max(total_net, 0.0)  # type: ignore[attr-defined]
-        sched._avg_import_price = _avg_price_in_window(  # type: ignore[attr-defined]
-            slots, window_start_abs, window_end_abs, now
+            for slot in slots:
+                slot_start = slot.start.astimezone(now.tzinfo)
+                slot_end = slot.end.astimezone(now.tzinfo)
+                if slot_end <= now:
+                    continue
+                if slot_start >= window_start_abs and slot_end <= window_end_abs:
+                    slot.recommendation = Recommendations.BatteriesDischargeMode.value
+
+            # Capture per-occurrence capacity and avg price
+            occ_net = 0.0
+            occ_prices: list[float] = []
+            for s in slots:
+                s_start = s.start.astimezone(now.tzinfo)
+                s_end = s.end.astimezone(now.tzinfo)
+                if (
+                    s.recommendation == Recommendations.BatteriesDischargeMode.value
+                    and s_start >= window_start_abs
+                    and s_end <= window_end_abs
+                ):
+                    occ_net += s.estimated_net_consumption
+                    occ_prices.append(s.price.import_price)
+
+            occ_needed = max(occ_net, 0.0)
+            occ_avg_price = (
+                round(sum(occ_prices) / len(occ_prices), 3) if occ_prices else 0.0
+            )
+            # Store: (window_start, window_end, needed_kwh, avg_discharge_price)
+            occurrences.append(
+                (window_start_abs, window_end_abs, occ_needed, occ_avg_price)
+            )
+            sched_total_net += occ_net
+
+            # Advance to the same window start on the following calendar day
+            window_start_abs += timedelta(days=1)
+
+        # _occurrences: per-day data consumed by apply_charge_schedules
+        sched._occurrences = occurrences  # type: ignore[attr-defined]
+        # _needed_capacity: aggregate across all occurrences (used by coordinator)
+        sched._needed_capacity = max(sched_total_net, 0.0)  # type: ignore[attr-defined]
+        # _avg_import_price: average across all occurrences
+        all_occ_prices = [avg for _, _, _, avg in occurrences if avg > 0]
+        sched._avg_import_price = (  # type: ignore[attr-defined]
+            round(sum(all_occ_prices) / len(all_occ_prices), 3)
+            if all_occ_prices
+            else 0.0
         )
 
 
@@ -130,70 +170,96 @@ def apply_charge_schedules(
         if not sched.enabled:
             continue
 
-        needed: float = getattr(sched, "_needed_capacity", 0.0)
-        avg_discharge_price: float = getattr(sched, "_avg_import_price", 0.0)
+        # Iterate each occurrence of the discharge window independently.
+        # Each occurrence needs its own pre-charge budget so day-2 discharge
+        # windows get their own cheap-hours charge allocation.
+        occurrences: list[tuple[datetime, datetime, float, float]] = getattr(
+            sched, "_occurrences", []
+        )
+        if not occurrences:
+            # Fallback for callers that didn't go through apply_discharge_schedules
+            needed_fb: float = getattr(sched, "_needed_capacity", 0.0)
+            avg_price_fb: float = getattr(sched, "_avg_import_price", 0.0)
+            if needed_fb > 0:
+                occurrences = [
+                    (
+                        next_window_start_dt(now, sched.start),
+                        next_window_start_dt(now, sched.start),
+                        needed_fb,
+                        avg_price_fb,
+                    )
+                ]
 
-        if needed <= 0:
-            continue
+        for (
+            window_start_abs,
+            _window_end_abs,
+            needed,
+            avg_discharge_price,
+        ) in occurrences:
+            if needed <= 0:
+                continue
 
-        eligible = [
-            s
-            for s in slots
-            if s.end.astimezone(now.tzinfo) > now
-            and interval_ends_before_window_start(
-                s.end.astimezone(now.tzinfo), sched.start, now
-            )
-            and s.recommendation is None
-        ]
+            # Eligible charge slots: future, unassigned, and ending before
+            # this specific occurrence's window start.
+            eligible = [
+                s
+                for s in slots
+                if s.end.astimezone(now.tzinfo) > now
+                and s.end.astimezone(now.tzinfo) <= window_start_abs
+                and s.recommendation is None
+            ]
 
-        charged = 0.0
+            charged = 0.0
 
-        # Priority 1: negative import price
-        for s in sorted(
-            (e for e in eligible if e.price.import_price < 0.0),
-            key=lambda x: (x.price.import_price, x.start),
-        ):
-            if charged >= needed:
-                break
-            energy = min(max_charge_per_interval, needed - charged)
-            if energy > 0:
-                s.recommendation = Recommendations.BatteriesChargeGrid.value
-                s.batteries_charged = round(energy, 3)
-                charged += energy
-
-        # Priority 2: solar surplus
-        if charged < needed:
+            # Priority 1: negative import price
             for s in sorted(
-                (
-                    e
-                    for e in eligible
-                    if e.estimated_net_consumption < SOLAR_SURPLUS_CHARGE_THRESHOLD_KWH
-                    and e.recommendation is None
-                ),
-                # NOTE: SOLAR_SURPLUS_CHARGE_THRESHOLD_KWH is negative, so this
-                # selects slots where net consumption is sufficiently negative
-                # (i.e., there is a meaningful solar surplus to charge from).
-                key=lambda x: (x.estimated_net_consumption, x.start),
+                (e for e in eligible if e.price.import_price < 0.0),
+                key=lambda x: (x.price.import_price, x.start),
             ):
                 if charged >= needed:
                     break
-                available_solar = abs(s.estimated_net_consumption)
-                energy = min(max_charge_per_interval, needed - charged, available_solar)
+                energy = min(max_charge_per_interval, needed - charged)
                 if energy > 0:
-                    s.recommendation = Recommendations.BatteriesChargeSolar.value
+                    s.recommendation = Recommendations.BatteriesChargeGrid.value
                     s.batteries_charged = round(energy, 3)
                     charged += energy
 
-        # Priority 3: cheapest grid hours (min price difference guard)
-        if charged < needed:
-            _apply_grid_charge(
-                eligible,
-                sched,
-                needed,
-                charged,
-                max_charge_per_interval,
-                avg_discharge_price,
-            )
+            # Priority 2: solar surplus
+            if charged < needed:
+                for s in sorted(
+                    (
+                        e
+                        for e in eligible
+                        if e.estimated_net_consumption
+                        < SOLAR_SURPLUS_CHARGE_THRESHOLD_KWH
+                        and e.recommendation is None
+                    ),
+                    # NOTE: SOLAR_SURPLUS_CHARGE_THRESHOLD_KWH is negative, so this
+                    # selects slots where net consumption is sufficiently negative
+                    # (i.e., there is a meaningful solar surplus to charge from).
+                    key=lambda x: (x.estimated_net_consumption, x.start),
+                ):
+                    if charged >= needed:
+                        break
+                    available_solar = abs(s.estimated_net_consumption)
+                    energy = min(
+                        max_charge_per_interval, needed - charged, available_solar
+                    )
+                    if energy > 0:
+                        s.recommendation = Recommendations.BatteriesChargeSolar.value
+                        s.batteries_charged = round(energy, 3)
+                        charged += energy
+
+            # Priority 3: cheapest grid hours (min price difference guard)
+            if charged < needed:
+                _apply_grid_charge(
+                    eligible,
+                    sched,
+                    needed,
+                    charged,
+                    max_charge_per_interval,
+                    avg_discharge_price,
+                )
 
 
 def _apply_grid_charge(
@@ -417,7 +483,9 @@ def apply_optimization_strategy(
         ):
             rec.recommendation = Recommendations.ForceExport.value
 
-    # Solar charging until battery full
+    # Solar charging until battery full — across the full planning horizon
+    # (not limited to today; a 48-hour window should charge from solar on
+    # both day 1 and day 2).
     batteries_needed_charge = max(usable_capacity - current_capacity, 0.0)
     charged = 0.0
 
@@ -425,8 +493,7 @@ def apply_optimization_strategy(
         (
             s
             for s in slots
-            if s.recommendation is None
-            and s.start.astimezone(now.tzinfo).date() == now.date()
+            if s.recommendation is None and s.start.astimezone(now.tzinfo) >= now
         ),
         key=lambda x: x.price.export_price,
     ):

--- a/tests/planner/test_48h_second_day.py
+++ b/tests/planner/test_48h_second_day.py
@@ -1,0 +1,414 @@
+"""Regression tests for 48-hour planning horizon — second-day slot correctness.
+
+Verifies that slots in the second 24 hours of a 48-hour planning window receive
+correct recommendations instead of defaulting entirely to ``BatteriesDischargeMode``.
+
+Root causes fixed:
+1. ``apply_discharge_schedules`` only applied each battery schedule once (for the
+   next single occurrence) rather than once per calendar day in the horizon.
+   Over a 48-hour window the second day's discharge window was never set, so the
+   seasonal fill fell through to ``BatteriesDischargeMode`` for all summer slots.
+
+2. ``apply_optimization_strategy`` filtered the solar-charging pass with
+   ``slot.start.date() == now.date()``, preventing solar charging from being
+   assigned on day 2.
+
+Acceptance criteria:
+- Second-day discharge windows are assigned ``BatteriesDischargeMode``.
+- Second-day non-discharge summer slots are NOT all ``BatteriesDischargeMode``.
+- Solar PV surplus slots on day 2 receive ``BatteriesChargeSolar``.
+- Both day-1 and day-2 discharge windows are reflected in ``discharge_windows``.
+"""
+
+from __future__ import annotations
+
+from datetime import time
+
+from custom_components.hsem.models.planner_inputs import (
+    BatteryScheduleInput,
+    HourlyConsumptionAverage,
+    PlannerInput,
+    PricePoint,
+    SolcastSlot,
+)
+from custom_components.hsem.planner import run_planner
+from custom_components.hsem.utils.recommendations import Recommendations
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_DISCHARGE_VALUES = {
+    Recommendations.BatteriesDischargeMode.value,
+    Recommendations.ForceBatteriesDischarge.value,
+}
+_CHARGE_VALUES = {
+    Recommendations.BatteriesChargeGrid.value,
+    Recommendations.BatteriesChargeSolar.value,
+}
+
+
+def _make_48h_input(
+    *,
+    now_iso: str = "2024-06-15T00:00:00+02:00",
+    battery_soc_pct: float = 50.0,
+    schedules: list[BatteryScheduleInput] | None = None,
+    pv_kwh_per_hour: float = 0.0,
+    load_kwh_per_hour: float = 0.5,
+    months_winter: list[int] | None = None,
+) -> PlannerInput:
+    """Return a 48-hour summer planning input for second-day regression tests."""
+    # Varying prices: cheap night (00-06), moderate day, expensive evening peak
+    import_prices_24h = [
+        0.08,
+        0.06,
+        0.05,
+        0.05,
+        0.06,
+        0.09,  # 00-06 cheap
+        0.15,
+        0.22,
+        0.26,
+        0.24,
+        0.12,
+        0.08,  # 06-12
+        0.06,
+        0.07,
+        0.10,
+        0.25,
+        0.30,
+        0.32,  # 12-18
+        0.29,
+        0.24,
+        0.18,
+        0.14,
+        0.11,
+        0.09,  # 18-24
+    ]
+
+    prices = [
+        PricePoint(
+            hour=h,
+            import_price=import_prices_24h[h],
+            export_price=max(import_prices_24h[h] - 0.02, 0.0),
+        )
+        for h in range(24)
+    ]
+    solar = [SolcastSlot(hour=h, pv_estimate=pv_kwh_per_hour) for h in range(24)]
+    consumption = [
+        HourlyConsumptionAverage(
+            hour=h,
+            avg_1d=load_kwh_per_hour,
+            avg_3d=load_kwh_per_hour,
+            avg_7d=load_kwh_per_hour,
+            avg_14d=load_kwh_per_hour,
+        )
+        for h in range(24)
+    ]
+
+    default_schedules = [
+        BatteryScheduleInput(
+            enabled=True,
+            start=time(7, 0),
+            end=time(9, 0),
+            min_price_difference=0.05,
+        ),
+        BatteryScheduleInput(
+            enabled=True,
+            start=time(17, 0),
+            end=time(21, 0),
+            min_price_difference=0.05,
+        ),
+    ]
+
+    return PlannerInput(
+        now_iso=now_iso,
+        interval_minutes=60,
+        interval_length_hours=48,
+        battery_soc_pct=battery_soc_pct,
+        battery_rated_capacity_kwh=10.0,
+        battery_end_of_discharge_soc_pct=10.0,
+        battery_max_charge_power_w=5000.0,
+        battery_conversion_loss_pct=10.0,
+        battery_purchase_price=0.0,
+        battery_expected_cycles=6000,
+        weight_1d=25,
+        weight_3d=30,
+        weight_7d=30,
+        weight_14d=15,
+        consumption_averages=consumption,
+        price_points=prices,
+        solcast_slots=solar,
+        battery_schedules=schedules if schedules is not None else default_schedules,
+        excess_export_enabled=False,
+        excess_export_discharge_buffer_pct=10.0,
+        excess_export_price_threshold=0.10,
+        months_winter=(
+            months_winter if months_winter is not None else [1, 2, 3, 4, 10, 11, 12]
+        ),
+        house_power_includes_ev=True,
+        is_read_only=True,
+    )
+
+
+# ===========================================================================
+# Basic 48-hour output contract
+# ===========================================================================
+
+
+class TestBasic48hContract:
+    """The planner must return 48 slots and assign all of them."""
+
+    def test_48h_produces_48_slots(self):
+        result = run_planner(_make_48h_input())
+        assert len(result.slots) == 48
+
+    def test_all_slots_have_recommendation(self):
+        result = run_planner(_make_48h_input())
+        for slot in result.slots:
+            assert slot.recommendation is not None, (
+                f"Slot {slot.start.isoformat()} has no recommendation in 48h plan"
+            )
+
+    def test_slots_span_two_calendar_days(self):
+        result = run_planner(_make_48h_input())
+        dates = {s.start.date() for s in result.slots}
+        assert len(dates) == 2, f"Expected slots on exactly 2 dates, got {dates}"
+
+
+# ===========================================================================
+# Discharge windows on day 2
+# ===========================================================================
+
+
+class TestDay2DischargeWindows:
+    """Second-day discharge schedule windows must be applied."""
+
+    def test_day2_discharge_window_present(self):
+        """The 07:00-09:00 discharge window must appear on BOTH calendar days."""
+        result = run_planner(_make_48h_input())
+        day1 = result.slots[0].start.date()
+        day2 = day1.replace(day=day1.day + 1)  # next calendar day
+
+        day2_discharge = [
+            s
+            for s in result.slots
+            if s.start.date() == day2
+            and s.recommendation in _DISCHARGE_VALUES
+            and s.start.hour in (7, 8)
+        ]
+        assert len(day2_discharge) >= 1, (
+            f"Expected discharge slots at 07:00-09:00 on day 2 ({day2}), "
+            f"found none. Day-2 recommendations: "
+            f"{[(s.start.hour, s.recommendation) for s in result.slots if s.start.date() == day2]}"
+        )
+
+    def test_day2_evening_discharge_window_present(self):
+        """The 17:00-21:00 evening discharge window must appear on BOTH days."""
+        result = run_planner(_make_48h_input())
+        day1 = result.slots[0].start.date()
+        day2 = day1.replace(day=day1.day + 1)
+
+        day2_eve_discharge = [
+            s
+            for s in result.slots
+            if s.start.date() == day2
+            and s.recommendation in _DISCHARGE_VALUES
+            and 17 <= s.start.hour < 21
+        ]
+        assert len(day2_eve_discharge) >= 1, (
+            "Expected discharge slots at 17:00-21:00 on day 2, found none."
+        )
+
+    def test_discharge_windows_list_covers_both_days(self):
+        """PlannerOutput.discharge_windows must include windows from both days."""
+        result = run_planner(_make_48h_input())
+        assert len(result.discharge_windows) >= 2, (
+            f"Expected at least 2 discharge windows (one per day), "
+            f"got {len(result.discharge_windows)}: "
+            f"{[(w.start.isoformat(), w.end.isoformat()) for w in result.discharge_windows]}"
+        )
+
+
+# ===========================================================================
+# Day-2 slots must not all be BatteriesDischargeMode
+# ===========================================================================
+
+
+class TestDay2NotAllDischarge:
+    """The second 24 hours must not be entirely discharge recommendations.
+
+    Before the fix, `apply_optimization_strategy` would assign
+    ``BatteriesDischargeMode`` to every unscheduled summer slot because:
+    - The solar charging pass only processed today's (day-1) slots.
+    - No charge windows were recognised for day-2 (schedules only fired once).
+    """
+
+    def test_day2_has_non_discharge_slots(self):
+        """At least some day-2 slots should not be BatteriesDischargeMode."""
+        result = run_planner(_make_48h_input())
+        day1 = result.slots[0].start.date()
+        day2 = day1.replace(day=day1.day + 1)
+
+        day2_slots = [s for s in result.slots if s.start.date() == day2]
+        non_discharge = [
+            s for s in day2_slots if s.recommendation not in _DISCHARGE_VALUES
+        ]
+        assert len(non_discharge) > 0, (
+            "Every day-2 slot is BatteriesDischargeMode — regression from the "
+            "second-day planning bug. Day-2 recommendations: "
+            f"{[(s.start.hour, s.recommendation) for s in day2_slots]}"
+        )
+
+    def test_day2_cheap_night_slots_are_not_discharge(self):
+        """Cheap night slots (00:00-06:00) on day 2 must not be discharge."""
+        result = run_planner(_make_48h_input())
+        day1 = result.slots[0].start.date()
+        day2 = day1.replace(day=day1.day + 1)
+
+        cheap_night_day2 = [
+            s for s in result.slots if s.start.date() == day2 and s.start.hour < 6
+        ]
+        assert cheap_night_day2, "No cheap-night day-2 slots found (unexpected)"
+
+        all_discharge = all(
+            s.recommendation in _DISCHARGE_VALUES for s in cheap_night_day2
+        )
+        assert not all_discharge, (
+            "Cheap night slots (00:00-06:00) on day 2 are all BatteriesDischargeMode. "
+            f"Recommendations: {[(s.start.hour, s.recommendation) for s in cheap_night_day2]}"
+        )
+
+
+# ===========================================================================
+# Day-2 solar charging
+# ===========================================================================
+
+
+class TestDay2SolarCharging:
+    """With PV surplus on day 2, BatteriesChargeSolar must be assigned."""
+
+    def test_day2_pv_surplus_gets_charge_solar(self):
+        """High PV production on day 2 should yield BatteriesChargeSolar slots."""
+        result = run_planner(
+            _make_48h_input(
+                pv_kwh_per_hour=5.0,  # strong PV — net surplus every hour
+                load_kwh_per_hour=0.3,
+                battery_soc_pct=10.0,  # low SoC — battery will accept charge
+                schedules=[],  # no discharge schedules to avoid interference
+            )
+        )
+        day1 = result.slots[0].start.date()
+        day2 = day1.replace(day=day1.day + 1)
+
+        day2_solar_charge = [
+            s
+            for s in result.slots
+            if s.start.date() == day2
+            and s.recommendation == Recommendations.BatteriesChargeSolar.value
+        ]
+        assert len(day2_solar_charge) > 0, (
+            "No BatteriesChargeSolar slots on day 2 despite high PV surplus and "
+            "low battery SoC. Day-2 recommendations: "
+            f"{[(s.start.hour, s.recommendation) for s in result.slots if s.start.date() == day2]}"
+        )
+
+
+# ===========================================================================
+# Pre-charge for day-2 discharge windows
+# ===========================================================================
+
+
+class TestDay2PreCharge:
+    """Cheap night slots before a day-2 discharge window must be charge candidates."""
+
+    def test_cheap_night_before_day2_discharge_can_be_grid_charge(self):
+        """With clear price spread, the planner should charge before day-2 peak."""
+        # Use a big price spread: night cheap, evening expensive
+        night_cheap_prices = [
+            PricePoint(hour=h, import_price=0.05, export_price=0.03)
+            for h in range(6)  # 00-06 very cheap
+        ]
+        mid_prices = [
+            PricePoint(hour=h, import_price=0.15, export_price=0.13)
+            for h in range(6, 17)
+        ]
+        evening_prices = [
+            PricePoint(hour=h, import_price=0.50, export_price=0.48)
+            for h in range(17, 21)  # 17-21 expensive discharge window
+        ]
+        late_prices = [
+            PricePoint(hour=h, import_price=0.12, export_price=0.10)
+            for h in range(21, 24)
+        ]
+        all_prices = night_cheap_prices + mid_prices + evening_prices + late_prices
+
+        consumption = [
+            HourlyConsumptionAverage(
+                hour=h, avg_1d=0.5, avg_3d=0.5, avg_7d=0.5, avg_14d=0.5
+            )
+            for h in range(24)
+        ]
+        solar = [SolcastSlot(hour=h, pv_estimate=0.0) for h in range(24)]
+
+        schedules = [
+            BatteryScheduleInput(
+                enabled=True,
+                start=time(17, 0),
+                end=time(21, 0),
+                min_price_difference=0.10,
+            )
+        ]
+
+        inp = PlannerInput(
+            now_iso="2024-06-15T00:00:00+02:00",
+            interval_minutes=60,
+            interval_length_hours=48,
+            battery_soc_pct=10.0,  # nearly empty — will want to charge
+            battery_rated_capacity_kwh=10.0,
+            battery_end_of_discharge_soc_pct=10.0,
+            battery_max_charge_power_w=5000.0,
+            battery_conversion_loss_pct=0.0,
+            battery_purchase_price=0.0,
+            battery_expected_cycles=6000,
+            weight_1d=25,
+            weight_3d=30,
+            weight_7d=30,
+            weight_14d=15,
+            consumption_averages=consumption,
+            price_points=all_prices,
+            solcast_slots=solar,
+            battery_schedules=schedules,
+            excess_export_enabled=False,
+            excess_export_discharge_buffer_pct=10.0,
+            excess_export_price_threshold=0.10,
+            months_winter=[1, 2, 3, 4, 10, 11, 12],
+            house_power_includes_ev=True,
+            is_read_only=True,
+        )
+
+        result = run_planner(inp)
+
+        day1 = result.slots[0].start.date()
+        day2 = day1.replace(day=day1.day + 1)
+
+        # Should have charge slots to cover BOTH day-1 and day-2 evening peaks
+        charge_slots = [s for s in result.slots if s.recommendation in _CHARGE_VALUES]
+        assert len(charge_slots) > 0, (
+            "Expected at least one charge slot for 48h plan with 17:00-21:00 discharge. "
+            f"All recommendations: {[(s.start.hour, s.start.date(), s.recommendation) for s in result.slots if s.start in charge_slots]}"
+        )
+
+        # Day-2 discharge window at 17:00-21:00 must be present
+        day2_discharge = [
+            s
+            for s in result.slots
+            if s.start.date() == day2
+            and s.recommendation in _DISCHARGE_VALUES
+            and 17 <= s.start.hour < 21
+        ]
+        assert len(day2_discharge) >= 1, (
+            f"Day-2 17:00-21:00 discharge window not found. "
+            f"Day-2 recommendations: "
+            f"{[(s.start.hour, s.recommendation) for s in result.slots if s.start.date() == day2]}"
+        )


### PR DESCRIPTION
## Summary

Fixes a bug where the second 24 hours of a 48-hour planning window showed `batteries_discharge_mode` for every slot instead of the correct mix of charge/wait/solar recommendations.

Related to #267 and #337.

---

## Root Cause

Three bugs in `charge_scheduler.py` combined to produce all-discharge on day 2:

### Bug 1 — `apply_discharge_schedules` only fired once per schedule

`next_window_start_dt` returns the **single next occurrence** of a window. A `07:00-09:00` schedule was only applied to today's slots. Day-2's matching slots were never marked as `BatteriesDischargeMode` by the scheduler — so the seasonal fill treated them as unassigned summer slots and assigned `BatteriesDischargeMode` to everything.

### Bug 2 — `apply_charge_schedules` only saw one charge deadline

Pre-charge eligibility used `interval_ends_before_window_start(slot.end, sched.start, now)` which resolves to the **single next** `window_start`. Cheap night slots at e.g. 02:00 on day 2 (which should charge for the 07:00 day-2 peak) were not eligible because the deadline pointed to the day-1 window.

**Result**: The planner never grid-charged for the day-2 discharge window even when night prices were cheap.

### Bug 3 — `apply_optimization_strategy` solar-charging pass limited to `now.date()`

```python
# Before (bug)
and s.start.astimezone(now.tzinfo).date() == now.date()
# After (fix)
and s.start.astimezone(now.tzinfo) >= now
```

Solar charging was only assigned on day 1; PV surplus slots on day 2 fell through to `BatteriesDischargeMode`.

---

## Changes

### `custom_components/hsem/planner/charge_scheduler.py`

**`apply_discharge_schedules`**
- Loops from the first upcoming occurrence, advancing one calendar day at a time until the horizon end
- Stores per-occurrence `(window_start, window_end, needed_kwh, avg_price)` tuples as `sched._occurrences`
- `sched._needed_capacity` remains the aggregate for the coordinator

**`apply_charge_schedules`**
- Iterates `sched._occurrences` and runs the full three-priority charge assignment (negative price → solar surplus → cheapest grid) **once per discharge window occurrence**
- Each occurrence uses its own `window_start_abs` as the charge deadline — cheap 02:00 slots are now eligible to pre-charge for a 07:00 day-2 window

**`apply_optimization_strategy`**
- Solar-charge pass now covers the full planning horizon (`s.start >= now`)

---

### `tests/planner/test_48h_second_day.py` (new, 10 tests)

| Class | Tests |
|---|---|
| `TestBasic48hContract` | 48 slots produced, all assigned, span 2 dates |
| `TestDay2DischargeWindows` | Morning + evening discharge windows present on day 2; `discharge_windows` list covers both days |
| `TestDay2NotAllDischarge` | Regression guard — day 2 must not be entirely discharge; cheap night slots must not be discharge |
| `TestDay2SolarCharging` | PV surplus on day 2 receives `BatteriesChargeSolar` |
| `TestDay2PreCharge` | Clear price spread (night cheap, evening expensive) triggers grid charge before day-2 evening discharge window |

---

## Test Results

```
950 passed, 0 failed
lint: OK
```
