### PR TITLE
feat(planner): add plan explanation output with strategy, score, and rejected plans

### DIFF
--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -61,6 +61,7 @@ from custom_components.hsem.models.planner_inputs import (
     PricePoint,
     SolcastSlot,
 )
+from custom_components.hsem.models.planner_outputs import PlanExplanation
 from custom_components.hsem.models.sensor_config import SensorConfig
 from custom_components.hsem.planner import run_planner
 from custom_components.hsem.utils.inverter_verify import CycleApplySummary
@@ -112,6 +113,8 @@ class CoordinatorData:
     #: Aggregated write-and-verify results from the most recent hardware apply cycle.
     #: ``None`` before the first hardware-write cycle completes.
     apply_summary: CycleApplySummary | None = None
+    #: Human-readable explanation of why the selected plan was chosen.
+    plan_explanation: PlanExplanation = field(default_factory=PlanExplanation)
 
 
 # ---------------------------------------------------------------------------
@@ -180,6 +183,8 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         # state_collector._register_listeners.  Cancelled during async_teardown.
         self._listener_unsubs: list = []
         self._avg_house_consumption_entity_id_cache: dict[str, str] = {}
+        # Most recent plan explanation produced by the planner engine.
+        self._plan_explanation: PlanExplanation = PlanExplanation()
 
     # ------------------------------------------------------------------
     # HA lifecycle
@@ -363,6 +368,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             state=state,
             last_updated=last_updated,
             next_update=self._next_update,
+            plan_explanation=self._plan_explanation,
         )
 
         # Notify all subscriber entities atomically.
@@ -582,6 +588,8 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         self._batteries_schedules_remaining_capacity_needed = sum(
             s.needed_batteries_capacity for s in self._batteries_schedules if s.enabled
         )
+        # Preserve the plan explanation for the next CoordinatorData snapshot.
+        self._plan_explanation = output.explanation
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/custom_components/hsem/custom_sensors/applier.py
+++ b/custom_components/hsem/custom_sensors/applier.py
@@ -345,11 +345,16 @@ async def async_apply_battery_settings(
                 )
                 return summary
 
-    # Excess PV use in TOU
+    # Excess PV use in TOU — fed_to_grid for wait/fully-fed modes, charge otherwise.
+    # ForceExport maps to WorkingModes.FullyFedToGrid at the hardware level so we
+    # check both BatteriesWaitMode and ForceExport recommendations here.
     desired_excess = (
         "fed_to_grid"
         if recommendation
-        in (Recommendations.BatteriesWaitMode.value, WorkingModes.FullyFedToGrid.value)
+        in (
+            Recommendations.BatteriesWaitMode.value,
+            Recommendations.ForceExport.value,
+        )
         else "charge"
     )
     if live.huawei_batteries_excess_pv_use_in_tou != desired_excess:

--- a/custom_components/hsem/custom_sensors/plan_explanation_sensor.py
+++ b/custom_components/hsem/custom_sensors/plan_explanation_sensor.py
@@ -1,0 +1,156 @@
+"""Diagnostic sensor that exposes the HSEM planner's plan explanation.
+
+State
+-----
+The sensor state is the ``selected_strategy`` string produced by the planner
+(e.g. ``"charge_grid_discharge_peak"``, ``"winter_wait"``,
+``"opportunistic_charge"``).  This makes it trivial to use in HA automations,
+conditional cards, and template sensors::
+
+    {{ states('sensor.hsem_plan_explanation_sensor') }}
+    {{ state_attr('sensor.hsem_plan_explanation_sensor', 'score') }}
+
+Attributes
+----------
+All fields from :class:`~custom_components.hsem.models.planner_outputs.PlanExplanation`
+are exposed as individual state attributes so users can reference them directly
+via ``state_attr()`` without parsing a nested dict.  The ``rejected_plans`` list
+is included as-is (a list of dicts).
+
+The sensor is a *diagnostic* entity (``EntityCategory.DIAGNOSTIC``) so it
+appears in the *Diagnostic* section of the device page and is excluded from
+the default Lovelace dashboard.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.const import EntityCategory
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from custom_components.hsem.coordinator import (
+    CoordinatorData,
+    HSEMDataUpdateCoordinator,
+)
+from custom_components.hsem.entity import HSEMEntity
+from custom_components.hsem.models.planner_outputs import PlanExplanation
+from custom_components.hsem.utils.sensornames import (
+    get_plan_explanation_sensor_entity_id,
+    get_plan_explanation_sensor_name,
+    get_plan_explanation_sensor_unique_id,
+)
+
+_UNKNOWN_STRATEGY = "unknown"
+
+
+class HSEMPlanExplanationSensor(
+    CoordinatorEntity[HSEMDataUpdateCoordinator],
+    SensorEntity,
+    HSEMEntity,
+    RestoreEntity,
+):
+    """Diagnostic sensor exposing the active HSEM planner strategy.
+
+    State: ``selected_strategy`` string from :class:`PlanExplanation`.
+    Attributes: all other :class:`PlanExplanation` fields as flat key-value
+    pairs, plus ``rejected_plans`` as a list of dicts.
+    """
+
+    _attr_icon = "mdi:chart-gantt"
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        config_entry,
+        coordinator: HSEMDataUpdateCoordinator,
+    ) -> None:
+        """Initialise the sensor.
+
+        Args:
+            config_entry: The HSEM config entry.
+            coordinator: The shared :class:`HSEMDataUpdateCoordinator`.
+        """
+        CoordinatorEntity.__init__(self, coordinator)
+        HSEMEntity.__init__(self, config_entry)
+
+        self._config_entry = config_entry
+        self._attr_unique_id = get_plan_explanation_sensor_unique_id()
+        self.entity_id = get_plan_explanation_sensor_entity_id()
+        self._name = get_plan_explanation_sensor_name()
+
+        # Restored state used before the first coordinator cycle completes.
+        self._restored_state: str | None = None
+
+    # ------------------------------------------------------------------
+    # HA entity properties
+    # ------------------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        """Return the display name."""
+        return self._name
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return the unique ID."""
+        return self._attr_unique_id
+
+    @property
+    def state(self) -> str:
+        """Return the currently active plan strategy.
+
+        Returns ``"unknown"`` while waiting for the first coordinator cycle.
+        Falls back to the last restored state on HA restart.
+        """
+        data: CoordinatorData | None = self.coordinator.data
+        if data is None:
+            return self._restored_state or _UNKNOWN_STRATEGY
+        return data.plan_explanation.selected_strategy or _UNKNOWN_STRATEGY
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling — driven by the coordinator."""
+        return False
+
+    @property
+    def available(self) -> bool:
+        """True once the coordinator has completed at least one successful cycle."""
+        return (
+            self.coordinator.last_update_success and self.coordinator.data is not None
+        ) or self._restored_state is not None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the full plan explanation as flat key-value attributes.
+
+        Each field on :class:`PlanExplanation` is exposed individually so
+        users can template against ``state_attr('sensor.hsem_plan_explanation_sensor',
+        'score')`` etc. without needing to unpack a nested dict.
+        """
+        data: CoordinatorData | None = self.coordinator.data
+        explanation: PlanExplanation = (
+            data.plan_explanation if data is not None else PlanExplanation()
+        )
+        d = explanation.as_dict()
+        # Hoist all keys to the top level (as_dict already returns a flat dict
+        # except for rejected_plans which is a list of dicts — leave that as-is).
+        return d
+
+    # ------------------------------------------------------------------
+    # HA lifecycle
+    # ------------------------------------------------------------------
+
+    async def async_added_to_hass(self) -> None:
+        """Restore previous state and register coordinator listener."""
+        await super().async_added_to_hass()
+        restored = await self.async_get_last_state()
+        if restored is not None and restored.state not in (
+            None,
+            "unavailable",
+            "unknown",
+        ):
+            self._restored_state = restored.state

--- a/custom_components/hsem/custom_sensors/working_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/working_mode_sensor.py
@@ -257,6 +257,7 @@ class HSEMWorkingModeSensor(
             "batteries_enable_excess_export": cfg.batteries_enable_excess_export,
             "batteries_excess_export_discharge_buffer": cfg.batteries_excess_export_discharge_buffer,
             "batteries_excess_export_price_threshold": cfg.batteries_excess_export_price_threshold,
+            "plan_explanation": data.plan_explanation.as_dict(),
         }
 
         apply_summary = data.apply_summary

--- a/custom_components/hsem/custom_sensors/working_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/working_mode_sensor.py
@@ -257,7 +257,6 @@ class HSEMWorkingModeSensor(
             "batteries_enable_excess_export": cfg.batteries_enable_excess_export,
             "batteries_excess_export_discharge_buffer": cfg.batteries_excess_export_discharge_buffer,
             "batteries_excess_export_price_threshold": cfg.batteries_excess_export_price_threshold,
-            "plan_explanation": data.plan_explanation.as_dict(),
         }
 
         apply_summary = data.apply_summary

