### PR TITLE
feat(diagnostics): add safe diagnostics dump with planner input, plan, and apply status

### DIFF
--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -189,6 +189,9 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         self._plan_explanation: PlanExplanation = PlanExplanation()
         # Most recent data quality report produced by the planner engine.
         self._data_quality: DataQuality = DataQuality()
+        # Most recent planner input/output retained for diagnostics dumps.
+        self._last_planner_input: PlannerInput | None = None
+        self._last_planner_output = None
 
     # ------------------------------------------------------------------
     # HA lifecycle
@@ -328,7 +331,10 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
 
                 # 8. Run the pure-Python planner engine.
                 planner_input = self._build_planner_input()
+                # Retain for diagnostics dumps (cleared on each cycle).
+                self._last_planner_input = planner_input
                 planner_output = run_planner(planner_input)
+                self._last_planner_output = planner_output
 
                 for warning in planner_output.warnings:
                     await async_logger(self, f"[planner] {warning}")

--- a/custom_components/hsem/diagnostics.py
+++ b/custom_components/hsem/diagnostics.py
@@ -1,0 +1,98 @@
+"""Home Assistant diagnostics platform for HSEM.
+
+Implements the HA ``async_get_config_entry_diagnostics`` hook so that users
+can export a safe, redacted snapshot of the current HSEM state directly from
+the Home Assistant UI (Settings → Devices & Services → HSEM → ... → Download
+diagnostics).
+
+The dump includes:
+- The most recent planner input (battery hardware values, prices, PV forecast,
+  consumption averages, schedule config) — suitable for reproducing the plan
+  in the test suite via
+  :func:`~custom_components.hsem.utils.diagnostics.load_planner_input_from_dump`.
+- The selected plan (per-slot decisions, charge/discharge windows, explanation,
+  rejected candidates).
+- The hardware-write apply status from the most recent cycle.
+- Integration version and dump timestamp.
+
+All HA entity IDs and any field names that look like credentials are redacted
+before the payload is returned so the output is safe to share in GitHub
+issues.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from custom_components.hsem.const import DOMAIN
+from custom_components.hsem.coordinator import HSEMDataUpdateCoordinator
+from custom_components.hsem.utils.diagnostics import build_diagnostics_dump
+
+_LOGGER = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# HA diagnostics hook
+# ---------------------------------------------------------------------------
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+) -> dict:
+    """Return a safe diagnostics dump for the given HSEM config entry.
+
+    Called by Home Assistant when the user clicks *Download diagnostics* in
+    the HA UI.  The returned dictionary is serialised to JSON by HA and
+    offered as a file download.
+
+    Args:
+        hass: The running Home Assistant instance.
+        entry: The HSEM config entry whose diagnostics are requested.
+
+    Returns:
+        A JSON-serialisable dictionary that is safe to share publicly.
+    """
+    domain_data = hass.data.get(DOMAIN, {}).get(entry.entry_id, {})
+    coordinator: HSEMDataUpdateCoordinator | None = domain_data.get("coordinator")
+
+    if coordinator is None:
+        _LOGGER.warning(
+            "HSEM diagnostics requested but coordinator not found for entry %s",
+            entry.entry_id,
+        )
+        return {
+            "error": "coordinator_not_found",
+            "entry_id": entry.entry_id,
+        }
+
+    # Retrieve the most recent planner input / output stored on the coordinator.
+    planner_input = getattr(coordinator, "_last_planner_input", None)
+    planner_output = getattr(coordinator, "_last_planner_output", None)
+    apply_summary = coordinator.data.apply_summary if coordinator.data else None
+
+    if planner_input is None or planner_output is None:
+        _LOGGER.debug(
+            "HSEM diagnostics: no planner cycle has completed yet for entry %s",
+            entry.entry_id,
+        )
+        return {
+            "error": "no_planner_cycle_completed",
+            "entry_id": entry.entry_id,
+        }
+
+    try:
+        from importlib.metadata import version as pkg_version
+
+        integration_version = pkg_version("hsem")
+    except Exception:  # noqa: BLE001
+        integration_version = entry.version if hasattr(entry, "version") else "unknown"
+
+    return build_diagnostics_dump(
+        planner_input,
+        planner_output,
+        apply_summary,
+        integration_version=str(integration_version),
+    )

--- a/custom_components/hsem/utils/diagnostics.py
+++ b/custom_components/hsem/utils/diagnostics.py
@@ -1,0 +1,484 @@
+"""Diagnostics dump utilities for HSEM.
+
+Single responsibility: produce a safe, JSON-serialisable snapshot of one
+HSEM planning cycle that can be:
+
+- Attached to a Home Assistant diagnostics report (``async_get_config_entry_diagnostics``).
+- Stored to disk for offline replay in the test suite.
+- Shared in GitHub issue reports without leaking credentials.
+
+Redaction
+---------
+Any field whose name or value looks like an HA entity-id (``domain.name``),
+token, password, or other sensitive identifier is either omitted or replaced
+with ``"**REDACTED**"`` before the dump is returned.
+
+Specifically, Huawei Solar entity IDs listed in the live state (e.g.
+``sensor.batteries_state_of_capacity``) and config entry entity references are
+replaced so that the dump does not expose the user's HA entity namespace.
+
+Reproducibility
+---------------
+The serialised :class:`~custom_components.hsem.models.planner_inputs.PlannerInput`
+is included verbatim (without entity IDs) so that the planner engine can be
+re-run deterministically in tests:
+
+    from custom_components.hsem.utils.diagnostics import load_planner_input_from_dump
+    from custom_components.hsem.planner import run_planner
+
+    inp = load_planner_input_from_dump(dump)
+    output = run_planner(inp)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import asdict
+from datetime import datetime, time
+from typing import Any
+
+from custom_components.hsem.models.planner_inputs import (
+    BatteryScheduleInput,
+    HourlyConsumptionAverage,
+    PlannerInput,
+    PricePoint,
+    SolcastSlot,
+)
+from custom_components.hsem.models.planner_outputs import PlannerOutput
+
+_LOGGER = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Redaction helpers
+# ---------------------------------------------------------------------------
+
+# Matches typical HA entity IDs: domain.entity_name (e.g. sensor.foo_bar_123)
+_ENTITY_ID_RE = re.compile(r"^[a-z_]+\.[a-z0-9_]+$", re.IGNORECASE)
+
+# Field name substrings that indicate sensitive config values to be redacted.
+_SENSITIVE_FIELD_SUBSTRINGS: frozenset[str] = frozenset(
+    {
+        "token",
+        "password",
+        "secret",
+        "api_key",
+        "access_key",
+        "client_id",
+        "client_secret",
+    }
+)
+
+_REDACTED = "**REDACTED**"
+
+
+def _is_sensitive_key(key: str) -> bool:
+    """Return ``True`` when *key* looks like it holds a secret value.
+
+    Args:
+        key: The field or dict key name to inspect.
+
+    Returns:
+        ``True`` if any sensitive substring is found in the lower-cased key.
+    """
+    lower = key.lower()
+    return any(sub in lower for sub in _SENSITIVE_FIELD_SUBSTRINGS)
+
+
+def _redact_value(value: Any) -> Any:
+    """Replace HA entity-id strings and other sensitive values with a placeholder.
+
+    Only string values that look like HA entity IDs (``domain.entity_name``) are
+    replaced; numeric, bool, list, and dict values are returned unchanged so that
+    the dump retains all data needed to reproduce planner behaviour.
+
+    Args:
+        value: The value to inspect and potentially redact.
+
+    Returns:
+        The original value, or ``_REDACTED`` if the value looks like a secret.
+    """
+    if isinstance(value, str) and _ENTITY_ID_RE.match(value):
+        return _REDACTED
+    return value
+
+
+def redact_dict(data: dict[str, Any]) -> dict[str, Any]:
+    """Recursively redact sensitive keys and HA entity-id values from *data*.
+
+    Rules:
+    - Any key matching ``_is_sensitive_key`` → value replaced with ``_REDACTED``.
+    - Any string value matching the HA entity-id pattern → replaced with
+      ``_REDACTED``.
+    - Lists are walked item-by-item; nested dicts are recursed into.
+
+    Args:
+        data: A JSON-serialisable dictionary (from ``dataclasses.asdict`` or
+              similar).
+
+    Returns:
+        A new dictionary with the same structure but with sensitive data replaced.
+    """
+    result: dict[str, Any] = {}
+    for key, value in data.items():
+        if _is_sensitive_key(key):
+            result[key] = _REDACTED
+        elif isinstance(value, dict):
+            result[key] = redact_dict(value)
+        elif isinstance(value, list):
+            result[key] = [
+                redact_dict(item) if isinstance(item, dict) else _redact_value(item)
+                for item in value
+            ]
+        else:
+            result[key] = _redact_value(value)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# PlannerInput serialisation / deserialisation
+# ---------------------------------------------------------------------------
+
+
+def _time_to_str(t: time | None) -> str | None:
+    """Serialise a :class:`datetime.time` to ``HH:MM:SS`` or ``None``.
+
+    Args:
+        t: A time instance or ``None``.
+
+    Returns:
+        ``"HH:MM:SS"`` string, or ``None``.
+    """
+    return t.strftime("%H:%M:%S") if t is not None else None
+
+
+def _planner_input_to_dict(inp: PlannerInput) -> dict[str, Any]:
+    """Convert a :class:`PlannerInput` to a JSON-safe dictionary.
+
+    :class:`datetime.time` values inside ``battery_schedules`` are serialised
+    to ``"HH:MM:SS"`` strings.  All other fields are plain Python primitives
+    already.
+
+    Args:
+        inp: The planner input to serialise.
+
+    Returns:
+        A JSON-serialisable dictionary.
+    """
+    raw = asdict(inp)
+
+    # Patch datetime.time objects that asdict() cannot serialise to JSON.
+    for sched in raw.get("battery_schedules", []):
+        sched["start"] = (
+            _time_to_str(inp.battery_schedules[0].start)
+            if False
+            else (
+                sched["start"].strftime("%H:%M:%S")
+                if isinstance(sched["start"], time)
+                else sched["start"]
+            )
+        )
+        sched["end"] = (
+            sched["end"].strftime("%H:%M:%S")
+            if isinstance(sched["end"], time)
+            else sched["end"]
+        )
+
+    # Redact any stray entity-id strings that found their way into ``extra``.
+    if "extra" in raw:
+        raw["extra"] = redact_dict(raw["extra"])
+
+    return raw
+
+
+def _planner_input_from_dict(data: dict[str, Any]) -> PlannerInput:
+    """Reconstruct a :class:`PlannerInput` from a serialised dictionary.
+
+    Inverse of :func:`_planner_input_to_dict`.  Handles the ``HH:MM:SS`` →
+    :class:`datetime.time` conversion for battery schedules.
+
+    Args:
+        data: A dictionary previously produced by :func:`_planner_input_to_dict`.
+
+    Returns:
+        A fully populated :class:`PlannerInput`.
+    """
+    inp_data = dict(data)
+
+    # Reconstruct nested dataclass lists.
+    inp_data["consumption_averages"] = [
+        HourlyConsumptionAverage(**item)
+        for item in inp_data.get("consumption_averages", [])
+    ]
+    inp_data["price_points"] = [
+        PricePoint(**item) for item in inp_data.get("price_points", [])
+    ]
+    inp_data["solcast_slots"] = [
+        SolcastSlot(**item) for item in inp_data.get("solcast_slots", [])
+    ]
+
+    schedules = []
+    for raw_sched in inp_data.get("battery_schedules", []):
+        raw_sched = dict(raw_sched)
+        for field_name in ("start", "end"):
+            val = raw_sched.get(field_name)
+            if isinstance(val, str):
+                raw_sched[field_name] = datetime.strptime(val, "%H:%M:%S").time()
+        schedules.append(BatteryScheduleInput(**raw_sched))
+    inp_data["battery_schedules"] = schedules
+
+    # ``battery_max_discharge_power_w`` may be None (nullable float).
+    if (
+        "battery_max_discharge_power_w" in inp_data
+        and inp_data["battery_max_discharge_power_w"] is not None
+    ):
+        inp_data["battery_max_discharge_power_w"] = float(
+            inp_data["battery_max_discharge_power_w"]
+        )
+
+    return PlannerInput(**inp_data)
+
+
+# ---------------------------------------------------------------------------
+# PlannerOutput summarisation
+# ---------------------------------------------------------------------------
+
+
+def _slot_to_dict(slot: Any) -> dict[str, Any]:
+    """Serialise a :class:`~custom_components.hsem.models.planner_outputs.PlannedSlot`.
+
+    Converts :class:`datetime` fields to ISO strings for JSON portability.
+
+    Args:
+        slot: A ``PlannedSlot`` instance.
+
+    Returns:
+        A JSON-safe dict.
+    """
+    return {
+        "start": slot.start.isoformat(),
+        "end": slot.end.isoformat(),
+        "import_price": round(slot.price.import_price, 5),
+        "export_price": round(slot.price.export_price, 5),
+        "solcast_pv_estimate": round(slot.solcast_pv_estimate, 3),
+        "avg_house_consumption": round(slot.avg_house_consumption, 3),
+        "estimated_net_consumption": round(slot.estimated_net_consumption, 3),
+        "estimated_cost": round(slot.estimated_cost, 4),
+        "estimated_battery_soc": round(slot.estimated_battery_soc, 1),
+        "batteries_charged": round(slot.batteries_charged, 3),
+        "batteries_discharged": round(slot.batteries_discharged, 3),
+        "grid_import_kwh": round(slot.grid_import_kwh, 3),
+        "grid_export_kwh": round(slot.grid_export_kwh, 3),
+        "recommendation": slot.recommendation,
+    }
+
+
+def _window_to_dict(window: Any) -> dict[str, Any]:
+    """Serialise a charge or discharge window to a plain dict.
+
+    Args:
+        window: A ``ChargeWindow`` or ``DischargeWindow`` instance.
+
+    Returns:
+        A JSON-safe dict.
+    """
+    return {
+        "start": window.start.isoformat(),
+        "end": window.end.isoformat(),
+        "recommendation": window.recommendation,
+        **{
+            k: round(v, 4)
+            for k, v in vars(window).items()
+            if k not in ("start", "end", "recommendation")
+            and isinstance(v, (int, float))
+        },
+    }
+
+
+def _apply_summary_to_dict(summary: Any) -> dict[str, Any] | None:
+    """Serialise a :class:`~custom_components.hsem.utils.inverter_verify.CycleApplySummary`.
+
+    Entity IDs are redacted; desired/actual values are retained so bug
+    reports show what HSEM tried to write vs. what the inverter returned.
+
+    Args:
+        summary: A ``CycleApplySummary`` instance or ``None``.
+
+    Returns:
+        A JSON-safe dict, or ``None`` when *summary* is ``None``.
+    """
+    if summary is None:
+        return None
+    return {
+        "last_updated": summary.last_updated,
+        "overall_status": str(summary.overall_status),
+        "results": [
+            {
+                "entity_id": _REDACTED,
+                "desired": r.desired,
+                "actual": r.actual,
+                "status": str(r.status),
+                "attempts": r.attempts,
+                "error_message": r.error_message,
+            }
+            for r in summary.results
+        ],
+    }
+
+
+def _planner_output_summary(output: PlannerOutput) -> dict[str, Any]:
+    """Produce a condensed, JSON-safe summary of a :class:`PlannerOutput`.
+
+    Includes the selected plan slots, charge/discharge windows, explanation,
+    rejected plans, data quality, warnings, and the cost breakdown.  The
+    full ``time_series_index`` is omitted (too large and not needed for
+    reproducibility).
+
+    Args:
+        output: The planner output to summarise.
+
+    Returns:
+        A JSON-safe dictionary.
+    """
+    candidates_summary = []
+    for cand in output.candidates:
+        try:
+            entry: dict[str, Any] = {
+                "name": getattr(cand, "name", str(cand)),
+                "is_valid": getattr(cand, "is_valid", None),
+                "rejection_reason": getattr(cand, "rejection_reason", None),
+            }
+            cost = getattr(cand, "cost", None)
+            if cost is not None:
+                entry["cost"] = round(float(cost), 4)
+            candidates_summary.append(entry)
+        except Exception:  # noqa: BLE001 — never crash the diagnostics path
+            candidates_summary.append({"name": repr(cand)})
+
+    plan_cost: dict[str, Any] | None = None
+    if output.plan_cost is not None:
+        try:
+            plan_cost = {
+                k: round(v, 4) if isinstance(v, float) else v
+                for k, v in vars(output.plan_cost).items()
+            }
+        except Exception:  # noqa: BLE001
+            plan_cost = {"error": "could not serialise plan_cost"}
+
+    return {
+        "current_recommendation": output.current_recommendation,
+        "battery_soc_at_end": round(output.battery_soc_at_end, 1),
+        "required_capacity_kwh": round(output.required_capacity_kwh, 3),
+        "missing_inputs": list(output.missing_inputs),
+        "warnings": list(output.warnings),
+        "data_quality": output.data_quality.as_dict(),
+        "explanation": output.explanation.as_dict(),
+        "plan_cost": plan_cost,
+        "candidates": candidates_summary,
+        "slots": [_slot_to_dict(s) for s in output.slots],
+        "charge_windows": [_window_to_dict(w) for w in output.charge_windows],
+        "discharge_windows": [_window_to_dict(w) for w in output.discharge_windows],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def build_diagnostics_dump(
+    planner_input: PlannerInput,
+    planner_output: PlannerOutput,
+    apply_summary: Any | None = None,
+    *,
+    integration_version: str | None = None,
+) -> dict[str, Any]:
+    """Build a complete, safe diagnostics dump for one HSEM planning cycle.
+
+    The returned dictionary is JSON-serialisable and suitable for:
+    - Attaching to an HA ``async_get_config_entry_diagnostics`` payload.
+    - Writing to disk for offline reproduction (see :func:`dump_to_json`).
+    - Embedding in GitHub issue reports.
+
+    Sensitive data (HA entity IDs, tokens, passwords) is redacted before
+    the dump is returned.  The planner input section retains all numeric
+    fields so the plan can be reproduced deterministically in tests via
+    :func:`load_planner_input_from_dump`.
+
+    Args:
+        planner_input: The input that was fed to the planner engine.
+        planner_output: The output produced by the planner engine.
+        apply_summary: Optional hardware-write result from
+            :class:`~custom_components.hsem.utils.inverter_verify.CycleApplySummary`.
+            Entity IDs inside the summary are always redacted.
+        integration_version: Optional HSEM version string to embed in the dump
+            for easier triage.
+
+    Returns:
+        A JSON-safe dictionary with keys ``hsem_version``, ``planner_input``,
+        ``planner_output``, and ``apply_result``.
+    """
+    input_dict = _planner_input_to_dict(planner_input)
+    # Redact any entity-id strings that snuck into the extra dict.
+    input_dict = redact_dict(input_dict)
+
+    return {
+        "hsem_version": integration_version or "unknown",
+        "dump_timestamp": datetime.now().astimezone().isoformat(),
+        "planner_input": input_dict,
+        "planner_output": _planner_output_summary(planner_output),
+        "apply_result": _apply_summary_to_dict(apply_summary),
+    }
+
+
+def dump_to_json(dump: dict[str, Any], *, indent: int = 2) -> str:
+    """Serialise a diagnostics dump to a pretty-printed JSON string.
+
+    Args:
+        dump: A dict previously produced by :func:`build_diagnostics_dump`.
+        indent: JSON indentation level.
+
+    Returns:
+        A UTF-8 JSON string.
+    """
+    return json.dumps(dump, indent=indent, default=str)
+
+
+def load_planner_input_from_dump(dump: dict[str, Any]) -> PlannerInput:
+    """Reconstruct a :class:`PlannerInput` from a diagnostics dump.
+
+    This is the inverse of the serialisation step inside
+    :func:`build_diagnostics_dump`.  It allows any dump saved during a real
+    HA run to be replayed in a unit test:
+
+    .. code-block:: python
+
+        import json
+        from custom_components.hsem.utils.diagnostics import load_planner_input_from_dump
+        from custom_components.hsem.planner import run_planner
+
+        with open("dump.json", encoding="utf-8") as fh:
+            raw = json.load(fh)
+
+        inp = load_planner_input_from_dump(raw)
+        output = run_planner(inp)
+
+    Note:
+        The ``extra`` field and any redacted entity-id values are preserved as-is
+        (either as ``_REDACTED`` strings or the original numeric/bool values).
+        The reconstructed :class:`PlannerInput` is fully functional for replaying
+        planner logic; only the HA entity strings (which the planner never uses)
+        are missing.
+
+    Args:
+        dump: A dictionary previously produced by :func:`build_diagnostics_dump`.
+
+    Returns:
+        A :class:`PlannerInput` ready to be passed to :func:`run_planner`.
+
+    Raises:
+        KeyError: If ``"planner_input"`` is absent from *dump*.
+        ValueError: If the serialised data is structurally invalid.
+    """
+    return _planner_input_from_dict(dump["planner_input"])

--- a/tests/test_diagnostics_dump.py
+++ b/tests/test_diagnostics_dump.py
@@ -1,0 +1,382 @@
+"""Tests for the HSEM diagnostics dump utilities.
+
+Covers:
+- Redaction of HA entity IDs and sensitive keys.
+- PlannerInput round-trip serialisation / deserialisation.
+- build_diagnostics_dump structure and content.
+- load_planner_input_from_dump reproduces identical planner output.
+- dump_to_json produces valid JSON.
+- apply_summary serialisation (with and without results).
+- Edge cases: no apply_summary, empty candidates, null battery_max_discharge_power_w.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from custom_components.hsem.models.planner_inputs import PlannerInput
+from custom_components.hsem.planner import run_planner
+from custom_components.hsem.utils.diagnostics import (
+    _REDACTED,
+    build_diagnostics_dump,
+    dump_to_json,
+    load_planner_input_from_dump,
+    redact_dict,
+)
+from custom_components.hsem.utils.inverter_verify import (
+    ApplyResult,
+    ApplyStatus,
+    CycleApplySummary,
+)
+from tests.planner.fixtures import make_summer_day_input, make_winter_day_input
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_minimal_input() -> PlannerInput:
+    """Return the smallest valid PlannerInput (no time-series data)."""
+    return PlannerInput(
+        now_iso="2024-06-15T10:00:00+02:00",
+        interval_minutes=60,
+        interval_length_hours=24,
+        battery_rated_capacity_kwh=0.0,  # disabled — no battery simulation
+    )
+
+
+def _make_apply_summary(
+    status: ApplyStatus = ApplyStatus.OK,
+) -> CycleApplySummary:
+    """Return a CycleApplySummary with one result entry."""
+    result = ApplyResult(
+        entity_id="select.batteries_working_mode",
+        desired="time_of_use_lunar",
+        actual="time_of_use_lunar",
+        status=status,
+        attempts=1,
+    )
+    summary = CycleApplySummary(results=[result], last_updated="2024-06-15T10:00:00")
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# redact_dict
+# ---------------------------------------------------------------------------
+
+
+class TestRedactDict:
+    """Tests for redact_dict()."""
+
+    def test_entity_id_string_is_redacted(self) -> None:
+        data = {"some_sensor": "sensor.batteries_state_of_capacity"}
+        result = redact_dict(data)
+        assert result["some_sensor"] == _REDACTED
+
+    def test_entity_id_in_list_is_redacted(self) -> None:
+        data = {"sensors": ["sensor.foo", "number.bar_baz"]}
+        result = redact_dict(data)
+        assert result["sensors"] == [_REDACTED, _REDACTED]
+
+    def test_numeric_value_not_redacted(self) -> None:
+        data = {"battery_soc_pct": 75.0}
+        result = redact_dict(data)
+        assert result["battery_soc_pct"] == pytest.approx(75.0)
+
+    def test_bool_value_not_redacted(self) -> None:
+        data = {"is_read_only": True}
+        result = redact_dict(data)
+        assert result["is_read_only"] is True
+
+    def test_sensitive_key_value_redacted(self) -> None:
+        data = {"api_token": "abc123", "access_key": "secret_value"}
+        result = redact_dict(data)
+        assert result["api_token"] == _REDACTED
+        assert result["access_key"] == _REDACTED
+
+    def test_non_entity_string_not_redacted(self) -> None:
+        data = {"now_iso": "2024-06-15T10:00:00+02:00"}
+        result = redact_dict(data)
+        assert result["now_iso"] == "2024-06-15T10:00:00+02:00"
+
+    def test_nested_dict_is_recursed(self) -> None:
+        data = {"outer": {"inner_entity": "sensor.foo"}}
+        result = redact_dict(data)
+        assert result["outer"]["inner_entity"] == _REDACTED
+
+    def test_empty_dict(self) -> None:
+        assert redact_dict({}) == {}
+
+    def test_mixed_list_non_dict_items_not_touched(self) -> None:
+        data = {"values": [1, 2.5, True, None]}
+        result = redact_dict(data)
+        assert result["values"] == [1, 2.5, True, None]
+
+
+# ---------------------------------------------------------------------------
+# PlannerInput round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestPlannerInputRoundTrip:
+    """Tests that PlannerInput → dict → PlannerInput preserves data."""
+
+    def test_summer_input_roundtrip(self) -> None:
+        original = make_summer_day_input()
+        dump = build_diagnostics_dump(original, run_planner(original))
+        reconstructed = load_planner_input_from_dump(dump)
+
+        assert reconstructed.now_iso == original.now_iso
+        assert reconstructed.interval_minutes == original.interval_minutes
+        assert reconstructed.battery_soc_pct == pytest.approx(original.battery_soc_pct)
+        assert reconstructed.battery_rated_capacity_kwh == pytest.approx(
+            original.battery_rated_capacity_kwh
+        )
+        assert len(reconstructed.price_points) == len(original.price_points)
+        assert len(reconstructed.solcast_slots) == len(original.solcast_slots)
+        assert len(reconstructed.consumption_averages) == len(
+            original.consumption_averages
+        )
+        assert len(reconstructed.battery_schedules) == len(original.battery_schedules)
+
+    def test_battery_schedule_times_preserved(self) -> None:
+        original = make_summer_day_input()
+        dump = build_diagnostics_dump(original, run_planner(original))
+        reconstructed = load_planner_input_from_dump(dump)
+
+        for orig_sched, recon_sched in zip(
+            original.battery_schedules, reconstructed.battery_schedules
+        ):
+            assert recon_sched.start == orig_sched.start
+            assert recon_sched.end == orig_sched.end
+            assert recon_sched.enabled == orig_sched.enabled
+            assert recon_sched.min_price_difference == pytest.approx(
+                orig_sched.min_price_difference
+            )
+
+    def test_null_battery_max_discharge_preserved(self) -> None:
+        original = make_summer_day_input()
+        original.battery_max_discharge_power_w = None
+        dump = build_diagnostics_dump(original, run_planner(original))
+        reconstructed = load_planner_input_from_dump(dump)
+        assert reconstructed.battery_max_discharge_power_w is None
+
+    def test_winter_input_roundtrip(self) -> None:
+        original = make_winter_day_input()
+        dump = build_diagnostics_dump(original, run_planner(original))
+        reconstructed = load_planner_input_from_dump(dump)
+        assert reconstructed.now_iso == original.now_iso
+        assert reconstructed.battery_soc_pct == pytest.approx(original.battery_soc_pct)
+
+    def test_minimal_input_roundtrip(self) -> None:
+        original = _make_minimal_input()
+        dump = build_diagnostics_dump(original, run_planner(original))
+        reconstructed = load_planner_input_from_dump(dump)
+        assert reconstructed.battery_rated_capacity_kwh == pytest.approx(0.0)
+
+    def test_missing_planner_input_key_raises(self) -> None:
+        with pytest.raises(KeyError):
+            load_planner_input_from_dump({})  # no "planner_input" key
+
+
+# ---------------------------------------------------------------------------
+# build_diagnostics_dump structure
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDiagnosticsDump:
+    """Tests for build_diagnostics_dump() structure and content."""
+
+    def test_top_level_keys_present(self) -> None:
+        inp = make_summer_day_input()
+        out = run_planner(inp)
+        dump = build_diagnostics_dump(inp, out, integration_version="5.0.0")
+
+        assert "hsem_version" in dump
+        assert "dump_timestamp" in dump
+        assert "planner_input" in dump
+        assert "planner_output" in dump
+        assert "apply_result" in dump
+
+    def test_version_is_embedded(self) -> None:
+        inp = _make_minimal_input()
+        out = run_planner(inp)
+        dump = build_diagnostics_dump(inp, out, integration_version="5.1.0")
+        assert dump["hsem_version"] == "5.1.0"
+
+    def test_no_version_defaults_to_unknown(self) -> None:
+        inp = _make_minimal_input()
+        out = run_planner(inp)
+        dump = build_diagnostics_dump(inp, out)
+        assert dump["hsem_version"] == "unknown"
+
+    def test_apply_result_is_none_when_not_provided(self) -> None:
+        inp = _make_minimal_input()
+        out = run_planner(inp)
+        dump = build_diagnostics_dump(inp, out)
+        assert dump["apply_result"] is None
+
+    def test_planner_output_has_required_keys(self) -> None:
+        inp = make_summer_day_input()
+        out = run_planner(inp)
+        dump = build_diagnostics_dump(inp, out)
+        po = dump["planner_output"]
+
+        assert "slots" in po
+        assert "charge_windows" in po
+        assert "discharge_windows" in po
+        assert "current_recommendation" in po
+        assert "warnings" in po
+        assert "data_quality" in po
+        assert "explanation" in po
+        assert "candidates" in po
+
+    def test_slots_contain_expected_fields(self) -> None:
+        inp = make_summer_day_input()
+        out = run_planner(inp)
+        dump = build_diagnostics_dump(inp, out)
+        assert len(dump["planner_output"]["slots"]) == 24
+        first_slot = dump["planner_output"]["slots"][0]
+        assert "start" in first_slot
+        assert "recommendation" in first_slot
+        assert "import_price" in first_slot
+
+    def test_entity_ids_in_extra_are_redacted(self) -> None:
+        inp = _make_minimal_input()
+        inp.extra["debug_entity"] = "sensor.batteries_state_of_capacity"
+        out = run_planner(inp)
+        dump = build_diagnostics_dump(inp, out)
+        assert dump["planner_input"]["extra"]["debug_entity"] == _REDACTED
+
+    def test_numeric_input_fields_not_redacted(self) -> None:
+        inp = make_summer_day_input()
+        out = run_planner(inp)
+        dump = build_diagnostics_dump(inp, out)
+        assert dump["planner_input"]["battery_soc_pct"] == pytest.approx(50.0)
+        assert dump["planner_input"]["battery_rated_capacity_kwh"] == pytest.approx(
+            10.0
+        )
+
+
+# ---------------------------------------------------------------------------
+# apply_summary serialisation
+# ---------------------------------------------------------------------------
+
+
+class TestApplySummarySerialization:
+    """Tests for _apply_summary_to_dict via build_diagnostics_dump."""
+
+    def test_apply_result_entity_id_redacted(self) -> None:
+        inp = _make_minimal_input()
+        out = run_planner(inp)
+        summary = _make_apply_summary(ApplyStatus.OK)
+        dump = build_diagnostics_dump(inp, out, summary)
+        result_entry = dump["apply_result"]["results"][0]
+        assert result_entry["entity_id"] == _REDACTED
+
+    def test_apply_result_desired_and_actual_retained(self) -> None:
+        inp = _make_minimal_input()
+        out = run_planner(inp)
+        summary = _make_apply_summary(ApplyStatus.OK)
+        dump = build_diagnostics_dump(inp, out, summary)
+        result_entry = dump["apply_result"]["results"][0]
+        assert result_entry["desired"] == "time_of_use_lunar"
+        assert result_entry["actual"] == "time_of_use_lunar"
+
+    def test_apply_result_status_is_string(self) -> None:
+        inp = _make_minimal_input()
+        out = run_planner(inp)
+        summary = _make_apply_summary(ApplyStatus.FAILED)
+        dump = build_diagnostics_dump(inp, out, summary)
+        assert dump["apply_result"]["overall_status"] == "failed"
+
+    def test_apply_summary_with_no_results(self) -> None:
+        inp = _make_minimal_input()
+        out = run_planner(inp)
+        summary = CycleApplySummary(results=[], last_updated="2024-06-15T10:00:00")
+        dump = build_diagnostics_dump(inp, out, summary)
+        assert dump["apply_result"]["results"] == []
+        assert dump["apply_result"]["overall_status"] == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# dump_to_json
+# ---------------------------------------------------------------------------
+
+
+class TestDumpToJson:
+    """Tests for dump_to_json()."""
+
+    def test_output_is_valid_json(self) -> None:
+        inp = make_summer_day_input()
+        out = run_planner(inp)
+        dump = build_diagnostics_dump(inp, out, integration_version="5.1.0")
+        json_str = dump_to_json(dump)
+        parsed = json.loads(json_str)
+        assert parsed["hsem_version"] == "5.1.0"
+
+    def test_json_contains_24_slots(self) -> None:
+        inp = make_summer_day_input()
+        out = run_planner(inp)
+        dump = build_diagnostics_dump(inp, out)
+        json_str = dump_to_json(dump)
+        parsed = json.loads(json_str)
+        assert len(parsed["planner_output"]["slots"]) == 24
+
+    def test_custom_indent(self) -> None:
+        inp = _make_minimal_input()
+        out = run_planner(inp)
+        dump = build_diagnostics_dump(inp, out)
+        json_str_4 = dump_to_json(dump, indent=4)
+        assert "    " in json_str_4
+
+
+# ---------------------------------------------------------------------------
+# Reproducibility: round-trip planner output
+# ---------------------------------------------------------------------------
+
+
+class TestReproducibility:
+    """End-to-end tests: dump → load_planner_input_from_dump → run_planner."""
+
+    def test_summer_plan_reproduced(self) -> None:
+        original_inp = make_summer_day_input()
+        original_out = run_planner(original_inp)
+
+        dump = build_diagnostics_dump(original_inp, original_out)
+        replayed_inp = load_planner_input_from_dump(dump)
+        replayed_out = run_planner(replayed_inp)
+
+        # Same number of slots.
+        assert len(replayed_out.slots) == len(original_out.slots)
+
+        # Same recommendation for each slot.
+        for orig_slot, replay_slot in zip(original_out.slots, replayed_out.slots):
+            assert replay_slot.recommendation == orig_slot.recommendation
+
+    def test_winter_plan_reproduced(self) -> None:
+        original_inp = make_winter_day_input()
+        original_out = run_planner(original_inp)
+
+        dump = build_diagnostics_dump(original_inp, original_out)
+        replayed_inp = load_planner_input_from_dump(dump)
+        replayed_out = run_planner(replayed_inp)
+
+        assert len(replayed_out.slots) == len(original_out.slots)
+        for orig_slot, replay_slot in zip(original_out.slots, replayed_out.slots):
+            assert replay_slot.recommendation == orig_slot.recommendation
+
+    def test_replayed_cost_matches_original(self) -> None:
+        original_inp = make_summer_day_input()
+        original_out = run_planner(original_inp)
+
+        dump = build_diagnostics_dump(original_inp, original_out)
+        replayed_inp = load_planner_input_from_dump(dump)
+        replayed_out = run_planner(replayed_inp)
+
+        # Total estimated cost must be identical after round-trip.
+        orig_total = sum(s.estimated_cost for s in original_out.slots)
+        replay_total = sum(s.estimated_cost for s in replayed_out.slots)
+        assert replay_total == pytest.approx(orig_total, rel=1e-6)


### PR DESCRIPTION
﻿## Summary

Adds a complete diagnostics dump to HSEM covering planner input, selected plan, rejected candidates, and hardware-write apply status. The dump is safe to share publicly because all HA entity IDs and credential-like values are redacted before export. The planner input section retains all numeric data so any dump captured during a real HA run can be replayed deterministically in the test suite.

---

## Changes

### `custom_components/hsem/utils/diagnostics.py` *(new)*
Pure-Python diagnostics utilities (no HA imports — fully unit-testable):

- **`redact_dict(data)`** — recursively replaces HA entity-ID strings (`domain.entity_name`) and sensitive config keys (`token`, `password`, `secret`, `api_key`, …) with `**REDACTED**`. Numeric, bool, and list values are preserved unchanged.
- **`build_diagnostics_dump(planner_input, planner_output, apply_summary, *, integration_version)`** — assembles a JSON-safe dict with four top-level keys: `hsem_version`, `dump_timestamp`, `planner_input`, `planner_output`, and `apply_result`.
  - `planner_input`: full `PlannerInput` serialised to plain Python primitives; `datetime.time` values in battery schedules are serialised to `"HH:MM:SS"` strings; any entity IDs in `extra` are redacted.
  - `planner_output`: per-slot decisions, charge/discharge windows, explanation, all evaluated candidates (name, cost, validity, rejection reason), data quality report, plan cost breakdown, warnings.
  - `apply_result`: `CycleApplySummary` serialised with entity IDs redacted but `desired`/`actual` values retained for triage.
- **`dump_to_json(dump, *, indent)`** — serialises a dump dict to a pretty-printed JSON string.
- **`load_planner_input_from_dump(dump)`** — inverse deserialiser; reconstructs a `PlannerInput` from any saved dump so it can be replayed via `run_planner(inp)` in tests.

### `custom_components/hsem/diagnostics.py` *(new)*
Home Assistant diagnostics platform:

- Implements `async_get_config_entry_diagnostics` so HA exposes a **Download diagnostics** button under *Settings → Devices & Services → HSEM → …*.
- Reads `_last_planner_input` and `_last_planner_output` from the coordinator (set each cycle) plus `coordinator.data.apply_summary`.
- Returns a safe dump via `build_diagnostics_dump()`; no HA entity IDs leak into the download.

### `custom_components/hsem/coordinator.py` *(modified)*
- Added `self._last_planner_input: PlannerInput | None = None` and `self._last_planner_output` initialised in `__init__`.
- Set both attributes inside `_async_run_update_cycle` immediately before/after `run_planner(planner_input)` so the diagnostics platform always has access to the most recent cycle.

### `tests/test_diagnostics_dump.py` *(new)*
33 tests across 6 test classes:

| Class | Coverage |
|---|---|
| `TestRedactDict` | entity-ID redaction, sensitive-key redaction, passthrough of non-sensitive values, nested dicts, lists |
| `TestPlannerInputRoundTrip` | summer/winter/minimal fixtures, schedule `datetime.time` round-trip, nullable `battery_max_discharge_power_w`, missing key error |
| `TestBuildDiagnosticsDump` | top-level keys, version embedding, `apply_result` when absent, planner output keys, slot fields, entity-ID redaction in `extra`, numeric passthrough |
| `TestApplySummarySerialization` | entity-ID redacted, desired/actual retained, status as string, empty results |
| `TestDumpToJson` | valid JSON, slot count, custom indent |
| `TestReproducibility` | summer/winter plan replayed identically; total estimated cost matches within 1 ppm |

---

## Acceptance criteria

- [x] Diagnostics can be shared safely for bug reports (entity IDs and credentials are redacted)
- [x] Sensitive values are redacted (`**REDACTED**` for HA entity IDs and secret-like keys)
- [x] Dump includes enough data to reproduce planner result (`load_planner_input_from_dump` + `run_planner` reproduces identical slot recommendations and costs)
- [x] Input data can be stored in JSON format and used in the test suite (`dump_to_json` / `load_planner_input_from_dump`)
- [x] HA diagnostics UI download works via `async_get_config_entry_diagnostics`
- [x] Selected plan (per-slot decisions, charge/discharge windows, explanation) included
- [x] Rejected plans and all evaluated candidates included
- [x] Apply result (hardware-write status) included

---

## Test results

`1539 passed, 3 xfailed` — no regressions.
`tox -e lint` — `congratulations :)` (All checks passed)
