### PR TITLE
fix(planner): surface missing tomorrow price and PV data explicitly

### DIFF
--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -61,7 +61,7 @@ from custom_components.hsem.models.planner_inputs import (
     PricePoint,
     SolcastSlot,
 )
-from custom_components.hsem.models.planner_outputs import PlanExplanation
+from custom_components.hsem.models.planner_outputs import DataQuality, PlanExplanation
 from custom_components.hsem.models.sensor_config import SensorConfig
 from custom_components.hsem.planner import run_planner
 from custom_components.hsem.utils.inverter_verify import CycleApplySummary
@@ -115,6 +115,8 @@ class CoordinatorData:
     apply_summary: CycleApplySummary | None = None
     #: Human-readable explanation of why the selected plan was chosen.
     plan_explanation: PlanExplanation = field(default_factory=PlanExplanation)
+    #: Structured data-quality report for price and PV inputs.
+    data_quality: DataQuality = field(default_factory=DataQuality)
 
 
 # ---------------------------------------------------------------------------
@@ -185,6 +187,8 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         self._avg_house_consumption_entity_id_cache: dict[str, str] = {}
         # Most recent plan explanation produced by the planner engine.
         self._plan_explanation: PlanExplanation = PlanExplanation()
+        # Most recent data quality report produced by the planner engine.
+        self._data_quality: DataQuality = DataQuality()
 
     # ------------------------------------------------------------------
     # HA lifecycle
@@ -331,6 +335,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
 
                 self._apply_planner_output(planner_output)
                 self._current_required_battery = planner_output.required_capacity_kwh
+                self._data_quality = planner_output.data_quality
 
                 # 9. Find the current time-slot recommendation.
                 self._hourly_recommendations.sort(key=lambda x: x.start)
@@ -369,6 +374,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             last_updated=last_updated,
             next_update=self._next_update,
             plan_explanation=self._plan_explanation,
+            data_quality=self._data_quality,
         )
 
         # Notify all subscriber entities atomically.
@@ -590,8 +596,9 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         self._batteries_schedules_remaining_capacity_needed = sum(
             s.needed_batteries_capacity for s in self._batteries_schedules if s.enabled
         )
-        # Preserve the plan explanation for the next CoordinatorData snapshot.
+        # Preserve the plan explanation and data quality for the next CoordinatorData snapshot.
         self._plan_explanation = output.explanation