--- a/custom_components/hsem/models/planner_outputs.py
+++ b/custom_components/hsem/models/planner_outputs.py
@@ -57,9 +57,11 @@ class PlanExplanation:
         summary:
             One-sentence human-readable summary of the selected plan.
         score:
-            Numeric score for the selected plan.  Higher is better.
-            Currently defined as the negated estimated total cost so that
-            cheaper plans score higher; the scale is local currency/kWh.
+            Estimated savings of the selected plan versus doing nothing
+            (battery fully idle).  Positive means the plan saves money
+            over the horizon; negative means pre-charging overhead exceeds
+            the expected discharge savings within this window.  Units are
+            local currency.
         estimated_total_cost:
             Estimated net grid cost for the planning horizon (local currency).
             Positive = net import cost; negative = net export revenue.

--- a/custom_components/hsem/models/planner_outputs.py
+++ b/custom_components/hsem/models/planner_outputs.py
@@ -17,6 +17,122 @@ from custom_components.hsem.utils.prices import SlotPrice
 if TYPE_CHECKING:
     from custom_components.hsem.models.time_series import TimeSeriesIndex
 
+# ---------------------------------------------------------------------------
+# Plan explanation dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RejectedPlan:
+    """A plan alternative that was considered but not selected.
+
+    Attributes:
+        name:
+            Short identifier for this alternative strategy
+            (e.g. ``"charge_only_grid"``, ``"discharge_only"``).
+        reason:
+            Human-readable explanation of why this plan was rejected.
+        estimated_cost:
+            Estimated total grid cost (local currency) under this plan.
+            Positive = net import cost; negative = net export revenue.
+    """
+
+    name: str
+    reason: str
+    estimated_cost: float = 0.0
+
+
+@dataclass
+class PlanExplanation:
+    """Human-readable explanation of the plan selected by the HSEM planner.
+
+    Attached to :class:`PlannerOutput` after each planning run.  Suitable for
+    surfacing as a Home Assistant sensor attribute so users can understand *why*
+    a particular strategy was chosen and what alternatives were rejected.
+
+    Attributes:
+        selected_strategy:
+            Short identifier for the active strategy
+            (e.g. ``"charge_grid_discharge_peak"``).
+        summary:
+            One-sentence human-readable summary of the selected plan.
+        score:
+            Numeric score for the selected plan.  Higher is better.
+            Currently defined as the negated estimated total cost so that
+            cheaper plans score higher; the scale is local currency/kWh.
+        estimated_total_cost:
+            Estimated net grid cost for the planning horizon (local currency).
+            Positive = net import cost; negative = net export revenue.
+        price_spread:
+            Difference between the maximum and minimum import price in the
+            planning horizon (local currency/kWh).  A larger spread indicates
+            more arbitrage potential.
+        peak_import_price:
+            Maximum import price seen across all future slots.
+        off_peak_import_price:
+            Minimum import price seen across all future slots.
+        forecast_pv_kwh:
+            Total PV production forecast for the planning horizon (kWh).
+        forecast_net_consumption_kwh:
+            Total estimated net consumption (load minus PV) for the planning
+            horizon (kWh).  Negative means net solar surplus.
+        battery_soc_pct:
+            Battery state-of-charge at the start of the planning run (%).
+        battery_soc_at_end_pct:
+            Estimated battery state-of-charge at the end of the planning
+            horizon (%).
+        constraints:
+            List of active constraints or flags that influenced the decision
+            (e.g. ``"winter_month"``, ``"no_price_spread"``,
+            ``"excess_export_enabled"``).
+        rejected_plans:
+            Alternative plans that were evaluated and rejected, each with a
+            name, reason, and estimated cost.
+    """
+
+    selected_strategy: str = "unknown"
+    summary: str = ""
+    score: float = 0.0
+    estimated_total_cost: float = 0.0
+    price_spread: float = 0.0
+    peak_import_price: float = 0.0
+    off_peak_import_price: float = 0.0
+    forecast_pv_kwh: float = 0.0
+    forecast_net_consumption_kwh: float = 0.0
+    battery_soc_pct: float = 0.0
+    battery_soc_at_end_pct: float = 0.0
+    constraints: list[str] = field(default_factory=list)
+    rejected_plans: list[RejectedPlan] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        """Serialise the explanation to a plain dict for HA attributes.
+
+        Returns:
+            A JSON-safe dictionary representation of the explanation.
+        """
+        return {
+            "selected_strategy": self.selected_strategy,
+            "summary": self.summary,
+            "score": round(self.score, 4),
+            "estimated_total_cost": round(self.estimated_total_cost, 4),
+            "price_spread": round(self.price_spread, 4),
+            "peak_import_price": round(self.peak_import_price, 4),
+            "off_peak_import_price": round(self.off_peak_import_price, 4),
+            "forecast_pv_kwh": round(self.forecast_pv_kwh, 3),
+            "forecast_net_consumption_kwh": round(self.forecast_net_consumption_kwh, 3),
+            "battery_soc_pct": round(self.battery_soc_pct, 1),
+            "battery_soc_at_end_pct": round(self.battery_soc_at_end_pct, 1),
+            "constraints": list(self.constraints),
+            "rejected_plans": [
+                {
+                    "name": rp.name,
+                    "reason": rp.reason,
+                    "estimated_cost": round(rp.estimated_cost, 4),
+                }
+                for rp in self.rejected_plans
+            ],
+        }
+
 
 @dataclass
 class PlannedSlot:
@@ -184,6 +300,10 @@ class PlannerOutput:
             ``None`` when the planner was invoked without a valid horizon.
         extra:
             Arbitrary key-value pairs for debug / introspection purposes.
+        explanation:
+            Human-readable explanation of why the selected plan was chosen,
+            including rejected alternatives, price spread, forecast summary,
+            SoC status, and active constraints.
     """
 
     slots: list[PlannedSlot] = field(default_factory=list)
@@ -196,6 +316,9 @@ class PlannerOutput:
     warnings: list[str] = field(default_factory=list)
     time_series_index: TimeSeriesIndex | None = field(default=None, repr=False)
     extra: dict[str, Any] = field(default_factory=dict)
+    #: Human-readable explanation of why the selected plan was chosen and what
+    #: alternatives were considered.  Populated by the planner engine.
+    explanation: PlanExplanation = field(default_factory=PlanExplanation)
 
     # ------------------------------------------------------------------
     # Convenience helpers used by tests

--- a/custom_components/hsem/planner/charge_scheduler.py
+++ b/custom_components/hsem/planner/charge_scheduler.py
@@ -403,8 +403,29 @@ def apply_excess_export(
     if battery_discharge_budget_kwh <= 0:
         return
 
-    battery_is_solar_charged = any(
-        s.recommendation == Recommendations.BatteriesChargeSolar.value for s in slots
+    # D16 fix: track actual solar vs grid fractions rather than a coarse flag.
+    # We compute the total kWh scheduled to be charged from solar vs from the
+    # grid within this planning run.  The solar fraction determines how much of
+    # the battery is considered "free" (solar-charged) vs paid-for (grid-charged).
+    # When the solar fraction exceeds 50 % of total planned charging we treat
+    # the battery as predominantly solar-charged and bypass the price threshold;
+    # otherwise the full price-difference guard applies.
+    solar_charged_kwh = sum(
+        s.batteries_charged
+        for s in slots
+        if s.recommendation == Recommendations.BatteriesChargeSolar.value
+    )
+    grid_charged_kwh = sum(
+        s.batteries_charged
+        for s in slots
+        if s.recommendation == Recommendations.BatteriesChargeGrid.value
+    )
+    total_planned_charge_kwh = solar_charged_kwh + grid_charged_kwh
+    # battery_is_solar_charged is True only when solar charging is the
+    # dominant (> 50 %) planned source, or when no grid charging is planned.
+    battery_is_solar_charged = (
+        total_planned_charge_kwh < 1e-9
+        or solar_charged_kwh / total_planned_charge_kwh > 0.5
     )
 
     candidates = sorted(
@@ -440,6 +461,93 @@ def apply_excess_export(
 
 
 # ---------------------------------------------------------------------------
+# Opportunistic grid charging (A2/H28/H29)
+# ---------------------------------------------------------------------------
+
+
+def apply_opportunistic_charge(
+    slots: list[PlannedSlot],
+    now: datetime,
+    current_capacity: float,
+    usable_capacity: float,
+    max_charge_per_interval: float,
+    depreciation_threshold: float,
+) -> None:
+    """Charge the battery opportunistically when import prices are very low.
+
+    This is a *schedule-independent* charge pass: it runs even when no
+    discharge window is configured.  It covers two cases:
+
+    1. **Negative import price** — the grid pays the consumer.  Every
+       negative-price future slot is eligible regardless of the battery level.
+    2. **Below-depreciation import price** — import is so cheap that
+       charging is economically sound even without an upcoming scheduled
+       discharge (the depreciation threshold is used as the ceiling).
+
+    Slots already assigned (by schedule pre-charge or prior passes) are
+    skipped.  Energy is limited to what the battery can still absorb.
+
+    Args:
+        slots: Mutable list of planned slots (modified in-place).
+        now: Timezone-aware current datetime.
+        current_capacity: Current available battery energy in kWh.
+        usable_capacity: Maximum usable battery energy in kWh.
+        max_charge_per_interval: Maximum energy chargeable per slot (kWh).
+        depreciation_threshold: Price ceiling below which grid charging is
+            considered economically justified (local currency / kWh).
+            Typically the depreciation + conversion-loss threshold from
+            :func:`~custom_components.hsem.utils.misc.calculate_recommended_threshold`.
+    """
+    if max_charge_per_interval <= 0:
+        return
+
+    remaining_capacity = max(usable_capacity - current_capacity, 0.0)
+    if remaining_capacity <= 0:
+        return
+
+    charged = 0.0
+
+    # Priority 1: negative import price — charge as much as possible
+    for s in sorted(
+        (
+            slot
+            for slot in slots
+            if slot.end.astimezone(now.tzinfo) > now
+            and slot.recommendation is None
+            and slot.price.import_price < 0
+        ),
+        key=lambda x: (x.price.import_price, x.start),
+    ):
+        if charged >= remaining_capacity:
+            break
+        energy = min(max_charge_per_interval, remaining_capacity - charged)
+        if energy > 0:
+            s.recommendation = Recommendations.BatteriesChargeGrid.value
+            s.batteries_charged = round(energy, 3)
+            charged += energy
+
+    # Priority 2: below-depreciation price (only if threshold is meaningful)
+    if abs(depreciation_threshold) > 1e-9:
+        for s in sorted(
+            (
+                slot
+                for slot in slots
+                if slot.end.astimezone(now.tzinfo) > now
+                and slot.recommendation is None
+                and 0 <= slot.price.import_price < depreciation_threshold
+            ),
+            key=lambda x: (x.price.import_price, x.start),
+        ):
+            if charged >= remaining_capacity:
+                break
+            energy = min(max_charge_per_interval, remaining_capacity - charged)
+            if energy > 0:
+                s.recommendation = Recommendations.BatteriesChargeGrid.value
+                s.batteries_charged = round(energy, 3)
+                charged += energy
+
+
+# ---------------------------------------------------------------------------
 # Seasonal optimization
 # ---------------------------------------------------------------------------
 
@@ -452,12 +560,14 @@ def apply_optimization_strategy(
     required_capacity: float,
     months_winter: list[int],
     warnings: list[str],
+    export_min_price: float = 0.0,
 ) -> None:
     """Apply seasonal optimization logic to remaining unassigned slots.
 
     Decision priority per unassigned slot:
 
