### PR TITLE
chore(docs): add planner specification and enforce it in all agent instruction files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,6 +33,17 @@ When asked to solve a GitHub issue, always follow these steps in order:
     - **Never** pass a multiline body inline via `--body "..."`: PowerShell corrupts the
       content (newlines become `∙` characters; backticks become `\x5c` escapes).
 
+## Planner Specification Rule (Mandatory)
+- **Always read `docs/hsem-planner-spec.md` before touching any planner code** — engine, cost
+  function, SoC simulation, candidate generation, slot population, or safety gates.
+- **Every planner change must satisfy all spec invariants**: energy balance per slot, SoC bounds,
+  cost identity (`winner.cost == final_output.cost`), terminal-SoC accounting, and safety gates.
+- **Update `docs/hsem-planner-spec.md`** when a change intentionally alters planner semantics.
+  Spec and implementation must never diverge silently.
+- **Add or update tests** covering the affected invariants for every planner change.
+- A planner PR is not done until: spec is consistent, invariant tests pass, and lint is clean.
+- See `AGENTS.md` → **Planner Specification** for the full compliance checklist.
+
 ## Huawei Solar Sensor Rule (Mandatory)
 - **Always use entities exposed by `wlcrs/huawei_solar`** for every inverter/battery value.
 - Never hard-code numeric battery constants — always source from the live HA entity.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,38 @@ The agent MUST:
 an entity ID. If a new entity is confirmed to exist in HA, add it to `docs/huawei_entities.md`
 as part of the same PR that wires it into HSEM.
 
+## Planner Specification (Mandatory Reference)
+
+The canonical definition of how the HSEM planner must behave is in
+**`docs/hsem-planner-spec.md`**.
+
+The agent MUST:
+
+1. **Read `docs/hsem-planner-spec.md` before touching any planner code** — engine, cost function,
+   SoC simulation, candidate generation, slot population, or safety gates.
+2. **Verify that every planner change is consistent with the spec** — energy balance per slot,
+   SoC bounds, cost function formula, terminal-SoC accounting, candidate invariants, and safety
+   gate behaviour must all match the spec exactly.
+3. **Update `docs/hsem-planner-spec.md`** whenever a change intentionally alters planner
+   semantics (goals, formulas, invariants, or safety gates).  The spec and the implementation
+   must never be allowed to diverge silently.
+4. **Add or update tests** that cover the invariants listed under *Invariants for tests* in the
+   spec for every planner change.
+5. **Include the spec check in the Definition of Done** — a planner change is not complete until
+   both the spec and the tests are updated and passing.
+
+Key invariants to verify for every planner PR (from the spec):
+
+- Energy balance holds for every slot.
+- SoC never leaves configured bounds.
+- Forced discharge/export changes SoC and cost/revenue.
+- Grid charge prices actual grid import (not stored energy).
+- `winner.cost == final_output.cost` — no post-selection mutation.
+- `winner.slots == final_output.slots`.
+- Terminal SoC affects cost; emptying the battery is not free.
+- No-action baseline includes normal PV/battery self-consumption.
+- Read-only / degraded / dry-run gates block hardware writes.
+
 ## HSEM Development Rules
 
 Solar energy systems must be treated as external hardware interfaces.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,35 @@ When implementing a utility or helper function:
 - Integer-valued comparisons (`== 0` on a sum of `int` weights) are fine; only float literals
   and float-typed variables are subject to this rule.
 