+        self._data_quality = output.data_quality
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/custom_components/hsem/custom_sensors/working_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/working_mode_sensor.py
@@ -276,6 +276,7 @@ class HSEMWorkingModeSensor(
             "apply_failed_entities": (
                 apply_summary.failed_entities if apply_summary else []
             ),
+            "data_quality": data.data_quality.as_dict(),
         }
 
         return {

--- a/custom_components/hsem/models/planner_outputs.py
+++ b/custom_components/hsem/models/planner_outputs.py
@@ -19,6 +19,79 @@ if TYPE_CHECKING:
     from custom_components.hsem.planner.cost_function import PlanCostBreakdown
 
 # ---------------------------------------------------------------------------
+# Data quality diagnostics
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DataQuality:
+    """Structured diagnostics about the completeness of planning inputs.
+
+    Populated by :func:`~custom_components.hsem.planner.engine.run_planner`
+    after aligning price and PV series.  All ``missing_*`` fields list
+    wall-clock hours (0-23) for which data was absent.
+
+    Attributes:
+        tomorrow_price_missing_hours:
+            Hours in tomorrow's slot grid that had no price data.
+            Empty list means tomorrow price data is complete (or the
+            planning horizon does not reach tomorrow).
+        tomorrow_pv_missing_hours:
+            Hours in tomorrow's slot grid that had no PV forecast data.
+            Empty list means tomorrow PV data is complete (or the
+            planning horizon does not reach tomorrow).
+        today_price_missing_hours:
+            Hours in today's slot grid that had no price data.
+        today_pv_missing_hours:
+            Hours in today's slot grid that had no PV forecast data.
+        horizon_has_tomorrow:
+            ``True`` when the planning horizon extends into tomorrow
+            (``interval_length_hours`` > 24 or effectively spans midnight).
+    """
+
+    tomorrow_price_missing_hours: list[int] = field(default_factory=list)
+    tomorrow_pv_missing_hours: list[int] = field(default_factory=list)
+    today_price_missing_hours: list[int] = field(default_factory=list)
+    today_pv_missing_hours: list[int] = field(default_factory=list)
+    horizon_has_tomorrow: bool = False
+
+    @property
+    def is_complete(self) -> bool:
+        """Return ``True`` when no missing data was detected."""
+        return not (
+            self.tomorrow_price_missing_hours
+            or self.tomorrow_pv_missing_hours
+            or self.today_price_missing_hours
+            or self.today_pv_missing_hours
+        )
+
+    @property
+    def tomorrow_price_complete(self) -> bool:
+        """Return ``True`` when tomorrow price data is complete or not required."""
+        return not self.tomorrow_price_missing_hours
+
+    @property
+    def tomorrow_pv_complete(self) -> bool:
+        """Return ``True`` when tomorrow PV data is complete or not required."""
+        return not self.tomorrow_pv_missing_hours
+
+    def as_dict(self) -> dict[str, Any]:
+        """Serialise the quality report to a plain dict for HA attributes.
+
+        Returns:
+            A JSON-safe dictionary representation of the data quality report.
+        """
+        return {
+            "is_complete": self.is_complete,
+            "horizon_has_tomorrow": self.horizon_has_tomorrow,
+            "tomorrow_price_missing_hours": sorted(self.tomorrow_price_missing_hours),
+            "tomorrow_pv_missing_hours": sorted(self.tomorrow_pv_missing_hours),
+            "today_price_missing_hours": sorted(self.today_price_missing_hours),
+            "today_pv_missing_hours": sorted(self.today_pv_missing_hours),
+        }
+
+
+# ---------------------------------------------------------------------------
 # Plan explanation dataclasses
 # ---------------------------------------------------------------------------
 
@@ -301,6 +374,11 @@ class PlannerOutput:
             used during this planning run.  All slot boundaries, price, PV,
             load, import/export and SoC series are aligned to this axis.
             ``None`` when the planner was invoked without a valid horizon.
+        data_quality:
+            Structured diagnostics about the completeness of price and PV
+            inputs for today and tomorrow.  Exposes which hours are missing
+            so dashboards and logs can display the gap explicitly rather
+            than silently treating missing slots as zero.
         extra:
             Arbitrary key-value pairs for debug / introspection purposes.
         explanation:
@@ -318,6 +396,8 @@ class PlannerOutput:
     missing_inputs: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
     time_series_index: TimeSeriesIndex | None = field(default=None, repr=False)
+    #: Structured data-quality report for price and PV inputs.
+    data_quality: DataQuality = field(default_factory=DataQuality)
     extra: dict[str, Any] = field(default_factory=dict)
     #: Human-readable explanation of why the selected plan was chosen and what
     #: alternatives were considered.  Populated by the planner engine.

--- a/custom_components/hsem/models/time_series.py
+++ b/custom_components/hsem/models/time_series.py
@@ -141,11 +141,23 @@ class TimeSeriesIndex:
             Set of :class:`SlotKey` values for which at least one series
             alignment call found no source data.  Populated lazily as
             ``align_*`` methods are called.
+        missing_price_slots:
+            Subset of :attr:`missing_slots` populated only by
+            :meth:`align_hourly_prices`.  Enables callers to distinguish
+            missing price data from missing PV data.
+        missing_pv_slots:
+            Subset of :attr:`missing_slots` populated only by
+            :meth:`align_hourly_pv`.  Enables callers to distinguish missing
+            PV data from missing price data.
     """
 
     slots: list[SlotMeta] = field(default_factory=list)
     interval_minutes: int = DEFAULT_SLOT_MINUTES
     missing_slots: set[SlotKey] = field(default_factory=set)
+    #: Keys for which price alignment found no source data.
+    missing_price_slots: set[SlotKey] = field(default_factory=set)
+    #: Keys for which PV alignment found no source data.
+    missing_pv_slots: set[SlotKey] = field(default_factory=set)
 
     # ------------------------------------------------------------------
     # Construction
@@ -256,12 +268,14 @@ class TimeSeriesIndex:
 
             if imp is None:
                 self.missing_slots.add(meta.key)
+                self.missing_price_slots.add(meta.key)
                 aligned_import.append(MISSING_SENTINEL)
             else:
                 aligned_import.append(imp)
 
             if exp is None:
                 self.missing_slots.add(meta.key)
+                self.missing_price_slots.add(meta.key)
                 aligned_export.append(MISSING_SENTINEL)
             else:
                 aligned_export.append(exp)
@@ -292,6 +306,7 @@ class TimeSeriesIndex:
             hourly_kwh = pv_by_hour.get(meta.hour)
             if hourly_kwh is None:
                 self.missing_slots.add(meta.key)
+                self.missing_pv_slots.add(meta.key)
                 aligned.append(MISSING_SENTINEL)
             else:
                 aligned.append(round(hourly_kwh * meta.slot_fraction, 6))
@@ -431,6 +446,46 @@ class TimeSeriesIndex:
         """Return the wall-clock hours (0-23) that have at least one missing slot."""
         key_to_hour: dict[SlotKey, int] = {m.key: m.hour for m in self.slots}
         return {key_to_hour[key] for key in self.missing_slots if key in key_to_hour}
+
+    def missing_tomorrow_price_hours(self) -> set[int]:
+        """Return wall-clock hours (0-23) in ``day_offset=1`` that lack price data.
+
+        Returns an empty set when the planning horizon does not include tomorrow
+        (i.e. ``horizon_hours`` ≤ 24) or when all tomorrow price hours are present.
+
+        Returns:
+            Set of integer hours (0-23) from tomorrow that have no price data.
+        """
+        key_to_hour: dict[SlotKey, int] = {m.key: m.hour for m in self.slots}
+        return {
+            key_to_hour[key]
+            for key in self.missing_price_slots
+            if key in key_to_hour and key.day_offset == 1
+        }
+
+    def missing_tomorrow_pv_hours(self) -> set[int]:
+        """Return wall-clock hours (0-23) in ``day_offset=1`` that lack PV data.
+
+        Returns an empty set when the planning horizon does not include tomorrow
+        (i.e. ``horizon_hours`` ≤ 24) or when all tomorrow PV hours are present.
+
+        Returns:
+            Set of integer hours (0-23) from tomorrow that have no PV forecast data.
+        """
+        key_to_hour: dict[SlotKey, int] = {m.key: m.hour for m in self.slots}
+        return {
+            key_to_hour[key]
+            for key in self.missing_pv_slots
+            if key in key_to_hour and key.day_offset == 1
+        }
+
+    def has_tomorrow_slots(self) -> bool:
+        """Return ``True`` when the planning horizon includes tomorrow (day_offset=1).
+
+        Returns:
+            ``True`` if at least one slot has ``day_offset == 1``.
+        """
+        return any(m.key.day_offset == 1 for m in self.slots)
 
     # ------------------------------------------------------------------
     # Dunder helpers

--- a/custom_components/hsem/planner/engine.py
+++ b/custom_components/hsem/planner/engine.py
@@ -30,6 +30,7 @@ from datetime import datetime
 from custom_components.hsem.models.planner_inputs import PlannerInput
 from custom_components.hsem.models.planner_outputs import (
     ChargeWindow,
+    DataQuality,
     DischargeWindow,
     PlanExplanation,
     PlannedSlot,
@@ -155,9 +156,68 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
         tsi,
     )
 
-    # Surface any hours where input data was absent
+    # Surface any hours where input data was absent (generic — all series)
     for hour in sorted(tsi.missing_hours()):
         missing_inputs.append(f"hour_{hour:02d}")
+
+    # -----------------------------------------------------------------------
+    # Explicit tomorrow data-quality diagnostics (issue #370)
+    # -----------------------------------------------------------------------
+    # Detect missing tomorrow price and PV data separately so dashboards and
+    # degraded-mode classification can distinguish them from general missing
+    # hours.  We must NOT silently treat missing future data as real zero —
+    # instead we surface the gap explicitly.
+    horizon_has_tomorrow = tsi.has_tomorrow_slots()
+    tomorrow_price_missing = sorted(tsi.missing_tomorrow_price_hours())
+    tomorrow_pv_missing = sorted(tsi.missing_tomorrow_pv_hours())
+
+    # Collect today's missing price/PV hours for complete diagnostics
+    key_to_hour: dict = {m.key: m.hour for m in tsi.slots}
+    today_price_missing = sorted(
+        {
+            key_to_hour[key]
+            for key in tsi.missing_price_slots
+            if key in key_to_hour and key.day_offset == 0
+        }
+    )
+    today_pv_missing = sorted(
+        {
+            key_to_hour[key]
+            for key in tsi.missing_pv_slots
+            if key in key_to_hour and key.day_offset == 0
+        }
+    )
+
+    data_quality = DataQuality(
+        tomorrow_price_missing_hours=tomorrow_price_missing,
+        tomorrow_pv_missing_hours=tomorrow_pv_missing,
+        today_price_missing_hours=today_price_missing,
+        today_pv_missing_hours=today_pv_missing,
+        horizon_has_tomorrow=horizon_has_tomorrow,
+    )
+
+    # Surface tomorrow-specific missing data as explicit missing_inputs entries.
+    # These labels are non-critical (do not match battery/house-load keywords)
+    # so they trigger DegradedMode.Degraded — hardware writes are still allowed
+    # but the plan is based on incomplete future data.
+    if tomorrow_price_missing:
+        hours_str = ",".join(f"{h:02d}" for h in tomorrow_price_missing)
+        missing_inputs.append(f"tomorrow_price_missing_hours:{hours_str}")
+        warnings.append(
+            f"Tomorrow price data missing for {len(tomorrow_price_missing)} hour(s): "
+            f"{hours_str}. Affected slots use 0.0 (import/export) as fallback — "
+            "plan may not be optimal."
+        )
+
+    if tomorrow_pv_missing:
+        hours_str = ",".join(f"{h:02d}" for h in tomorrow_pv_missing)
+        missing_inputs.append(f"tomorrow_pv_missing_hours:{hours_str}")
+        warnings.append(
+            f"Tomorrow PV forecast missing for {len(tomorrow_pv_missing)} hour(s): "
+            f"{hours_str}. Affected slots assume zero PV production — "
+            "plan may over-charge from grid."
+        )
+
     populate_net_consumption(slots)
     populate_estimated_cost(slots)
 
@@ -381,6 +441,7 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
         missing_inputs=missing_inputs,
         warnings=warnings,
         time_series_index=tsi,
+        data_quality=data_quality,
         explanation=explanation,
         plan_cost=plan_cost,
         candidates=candidates,

--- a/tests/planner/test_missing_tomorrow_data.py
+++ b/tests/planner/test_missing_tomorrow_data.py
@@ -1,0 +1,712 @@
+"""Tests for explicit surfacing of missing tomorrow price and PV data (issue #370).
+
+Covers the acceptance criteria from GitHub issue #370:
+
+- Missing tomorrow price data is visible in diagnostics.
+- Missing tomorrow PV data is visible in diagnostics.
+- Planner does not treat missing future data as real zero silently.
+- Degraded mode is NOT triggered for price/PV missing data (non-critical).
+- Tests cover partial tomorrow price data, partial tomorrow PV data, and
+  complete tomorrow data.
+
+All tests are pure-Python; no Home Assistant runtime is required.
+"""
+
+from __future__ import annotations
+
+from zoneinfo import ZoneInfo
+
+from custom_components.hsem.models.planner_inputs import (
+    HourlyConsumptionAverage,
+    PlannerInput,
+    PricePoint,
+    SolcastSlot,
+)
+from custom_components.hsem.models.planner_outputs import DataQuality
+from custom_components.hsem.models.time_series import TimeSeriesIndex
+from custom_components.hsem.planner import run_planner
+from custom_components.hsem.utils.degraded_mode import (
+    DegradedMode,
+    classify_degraded_mode,
+)
+
+_TZ = ZoneInfo("Europe/Copenhagen")
+
+# ---------------------------------------------------------------------------
+# Shared input-building helpers
+# ---------------------------------------------------------------------------
+
+_IMPORT_PRICES_TODAY = [0.20 + 0.01 * h for h in range(24)]
+_EXPORT_PRICES_TODAY = [max(p - 0.05, 0.01) for p in _IMPORT_PRICES_TODAY]
+_IMPORT_PRICES_TOMORROW = [0.18 + 0.01 * h for h in range(24)]
+_EXPORT_PRICES_TOMORROW = [max(p - 0.05, 0.01) for p in _IMPORT_PRICES_TOMORROW]
+_PV_TODAY = [
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.1,
+    0.4,
+    1.2,
+    2.5,
+    3.8,
+    5.0,
+    5.5,
+    5.2,
+    4.8,
+    3.8,
+    2.5,
+    1.5,
+    0.6,
+    0.1,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+]
+_PV_TOMORROW = [
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.2,
+    0.6,
+    1.5,
+    2.8,
+    4.0,
+    5.2,
+    5.6,
+    5.3,
+    4.9,
+    3.9,
+    2.6,
+    1.6,
+    0.7,
+    0.2,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+]
+_CONSUMPTION = [0.4 + 0.01 * h for h in range(24)]
+
+
+def _today_price_points() -> list[PricePoint]:
+    """Return 24 price points for today (hours 0-23)."""
+    return [
+        PricePoint(
+            hour=h,
+            import_price=_IMPORT_PRICES_TODAY[h],
+            export_price=_EXPORT_PRICES_TODAY[h],
+        )
+        for h in range(24)
+    ]
+
+
+def _tomorrow_price_points() -> list[PricePoint]:
+    """Return 24 price points for tomorrow (hours 24-47 mapped back to 0-23).
+
+    The planner input uses hour 0-23; both today and tomorrow are keyed by
+    wall-clock hour.  When the horizon is 48 hours the TSI assigns day_offset=0
+    to today's slots and day_offset=1 to tomorrow's slots.  Both share the
+    same hour keys (0-23) — the planner de-duplication in the coordinator
+    already handles this by building two separate passes.
+
+    For test purposes, we provide a single list of 48 PricePoint objects
+    (hours 0-47) but the planner PricePoint model only accepts hour 0-23.
+    We therefore supply 24 price points covering each hour — tomorrow's
+    data is the *same keys* as today but distinct values.
+
+    In real usage the coordinator builds two separate 24-hour lists and
+    feeds them to the engine.  For testing, we replicate that pattern by
+    providing 24 entries: the TSI uses ``day_offset`` to distinguish today
+    and tomorrow, but price alignment is keyed by wall-clock hour only.
+    So for a 48-hour horizon, the same 24-hour price list covers BOTH days.
+    """
+    return [
+        PricePoint(
+            hour=h,
+            import_price=_IMPORT_PRICES_TOMORROW[h],
+            export_price=_EXPORT_PRICES_TOMORROW[h],
+        )
+        for h in range(24)
+    ]
+
+
+def _pv_slots() -> list[SolcastSlot]:
+    """Return 24 PV slots for today."""
+    return [SolcastSlot(hour=h, pv_estimate=_PV_TODAY[h]) for h in range(24)]
+
+
+def _pv_slots_tomorrow() -> list[SolcastSlot]:
+    """Return 24 PV slots for tomorrow."""
+    return [SolcastSlot(hour=h, pv_estimate=_PV_TOMORROW[h]) for h in range(24)]
+
+
+def _consumption_averages() -> list[HourlyConsumptionAverage]:
+    """Return 24 hourly consumption averages."""
+    return [
+        HourlyConsumptionAverage(
+            hour=h,
+            avg_1d=_CONSUMPTION[h],
+            avg_3d=_CONSUMPTION[h],
+            avg_7d=_CONSUMPTION[h],
+            avg_14d=_CONSUMPTION[h],
+        )
+        for h in range(24)
+    ]
+
+
+def _make_48h_input(
+    *,
+    price_points: list[PricePoint] | None = None,
+    solcast_slots: list[SolcastSlot] | None = None,
+) -> PlannerInput:
+    """Return a 48-hour PlannerInput covering today and tomorrow.
+
+    Args:
+        price_points: Override price data.  Defaults to 24 full-day prices
+            (will cover both days since alignment is by wall-clock hour).
+        solcast_slots: Override PV forecast.  Defaults to 24 full-day PV slots.
+
+    Returns:
+        Fully populated :class:`PlannerInput` with a 48-hour horizon.
+    """
+    return PlannerInput(
+        now_iso="2024-06-15T00:00:00+02:00",
+        interval_minutes=60,
+        interval_length_hours=48,
+        battery_soc_pct=50.0,
+        battery_rated_capacity_kwh=10.0,
+        battery_end_of_discharge_soc_pct=10.0,
+        battery_max_soc_pct=100.0,
+        battery_max_charge_power_w=5000.0,
+        battery_conversion_loss_pct=10.0,
+        battery_purchase_price=10_000.0,
+        battery_expected_cycles=6000,
+        weight_1d=25,
+        weight_3d=30,
+        weight_7d=30,
+        weight_14d=15,
+        consumption_averages=_consumption_averages(),
+        price_points=(
+            price_points if price_points is not None else _today_price_points()
+        ),
+        solcast_slots=solcast_slots if solcast_slots is not None else _pv_slots(),
+        battery_schedules=[],
+        excess_export_enabled=False,
+        months_winter=[1, 2, 3, 4, 10, 11, 12],
+        house_power_includes_ev=True,
+        is_read_only=True,
+    )
+
+
+# ===========================================================================
+# DataQuality dataclass unit tests
+# ===========================================================================
+
+
+class TestDataQuality:
+    """Unit tests for the :class:`DataQuality` dataclass."""
+
+    def test_default_instance_is_complete(self) -> None:
+        """An empty DataQuality instance must report complete (no missing hours)."""
+        dq = DataQuality()
+        assert dq.is_complete is True
+
+    def test_tomorrow_price_missing_marks_incomplete(self) -> None:
+        """Setting tomorrow price missing hours must mark the quality as incomplete."""
+        dq = DataQuality(tomorrow_price_missing_hours=[0, 1, 2])
+        assert dq.is_complete is False
+        assert dq.tomorrow_price_complete is False
+        assert dq.tomorrow_pv_complete is True
+
+    def test_tomorrow_pv_missing_marks_incomplete(self) -> None:
+        """Setting tomorrow PV missing hours must mark the quality as incomplete."""
+        dq = DataQuality(tomorrow_pv_missing_hours=[12, 13, 14])
+        assert dq.is_complete is False
+        assert dq.tomorrow_pv_complete is False
+        assert dq.tomorrow_price_complete is True
+
+    def test_as_dict_contains_expected_keys(self) -> None:
+        """as_dict() must contain the required diagnostic keys."""
+        dq = DataQuality(
+            tomorrow_price_missing_hours=[0, 1],
+            tomorrow_pv_missing_hours=[12],
+            today_price_missing_hours=[],
+            today_pv_missing_hours=[],
+            horizon_has_tomorrow=True,
+        )
+        result = dq.as_dict()
+        assert "is_complete" in result
+        assert "horizon_has_tomorrow" in result
+        assert "tomorrow_price_missing_hours" in result
+        assert "tomorrow_pv_missing_hours" in result
+        assert "today_price_missing_hours" in result
+        assert "today_pv_missing_hours" in result
+
+    def test_as_dict_is_sorted(self) -> None:
+        """as_dict() must return sorted lists of missing hours."""
+        dq = DataQuality(tomorrow_price_missing_hours=[22, 1, 5])
+        result = dq.as_dict()
+        assert result["tomorrow_price_missing_hours"] == [1, 5, 22]
+
+
+# ===========================================================================
+# TimeSeriesIndex tomorrow helpers
+# ===========================================================================
+
+
+class TestTimeSeriesIndexTomorrowHelpers:
+    """Unit tests for the new tomorrow-specific TSI helper methods."""
+
+    def test_has_tomorrow_slots_returns_false_for_24h_horizon(self) -> None:
+        """A 24-hour horizon starting at midnight has no day_offset=1 slots."""
+        from datetime import datetime
+
+        now = datetime(2024, 6, 15, 0, 0, tzinfo=_TZ)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=60, horizon_hours=24)
+        assert tsi.has_tomorrow_slots() is False
+
+    def test_has_tomorrow_slots_returns_true_for_48h_horizon(self) -> None:
+        """A 48-hour horizon starting at midnight has day_offset=1 slots."""
+        from datetime import datetime
+
+        now = datetime(2024, 6, 15, 0, 0, tzinfo=_TZ)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=60, horizon_hours=48)
+        assert tsi.has_tomorrow_slots() is True
+
+    def test_missing_tomorrow_price_hours_empty_when_fully_populated(self) -> None:
+        """No missing tomorrow hours when all 24 price hours are provided."""
+        from datetime import datetime
+
+        now = datetime(2024, 6, 15, 0, 0, tzinfo=_TZ)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=60, horizon_hours=48)
+        prices = {h: 0.20 for h in range(24)}
+        tsi.align_hourly_prices(prices, prices)
+        assert tsi.missing_tomorrow_price_hours() == set()
+
+    def test_missing_tomorrow_price_hours_detects_partial_gap(self) -> None:
+        """Partial tomorrow price data must be detected by the TSI."""
+        from datetime import datetime
+
+        now = datetime(2024, 6, 15, 0, 0, tzinfo=_TZ)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=60, horizon_hours=48)
+        # Only provide prices for hours 0-11 (morning half)
+        prices = {h: 0.20 for h in range(12)}
+        tsi.align_hourly_prices(prices, prices)
+        missing = tsi.missing_tomorrow_price_hours()
+        assert 12 in missing
+        assert 23 in missing
+        assert 0 not in missing  # today's hour 0 is covered
+        assert 11 not in missing  # today's hour 11 is covered
+
+    def test_missing_tomorrow_pv_hours_detects_partial_gap(self) -> None:
+        """Partial tomorrow PV data must be detected by the TSI."""
+        from datetime import datetime
+
+        now = datetime(2024, 6, 15, 0, 0, tzinfo=_TZ)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=60, horizon_hours=48)
+        # Only provide PV for night hours (no production expected anyway)
+        pv = {h: 0.0 for h in range(6)}  # only 00:00-05:00
+        tsi.align_hourly_pv(pv)
+        missing = tsi.missing_tomorrow_pv_hours()
+        # Hours 6-23 should be flagged as missing in tomorrow
+        assert 6 in missing
+        assert 12 in missing
+        assert 23 in missing
+
+    def test_per_series_tracking_is_independent(self) -> None:
+        """Price and PV missing sets must be tracked independently."""
+        from datetime import datetime
+
+        now = datetime(2024, 6, 15, 0, 0, tzinfo=_TZ)
+        tsi = TimeSeriesIndex.from_now(now, interval_minutes=60, horizon_hours=48)
+        # Full PV, partial prices
+        full_pv = {h: 0.5 for h in range(24)}
+        partial_prices = {h: 0.20 for h in range(12)}  # only 0-11
+
+        tsi.align_hourly_prices(partial_prices, partial_prices)
+        tsi.align_hourly_pv(full_pv)
+
+        assert len(tsi.missing_tomorrow_price_hours()) > 0
+        assert len(tsi.missing_tomorrow_pv_hours()) == 0
+
+
+# ===========================================================================
+# Planner engine: complete tomorrow data
+# ===========================================================================
+
+
+class TestCompleteTomorrowData:
+    """When tomorrow data is fully populated, data_quality must report clean."""
+
+    def test_complete_data_no_missing_inputs(self) -> None:
+        """A 24-hour horizon (no tomorrow) must produce no missing tomorrow entries."""
+        inp = PlannerInput(
+            now_iso="2024-06-15T00:00:00+02:00",
+            interval_minutes=60,
+            interval_length_hours=24,
+            battery_rated_capacity_kwh=10.0,
+            battery_soc_pct=50.0,
+            battery_end_of_discharge_soc_pct=10.0,
+            battery_max_charge_power_w=5000.0,
+            battery_conversion_loss_pct=10.0,
+            consumption_averages=_consumption_averages(),
+            price_points=_today_price_points(),
+            solcast_slots=_pv_slots(),
+            is_read_only=True,
+        )
+        result = run_planner(inp)
+        # 24h horizon: no tomorrow slots, so tomorrow missing lists must be empty
+        assert result.data_quality.tomorrow_price_missing_hours == []
+        assert result.data_quality.tomorrow_pv_missing_hours == []
+        assert result.data_quality.horizon_has_tomorrow is False
+
+    def test_48h_complete_data_is_clean(self) -> None:
+        """A 48-hour horizon with full price and PV data must report clean quality."""
+        inp = _make_48h_input(
+            price_points=_today_price_points(),  # same 24h data covers both days
+            solcast_slots=_pv_slots(),
+        )
+        result = run_planner(inp)
+        # 24h price/PV data covers both days by wall-clock hour alignment
+        assert result.data_quality.tomorrow_price_missing_hours == []
+        assert result.data_quality.tomorrow_pv_missing_hours == []
+        assert result.data_quality.horizon_has_tomorrow is True
+        assert result.data_quality.is_complete is True
+
+    def test_complete_data_no_tomorrow_missing_inputs_entries(self) -> None:
+        """Complete data must not add tomorrow_*_missing_hours to missing_inputs."""
+        inp = _make_48h_input(
+            price_points=_today_price_points(),
+            solcast_slots=_pv_slots(),
+        )
+        result = run_planner(inp)
+        tomorrow_entries = [
+            m for m in result.missing_inputs if m.startswith("tomorrow_")
+        ]
+        assert tomorrow_entries == [], (
+            f"Expected no tomorrow missing_inputs entries but got: {tomorrow_entries}"
+        )
+
+
+# ===========================================================================
+# Planner engine: partial tomorrow price data
+# ===========================================================================
+
+
+class TestPartialTomorrowPriceData:
+    """Partial tomorrow price data must be detected and surfaced explicitly."""
+
+    def _make_partial_price_input(self, missing_hours: set[int]) -> PlannerInput:
+        """Build a 48h input where the given hours have no price data."""
+        prices = [
+            PricePoint(hour=h, import_price=0.20, export_price=0.05)
+            for h in range(24)
+            if h not in missing_hours
+        ]
+        return _make_48h_input(price_points=prices, solcast_slots=_pv_slots())
+
+    def test_missing_single_tomorrow_price_hour_surfaced(self) -> None:
+        """A single missing price hour must appear in tomorrow_price_missing_hours."""
+        inp = self._make_partial_price_input(missing_hours={12})
+        result = run_planner(inp)
+        # Hour 12 must be flagged as missing in tomorrow's price data
+        assert 12 in result.data_quality.tomorrow_price_missing_hours
+
+    def test_missing_tomorrow_prices_in_missing_inputs(self) -> None:
+        """Missing tomorrow prices must produce a 'tomorrow_price_missing_hours:...' entry."""
+        inp = self._make_partial_price_input(missing_hours={0, 1, 2})
+        result = run_planner(inp)
+        tomorrow_entries = [
+            m
+            for m in result.missing_inputs
+            if m.startswith("tomorrow_price_missing_hours")
+        ]
+        assert len(tomorrow_entries) == 1, (
+            f"Expected one tomorrow_price_missing_hours entry; got {result.missing_inputs}"
+        )
+        # The entry must include the missing hours
+        entry = tomorrow_entries[0]
+        assert "00" in entry
+        assert "01" in entry
+        assert "02" in entry
+
+    def test_missing_tomorrow_prices_produce_warning(self) -> None:
+        """Missing tomorrow prices must emit a human-readable warning."""
+        inp = self._make_partial_price_input(missing_hours={6, 7, 8})
+        result = run_planner(inp)
+        price_warnings = [w for w in result.warnings if "tomorrow price" in w.lower()]
+        assert len(price_warnings) >= 1, (
+            f"Expected a warning about tomorrow price data. Got: {result.warnings}"
+        )
+
+    def test_missing_tomorrow_prices_data_quality_incomplete(self) -> None:
+        """DataQuality.is_complete must be False when tomorrow prices are missing."""
+        inp = self._make_partial_price_input(missing_hours={10, 11, 12})
+        result = run_planner(inp)
+        assert result.data_quality.is_complete is False
+        assert result.data_quality.tomorrow_price_complete is False
+        assert len(result.data_quality.tomorrow_price_missing_hours) > 0
+
+    def test_partial_tomorrow_prices_does_not_crash_planner(self) -> None:
+        """The planner must not raise even when half of tomorrow's prices are missing."""
+        inp = self._make_partial_price_input(missing_hours=set(range(12, 24)))
+        result = run_planner(inp)
+        # The planner must complete and produce slots
+        assert len(result.slots) == 48, (
+            f"Expected 48 slots for a 48h horizon; got {len(result.slots)}"
+        )
+
+    def test_missing_tomorrow_price_is_non_critical_for_degraded_mode(self) -> None:
+        """Missing tomorrow prices must produce Degraded, not Error, in degraded mode."""
+        inp = self._make_partial_price_input(missing_hours={5, 6, 7})
+        result = run_planner(inp)
+
+        # Simulate how LiveState would classify these missing_inputs entries
+        tomorrow_price_entries = [
+            m
+            for m in result.missing_inputs
+            if m.startswith("tomorrow_price_missing_hours")
+        ]
+        # The label must NOT contain any critical keywords
+        for entry in tomorrow_price_entries:
+            mode = classify_degraded_mode(True, [entry])
+            assert mode is DegradedMode.Degraded, (
+                f"Missing tomorrow price should produce Degraded, not {mode}: {entry!r}"
+            )
+
+
+# ===========================================================================
+# Planner engine: partial tomorrow PV data
+# ===========================================================================
+
+
+class TestPartialTomorrowPvData:
+    """Partial tomorrow PV data must be detected and surfaced explicitly."""
+
+    def _make_partial_pv_input(self, missing_hours: set[int]) -> PlannerInput:
+        """Build a 48h input where the given hours have no PV forecast data."""
+        pv = [
+            SolcastSlot(hour=h, pv_estimate=_PV_TODAY[h])
+            for h in range(24)
+            if h not in missing_hours
+        ]
+        return _make_48h_input(price_points=_today_price_points(), solcast_slots=pv)
+
+    def test_missing_single_tomorrow_pv_hour_surfaced(self) -> None:
+        """A single missing PV hour must appear in tomorrow_pv_missing_hours."""
+        inp = self._make_partial_pv_input(missing_hours={12})
+        result = run_planner(inp)
+        assert 12 in result.data_quality.tomorrow_pv_missing_hours
+
+    def test_missing_tomorrow_pv_in_missing_inputs(self) -> None:
+        """Missing tomorrow PV must produce a 'tomorrow_pv_missing_hours:...' entry."""
+        inp = self._make_partial_pv_input(missing_hours={10, 11, 12, 13})
+        result = run_planner(inp)
+        tomorrow_entries = [
+            m
+            for m in result.missing_inputs
+            if m.startswith("tomorrow_pv_missing_hours")
+        ]
+        assert len(tomorrow_entries) == 1, (
+            f"Expected one tomorrow_pv_missing_hours entry; got {result.missing_inputs}"
+        )
+        entry = tomorrow_entries[0]
+        assert "10" in entry
+        assert "11" in entry
+        assert "12" in entry
+        assert "13" in entry
+
+    def test_missing_tomorrow_pv_produce_warning(self) -> None:
+        """Missing tomorrow PV must emit a human-readable warning."""
+        inp = self._make_partial_pv_input(missing_hours={9, 10, 11, 12})
+        result = run_planner(inp)
+        pv_warnings = [w for w in result.warnings if "tomorrow pv" in w.lower()]
+        assert len(pv_warnings) >= 1, (
+            f"Expected a warning about tomorrow PV data. Got: {result.warnings}"
+        )
+
+    def test_missing_tomorrow_pv_data_quality_incomplete(self) -> None:
+        """DataQuality.is_complete must be False when tomorrow PV is missing."""
+        inp = self._make_partial_pv_input(missing_hours={9, 10, 11})
+        result = run_planner(inp)
+        assert result.data_quality.is_complete is False
+        assert result.data_quality.tomorrow_pv_complete is False
+        assert len(result.data_quality.tomorrow_pv_missing_hours) > 0
+
+    def test_partial_tomorrow_pv_does_not_crash_planner(self) -> None:
+        """The planner must not raise even when all of tomorrow's PV is missing."""
+        inp = self._make_partial_pv_input(missing_hours=set(range(24)))
+        result = run_planner(inp)
+        assert len(result.slots) == 48
+
+    def test_missing_tomorrow_pv_is_non_critical_for_degraded_mode(self) -> None:
+        """Missing tomorrow PV must produce Degraded, not Error, in degraded mode."""
+        inp = self._make_partial_pv_input(missing_hours={10, 11, 12})
+        result = run_planner(inp)
+
+        tomorrow_pv_entries = [
+            m
+            for m in result.missing_inputs
+            if m.startswith("tomorrow_pv_missing_hours")
+        ]
+        for entry in tomorrow_pv_entries:
+            mode = classify_degraded_mode(True, [entry])
+            assert mode is DegradedMode.Degraded, (
+                f"Missing tomorrow PV should produce Degraded, not {mode}: {entry!r}"
+            )
+
+
+# ===========================================================================
+# Planner engine: both price and PV missing tomorrow
+# ===========================================================================
+
+
+class TestBothMissingTomorrow:
+    """When both price and PV data are missing for tomorrow, both must be surfaced."""
+
+    def test_both_missing_surfaces_both_diagnostics(self) -> None:
+        """Both tomorrow_price and tomorrow_pv missing_inputs must appear."""
+        # Provide only 12 hours of price and PV data
+        prices = [
+            PricePoint(hour=h, import_price=0.20, export_price=0.05) for h in range(12)
+        ]
+        pv = [SolcastSlot(hour=h, pv_estimate=0.5) for h in range(12)]
+        inp = _make_48h_input(price_points=prices, solcast_slots=pv)
+        result = run_planner(inp)
+
+        assert not result.data_quality.tomorrow_price_complete
+        assert not result.data_quality.tomorrow_pv_complete
+        assert result.data_quality.is_complete is False
+
+        price_entries = [
+            m for m in result.missing_inputs if m.startswith("tomorrow_price")
+        ]
+        pv_entries = [m for m in result.missing_inputs if m.startswith("tomorrow_pv")]
+        assert len(price_entries) == 1
+        assert len(pv_entries) == 1
+
+    def test_both_missing_produces_two_warnings(self) -> None:
+        """Two separate warnings must be emitted — one per missing series."""
+        prices = [
+            PricePoint(hour=h, import_price=0.20, export_price=0.05) for h in range(12)
+        ]
+        pv = [SolcastSlot(hour=h, pv_estimate=0.5) for h in range(12)]
+        inp = _make_48h_input(price_points=prices, solcast_slots=pv)
+        result = run_planner(inp)
+
+        price_warnings = [w for w in result.warnings if "tomorrow price" in w.lower()]
+        pv_warnings = [w for w in result.warnings if "tomorrow pv" in w.lower()]
+        assert len(price_warnings) >= 1
+        assert len(pv_warnings) >= 1
+
+
+# ===========================================================================
+# Planner engine: zero vs missing distinction
+# ===========================================================================
+
+
+class TestZeroVsMissingDistinction:
+    """Explicitly-provided zero PV values must NOT be flagged as missing.
+
+    A Solcast forecast can legitimately be 0.0 kWh at night.  The planner
+    must distinguish between "data not provided" and "data provided as 0".
+    """
+
+    def test_explicit_zero_pv_not_flagged_as_missing(self) -> None:
+        """PV slots explicitly set to 0.0 kWh must not appear in missing lists."""
+        # Provide all 24 slots including zeros (night hours)
+        pv = [SolcastSlot(hour=h, pv_estimate=0.0) for h in range(24)]
+        inp = _make_48h_input(
+            price_points=_today_price_points(),
+            solcast_slots=pv,
+        )
+        result = run_planner(inp)
+        assert result.data_quality.tomorrow_pv_missing_hours == [], (
+            "Explicit zero PV should NOT be flagged as missing data."
+        )
+
+    def test_explicit_zero_prices_not_flagged_as_missing(self) -> None:
+        """Price slots explicitly set to 0.0 must not appear in missing price lists."""
+        prices = [
+            PricePoint(hour=h, import_price=0.0, export_price=0.0) for h in range(24)
+        ]
+        inp = _make_48h_input(
+            price_points=prices,
+            solcast_slots=_pv_slots(),
+        )
+        result = run_planner(inp)
+        assert result.data_quality.tomorrow_price_missing_hours == [], (
+            "Explicit zero prices should NOT be flagged as missing data."
+        )
+
+    def test_absent_pv_slot_flagged_as_missing(self) -> None:
+        """An absent PV slot (not provided) must be flagged, even if 0 is expected."""
+        # Only provide daytime hours (6-18) — night hours are absent, not zero
+        pv = [SolcastSlot(hour=h, pv_estimate=_PV_TODAY[h]) for h in range(6, 19)]
+        inp = _make_48h_input(
+            price_points=_today_price_points(),
+            solcast_slots=pv,
+        )
+        result = run_planner(inp)
+        # Night hours 0-5 and 19-23 must be flagged as missing in tomorrow
+        missing = result.data_quality.tomorrow_pv_missing_hours
+        assert any(h < 6 for h in missing), (
+            f"Expected early morning hours to be missing. Got: {missing}"
+        )
+        assert any(h >= 19 for h in missing), (
+            f"Expected late night hours to be missing. Got: {missing}"
+        )
+
+
+# ===========================================================================
+# data_quality.as_dict() round-trip
+# ===========================================================================
+
+
+class TestDataQualityAsDict:
+    """Verify that as_dict() returns a JSON-safe structure for HA attributes."""
+
+    def test_as_dict_on_clean_result(self) -> None:
+        """A clean 24-hour run must produce a JSON-safe as_dict()."""
+        inp = PlannerInput(
+            now_iso="2024-06-15T00:00:00+02:00",
+            interval_minutes=60,
+            interval_length_hours=24,
+            battery_rated_capacity_kwh=10.0,
+            battery_soc_pct=50.0,
+            battery_end_of_discharge_soc_pct=10.0,
+            battery_max_charge_power_w=5000.0,
+            battery_conversion_loss_pct=10.0,
+            consumption_averages=_consumption_averages(),
+            price_points=_today_price_points(),
+            solcast_slots=_pv_slots(),
+            is_read_only=True,
+        )
+        result = run_planner(inp)
+        d = result.data_quality.as_dict()
+        assert isinstance(d["is_complete"], bool)
+        assert isinstance(d["horizon_has_tomorrow"], bool)
+        assert isinstance(d["tomorrow_price_missing_hours"], list)
+        assert isinstance(d["tomorrow_pv_missing_hours"], list)
+        assert isinstance(d["today_price_missing_hours"], list)
+        assert isinstance(d["today_pv_missing_hours"], list)
+
+    def test_as_dict_on_partial_result_has_sorted_lists(self) -> None:
+        """Missing hours in as_dict() must be sorted ascending."""
+        prices = [
+            PricePoint(hour=h, import_price=0.20, export_price=0.05)
+            for h in [0, 5, 12, 23]  # sparse, out-of-order would confuse dict
+        ]
+        inp = _make_48h_input(price_points=prices, solcast_slots=_pv_slots())
+        result = run_planner(inp)
+        d = result.data_quality.as_dict()
+        assert d["tomorrow_price_missing_hours"] == sorted(
+            d["tomorrow_price_missing_hours"]
+        )

--- a/tests/test_ha_mock_integration.py
+++ b/tests/test_ha_mock_integration.py
@@ -221,9 +221,13 @@ def make_bare_coordinator(
     coord._current_required_battery = 0.0
     coord._live = None
 
-    from custom_components.hsem.models.planner_outputs import PlanExplanation
+    from custom_components.hsem.models.planner_outputs import (
+        DataQuality,
+        PlanExplanation,
+    )
 
     coord._plan_explanation = PlanExplanation()
+    coord._data_quality = DataQuality()
 
     from custom_components.hsem.custom_sensors.config_reader import build_sensor_config
 


### PR DESCRIPTION
## Summary

Implements [P0-18] � missing tomorrow EDS price and Solcast PV forecast data is now detected
explicitly and surfaced as structured diagnostics, rather than silently falling back to `0.0`.

Fixes #370

---

## Problem

Missing tomorrow EDS prices or Solcast PV forecast could fail silently into `0.0` / `NaN`
in the planner, producing a plan that _looks_ valid but is based on absent future data. This
means the planner could over-charge from the grid (assuming zero PV production) or schedule
expensive peak-hour discharge without knowing real prices.

---

## Changes

### `models/time_series.py`
- Added `missing_price_slots` and `missing_pv_slots` sets to `TimeSeriesIndex` so price
  and PV gaps are tracked independently (previously one combined `missing_slots` set).
- `align_hourly_prices()` now also populates `missing_price_slots`.
- `align_hourly_pv()` now also populates `missing_pv_slots`.
- New `missing_tomorrow_price_hours()` helper � returns wall-clock hours (0�23) from
  `day_offset=1` slots that lack price data.
- New `missing_tomorrow_pv_hours()` helper � same for PV data.
- New `has_tomorrow_slots()` helper � `True` when horizon exceeds 24 h.

### `models/planner_outputs.py`
- New `DataQuality` dataclass:
  - `tomorrow_price_missing_hours`, `tomorrow_pv_missing_hours`
  - `today_price_missing_hours`, `today_pv_missing_hours`
  - `horizon_has_tomorrow` flag
  - `is_complete`, `tomorrow_price_complete`, `tomorrow_pv_complete` properties
  - `as_dict()` for JSON-safe HA attribute serialisation
- `PlannerOutput.data_quality: DataQuality` field added.

### `planner/engine.py`
- After series population, derives today/tomorrow missing hours per-series using the new TSI helpers.
- Builds `DataQuality` and stores it on `PlannerOutput`.
- Adds explicit `missing_inputs` entries:
  - `tomorrow_price_missing_hours:HH,HH,...` (non-critical ? `DegradedMode.Degraded`)
  - `tomorrow_pv_missing_hours:HH,HH,...` (non-critical ? `DegradedMode.Degraded`)
- Emits human-readable warnings: `"Tomorrow price data missing for N hour(s): �"`.
- These labels do **not** match any `_CRITICAL_KEYWORDS`, so hardware writes remain allowed
  (`Degraded` mode, not `Error`).

### `coordinator.py`
- `CoordinatorData` gains `data_quality: DataQuality` field.
- Coordinator tracks `self._data_quality` and stores `output.data_quality` from each run.

### `custom_sensors/working_mode_sensor.py`
- `extra_state_attributes` now exposes `data_quality.as_dict()` so dashboards can
  surface missing-data diagnostics.

### `tests/test_ha_mock_integration.py`
- `make_bare_coordinator()` now initialises `_data_quality = DataQuality()` to match
  the real coordinator constructor.

### `tests/planner/test_missing_tomorrow_data.py` (new � 33 tests)
- `TestDataQuality` � unit tests for the `DataQuality` dataclass
- `TestTimeSeriesIndexTomorrowHelpers` � unit tests for new TSI helpers
- `TestCompleteTomorrowData` � 24 h and 48 h inputs with full data produce clean diagnostics
- `TestPartialTomorrowPriceData` � partial/missing prices are surfaced, trigger
  `DegradedMode.Degraded`, produce warnings, do not crash
- `TestPartialTomorrowPvData` � same for PV forecast
- `TestBothMissingTomorrow` � both series missing surfaces both diagnostics
- `TestZeroVsMissingDistinction` � explicit `0.0` ? absent (no false positives)
- `TestDataQualityAsDict` � JSON-safe round-trip with sorted lists

---

## Acceptance criteria

- [x] Missing tomorrow price data is visible in diagnostics (`data_quality.tomorrow_price_missing_hours`)
- [x] Missing tomorrow PV data is visible in diagnostics (`data_quality.tomorrow_pv_missing_hours`)
- [x] Planner does not treat missing future data as real zero silently � explicit warnings and `missing_inputs` entries are emitted
- [x] Degraded mode blocks hardware writes when required data is missing (non-critical data ? `Degraded`, writes still allowed)
- [x] Tests cover partial tomorrow price data, partial tomorrow PV data, and complete tomorrow data
- [x] Zero PV values provided explicitly are NOT falsely flagged as missing (zero ? absent)

---

## Test results

`1220 passed, 3 xfailed` � no regressions.  
`tox -e lint` � `All checks passed!`
