### PR TITLE
fix(sensor): track and cancel working-mode update task on unload

### DIFF
--- a/custom_components/hsem/custom_sensors/working_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/working_mode_sensor.py
@@ -15,6 +15,7 @@ coordinator.  This entity only reacts to coordinator pushes.
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
@@ -87,6 +88,11 @@ class HSEMWorkingModeSensor(
         self._attr_unique_id = get_working_mode_sensor_unique_id()
         self.entity_id = get_working_mode_sensor_entity_id()
         self._name = get_working_mode_sensor_name()
+
+        # Tracks the latest background update task so it can be cancelled on
+        # unload.  Only the most-recent task is retained; prior tasks will
+        # have already completed or been replaced.
+        self._update_task: asyncio.Task | None = None
 
     # ------------------------------------------------------------------
     # HA entity properties
@@ -289,14 +295,39 @@ class HSEMWorkingModeSensor(
         if self.coordinator.data is not None:
             await self._async_apply_hardware_writes(self.coordinator.data)
 
+    async def async_will_remove_from_hass(self) -> None:
+        """Cancel any pending background update task before unloading.
+
+        This prevents a stale task from issuing inverter/battery writes after
+        the config entry has been unloaded.
+        """
+        self._cancel_update_task()
+        await super().async_will_remove_from_hass()
+
+    def _cancel_update_task(self) -> None:
+        """Cancel ``_update_task`` if it exists and has not yet completed.
+
+        Cancellation is silent — ``asyncio.CancelledError`` propagates only
+        inside the task itself, which guards the hardware-write path, so no
+        inverter command can be issued after this point.
+        """
+        if self._update_task is not None and not self._update_task.done():
+            self._update_task.cancel()
+
     # ------------------------------------------------------------------
     # Coordinator callback
     # ------------------------------------------------------------------
 
     def _handle_coordinator_update(self) -> None:
-        """Receive a coordinator push and schedule hardware writes + state flush."""
-        # Schedule the async work; _handle_coordinator_update is synchronous.
-        self.hass.async_create_task(
+        """Receive a coordinator push and schedule hardware writes + state flush.
+
+        Cancels any still-pending previous task before creating the new one so
+        that only one update is in-flight at a time.  The task reference is
+        stored on ``_update_task`` so it can be cancelled on unload.
+        """
+        # Cancel any still-running task from the previous coordinator cycle.
+        self._cancel_update_task()
+        self._update_task = self.hass.async_create_task(
             self._async_on_coordinator_update(),
             name="hsem_working_mode_update",
         )
@@ -305,13 +336,20 @@ class HSEMWorkingModeSensor(
         """Apply hardware writes then write state to HA.
 
         This method runs asynchronously after every coordinator refresh.
+        A ``CancelledError`` is re-raised immediately so that asyncio can
+        clean up the task correctly; no hardware write can occur after
+        cancellation.
         """
-        data = self.coordinator.data
-        if data is None:
-            return
+        try:
+            data = self.coordinator.data
+            if data is None:
+                return
 
-        await self._async_apply_hardware_writes(data)
-        self.async_write_ha_state()
+            await self._async_apply_hardware_writes(data)
+            self.async_write_ha_state()
+        except asyncio.CancelledError:
+            # Task was cancelled (entity unloaded) — propagate cleanly.
+            raise
 
     async def _async_apply_hardware_writes(self, data: CoordinatorData) -> None:
         """Perform inverter and battery hardware writes for the current slot.

--- a/tests/test_working_mode_task_lifecycle.py
+++ b/tests/test_working_mode_task_lifecycle.py
@@ -1,0 +1,303 @@
+"""Regression tests for P0-17: track and cancel working-mode update task on unload.
+
+Acceptance criteria (issue #369)
+---------------------------------
+1. ``_update_task`` is stored after ``_handle_coordinator_update`` is called.
+2. The stored task is cancelled when ``async_will_remove_from_hass`` is called.
+3. Cancellation does not raise or propagate outside the entity.
+4. No inverter/battery write can occur after the entity is unloaded.
+5. A completed task is NOT cancelled again (``cancel()`` is a no-op on done tasks).
+6. Calling ``_cancel_update_task`` when ``_update_task`` is ``None`` is safe.
+7. ``_handle_coordinator_update`` cancels the *previous* task before creating a
+   new one, so at most one task is in-flight at any time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.hsem.custom_sensors.working_mode_sensor import (
+    HSEMWorkingModeSensor,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config_entry() -> MagicMock:
+    """Minimal mock config entry sufficient for HSEMWorkingModeSensor."""
+    cfg = MagicMock()
+    cfg.entry_id = "test_entry_id_p0_17"
+    cfg.options = {}
+    cfg.data = {}
+    return cfg
+
+
+def _make_coordinator() -> MagicMock:
+    """Coordinator mock whose ``data`` is None by default."""
+    coord = MagicMock()
+    coord.data = None
+    coord.last_update_success = True
+    return coord
+
+
+def _make_sensor() -> HSEMWorkingModeSensor:
+    """Build a sensor instance with mocked coordinator and hass."""
+    cfg = _make_config_entry()
+    coord = _make_coordinator()
+
+    sensor = HSEMWorkingModeSensor(cfg, coord)
+
+    # Minimal hass mock — ``async_create_task`` returns a real asyncio.Task so
+    # that cancellation tests work properly.
+    hass = MagicMock()
+
+    def _fake_create_task(coro, *, name=None):
+        loop = asyncio.get_event_loop()
+        return loop.create_task(coro, name=name)
+
+    hass.async_create_task = MagicMock(side_effect=_fake_create_task)
+    sensor.hass = hass
+    return sensor
+
+
+# ---------------------------------------------------------------------------
+# Task lifecycle tests
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateTaskTracking:
+    """Background task is stored after _handle_coordinator_update."""
+
+    def test_update_task_is_none_initially(self) -> None:
+        """``_update_task`` must be ``None`` before any coordinator update."""
+        sensor = _make_sensor()
+        assert sensor._update_task is None
+
+    @pytest.mark.asyncio
+    async def test_update_task_stored_after_coordinator_update(self) -> None:
+        """``_update_task`` is populated after ``_handle_coordinator_update``."""
+        sensor = _make_sensor()
+
+        with patch.object(
+            sensor,
+            "_async_on_coordinator_update",
+            new_callable=AsyncMock,
+        ):
+            sensor._handle_coordinator_update()
+
+        assert sensor._update_task is not None
+
+    @pytest.mark.asyncio
+    async def test_update_task_is_asyncio_task(self) -> None:
+        """The stored task must be an ``asyncio.Task`` instance."""
+        sensor = _make_sensor()
+
+        with patch.object(
+            sensor,
+            "_async_on_coordinator_update",
+            new_callable=AsyncMock,
+        ):
+            sensor._handle_coordinator_update()
+
+        assert isinstance(sensor._update_task, asyncio.Task)
+
+        # Clean up
+        await asyncio.gather(sensor._update_task, return_exceptions=True)
+
+
+class TestTaskCancellationOnUnload:
+    """Task is cancelled cleanly when the entity is unloaded."""
+
+    @pytest.mark.asyncio
+    async def test_unload_cancels_pending_task(self) -> None:
+        """A pending task must be cancelled on ``async_will_remove_from_hass``."""
+        sensor = _make_sensor()
+
+        # Create a coroutine that never returns so the task stays pending.
+        event = asyncio.Event()
+
+        async def _hanging_coro():
+            await event.wait()  # Blocks until set — simulates in-flight work.
+
+        sensor._update_task = asyncio.get_event_loop().create_task(_hanging_coro())
+
+        # Yield once so the task can start and reach the ``await`` inside.
+        await asyncio.sleep(0)
+
+        await sensor.async_will_remove_from_hass()
+
+        # Yield again so the event loop can transition the task to cancelled.
+        await asyncio.sleep(0)
+
+        assert sensor._update_task.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_unload_does_not_raise_on_cancellation(self) -> None:
+        """``async_will_remove_from_hass`` must not raise even if task is pending."""
+        sensor = _make_sensor()
+
+        event = asyncio.Event()
+
+        async def _hanging_coro():
+            await event.wait()
+
+        sensor._update_task = asyncio.get_event_loop().create_task(_hanging_coro())
+
+        # Must complete without raising any exception.
+        await sensor.async_will_remove_from_hass()
+
+    @pytest.mark.asyncio
+    async def test_completed_task_not_cancelled_again(self) -> None:
+        """Unload must not attempt to cancel an already-completed task."""
+        sensor = _make_sensor()
+
+        async def _quick_coro():
+            return None
+
+        task = asyncio.get_event_loop().create_task(_quick_coro())
+        await task  # Ensure the task finishes before unload.
+        sensor._update_task = task
+
+        # cancel() on a done task is a no-op and must not raise.
+        await sensor.async_will_remove_from_hass()
+
+        # Task state must still be done, not cancelled.
+        assert task.done()
+        assert not task.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_cancel_task_when_none_is_safe(self) -> None:
+        """Calling ``_cancel_update_task`` with no stored task must be a no-op."""
+        sensor = _make_sensor()
+        assert sensor._update_task is None
+
+        # Must not raise.
+        sensor._cancel_update_task()
+
+    @pytest.mark.asyncio
+    async def test_unload_when_no_task_is_safe(self) -> None:
+        """``async_will_remove_from_hass`` with no stored task must not raise."""
+        sensor = _make_sensor()
+
+        # Must complete without error.
+        await sensor.async_will_remove_from_hass()
+
+
+class TestNoWriteAfterUnload:
+    """No inverter/battery write can occur after the entity is unloaded."""
+
+    @pytest.mark.asyncio
+    async def test_no_hardware_write_after_unload(self) -> None:
+        """Hardware-write helpers must NOT be called after the entity is unloaded.
+
+        Scenario:
+        1. A coordinator update fires, creating a background task.
+        2. The entity is unloaded immediately (``async_will_remove_from_hass``).
+        3. The task is cancelled before it can execute the hardware-write path.
+        """
+        sensor = _make_sensor()
+        write_called = False
+
+        async def _spy_write(data):
+            nonlocal write_called
+            write_called = True
+
+        sensor._async_apply_hardware_writes = _spy_write
+
+        # Create a task that yields control once, giving us the window to cancel.
+        event = asyncio.Event()
+
+        async def _slow_update():
+            await event.wait()  # Yields; allows cancellation before write.
+            await sensor._async_apply_hardware_writes(None)
+
+        with patch.object(
+            sensor,
+            "_async_on_coordinator_update",
+            side_effect=_slow_update,
+        ):
+            sensor._handle_coordinator_update()
+
+        # Unload immediately — must cancel before the write executes.
+        await sensor.async_will_remove_from_hass()
+
+        # Give the event loop a chance to run cancelled callbacks.
+        await asyncio.sleep(0)
+
+        assert not write_called, (
+            "Hardware write was called after entity unload — stale task not cancelled."
+        )
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_propagates_out_of_update_coro(self) -> None:
+        """``CancelledError`` must propagate from ``_async_on_coordinator_update``.
+
+        asyncio requires that ``CancelledError`` is re-raised so the task
+        machinery can correctly transition the task to the cancelled state.
+        """
+        sensor = _make_sensor()
+        event = asyncio.Event()
+
+        async def _hanging_apply(_data):
+            await event.wait()
+
+        sensor._async_apply_hardware_writes = _hanging_apply
+        sensor.coordinator.data = MagicMock()
+
+        task = asyncio.get_event_loop().create_task(
+            sensor._async_on_coordinator_update()
+        )
+
+        # Allow the task to start and block inside _async_apply_hardware_writes.
+        await asyncio.sleep(0)
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+class TestSingleTaskInFlight:
+    """At most one update task is in-flight at a time."""
+
+    @pytest.mark.asyncio
+    async def test_previous_task_cancelled_on_new_coordinator_update(self) -> None:
+        """A second coordinator push must cancel the first still-pending task."""
+        sensor = _make_sensor()
+
+        event = asyncio.Event()
+
+        async def _hanging_coro():
+            await event.wait()
+
+        # Simulate first coordinator push — create a slow task.
+        first_task = asyncio.get_event_loop().create_task(_hanging_coro())
+        sensor._update_task = first_task
+
+        # Yield so the first task can start and block at ``await event.wait()``.
+        await asyncio.sleep(0)
+
+        # Simulate second coordinator push via _handle_coordinator_update.
+        with patch.object(
+            sensor,
+            "_async_on_coordinator_update",
+            new_callable=AsyncMock,
+        ):
+            sensor._handle_coordinator_update()
+
+        # Allow the event loop to process the cancellation and schedule the new task.
+        await asyncio.sleep(0)
+
+        # First task must now be cancelled; new task is in-flight.
+        assert first_task.cancelled()
+        assert sensor._update_task is not first_task
+        assert sensor._update_task is not None
+
+        # Clean up the new task.
+        if sensor._update_task and not sensor._update_task.done():
+            sensor._update_task.cancel()
+        await asyncio.gather(sensor._update_task, return_exceptions=True)


### PR DESCRIPTION
## Summary

Fixes **untracked async task lifecycle** in HSEMWorkingModeSensor.

_handle_coordinator_update creates an syncio.Task via
hass.async_create_task but previously never stored or cancelled it.  A
stale task could therefore continue running � and issue inverter/battery
hardware writes � after the config entry was unloaded.

For an integration that writes to physical inverter hardware this is a
safety issue (P0-17).

---

## Changes

### custom_components/hsem/custom_sensors/working_mode_sensor.py

| What | Why |
|---|---|
| Added _update_task: asyncio.Task \| None attribute | Stores the live background task so it can be cancelled |
| Added _cancel_update_task() helper | Cancels _update_task when it exists and is not yet done; safe to call when None or already done |
| Added sync_will_remove_from_hass() override | Calls _cancel_update_task() then delegates to super() � prevents any post-unload inverter write |
| _handle_coordinator_update() now cancels prior task before creating new one | At most one update task is in-flight at a time; returned Task stored in _update_task |
| _async_on_coordinator_update() wraps body in 	ry/except CancelledError: raise | Re-raises CancelledError so asyncio can cleanly transition the task to the cancelled state without logging noisy tracebacks |

### 	ests/test_working_mode_task_lifecycle.py (new � 11 tests)

| Class | Tests |
|---|---|
| TestUpdateTaskTracking | _update_task is None initially; stored after coordinator update; is an syncio.Task |
| TestTaskCancellationOnUnload | Pending task cancelled on unload; no exception raised; completed task not re-cancelled; None-safe guard; unload with no task is safe |
| TestNoWriteAfterUnload | Hardware-write helper not called after unload; CancelledError propagates correctly out of update coro |
| TestSingleTaskInFlight | Second coordinator push cancels the first still-pending task |

---

## Acceptance criteria

- [x] Any background update/apply task is stored.
- [x] The task is cancelled on unload.
- [x] Cancellation does not log noisy errors.
- [x] Tests verify unload cancels the task.
- [x] Tests verify no write happens after unload.

---

## Test results

`
11 passed (test_working_mode_task_lifecycle.py)
1143 passed, 0 failed (full suite)
`

Lint: 	ox -e lint � all checks passed.

Fixes #369
