### PR TITLE
chore(docs): fix Huawei entity IDs and create canonical entity reference

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -41,7 +41,9 @@ When asked to solve a GitHub issue, always follow these steps in order:
   `options` `huawei_solar` steps) → `models/sensor_config.py` →
   `custom_sensors/config_reader.py` → `custom_sensors/state_collector.py` →
   `models/live_state.py` → `coordinator.py`
-- See `AGENTS.md` → **Huawei Solar Sensor Usage Rule** for the canonical entity table.
+- **Always check `docs/huawei_entities.md` first** for the verified list of available HA entities
+  before searching the upstream `wlcrs/huawei_solar` repo or guessing an entity ID.
+- See `AGENTS.md` → **Huawei Solar Sensor Usage Rule** for the full wiring protocol.
 
 ## Issue-Solving Rules
 - Always read `AGENTS.md` and `CLAUDE.md` before starting any issue work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,9 +55,11 @@ The agent must use the exact versions defined in the project configuration files
 
 The agent MUST:
 
-1. **Before using any battery/inverter value**, check whether `wlcrs/huawei_solar` already exposes
-   a matching entity.  The canonical source is `number.py`, `sensor.py`, and `select.py` in that
-   repository.
+1. **Before using any battery/inverter value**, check `docs/huawei_entities.md` in this
+   repository first — it is the canonical, verified list of every entity exposed by the
+   `wlcrs/huawei_solar` integration on this installation.  Only fall back to searching
+   `number.py`, `sensor.py`, and `select.py` in that repository when you need a register name
+   or an entity that is not yet listed in `docs/huawei_entities.md`.
 2. **If the entity already exists in HSEM** (in `flows/huawei_solar.py`, `sensor_config.py`,
    `config_reader.py`, `state_collector.py`, and `live_state.py`): re-use it — never hard-code
    the value.
@@ -77,18 +79,23 @@ The agent MUST:
 
 **Key entity mappings** (register name → HA entity id pattern):
 
-| Register | Entity | Meaning |
+| Register / source | Entity | Meaning |
 |---|---|---|
-| `STORAGE_CHARGING_CUTOFF_CAPACITY` | `number.batteries_charging_cutoff_capacity` | Max SoC during charging (90-100 %) |
+| `STORAGE_CHARGING_CUTOFF_CAPACITY` | `number.batteries_end_of_charge_soc` | Max SoC during charging (90-100 %) |
 | `STORAGE_GRID_CHARGE_CUTOFF_STATE_OF_CHARGE` | `number.batteries_grid_charge_cutoff_soc` | Max SoC when charging **from grid** |
 | `STORAGE_DISCHARGING_CUTOFF_CAPACITY` | `number.batteries_end_of_discharge_soc` | Min SoC floor |
 | `STORAGE_MAXIMUM_CHARGING_POWER` | `number.batteries_maximum_charging_power` | Max charge power (W) |
 | `STORAGE_MAXIMUM_DISCHARGING_POWER` | `number.batteries_maximum_discharging_power` | Max discharge power (W) |
 | `STORAGE_STATE_OF_CAPACITY` | `sensor.batteries_state_of_capacity` | Current SoC (%) |
 | `STORAGE_RATED_CAPACITY` | `sensor.batteries_rated_capacity` | Nameplate capacity (Wh) |
+| `STORAGE_WORKING_MODE_SETTINGS` | `select.batteries_working_mode` | Working mode select |
+| `STORAGE_EXCESS_PV_ENERGY_USE_IN_TOU` | `select.batteries_excess_pv_energy_use_in_tou` | Excess PV use mode in TOU |
+| `STORAGE_HUAWEI_LUNA2000_TOU_…_PERIODS` | `sensor.batteries_tou_charging_and_discharging_periods` | TOU period schedule |
+| `HuaweiSolarActivePowerControlModeEntity` | `sensor.inverter_active_power_control` | Active power / export control mode |
 
-If you are unsure which entity to use, search `wlcrs/huawei_solar` `number.py` and `sensor.py`
-for the register name before implementing.
+**Always check `docs/huawei_entities.md` first** before searching the upstream repo or guessing
+an entity ID. If a new entity is confirmed to exist in HA, add it to `docs/huawei_entities.md`
+as part of the same PR that wires it into HSEM.
 
 ## HSEM Development Rules
 