+## Planner Specification Compliance (Mandatory)
+
+**Before touching any planner code**, read `docs/hsem-planner-spec.md` — it is the single source
+of truth for planner semantics.
+
+Rules:
+
+1. **Read the spec first** — applies to engine, cost function, SoC simulation, candidate
+   generation, slot population, and safety gates.
+2. **Verify consistency** — every change must satisfy the invariants listed under
+   *Invariants for tests* in the spec (energy balance, SoC bounds, cost identity,
+   terminal-SoC accounting, safety gate behaviour).
+3. **Update the spec** when a change intentionally alters planner semantics. Spec and
+   implementation must never diverge silently.
+4. **Add or update tests** covering the affected invariants for every planner change.
+5. **Definition of Done** for planner work: spec updated (if needed) + invariant tests passing.
+
+Quick checklist before opening a planner PR:
+
+- [ ] `docs/hsem-planner-spec.md` read and understood
+- [ ] Energy balance holds for every slot
+- [ ] SoC stays within configured bounds
+- [ ] `winner.cost == final_output.cost` (no post-selection mutation)
+- [ ] Terminal SoC affects cost (emptying the battery is not free)
+- [ ] No-action baseline includes normal PV/battery self-consumption
+- [ ] Read-only / degraded / dry-run gates block hardware writes
+- [ ] Spec updated if semantics changed
+- [ ] Tests added or updated
+
 ## Development Workflow
 
 ```bash

--- a/docs/hsem-planner-spec.md
+++ b/docs/hsem-planner-spec.md
@@ -1,0 +1,284 @@
+# HSEM Planner Specification
+
+This document defines how the HSEM planner should work.
+
+Use it as the reference for reviewing planner code, cost planning, and optimization changes.
+
+## Goals
+
+The planner must:
+
+- minimize expected total cost within the configured horizon
+- respect battery and inverter constraints
+- keep energy accounting physically consistent
+- avoid hardware writes when inputs are unsafe
+- explain why a plan was selected
+- produce deterministic output for the same input
+
+## Core concepts
+
+### Slot
+
+A slot is one time interval in the planning horizon.
+
+Each slot must have:
+
+- start time
+- end time
+- duration in hours
+- expected house load in kWh
+- expected PV production in kWh
+- import price per kWh
+- export price per kWh
+- optional tariff per kWh
+- recommendation
+- planned battery charge in kWh
+- planned battery discharge in kWh
+- expected SoC before and after the slot
+
+Power values in kW must be converted to energy using:
+
+```text
+energy_kwh = power_kw * duration_hours
+```
+
+## Energy balance per slot
+
+For every slot:
+
+```text
+net_load_kwh = house_load_kwh - pv_kwh
+```
+
+Positive `net_load_kwh` means the house needs energy.
+
+Negative `net_load_kwh` means there is PV surplus.
+
+Battery and grid flows must satisfy:
+
+```text
+house_load_kwh
+= pv_used_for_house_kwh
++ battery_discharge_to_house_kwh
++ grid_import_for_house_kwh
+```
+
+PV production must satisfy:
+
+```text
+pv_kwh
+= pv_used_for_house_kwh
++ pv_used_for_battery_kwh
++ pv_exported_kwh
++ pv_curtailed_kwh
+```
+
+Battery charge must satisfy:
+
+```text
+battery_charge_stored_kwh
+= pv_used_for_battery_kwh * charge_efficiency
++ grid_import_for_battery_kwh * charge_efficiency
+```
+
+Battery discharge must satisfy:
+
+```text
+usable_battery_discharge_kwh
+= battery_energy_removed_kwh * discharge_efficiency
+```
+
+## SoC simulation
+
+SoC must be simulated forward through the full horizon.
+
+For each slot:
+
+```text
+soc_after_kwh
+= soc_before_kwh
++ battery_charge_stored_kwh
+- battery_energy_removed_kwh
+```
+
+The simulator must enforce:
+
+- `soc_after_kwh >= min_soc_kwh`
+- `soc_after_kwh <= max_soc_kwh`
+- charge power limit
+- discharge power limit
+- grid import limit
+- export limit if configured
+
+The simulator must read the slot recommendation.
+
+If a slot recommends forced discharge, force export, or discharge-only behavior, that energy flow must appear in:
+
+- `batteries_discharged`
+- SoC change
+- import/export calculation
+- plan cost
+
+No recommendation may be energetically invisible.
+
+## Cost function
+
+The total plan cost is:
+
+```text
+total_cost
+= grid_import_cost
+- export_revenue
++ battery_cycle_cost
++ conversion_loss_cost
++ tariff_cost
++ constraint_penalties
++ terminal_soc_penalty_or_credit
+```
+
+### Grid import cost
+
+Grid import cost must use actual grid energy pulled.
+
+If the battery stores `x` kWh from grid and charge efficiency is `e`, grid import is:
+
+```text
+grid_import_for_battery_kwh = x / e
+```
+
+Do not price stored energy as if it was grid energy.
+
+### Export revenue
+
+Export revenue is:
+
+```text
+grid_export_kwh * export_price_per_kwh
+```
+
+### Battery cycle cost
+
+Cycle cost should count physical battery throughput.
+
+Recommended:
+
+```text
+battery_throughput_kwh = battery_charge_stored_kwh + battery_energy_removed_kwh
+cycle_cost = battery_throughput_kwh * cycle_cost_per_kwh
+```
+
+If using equivalent full cycles, document the formula.
+
+Avoid double-counting the same energy as both charge and discharge unless the cycle-cost definition explicitly expects throughput.
+
+### Terminal SoC value
+
+Plans must not look better merely because they empty the battery before the horizon ends.
+
+The cost function must include either:
+
+- terminal SoC credit
+- terminal SoC penalty
+- or a constraint that compares plans at equal terminal SoC
+
+A simple default:
+
+```text
+terminal_soc_delta_kwh = baseline_terminal_soc_kwh - candidate_terminal_soc_kwh
+terminal_soc_penalty = terminal_soc_delta_kwh * replacement_energy_price
+```
+
+## Candidate plans
+
+Every candidate plan must be fully simulated and scored.
+
+Required candidates:
+
+- no-action baseline
+- current heuristic plan
+- grid-charge candidates
+- discharge candidates
+- excess-export candidates if enabled
+- aggressive candidates if enabled
+
+The selected plan must be the lowest-cost valid candidate within the implemented search space.
+
+The final returned plan must be the same plan that was selected.
+
+This invariant must always hold:
+
+```text
+output.plan_cost == selected_candidate.cost
+output.slots == selected_candidate.slots
+```
+
+No post-selection pass may mutate slots unless the plan is re-simulated and re-scored.
+
+## No-action baseline
+
+The no-action plan means:
+
+- no forced grid charge
+- no forced discharge
+- no force export
+- normal self-consumption behavior only
+
+It must still account for:
+
+- PV charging battery if that is normal inverter behavior
+- PV export
+- house load
+- battery self-consumption behavior if modeled
+- terminal SoC
+
+No-action must not be treated as “zero battery movement” unless the physical model says no battery movement occurs.
+
+## Safety gates
+
+The planner may compute in read-only or degraded states.
+
+The applier must not write to hardware when:
+
+- read-only mode is enabled
+- dry-run mode is enabled
+- degraded mode blocks writes
+- error mode is active
+- required data is missing
+- config entry is unloading
+
+## Invariants for tests
+
+Add tests for these invariants:
+
+- Energy balance holds for every slot.
+- SoC never leaves configured bounds.
+- Forced discharge changes SoC and cost.
+- Force export changes SoC and export revenue.
+- Grid charge prices actual grid import, not stored energy.
+- Candidate winner cost equals final output cost.
+- Final output slots equal selected candidate slots.
+- No post-selection mutation happens without re-score.
+- No-action includes normal PV/battery behavior.
+- Terminal SoC affects cost.
+- Emptying the battery is not free.
+- `winner.cost <= no_action.cost` within the implemented candidate set.
+- Current partial slot uses remaining duration only.
+- Missing price/PV data does not become real zero silently.
+- Read-only/degraded/dry-run gates block writes.
+
+## Documentation expectations
+
+Every planner change should update:
+
+- this spec if semantics change
+- plan explanation output
+- tests for at least one hand-calculated scenario
+
+Every test fixture should state:
+
+- slot duration
+- input units
+- expected SoC trajectory
+- expected import/export
+- expected total cost
+


### PR DESCRIPTION
﻿## Summary

Establishes `docs/hsem-planner-spec.md` as the canonical, normative reference for all HSEM
planner behaviour, and wires it into all three agent instruction files so every AI coding
agent is required to read and comply with it before touching planner code.

## Changes

### `docs/hsem-planner-spec.md` (added in first commit)
Normative specification defining:
- Planner goals (cost minimisation, physical consistency, determinism)
- Slot structure and energy-balance equations per slot
- SoC simulation rules and hard bounds
- Full cost function (grid import, export revenue, cycle cost, terminal-SoC penalty)
- Required candidate plans (no-action baseline, grid-charge, discharge, excess-export)
- No-action baseline semantics (includes normal PV/battery self-consumption)
- Safety gates that block hardware writes (read-only, dry-run, degraded, error modes)
- Invariants for tests — the list every planner PR must satisfy

### `AGENTS.md` (updated)
Added **Planner Specification (Mandatory Reference)** section with:
- 5 explicit agent rules (read spec → verify consistency → update spec → add tests → DoD check)
- Key invariants checklist to verify before every planner PR
- Requirement that a planner change is not done until spec and tests are both updated and passing

### `CLAUDE.md` (updated)
Added **Planner Specification Compliance (Mandatory)** section with:
- Same 5 rules as AGENTS.md, Claude-specific framing
- Full pre-PR checklist (energy balance, SoC bounds, cost identity, terminal SoC, safety gates,
  spec update, test coverage)

### `.github/copilot-instructions.md` (updated)
Added **Planner Specification Rule (Mandatory)** block (before Huawei Solar Sensor Rule) with:
- Concise 5-bullet rule set pointing agents at `docs/hsem-planner-spec.md`
- Reference to `AGENTS.md → Planner Specification` for the full checklist

## Why

The planner spec was added as a bare document without enforcement.  Any agent (Copilot, Claude,
OpenAI) working on planner code had no explicit instruction to consult it.  This PR closes that
gap so future planner PRs are automatically grounded in the spec and its invariants.

## What comes next

A follow-up PR will audit the existing planner engine and test suite against every invariant
listed in the spec and add or fix tests as needed.

## Acceptance criteria

- [x] `docs/hsem-planner-spec.md` present and complete
- [x] `AGENTS.md` contains Planner Specification section
- [x] `CLAUDE.md` contains Planner Specification Compliance section
- [x] `.github/copilot-instructions.md` contains Planner Specification Rule
- [x] All three files require reading the spec before planner changes
- [x] All three files require updating the spec when semantics change
- [x] All three files require adding/updating invariant tests