-    1. Export price > import price → ``ForceExport``
+    1. Export price > import price **and** export price ≥ ``export_min_price``
+       → ``ForceExport``
     2. Solar surplus → ``BatteriesChargeSolar`` (until battery full)
     3. Future forced export pending and battery above required → ``BatteriesWaitMode``
     4. Winter month → ``BatteriesWaitMode``
@@ -471,14 +581,19 @@ def apply_optimization_strategy(
         required_capacity: Energy required until next solar surplus (kWh).
         months_winter: List of month integers (1-12) treated as winter.
         warnings: Mutable list for diagnostic messages (currently unused here).
+        export_min_price: Minimum export price required to trigger
+            ``ForceExport``.  Slots where export price is below this
+            threshold are not marked for export even if export > import.
+            Defaults to ``0.0`` (any positive export price qualifies).
     """
     current_month = now.month
     months_summer = [m for m in range(1, 13) if m not in months_winter]
 
-    # ForceExport when export > import
+    # ForceExport when export > import AND export >= export_min_price (A3 fix)
     for rec in slots:
         if (
             rec.price.export_price > rec.price.import_price
+            and rec.price.export_price >= export_min_price
             and rec.recommendation is None
         ):
             rec.recommendation = Recommendations.ForceExport.value

--- a/custom_components/hsem/planner/engine.py
+++ b/custom_components/hsem/planner/engine.py
@@ -40,6 +40,7 @@ from custom_components.hsem.planner.charge_scheduler import (
     apply_charge_schedules,
     apply_discharge_schedules,
     apply_excess_export,
+    apply_opportunistic_charge,
     apply_optimization_strategy,
     calculate_required_battery_until_solar,
 )
@@ -157,7 +158,13 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
     populate_net_consumption(slots)
     populate_estimated_cost(slots)
 
-    # Depreciation threshold diagnostic
+    # Depreciation threshold diagnostic and C13 auto-fill.
+    # calculate_recommended_threshold returns the minimum economically
+    # justified price difference (depreciation + conversion loss).
+    # When a battery schedule has min_price_difference == 0 (user left it
+    # at the default), we automatically fill it with the depreciation
+    # threshold so the planner never charges from the grid unless it is
+    # actually profitable.
     recommended_threshold = calculate_recommended_threshold(
         inp.battery_purchase_price,
         inp.battery_expected_cycles,
@@ -169,6 +176,9 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
             f"Recommended price threshold: {recommended_threshold:.4f} "
             f"(depreciation + conversion loss)."
         )
+        for sched in inp.battery_schedules:
+            if sched.enabled and abs(sched.min_price_difference) < 1e-9:
+                sched.min_price_difference = recommended_threshold
 
     # Mark past slots
     mark_time_passed(slots, now)
@@ -184,6 +194,18 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
     max_charge_per_interval = max_charge_per_hour / (60 / inp.interval_minutes)
 
     apply_charge_schedules(slots, inp.battery_schedules, now, max_charge_per_interval)
+
+    # Opportunistic grid charge (A2/H28/H29): charge from grid when prices
+    # are negative or below the depreciation threshold, independent of any
+    # configured discharge schedule.
+    apply_opportunistic_charge(
+        slots,
+        now,
+        current_kwh,
+        usable_kwh,
+        max_charge_per_interval,
+        recommended_threshold,
+    )
 
     # Derive per-slot power limits
     max_charge_per_slot = (
@@ -218,7 +240,7 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
             warnings,
         )
 
-    # Seasonal optimization
+    # Seasonal optimization (A3: export_min_price guards ForceExport)
     apply_optimization_strategy(
         slots,
         now,
@@ -227,6 +249,7 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
         required_capacity,
         inp.months_winter,
         warnings,
+        export_min_price=inp.export_min_price,
     )
 
     # Full SoC simulation (second pass — after charges assigned, with power limits)
@@ -432,11 +455,13 @@ def _build_explanation(
         }
         for s in future_slots
     )
+    # has_force_export: excess capacity sent to grid (ForceBatteriesDischarge)
     has_force_export = any(
         s.recommendation == Recommendations.ForceBatteriesDischarge.value
         for s in future_slots
     )
-    has_force_mode = any(
+    # has_force_export_pv: export price > import price slots (ForceExport)
+    has_force_export_pv = any(
         s.recommendation == Recommendations.ForceExport.value for s in future_slots
     )
 
@@ -449,6 +474,12 @@ def _build_explanation(
             f"Battery will be charged from the grid during cheap hours "
             f"(min {off_peak_import:.3f}) and discharged during peak hours "
             f"(max {peak_import:.3f})."
+        )
+    elif has_grid_charge and not has_discharge:
+        selected_strategy = "opportunistic_charge"
+        summary = (
+            f"Opportunistic grid charging during very cheap or negative-price "
+            f"hours (min {off_peak_import:.3f}); no scheduled discharge window."
         )
     elif has_solar_charge and has_discharge:
         selected_strategy = "charge_solar_discharge_peak"
@@ -463,7 +494,7 @@ def _build_explanation(
             f"Surplus battery capacity will be exported to the grid at "
             f"high export prices (max {max(export_prices):.3f})."
         )
-    elif has_force_mode:
+    elif has_force_export_pv:
         selected_strategy = "force_export_pv"
         summary = "Export price exceeds import price; PV surplus exported."
     elif has_discharge and not has_grid_charge and not has_solar_charge:

--- a/custom_components/hsem/planner/engine.py
+++ b/custom_components/hsem/planner/engine.py
@@ -405,6 +405,16 @@ def _build_explanation(
     # --- Cost of the selected plan ---------------------------------------
     selected_cost = round(sum(s.estimated_cost for s in future_slots), 4)
 
+    # --- Do-nothing baseline cost (battery fully idle, pay import for all load) ---
+    # Computed here so strategy detection can use it in summaries.
+    do_nothing_cost = round(
+        sum(
+            max(s.estimated_net_consumption, 0.0) * s.price.import_price
+            for s in future_slots
+        ),
+        4,
+    )
+
     # --- Strategy detection ----------------------------------------------
     has_grid_charge = any(
         s.recommendation == Recommendations.BatteriesChargeGrid.value
@@ -491,23 +501,43 @@ def _build_explanation(
         constraints.append("battery_full")
     if inp.battery_soc_pct <= inp.battery_end_of_discharge_soc_pct:
         constraints.append("battery_empty")
+    if battery_soc_at_end <= inp.battery_end_of_discharge_soc_pct:
+        constraints.append("battery_low_at_end")
 
     # --- Rejected plans -------------------------------------------------
     rejected: list[RejectedPlan] = []
 
-    # Alternative: do-nothing (battery idle for the whole horizon)
-    do_nothing_cost = round(
-        sum(s.estimated_net_consumption * s.price.import_price for s in future_slots),
-        4,
-    )
+    # The "savings" the selected plan achieves vs doing nothing.
+    # Positive = selected plan is cheaper (saves money vs idle battery).
+    # Negative = selected plan costs more (e.g. pre-charging costs exceed discharge savings).
+    savings = round(do_nothing_cost - selected_cost, 4)
+
+    # Alternative: do-nothing (battery fully idle for the whole horizon).
+    # Always include this as a rejected alternative so the user can see
+    # the baseline comparison even when the savings are marginal or negative.
     if selected_strategy != "discharge_only":
+        if savings > 1e-4:
+            do_nothing_reason = (
+                f"Battery idle would cost {do_nothing_cost:.4f}; "
+                f"selected plan saves {savings:.4f} over the horizon."
+            )
+        elif savings < -1e-4:
+            do_nothing_reason = (
+                f"Battery idle would cost {do_nothing_cost:.4f}. "
+                f"Selected plan costs {abs(savings):.4f} more due to "
+                "charging overhead; discharge savings expected to materialise "
+                "within the current scheduling window."
+            )
+        else:
+            do_nothing_reason = (
+                f"Battery idle cost ({do_nothing_cost:.4f}) and selected plan "
+                f"cost ({selected_cost:.4f}) are approximately equal; "
+                "strategy chosen for schedule adherence."
+            )
         rejected.append(
             RejectedPlan(
                 name="do_nothing",
-                reason=(
-                    "Battery held idle; estimated grid cost "
-                    f"{do_nothing_cost:.4f} vs selected {selected_cost:.4f}."
-                ),
+                reason=do_nothing_reason,
                 estimated_cost=do_nothing_cost,
             )
         )
@@ -546,8 +576,10 @@ def _build_explanation(
                 )
             )
 
-    # Score: negate the estimated cost so cheaper = higher score
-    score = round(-selected_cost, 4)
+    # Score: estimated savings vs doing nothing.
+    # Positive = the plan saves money compared to leaving the battery idle.
+    # Negative = the plan costs more than idle (pre-charge overhead dominates).
+    score = savings
 
     return PlanExplanation(
         selected_strategy=selected_strategy,

--- a/custom_components/hsem/planner/engine.py
+++ b/custom_components/hsem/planner/engine.py
@@ -31,8 +31,10 @@ from custom_components.hsem.models.planner_inputs import PlannerInput
 from custom_components.hsem.models.planner_outputs import (
     ChargeWindow,
     DischargeWindow,
+    PlanExplanation,
     PlannedSlot,
     PlannerOutput,
+    RejectedPlan,
 )
 from custom_components.hsem.planner.charge_scheduler import (
     apply_charge_schedules,
@@ -254,6 +256,9 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
     # Derive contiguous charge/discharge windows
     charge_windows, discharge_windows = _derive_windows(slots)
 
+    # Build human-readable plan explanation
+    explanation = _build_explanation(inp, slots, battery_soc_at_end, now)
+
     return PlannerOutput(
         slots=slots,
         charge_windows=charge_windows,
@@ -264,6 +269,7 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
         missing_inputs=missing_inputs,
         warnings=warnings,
         time_series_index=tsi,
+        explanation=explanation,
     )
 
 
@@ -360,3 +366,201 @@ def _derive_windows(
         _flush_discharge(current_discharge_group)
 
     return charge_windows, discharge_windows
+
+
+def _build_explanation(
+    inp: PlannerInput,
+    slots: list[PlannedSlot],
+    battery_soc_at_end: float,
+    now: datetime,
+) -> PlanExplanation:
+    """Build a human-readable explanation of the chosen plan.
+
+    Derives key metrics from the finalised slot list, identifies which strategy
+    was selected, lists active constraints, and constructs rejected-plan entries
+    describing what alternatives would have looked like.
+
+    Args:
+        inp: The planner inputs used in this run.
+        slots: The fully-populated slot list after all scheduling passes.
+        battery_soc_at_end: Estimated battery SoC (%) at the end of horizon.
+        now: Timezone-aware current datetime.
+
+    Returns:
+        A populated :class:`PlanExplanation` instance.
+    """
+    future_slots = [s for s in slots if s.end.astimezone(now.tzinfo) > now]
+
+    # --- Price metrics ---------------------------------------------------
+    import_prices = [s.price.import_price for s in future_slots]
+    export_prices = [s.price.export_price for s in future_slots]
+    peak_import = max(import_prices) if import_prices else 0.0
+    off_peak_import = min(import_prices) if import_prices else 0.0
+    price_spread = round(peak_import - off_peak_import, 4)
+
+    # --- Forecast metrics ------------------------------------------------
+    forecast_pv = round(sum(s.solcast_pv_estimate for s in future_slots), 3)
+    forecast_net = round(sum(s.estimated_net_consumption for s in future_slots), 3)
+
+    # --- Cost of the selected plan ---------------------------------------
+    selected_cost = round(sum(s.estimated_cost for s in future_slots), 4)
+
+    # --- Strategy detection ----------------------------------------------
+    has_grid_charge = any(
+        s.recommendation == Recommendations.BatteriesChargeGrid.value
+        for s in future_slots
+    )
+    has_solar_charge = any(
+        s.recommendation == Recommendations.BatteriesChargeSolar.value
+        for s in future_slots
+    )
+    has_discharge = any(
+        s.recommendation
+        in {
+            Recommendations.BatteriesDischargeMode.value,
+            Recommendations.ForceBatteriesDischarge.value,
+        }
+        for s in future_slots
+    )
+    has_force_export = any(
+        s.recommendation == Recommendations.ForceBatteriesDischarge.value
+        for s in future_slots
+    )
+    has_force_mode = any(
+        s.recommendation == Recommendations.ForceExport.value for s in future_slots
+    )
+
+    current_month = now.month
+    is_winter = current_month in inp.months_winter
+
+    if has_grid_charge and has_discharge:
+        selected_strategy = "charge_grid_discharge_peak"
+        summary = (
+            f"Battery will be charged from the grid during cheap hours "
+            f"(min {off_peak_import:.3f}) and discharged during peak hours "
+            f"(max {peak_import:.3f})."
+        )
+    elif has_solar_charge and has_discharge:
+        selected_strategy = "charge_solar_discharge_peak"
+        summary = (
+            f"Battery will be charged from solar surplus "
+            f"({forecast_pv:.1f} kWh forecast) and discharged during "
+            f"peak hours (max {peak_import:.3f})."
+        )
+    elif has_force_export:
+        selected_strategy = "force_export"
+        summary = (
+            f"Surplus battery capacity will be exported to the grid at "
+            f"high export prices (max {max(export_prices):.3f})."
+        )
+    elif has_force_mode:
+        selected_strategy = "force_export_pv"
+        summary = "Export price exceeds import price; PV surplus exported."
+    elif has_discharge and not has_grid_charge and not has_solar_charge:
+        selected_strategy = "discharge_only"
+        summary = (
+            f"Battery will be discharged during scheduled windows; "
+            f"no cheap charging slots available (spread {price_spread:.3f})."
+        )
+    elif is_winter:
+        selected_strategy = "winter_wait"
+        summary = (
+            f"Winter month ({current_month}): battery is held in reserve; "
+            f"no arbitrage or solar charging warranted."
+        )
+    else:
+        selected_strategy = "solar_charge_only"
+        summary = (
+            f"Summer month ({current_month}): charging from solar surplus only "
+            f"({forecast_pv:.1f} kWh forecast)."
+        )
+
+    # --- Active constraints ----------------------------------------------
+    constraints: list[str] = []
+    if is_winter:
+        constraints.append("winter_month")
+    else:
+        constraints.append("summer_month")
+    if abs(price_spread) < 1e-9:
+        constraints.append("no_price_spread")
+    if inp.excess_export_enabled:
+        constraints.append("excess_export_enabled")
+    if inp.battery_rated_capacity_kwh <= 0:
+        constraints.append("battery_disabled")
+    if inp.battery_soc_pct >= inp.battery_max_soc_pct:
+        constraints.append("battery_full")
+    if inp.battery_soc_pct <= inp.battery_end_of_discharge_soc_pct:
+        constraints.append("battery_empty")
+
+    # --- Rejected plans -------------------------------------------------
+    rejected: list[RejectedPlan] = []
+
+    # Alternative: do-nothing (battery idle for the whole horizon)
+    do_nothing_cost = round(
+        sum(s.estimated_net_consumption * s.price.import_price for s in future_slots),
+        4,
+    )
+    if selected_strategy != "discharge_only":
+        rejected.append(
+            RejectedPlan(
+                name="do_nothing",
+                reason=(
+                    "Battery held idle; estimated grid cost "
+                    f"{do_nothing_cost:.4f} vs selected {selected_cost:.4f}."
+                ),
+                estimated_cost=do_nothing_cost,
+            )
+        )
+
+    # Alternative: charge-only (no discharge), relevant when discharge was chosen
+    if has_discharge and not has_grid_charge:
+        rejected.append(
+            RejectedPlan(
+                name="charge_only_solar",
+                reason=(
+                    "Charging from solar without discharging would leave "
+                    f"{forecast_pv:.1f} kWh of PV unused during peak demand."
+                ),
+                estimated_cost=do_nothing_cost,
+            )
+        )
+
+    # Alternative: grid charge skipped when price spread too small
+    if not has_grid_charge and price_spread > 0:
+        min_diff_values = [
+            s.min_price_difference
+            for s in inp.battery_schedules
+            if s.enabled and abs(s.min_price_difference) > 1e-9
+        ]
+        min_diff = min(min_diff_values) if min_diff_values else 0.0
+        if price_spread < min_diff:
+            rejected.append(
+                RejectedPlan(
+                    name="grid_charge_rejected_spread",
+                    reason=(
+                        f"Price spread {price_spread:.4f} is below the minimum "
+                        f"required difference {min_diff:.4f}; grid charging "
+                        "not profitable."
+                    ),
+                    estimated_cost=do_nothing_cost,
+                )
+            )
+
+    # Score: negate the estimated cost so cheaper = higher score
+    score = round(-selected_cost, 4)
+
+    return PlanExplanation(
+        selected_strategy=selected_strategy,
+        summary=summary,
+        score=score,
+        estimated_total_cost=selected_cost,
+        price_spread=price_spread,
+        peak_import_price=round(peak_import, 4),
+        off_peak_import_price=round(off_peak_import, 4),
+        forecast_pv_kwh=forecast_pv,
+        forecast_net_consumption_kwh=forecast_net,
+        battery_soc_pct=round(inp.battery_soc_pct, 1),
+        battery_soc_at_end_pct=round(battery_soc_at_end, 1),
+        constraints=constraints,
+        rejected_plans=rejected,
+    )

--- a/custom_components/hsem/sensor.py
+++ b/custom_components/hsem/sensor.py
@@ -35,6 +35,9 @@ from custom_components.hsem.custom_sensors.net_consumption_sensor import (
 from custom_components.hsem.custom_sensors.next_update_sensor import (
     HSEMNextUpdateSensor,
 )
+from custom_components.hsem.custom_sensors.plan_explanation_sensor import (
+    HSEMPlanExplanationSensor,
+)
 from custom_components.hsem.custom_sensors.read_only_sensor import HSEMReadOnlySensor
 from custom_components.hsem.custom_sensors.recommendation_interval_sensor import (
     HSEMRecommendationIntervalSensor,
@@ -81,6 +84,9 @@ async def async_setup_entry(
     # Applier-status sensor — exposes write-and-verify results per cycle.
     applier_status_sensor = HSEMApplierStatusSensor(config_entry, coordinator)
 
+    # Plan-explanation sensor — exposes the active planner strategy and score.
+    plan_explanation_sensor = HSEMPlanExplanationSensor(config_entry, coordinator)
+
     async_add_entities(
         [
             degraded_mode_sensor,
@@ -96,6 +102,7 @@ async def async_setup_entry(
             force_mode_sensor,
             ev_charging_sensor,
             applier_status_sensor,
+            plan_explanation_sensor,
             working_mode_sensor,
         ]
     )

--- a/custom_components/hsem/utils/recommendations.py
+++ b/custom_components/hsem/utils/recommendations.py
@@ -18,5 +18,4 @@ class Recommendations(Enum):
     EVSmartCharging = "ev_smart_charging"
     ForceBatteriesDischarge = "force_batteries_discharge"
     ForceExport = "force_export"
-    FullyFedToGrid = "fully_fed_to_grid"
     MissingInputEntities = "missing_input_entities"

--- a/custom_components/hsem/utils/sensornames.py
+++ b/custom_components/hsem/utils/sensornames.py
@@ -450,6 +450,22 @@ def get_ev_charging_sensor_entity_id() -> str:
     return sensor.ENTITY_ID_FORMAT.format(s(f"{DOMAIN}_ev_charging_sensor"))
 
 
+# Plan Explanation Sensor
+def get_plan_explanation_sensor_name() -> str:
+    """Return the display name for the plan-explanation diagnostic sensor."""
+    return "Plan Strategy"
+
+
+def get_plan_explanation_sensor_unique_id() -> str:
+    """Return a unique ID for the plan-explanation sensor."""
+    return f"{DOMAIN}_plan_explanation_sensor"
+
+
+def get_plan_explanation_sensor_entity_id() -> str:
+    """Return the entity_id for the plan-explanation sensor."""
+    return sensor.ENTITY_ID_FORMAT.format(s(f"{DOMAIN}_plan_explanation_sensor"))
+
+
 # Applier Status Sensor
 def get_applier_status_sensor_name() -> str:
     """Return the display name for the applier-status diagnostic sensor."""

--- a/tests/planner/test_plan_explanation.py
+++ b/tests/planner/test_plan_explanation.py
@@ -116,13 +116,13 @@ class TestPlanExplanationDataclass:
     def test_as_dict_values_are_rounded(self):
         """Floating-point values in as_dict() are rounded to avoid precision noise."""
         exp = PlanExplanation(
-            score=-1.23456789,
+            score=1.23456789,
             estimated_total_cost=1.23456789,
             price_spread=0.123456789,
             forecast_pv_kwh=5.123456789,
         )
         d = exp.as_dict()
-        assert d["score"] == pytest.approx(-1.2346, abs=1e-4)
+        assert d["score"] == pytest.approx(1.2346, abs=1e-4)
         assert d["estimated_total_cost"] == pytest.approx(1.2346, abs=1e-4)
         assert d["price_spread"] == pytest.approx(0.1235, abs=1e-4)
         assert d["forecast_pv_kwh"] == pytest.approx(5.123, abs=1e-3)
@@ -158,11 +158,24 @@ class TestPlannerOutputHasExplanation:
         assert output.explanation.summary
         assert len(output.explanation.summary) > 10
 
-    def test_score_equals_negated_cost(self):
-        """score must equal -estimated_total_cost."""
+    def test_score_is_savings_vs_do_nothing(self):
+        """score must equal do_nothing_cost minus estimated_total_cost.
+
+        A positive score means the selected plan is cheaper than idle;
+        a negative score means charging overhead exceeds discharge savings
+        within the planning window.
+        """
         output = run_planner(make_summer_day_input())
         exp = output.explanation
-        assert exp.score == pytest.approx(-exp.estimated_total_cost, abs=1e-4)
+        # The do_nothing rejected plan carries the baseline cost.
+        do_nothing = next(
+            (rp for rp in exp.rejected_plans if rp.name == "do_nothing"), None
+        )
+        if do_nothing is not None:
+            expected_score = round(
+                do_nothing.estimated_cost - exp.estimated_total_cost, 4
+            )
+            assert exp.score == pytest.approx(expected_score, abs=1e-3)
 
     def test_constraints_is_list(self):
         """constraints must be a list (possibly empty but always present)."""

--- a/tests/planner/test_plan_explanation.py
+++ b/tests/planner/test_plan_explanation.py
@@ -1,0 +1,304 @@
+"""Tests for the HSEM planner plan explanation output (issue #304).
+
+Acceptance criteria verified here
+----------------------------------
+- ``PlannerOutput.explanation`` is populated after every ``run_planner`` call.
+- ``explanation.selected_strategy`` is a non-empty string.
+- ``explanation.summary`` is a human-readable sentence.
+- ``explanation.score`` equals the negated estimated total cost.
+- ``explanation.rejected_plans`` is a list of :class:`RejectedPlan` objects
+  each with a ``name`` and a ``reason`` string.
+- ``explanation.constraints`` lists active constraint flags.
+- ``PlanExplanation.as_dict()`` returns a JSON-safe dict with the correct keys.
+- Simple fixture scenarios (summer, winter, no-battery) produce the correct
+  ``selected_strategy`` value.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.hsem.models.planner_outputs import (
+    PlanExplanation,
+    PlannerOutput,
+    RejectedPlan,
+)
+from custom_components.hsem.planner import run_planner
+from tests.planner.fixtures import (
+    make_flat_price_input,
+    make_summer_day_input,
+    make_winter_day_input,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_EXPECTED_EXPLANATION_KEYS = {
+    "selected_strategy",
+    "summary",
+    "score",
+    "estimated_total_cost",
+    "price_spread",
+    "peak_import_price",
+    "off_peak_import_price",
+    "forecast_pv_kwh",
+    "forecast_net_consumption_kwh",
+    "battery_soc_pct",
+    "battery_soc_at_end_pct",
+    "constraints",
+    "rejected_plans",
+}
+
+
+# ===========================================================================
+# 1. PlanExplanation dataclass unit tests
+# ===========================================================================
+
+
+class TestPlanExplanationDataclass:
+    """PlanExplanation and RejectedPlan dataclasses behave correctly."""
+
+    def test_default_construction(self):
+        """PlanExplanation can be created with no arguments."""
+        exp = PlanExplanation()
+        assert exp.selected_strategy == "unknown"
+        assert exp.summary == ""
+        assert exp.constraints == []
+        assert exp.rejected_plans == []
+        assert isinstance(exp.score, float)
+
+    def test_rejected_plan_fields(self):
+        """RejectedPlan stores name, reason, and estimated_cost."""
+        rp = RejectedPlan(
+            name="do_nothing",
+            reason="Battery idle would cost 1.23.",
+            estimated_cost=1.23,
+        )
+        assert rp.name == "do_nothing"
+        assert "idle" in rp.reason
+        assert rp.estimated_cost == pytest.approx(1.23)
+
+    def test_as_dict_returns_all_keys(self):
+        """as_dict() must contain every expected top-level key."""
+        exp = PlanExplanation(
+            selected_strategy="winter_wait",
+            summary="Winter: battery held in reserve.",
+            score=-0.5,
+            estimated_total_cost=0.5,
+            price_spread=0.1,
+            peak_import_price=0.45,
+            off_peak_import_price=0.08,
+            forecast_pv_kwh=0.5,
+            forecast_net_consumption_kwh=10.0,
+            battery_soc_pct=80.0,
+            battery_soc_at_end_pct=70.0,
+            constraints=["winter_month"],
+            rejected_plans=[RejectedPlan("do_nothing", "Would cost more.", 0.9)],
+        )
+        result = exp.as_dict()
+        assert set(result.keys()) == _EXPECTED_EXPLANATION_KEYS
+
+    def test_as_dict_rejected_plans_serialised(self):
+        """rejected_plans in as_dict() contains dicts with name/reason/cost."""
+        exp = PlanExplanation(
+            rejected_plans=[
+                RejectedPlan("grid_charge_rejected_spread", "Spread too small.", 2.0)
+            ]
+        )
+        d = exp.as_dict()
+        assert len(d["rejected_plans"]) == 1
+        rp_dict = d["rejected_plans"][0]
+        assert rp_dict["name"] == "grid_charge_rejected_spread"
+        assert isinstance(rp_dict["reason"], str)
+        assert isinstance(rp_dict["estimated_cost"], float)
+
+    def test_as_dict_values_are_rounded(self):
+        """Floating-point values in as_dict() are rounded to avoid precision noise."""
+        exp = PlanExplanation(
+            score=-1.23456789,
+            estimated_total_cost=1.23456789,
+            price_spread=0.123456789,
+            forecast_pv_kwh=5.123456789,
+        )
+        d = exp.as_dict()
+        assert d["score"] == pytest.approx(-1.2346, abs=1e-4)
+        assert d["estimated_total_cost"] == pytest.approx(1.2346, abs=1e-4)
+        assert d["price_spread"] == pytest.approx(0.1235, abs=1e-4)
+        assert d["forecast_pv_kwh"] == pytest.approx(5.123, abs=1e-3)
+
+
+# ===========================================================================
+# 2. PlannerOutput integration tests
+# ===========================================================================
+
+
+class TestPlannerOutputHasExplanation:
+    """run_planner always returns a PlannerOutput with a valid explanation."""
+
+    def test_explanation_is_present(self):
+        """explanation field must be a PlanExplanation instance."""
+        output = run_planner(make_summer_day_input())
+        assert isinstance(output.explanation, PlanExplanation)
+
+    def test_explanation_present_on_empty_output(self):
+        """Even a minimal no-slot output must carry a default explanation."""
+        output = PlannerOutput()
+        assert isinstance(output.explanation, PlanExplanation)
+
+    def test_selected_strategy_is_non_empty(self):
+        """selected_strategy must be a non-empty string after a normal run."""
+        output = run_planner(make_summer_day_input())
+        assert output.explanation.selected_strategy
+        assert isinstance(output.explanation.selected_strategy, str)
+
+    def test_summary_is_non_empty(self):
+        """summary must be a human-readable non-empty string."""
+        output = run_planner(make_summer_day_input())
+        assert output.explanation.summary
+        assert len(output.explanation.summary) > 10
+
+    def test_score_equals_negated_cost(self):
+        """score must equal -estimated_total_cost."""
+        output = run_planner(make_summer_day_input())
+        exp = output.explanation
+        assert exp.score == pytest.approx(-exp.estimated_total_cost, abs=1e-4)
+
+    def test_constraints_is_list(self):
+        """constraints must be a list (possibly empty but always present)."""
+        output = run_planner(make_summer_day_input())
+        assert isinstance(output.explanation.constraints, list)
+
+    def test_rejected_plans_is_list(self):
+        """rejected_plans must be a list of RejectedPlan objects."""
+        output = run_planner(make_summer_day_input())
+        assert isinstance(output.explanation.rejected_plans, list)
+        for rp in output.explanation.rejected_plans:
+            assert isinstance(rp, RejectedPlan)
+            assert rp.name
+            assert rp.reason
+
+    def test_price_spread_non_negative(self):
+        """price_spread is peak_import minus off_peak_import, so always ≥ 0."""
+        output = run_planner(make_summer_day_input())
+        assert output.explanation.price_spread >= 0.0
+
+    def test_forecast_pv_kwh_non_negative(self):
+        """forecast_pv_kwh is total PV production forecast, always ≥ 0."""
+        output = run_planner(make_summer_day_input())
+        assert output.explanation.forecast_pv_kwh >= 0.0
+
+    def test_battery_soc_pct_matches_input(self):
+        """battery_soc_pct must equal the input battery_soc_pct."""
+        inp = make_summer_day_input(battery_soc_pct=65.0)
+        output = run_planner(inp)
+        assert output.explanation.battery_soc_pct == pytest.approx(65.0, abs=0.1)
+
+    def test_as_dict_complete(self):
+        """as_dict() on the planner output explanation has all required keys."""
+        output = run_planner(make_summer_day_input())
+        d = output.explanation.as_dict()
+        assert set(d.keys()) == _EXPECTED_EXPLANATION_KEYS
+
+
+# ===========================================================================
+# 3. Strategy-specific tests
+# ===========================================================================
+
+
+class TestStrategyDetection:
+    """The correct selected_strategy is chosen for different scenarios."""
+
+    def test_summer_day_uses_charge_or_solar_strategy(self):
+        """Summer fixture has schedules + solar, so a charge/discharge or solar strategy is chosen."""
+        output = run_planner(make_summer_day_input())
+        valid_strategies = {
+            "charge_grid_discharge_peak",
+            "charge_solar_discharge_peak",
+            "solar_charge_only",
+            "discharge_only",
+            "force_export",
+            "force_export_pv",
+        }
+        assert output.explanation.selected_strategy in valid_strategies
+
+    def test_winter_day_reports_winter_constraint(self):
+        """Winter fixture must include 'winter_month' in constraints."""
+        output = run_planner(make_winter_day_input())
+        assert "winter_month" in output.explanation.constraints
+
+    def test_summer_day_reports_summer_constraint(self):
+        """Summer fixture (June) must include 'summer_month' in constraints."""
+        output = run_planner(make_summer_day_input())
+        assert "summer_month" in output.explanation.constraints
+
+    def test_flat_price_reports_no_spread_constraint(self):
+        """Flat-price fixture has zero price spread; 'no_price_spread' in constraints."""
+        output = run_planner(make_flat_price_input())
+        # Price spread should be near zero
+        assert output.explanation.price_spread == pytest.approx(0.0, abs=1e-4)
+        assert "no_price_spread" in output.explanation.constraints
+
+    def test_winter_day_strategy(self):
+        """Winter fixture without schedules should select a winter/wait strategy."""
+        inp = make_winter_day_input(schedules=[])
+        output = run_planner(inp)
+        valid_winter_strategies = {
+            "winter_wait",
+            "discharge_only",
+            "charge_grid_discharge_peak",
+            "charge_solar_discharge_peak",
+            "solar_charge_only",
+            "force_export",
+            "force_export_pv",
+        }
+        assert output.explanation.selected_strategy in valid_winter_strategies
+
+    def test_battery_disabled_reports_constraint(self):
+        """Zero-capacity battery should add 'battery_disabled' to constraints."""
+        inp = make_summer_day_input(battery_rated_capacity_kwh=0.0)
+        output = run_planner(inp)
+        assert "battery_disabled" in output.explanation.constraints
+
+    def test_full_battery_reports_constraint(self):
+        """Battery at 100 % SoC should add 'battery_full' to constraints."""
+        inp = make_summer_day_input(battery_soc_pct=100.0)
+        output = run_planner(inp)
+        assert "battery_full" in output.explanation.constraints
+
+
+# ===========================================================================
+# 4. Rejected-plan content tests
+# ===========================================================================
+
+
+class TestRejectedPlans:
+    """Rejected plans contain meaningful names and reasons."""
+
+    def test_do_nothing_always_present(self):
+        """'do_nothing' alternative should appear in rejected plans for all
+        scenarios that do not themselves select 'discharge_only'."""
+        output = run_planner(make_summer_day_input())
+        if output.explanation.selected_strategy != "discharge_only":
+            names = [rp.name for rp in output.explanation.rejected_plans]
+            assert "do_nothing" in names
+
+    def test_rejected_plan_has_reason(self):
+        """Every rejected plan must have a non-empty reason string."""
+        output = run_planner(make_summer_day_input())
+        for rp in output.explanation.rejected_plans:
+            assert rp.reason, f"RejectedPlan '{rp.name}' has empty reason"
+
+    def test_rejected_plan_cost_is_float(self):
+        """estimated_cost on every rejected plan must be a float."""
+        output = run_planner(make_summer_day_input())
+        for rp in output.explanation.rejected_plans:
+            assert isinstance(rp.estimated_cost, float)
+
+    def test_winter_do_nothing_always_present(self):
+        """Winter scenario: 'do_nothing' rejected plan present when strategy
+        is not 'discharge_only'."""
+        output = run_planner(make_winter_day_input())
+        if output.explanation.selected_strategy != "discharge_only":
+            names = [rp.name for rp in output.explanation.rejected_plans]
+            assert "do_nothing" in names

--- a/tests/sensors/test_plan_explanation_sensor.py
+++ b/tests/sensors/test_plan_explanation_sensor.py
@@ -1,0 +1,249 @@
+"""Tests for the HSEMPlanExplanationSensor diagnostic sensor.
+
+Acceptance criteria
+-------------------
+- ``state`` returns ``selected_strategy`` from ``CoordinatorData.plan_explanation``.
+- ``state`` returns ``"unknown"`` when the coordinator has no data yet.
+- ``state`` falls back to the restored state before the first coordinator cycle.
+- ``extra_state_attributes`` returns all keys from ``PlanExplanation.as_dict()``.
+- ``extra_state_attributes`` values are correct for a known explanation.
+- ``available`` is False before the first cycle and True after.
+- The sensor is wired as a diagnostic entity category.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.const import EntityCategory
+
+from custom_components.hsem.coordinator import CoordinatorData
+from custom_components.hsem.custom_sensors.plan_explanation_sensor import (
+    HSEMPlanExplanationSensor,
+)
+from custom_components.hsem.models.planner_outputs import PlanExplanation, RejectedPlan
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_EXPECTED_ATTR_KEYS = {
+    "selected_strategy",
+    "summary",
+    "score",
+    "estimated_total_cost",
+    "price_spread",
+    "peak_import_price",
+    "off_peak_import_price",
+    "forecast_pv_kwh",
+    "forecast_net_consumption_kwh",
+    "battery_soc_pct",
+    "battery_soc_at_end_pct",
+    "constraints",
+    "rejected_plans",
+}
+
+
+def _make_explanation(**kwargs) -> PlanExplanation:
+    """Return a PlanExplanation with sensible defaults overridable by kwargs."""
+    defaults = dict(
+        selected_strategy="charge_grid_discharge_peak",
+        summary="Battery charged from grid and discharged at peak.",
+        score=0.45,
+        estimated_total_cost=1.20,
+        price_spread=0.27,
+        peak_import_price=0.32,
+        off_peak_import_price=0.05,
+        forecast_pv_kwh=18.3,
+        forecast_net_consumption_kwh=7.4,
+        battery_soc_pct=50.0,
+        battery_soc_at_end_pct=20.0,
+        constraints=["summer_month"],
+        rejected_plans=[RejectedPlan("do_nothing", "Costs more idle.", 1.65)],
+    )
+    defaults.update(kwargs)
+    return PlanExplanation(**defaults)
+
+
+def _make_coordinator_data(
+    explanation: PlanExplanation | None = None,
+) -> CoordinatorData:
+    """Return a minimal CoordinatorData carrying a plan explanation."""
+    return CoordinatorData(plan_explanation=explanation or _make_explanation())
+
+
+def _make_sensor(data: CoordinatorData | None = None) -> HSEMPlanExplanationSensor:
+    """Return a bare HSEMPlanExplanationSensor wired to a mock coordinator."""
+    coordinator = MagicMock()
+    coordinator.data = data
+    coordinator.last_update_success = data is not None
+
+    config_entry = MagicMock()
+
+    sensor = object.__new__(HSEMPlanExplanationSensor)
+    # Minimal attribute injection — bypasses __init__ CoordinatorEntity plumbing.
+    sensor.coordinator = coordinator
+    sensor._config_entry = config_entry
+    sensor._attr_unique_id = "hsem_plan_explanation_sensor"
+    sensor.entity_id = "sensor.hsem_plan_explanation_sensor"
+    sensor._name = "Plan Strategy"
+    sensor._restored_state = None
+    return sensor
+
+
+# ===========================================================================
+# 1. Entity metadata
+# ===========================================================================
+
+
+class TestEntityMetadata:
+    """The sensor has the correct HA entity metadata."""
+
+    def test_sensor_is_diagnostic_entity(self):
+        """entity_category must resolve to DIAGNOSTIC on an instantiated sensor."""
+        sensor = _make_sensor(_make_coordinator_data())
+        cat = getattr(sensor, "entity_category", None) or getattr(
+            sensor, "_attr_entity_category", None
+        )
+        assert cat is EntityCategory.DIAGNOSTIC
+
+
+# ===========================================================================
+# 2. State
+# ===========================================================================
+
+
+class TestSensorState:
+    """state property returns the correct value in all scenarios."""
+
+    def test_state_returns_selected_strategy(self):
+        """state must equal explanation.selected_strategy when data is present."""
+        sensor = _make_sensor(_make_coordinator_data())
+        assert sensor.state == "charge_grid_discharge_peak"
+
+    def test_state_unknown_when_no_coordinator_data(self):
+        """state must return 'unknown' before the first cycle."""
+        sensor = _make_sensor(data=None)
+        assert sensor.state == "unknown"
+
+    def test_state_falls_back_to_restored_state(self):
+        """state uses _restored_state when coordinator.data is None."""
+        sensor = _make_sensor(data=None)
+        sensor._restored_state = "winter_wait"
+        assert sensor.state == "winter_wait"
+
+    def test_state_prefers_live_over_restored(self):
+        """When coordinator.data is available, live data takes priority."""
+        sensor = _make_sensor(
+            _make_coordinator_data(
+                _make_explanation(selected_strategy="solar_charge_only")
+            )
+        )
+        sensor._restored_state = "old_strategy"
+        assert sensor.state == "solar_charge_only"
+
+    def test_state_unknown_strategy_fallback(self):
+        """Empty selected_strategy string returns 'unknown'."""
+        sensor = _make_sensor(
+            _make_coordinator_data(_make_explanation(selected_strategy=""))
+        )
+        assert sensor.state == "unknown"
+
+    @pytest.mark.parametrize(
+        "strategy",
+        [
+            "charge_grid_discharge_peak",
+            "charge_solar_discharge_peak",
+            "opportunistic_charge",
+            "force_export",
+            "force_export_pv",
+            "discharge_only",
+            "winter_wait",
+            "solar_charge_only",
+        ],
+    )
+    def test_state_for_all_known_strategies(self, strategy: str):
+        """All known strategy values round-trip correctly through state."""
+        sensor = _make_sensor(
+            _make_coordinator_data(_make_explanation(selected_strategy=strategy))
+        )
+        assert sensor.state == strategy
+
+
+# ===========================================================================
+# 3. Availability
+# ===========================================================================
+
+
+class TestSensorAvailability:
+    """available property is correct in all states."""
+
+    def test_available_when_coordinator_has_data(self):
+        """available is True when coordinator has data and last_update_success."""
+        sensor = _make_sensor(_make_coordinator_data())
+        assert sensor.available is True
+
+    def test_not_available_when_no_data(self):
+        """available is False when coordinator.data is None and no restored state."""
+        sensor = _make_sensor(data=None)
+        assert sensor.available is False
+
+    def test_available_via_restored_state(self):
+        """available is True when _restored_state is set (HA restart scenario)."""
+        sensor = _make_sensor(data=None)
+        sensor._restored_state = "winter_wait"
+        assert sensor.available is True
+
+
+# ===========================================================================
+# 4. Extra state attributes
+# ===========================================================================
+
+
+class TestSensorAttributes:
+    """extra_state_attributes returns the correct keys and values."""
+
+    def test_all_expected_keys_present(self):
+        """Attributes must contain every expected key from PlanExplanation."""
+        sensor = _make_sensor(_make_coordinator_data())
+        assert set(sensor.extra_state_attributes.keys()) == _EXPECTED_ATTR_KEYS
+
+    def test_score_value_matches_explanation(self):
+        """score attribute must match the explanation score."""
+        exp = _make_explanation(score=1.2345)
+        sensor = _make_sensor(_make_coordinator_data(exp))
+        assert sensor.extra_state_attributes["score"] == pytest.approx(1.2345, abs=1e-3)
+
+    def test_constraints_is_list(self):
+        """constraints attribute must be a list."""
+        sensor = _make_sensor(_make_coordinator_data())
+        assert isinstance(sensor.extra_state_attributes["constraints"], list)
+
+    def test_rejected_plans_is_list_of_dicts(self):
+        """rejected_plans attribute must be a list of dicts with name/reason/cost."""
+        sensor = _make_sensor(_make_coordinator_data())
+        plans = sensor.extra_state_attributes["rejected_plans"]
+        assert isinstance(plans, list)
+        assert len(plans) == 1
+        assert {"name", "reason", "estimated_cost"} <= set(plans[0].keys())
+
+    def test_attributes_when_no_data(self):
+        """Attributes fall back to a default PlanExplanation when no coordinator data."""
+        sensor = _make_sensor(data=None)
+        attrs = sensor.extra_state_attributes
+        assert set(attrs.keys()) == _EXPECTED_ATTR_KEYS
+        assert attrs["selected_strategy"] == "unknown"
+
+    def test_price_spread_rounded(self):
+        """price_spread is rounded to 4 decimal places."""
+        exp = _make_explanation(price_spread=0.123456789)
+        sensor = _make_sensor(_make_coordinator_data(exp))
+        spread = sensor.extra_state_attributes["price_spread"]
+        # as_dict() rounds to 4dp
+        assert spread == pytest.approx(0.1235, abs=1e-4)
+
+    def test_forecast_pv_kwh_non_negative(self):
+        """forecast_pv_kwh attribute must be non-negative."""
+        sensor = _make_sensor(_make_coordinator_data())
+        assert sensor.extra_state_attributes["forecast_pv_kwh"] >= 0.0

--- a/tests/test_ha_mock_integration.py
+++ b/tests/test_ha_mock_integration.py
@@ -221,6 +221,10 @@ def make_bare_coordinator(
     coord._current_required_battery = 0.0
     coord._live = None
 
+    from custom_components.hsem.models.planner_outputs import PlanExplanation
+
+    coord._plan_explanation = PlanExplanation()
+
     from custom_components.hsem.custom_sensors.config_reader import build_sensor_config
 
     coord._cfg = build_sensor_config(config_entry)


### PR DESCRIPTION
## Summary

Adds a human-readable plan explanation to the HSEM planner and exposes it as a dedicated `sensor.hsem_plan_explanation_sensor` diagnostic entity.  The PR also fixes six gaps identified between the README feature claims and the actual planner implementation.

Fixes #304

---

## What changed

### New sensor � `sensor.hsem_plan_explanation_sensor`

A dedicated diagnostic sensor whose **state is the active planner strategy** and whose attributes expose every field of `PlanExplanation` as flat, individually templateable key-value pairs.

| Field | Description |
|---|---|
| **state** | `selected_strategy` string (e.g. `charge_grid_discharge_peak`) |
| `score` | Estimated savings vs doing nothing (positive = plan saves money) |
| `estimated_total_cost` | Net grid cost for the planning horizon |
| `price_spread` | Peak minus off-peak import price |
| `peak_import_price` / `off_peak_import_price` | Price range |
| `forecast_pv_kwh` / `forecast_net_consumption_kwh` | Solcast / load summary |
| `battery_soc_pct` / `battery_soc_at_end_pct` | Current and projected SoC |
| `constraints` | Active flags: `winter_month`, `battery_full`, `excess_export_enabled`, `battery_low_at_end`, � |
| `rejected_plans` | Alternatives with `name`, `reason`, `estimated_cost` |

HA template examples:
```yaml
{{ states('sensor.hsem_plan_explanation_sensor') }}
{{ state_attr('sensor.hsem_plan_explanation_sensor', 'score') | round(2) }}
{{ state_attr('sensor.hsem_plan_explanation_sensor', 'constraints') | join(', ') }}
```

`plan_explanation` was removed from `working_mode_sensor` attributes � it now lives entirely in its own sensor.

---

### Planner fixes (six README gaps closed)

**A2 / H28 / H29 � Opportunistic grid charge independent of schedules**
New `apply_opportunistic_charge()` in `charge_scheduler.py` charges the battery from the grid when import prices are negative or below the depreciation threshold, even when no discharge schedule is configured.  Previously `BatteriesChargeGrid` was only emitted as pre-charge for an active schedule window.

**A3 � `ForceExport` respects `export_min_price`**
`apply_optimization_strategy()` gains an `export_min_price=` kwarg.  Slots where `export_price > import_price` but `export_price < export_min_price` are no longer marked `ForceExport`.  Previously the threshold was applied only in the applier for inverter power control, not for slot-level recommendation assignment.

**C13 � Depreciation threshold auto-fills `min_price_difference = 0` schedules**
`engine.py` uses `calculate_recommended_threshold()` to compute the minimum economically justified price delta and silently fills any `BatteryScheduleInput.min_price_difference == 0` before calling `apply_charge_schedules()`.  Previously the threshold was advisory-only and never used by the planner.

**D16 � Accurate solar-vs-grid source tracking for excess export**
`apply_excess_export()` now sums `batteries_charged` by recommendation type to derive actual `solar_charged_kwh` vs `grid_charged_kwh`.  `battery_is_solar_charged` is `True` only when solar accounts for > 50 % of total planned charging.  Previously a coarse boolean (`any slot is solar-charged?`) could bypass the price threshold incorrectly in mixed-charge scenarios.

**H35 � `FullyFedToGrid` removed from `Recommendations` enum**
`FullyFedToGrid = "fully_fed_to_grid"` was defined in `Recommendations` but never emitted by the planner (`ForceExport` was always used).  It is removed to prevent confusion.  `WorkingModes.FullyFedToGrid` (the hardware mode) is unchanged.  The applier's excess-PV-use check is updated to compare against `Recommendations.ForceExport.value`.

---

### Score semantics fix
`score` is defined as `do_nothing_cost - selected_cost` (savings vs idle battery), not `-estimated_total_cost`.  The `do_nothing` baseline uses `max(net_consumption, 0) � import_price` so solar-surplus slots do not distort the comparison.  Rejection reasons distinguish: plan saves money / charging overhead exceeds savings / approximately equal.

---

### Files changed

| File | Change |
|---|---|
| `custom_components/hsem/models/planner_outputs.py` | `RejectedPlan` + `PlanExplanation` dataclasses; `PlannerOutput.explanation` field |
| `custom_components/hsem/planner/engine.py` | `_build_explanation()`; opportunistic charge call; `export_min_price` forwarded; depreciation auto-fill |
| `custom_components/hsem/planner/charge_scheduler.py` | `apply_opportunistic_charge()`; `export_min_price` guard in `apply_optimization_strategy()`; solar/grid kWh tracking in `apply_excess_export()` |
| `custom_components/hsem/coordinator.py` | `plan_explanation` field on `CoordinatorData`; stored and passed through each cycle |
| `custom_components/hsem/utils/recommendations.py` | `FullyFedToGrid` removed |
| `custom_components/hsem/custom_sensors/applier.py` | Excess-PV check updated to use `ForceExport` |
| `custom_components/hsem/custom_sensors/plan_explanation_sensor.py` | New diagnostic sensor |
| `custom_components/hsem/utils/sensornames.py` | Name / unique-id / entity-id helpers for new sensor |
| `custom_components/hsem/sensor.py` | New sensor registered |
| `custom_components/hsem/custom_sensors/working_mode_sensor.py` | `plan_explanation` key removed from attributes |
| `tests/planner/test_plan_explanation.py` | 27 tests (new) |
| `tests/sensors/test_plan_explanation_sensor.py` | 24 tests (new) |
| `tests/test_ha_mock_integration.py` | `make_bare_coordinator()` injects `_plan_explanation` |

---

## Acceptance criteria

- [x] A dedicated HA sensor (`sensor.hsem_plan_explanation_sensor`) shows why the plan was chosen � state is the strategy string.
- [x] Rejected plans include name and human-readable reason.
- [x] `score` is positive when the plan saves money vs idle battery; negative when charging overhead dominates.
- [x] Price spread, forecast PV, SoC, estimated cost, and active constraints are all exposed as attributes.
- [x] Tests verify explanation content for summer, winter, flat-price, disabled-battery, and full-battery scenarios.
- [x] Opportunistic grid charge works without a configured discharge schedule.
- [x] `ForceExport` is blocked when export price is below the user-configured minimum.
- [x] Battery depreciation threshold is automatically applied when `min_price_difference` is left at 0.
- [x] Solar vs grid export threshold uses actual charged-kWh fractions, not a coarse flag.

---

## Test results

```
1038 passed
```

## Lint

```
tox -e lint � All checks passed!
```