--- a/custom_components/hsem/const.py
+++ b/custom_components/hsem/const.py
@@ -68,7 +68,7 @@ DEFAULT_CONFIG_VALUES = {
     "hsem_house_consumption_energy_weight_7d": 30,
     "hsem_house_consumption_power": "sensor.power_house_load",
     "hsem_house_power_includes_ev_charger_power": True,
-    "hsem_huawei_solar_batteries_charging_cutoff_capacity": "number.batteries_charging_cutoff_capacity",
+    "hsem_huawei_solar_batteries_charging_cutoff_capacity": "number.batteries_end_of_charge_soc",
     "hsem_huawei_solar_batteries_end_of_discharge_soc": "number.batteries_end_of_discharge_soc",
     "hsem_huawei_solar_batteries_excess_pv_energy_use_in_tou": "select.batteries_excess_pv_energy_use_in_tou",
     "hsem_huawei_solar_batteries_grid_charge_cutoff_soc": "number.batteries_grid_charge_cutoff_soc",

--- a/docs/huawei_entities.md
+++ b/docs/huawei_entities.md
@@ -1,0 +1,117 @@
+# Huawei Solar — Available HA Entities
+
+> **Canonical reference for all AI agents and developers.**
+> Before using any battery, inverter, or power-meter value in HSEM, look up the correct
+> entity ID here. Do **not** guess or invent entity IDs — use only what appears in this file.
+>
+> This file reflects the actual entities exposed by the `wlcrs/huawei_solar` integration on
+> this installation. Update it whenever the integration or hardware changes.
+
+---
+
+## Batteries
+
+### number entities
+
+| Friendly name | Entity ID | Unit | Used by HSEM |
+|---|---|---|---|
+| End-of-charge SOC | `number.batteries_end_of_charge_soc` | % | ✅ `hsem_huawei_solar_batteries_charging_cutoff_capacity` |
+| End-of-discharge SOC | `number.batteries_end_of_discharge_soc` | % | ✅ `hsem_huawei_solar_batteries_end_of_discharge_soc` |
+| Grid charge cutoff SOC | `number.batteries_grid_charge_cutoff_soc` | % | ✅ `hsem_huawei_solar_batteries_grid_charge_cutoff_soc` |
+| Grid charge maximum power | `number.batteries_grid_charge_maximum_power` | W | — |
+| Maximum charging power | `number.batteries_maximum_charging_power` | W | ✅ `hsem_huawei_solar_batteries_maximum_charging_power` |
+| Maximum discharging power | `number.batteries_maximum_discharging_power` | W | ✅ `hsem_huawei_solar_batteries_maximum_discharging_power` |
+| Peak Shaving SOC | `number.batteries_peak_shaving_soc` | % | — |
+
+### sensor entities
+
+| Friendly name | Entity ID | Unit | Used by HSEM |
+|---|---|---|---|
+| State of capacity (SoC) | `sensor.batteries_state_of_capacity` | % | ✅ `hsem_huawei_solar_batteries_state_of_capacity` |
+| Rated capacity | `sensor.batteries_rated_capacity` | Wh | ✅ `hsem_huawei_solar_batteries_rated_capacity` |
+| TOU charging and discharging periods | `sensor.batteries_tou_charging_and_discharging_periods` | — | ✅ `hsem_huawei_solar_batteries_tou_charging_and_discharging_periods` |
+
+### select entities
+
+| Friendly name | Entity ID | Used by HSEM |
+|---|---|---|
+| Working mode | `select.batteries_working_mode` | ✅ `hsem_huawei_solar_batteries_working_mode` |
+| Excess PV energy use in TOU | `select.batteries_excess_pv_energy_use_in_tou` | ✅ `hsem_huawei_solar_batteries_excess_pv_energy_use_in_tou` |
+
+---
+
+## Inverter
+
+### sensor entities
+
+| Friendly name | Entity ID | Unit | Used by HSEM |
+|---|---|---|---|
+| Active power control | `sensor.inverter_active_power_control` | — | ✅ `hsem_huawei_solar_inverter_active_power_control` |
+| Locking status | `sensor.inverter_locking_status` | — | — |
+| Max active power | `sensor.inverter_max_active_power` | W | — |
+| Monthly yield | `sensor.inverter_monthly_yield` | kWh | — |
+| Off-grid status | `sensor.inverter_off_grid_status` | — | — |
+| Off-grid switch | `sensor.inverter_off_grid_switch` | — | — |
+| Phase A current | `sensor.inverter_phase_a_current` | A | — |
+| Phase A voltage | `sensor.inverter_phase_a_voltage` | V | — |
+| Phase B current | `sensor.inverter_phase_b_current` | A | — |
+| Phase B voltage | `sensor.inverter_phase_b_voltage` | V | — |
+| Phase C current | `sensor.inverter_phase_c_current` | A | — |
+| Phase C voltage | `sensor.inverter_phase_c_voltage` | V | — |
+| Power factor | `sensor.inverter_power_factor` | — | — |
+| PV 1 current | `sensor.inverter_pv_1_current` | A | — |
+| PV 1 voltage | `sensor.inverter_pv_1_voltage` | V | — |
+| PV 2 current | `sensor.inverter_pv_2_current` | A | — |
+| PV 2 voltage | `sensor.inverter_pv_2_voltage` | V | — |
+| PV connection status | `sensor.inverter_pv_connection_status` | — | — |
+| Rated power | `sensor.inverter_rated_power` | W | — |
+| Reactive power | `sensor.inverter_reactive_power` | var | — |
+| Shutdown time | `sensor.inverter_shutdown_time` | — | — |
+| Startup time | `sensor.inverter_startup_time` | — | — |
+| State | `sensor.inverter_inverter_state` | — | — |
+| Total DC input energy | `sensor.inverter_total_dc_input_energy` | kWh | — |
+| Total yield | `sensor.inverter_total_yield` | kWh | — |
+| Yearly yield | `sensor.inverter_yearly_yield` | kWh | — |
+
+### number entities
+
+| Friendly name | Entity ID | Unit | Used by HSEM |
+|---|---|---|---|
+| MPPT-Scan Interval | `number.inverter_mppt_scan_interval` | min | — |
+| Power derating | `number.inverter_power_derating` | W | — |
+| Power derating (by percentage) | `number.inverter_power_derating_by_percentage` | % | — |
+
+### switch entities
+
+| Friendly name | Entity ID | Used by HSEM |
+|---|---|---|
+| MPPT-Scan | `switch.inverter_mppt_scanning` | — |
+
+---
+
+## Power Meter
+
+### sensor entities
+
+| Friendly name | Entity ID | Unit | Used by HSEM |
+|---|---|---|---|
+| A-B line voltage | `sensor.power_meter_a_b_line_voltage` | V | — |
+| Active power | `sensor.power_meter_active_power` | W | — |
+| B-C line voltage | `sensor.power_meter_b_c_line_voltage` | V | — |
+| C-A line voltage | `sensor.power_meter_c_a_line_voltage` | V | — |
+| Consumption | `sensor.power_meter_consumption` | kWh | — |
+| Exported | `sensor.power_meter_exported` | kWh | — |
+| Frequency | `sensor.power_meter_frequency` | Hz | — |
+| Meter status | `sensor.power_meter_meter_status` | — | — |
+| Phase A active power | `sensor.power_meter_phase_a_active_power` | W | — |
+| Phase A current | `sensor.power_meter_current` | A | — |
+| Phase A voltage | `sensor.power_meter_phase_a_voltage` | V | — |
+| Phase B active power | `sensor.power_meter_phase_b_active_power` | W | — |
+| Phase B current | `sensor.power_meter_current_2` | A | — |
+| Phase B voltage | `sensor.power_meter_phase_b_voltage` | V | — |
+| Phase C active power | `sensor.power_meter_phase_c_active_power` | W | — |
+| Phase C current | `sensor.power_meter_current_3` | A | — |
+| Phase C voltage | `sensor.power_meter_phase_c_voltage` | V | — |
+| Power factor | `sensor.power_meter_power_factor` | — | — |
+| Reactive energy | `sensor.power_meter_reactive_energy` | kvarh | — |
+| Reactive power | `sensor.power_meter_reactive_power` | var | — |


### PR DESCRIPTION
## Summary

Fixes a wrong default entity ID for the batteries charging cutoff capacity, and introduces a canonical Huawei Solar entity reference document used by both developers and AI agents.

---

## Changes

### `custom_components/hsem/const.py`
- Fixed `hsem_huawei_solar_batteries_charging_cutoff_capacity` default value:
  - ❌ `number.batteries_charging_cutoff_capacity` — entity does not exist
  - ✅ `number.batteries_end_of_charge_soc` — verified on real HA instance (friendly name: "Inverter End-of-charge SOC", min: 90, max: 100, unit: %)

### `docs/huawei_entities.md` (new file)
- Created canonical reference listing every entity exposed by the `wlcrs/huawei_solar` integration on this installation
- Structured into **Batteries**, **Inverter**, and **Power Meter** sections
- Each section is split by domain (`number`, `sensor`, `select`, `switch`)
- Each entity row includes a **"Used by HSEM"** column linking to the corresponding config key
- AI agents and developers must check this file **first** before searching the upstream repo or guessing entity IDs

### `AGENTS.md`
- Rule #1 updated: agents must check `docs/huawei_entities.md` first, only falling back to searching `wlcrs/huawei_solar` source when an entity is absent from the file
- Completed the entity mapping table with 4 previously missing rows:
  - `select.batteries_working_mode`
  - `select.batteries_excess_pv_energy_use_in_tou`
  - `sensor.batteries_tou_charging_and_discharging_periods`
  - `sensor.inverter_active_power_control`

### `.github/copilot-instructions.md`
- Added explicit pointer to `docs/huawei_entities.md` in the Huawei Solar Sensor Rule section

---

## Acceptance Criteria

- [x] `number.batteries_end_of_charge_soc` is the default for the charging cutoff capacity config key
- [x] `docs/huawei_entities.md` lists all 11 Huawei entities used by HSEM with correct entity IDs
- [x] `AGENTS.md` entity mapping table is complete (11 entries)
- [x] All agent instruction files reference `docs/huawei_entities.md` as the first lookup source
