### PR TITLE
refactor(flows): deduplicate schedule and EV config flows via shared helpers

### DIFF
--- a/custom_components/hsem/flows/batteries_schedule_1.py
+++ b/custom_components/hsem/flows/batteries_schedule_1.py
@@ -1,116 +1,33 @@
-import voluptuous as vol
-from homeassistant.helpers.selector import selector
+"""Config flow step for battery schedule 1.
 
-from custom_components.hsem.utils.config_validator import validate_time_window
-from custom_components.hsem.utils.misc import (
-    calculate_recommended_threshold,
-    convert_to_float,
-    convert_to_int,
-    get_config_value,
+This module is a thin numbered wrapper around the shared helpers in
+:mod:`custom_components.hsem.flows.schedule_helpers`.  All schema
+construction and validation logic lives there.
+"""
+
+import voluptuous as vol
+
+from custom_components.hsem.flows.schedule_helpers import (
+    build_batteries_schedule_step_schema,
+    resolve_usable_capacity_kwh,
+    validate_batteries_schedule_input,
 )
 
-
-def _resolve_usable_capacity_kwh(
-    hass,
-    config_entry,
-    user_input: dict | None = None,
-) -> float:
-    """Return the usable battery capacity in kWh for threshold preview calculations.
-
-    Resolves the live HA state of ``hsem_huawei_solar_batteries_rated_capacity``
-    (stored in Wh) and converts it to kWh.  Falls back to 10.0 kWh when the
-    entity is unavailable or the state cannot be parsed.
-
-    Priority for the entity-id string:
-    1. ``config_entry`` (options flow / existing config)
-    2. ``user_input`` (config flow — data from previous steps)
-    3. Built-in fallback: 10.0 kWh
-    """
-    rated_capacity_entity = get_config_value(
-        config_entry, "hsem_huawei_solar_batteries_rated_capacity"
-    ) or (
-        user_input.get("hsem_huawei_solar_batteries_rated_capacity")
-        if user_input
-        else None
-    )
-    if hass and rated_capacity_entity:
-        state = hass.states.get(rated_capacity_entity)
-        if state is not None:
-            rated_wh = convert_to_float(state.state)
-            if rated_wh and rated_wh > 0:
-                return rated_wh / 1000.0
-    # Fall back to a representative default for the UI preview.
-    return 10.0
+# Re-export the shared capacity resolver under the legacy private name so
+# that any external code that imports ``_resolve_usable_capacity_kwh`` from
+# this module continues to work without changes.
+_resolve_usable_capacity_kwh = resolve_usable_capacity_kwh
 
 
 async def get_batteries_schedule_1_step_schema(
     config_entry, hass=None, user_input: dict | None = None
 ) -> vol.Schema:
-    """Return the data schema for the 'batteries_schedule' step."""
-
-    # Calculate recommended threshold as default if not already set
-    purchase_price = convert_to_float(
-        get_config_value(config_entry, "hsem_batteries_purchase_price") or 0.0
-    )
-    _cycles_1 = convert_to_int(
-        get_config_value(config_entry, "hsem_batteries_expected_cycles")
-    )
-    expected_cycles = _cycles_1 if _cycles_1 is not None else 6000
-    usable_capacity = _resolve_usable_capacity_kwh(hass, config_entry, user_input)
-    conversion_loss = convert_to_float(
-        get_config_value(config_entry, "hsem_batteries_conversion_loss") or 10.0
-    )
-
-    recommended = calculate_recommended_threshold(
-        purchase_price, expected_cycles, usable_capacity, conversion_loss
-    )
-
-    return vol.Schema(
-        {
-            vol.Required(
-                "hsem_batteries_enable_batteries_schedule_1",
-                default=get_config_value(
-                    config_entry, "hsem_batteries_enable_batteries_schedule_1"
-                ),
-            ): selector({"boolean": {}}),
-            vol.Required(
-                "hsem_batteries_enable_batteries_schedule_1_start",
-                default=get_config_value(
-                    config_entry, "hsem_batteries_enable_batteries_schedule_1_start"
-                ),
-            ): selector({"time": {}}),
-            vol.Required(
-                "hsem_batteries_enable_batteries_schedule_1_end",
-                default=get_config_value(
-                    config_entry, "hsem_batteries_enable_batteries_schedule_1_end"
-                ),
-            ): selector({"time": {}}),
-            vol.Required(
-                "hsem_batteries_enable_batteries_schedule_1_min_price_difference",
-                default=get_config_value(
-                    config_entry,
-                    "hsem_batteries_enable_batteries_schedule_1_min_price_difference",
-                )
-                or recommended,
-            ): selector(
-                {
-                    "number": {
-                        "min": 0,
-                        "max": 5,
-                        "step": 0.01,
-                        "mode": "box",
-                    }
-                }
-            ),
-        }
+    """Return the data schema for the batteries_schedule_1 flow step."""
+    return await build_batteries_schedule_step_schema(
+        1, config_entry, hass=hass, user_input=user_input
     )
 
 
 async def validate_batteries_schedule_1_input(user_input) -> dict[str, str]:
     """Validate user input for the battery schedule 1 step."""
-    return validate_time_window(
-        user_input,
-        enabled_field="hsem_batteries_enable_batteries_schedule_1",
-        start_field="hsem_batteries_enable_batteries_schedule_1_start",
-        end_field="hsem_batteries_enable_batteries_schedule_1_end",
-    )
+    return await validate_batteries_schedule_input(1, user_input)

--- a/custom_components/hsem/flows/batteries_schedule_2.py
+++ b/custom_components/hsem/flows/batteries_schedule_2.py
@@ -1,86 +1,27 @@
-import voluptuous as vol
-from homeassistant.helpers.selector import selector
+"""Config flow step for battery schedule 2.
 
-from custom_components.hsem.flows.batteries_schedule_1 import (
-    _resolve_usable_capacity_kwh,
-)
-from custom_components.hsem.utils.config_validator import validate_time_window
-from custom_components.hsem.utils.misc import (
-    calculate_recommended_threshold,
-    convert_to_float,
-    convert_to_int,
-    get_config_value,
+This module is a thin numbered wrapper around the shared helpers in
+:mod:`custom_components.hsem.flows.schedule_helpers`.  All schema
+construction and validation logic lives there.
+"""
+
+import voluptuous as vol
+
+from custom_components.hsem.flows.schedule_helpers import (
+    build_batteries_schedule_step_schema,
+    validate_batteries_schedule_input,
 )
 
 
 async def get_batteries_schedule_2_step_schema(
     config_entry, hass=None, user_input: dict | None = None
 ) -> vol.Schema:
-    """Return the data schema for the 'batteries_schedule' step."""
-
-    # Calculate recommended threshold as default if not already set
-    purchase_price = convert_to_float(
-        get_config_value(config_entry, "hsem_batteries_purchase_price") or 0.0
-    )
-    _cycles_2 = convert_to_int(
-        get_config_value(config_entry, "hsem_batteries_expected_cycles")
-    )
-    expected_cycles = _cycles_2 if _cycles_2 is not None else 6000
-    usable_capacity = _resolve_usable_capacity_kwh(hass, config_entry, user_input)
-    conversion_loss = convert_to_float(
-        get_config_value(config_entry, "hsem_batteries_conversion_loss") or 10.0
-    )
-
-    recommended = calculate_recommended_threshold(
-        purchase_price, expected_cycles, usable_capacity, conversion_loss
-    )
-
-    return vol.Schema(
-        {
-            vol.Required(
-                "hsem_batteries_enable_batteries_schedule_2",
-                default=get_config_value(
-                    config_entry, "hsem_batteries_enable_batteries_schedule_2"
-                ),
-            ): selector({"boolean": {}}),
-            vol.Required(
-                "hsem_batteries_enable_batteries_schedule_2_start",
-                default=get_config_value(
-                    config_entry, "hsem_batteries_enable_batteries_schedule_2_start"
-                ),
-            ): selector({"time": {}}),
-            vol.Required(
-                "hsem_batteries_enable_batteries_schedule_2_end",
-                default=get_config_value(
-                    config_entry, "hsem_batteries_enable_batteries_schedule_2_end"
-                ),
-            ): selector({"time": {}}),
-            vol.Required(
-                "hsem_batteries_enable_batteries_schedule_2_min_price_difference",
-                default=get_config_value(
-                    config_entry,
-                    "hsem_batteries_enable_batteries_schedule_2_min_price_difference",
-                )
-                or recommended,
-            ): selector(
-                {
-                    "number": {
-                        "min": 0,
-                        "max": 5,
-                        "step": 0.01,
-                        "mode": "box",
-                    }
-                }
-            ),
-        }
+    """Return the data schema for the batteries_schedule_2 flow step."""
+    return await build_batteries_schedule_step_schema(
+        2, config_entry, hass=hass, user_input=user_input
     )
 
 
 async def validate_batteries_schedule_2_input(user_input) -> dict[str, str]:
     """Validate user input for the battery schedule 2 step."""
-    return validate_time_window(
-        user_input,
-        enabled_field="hsem_batteries_enable_batteries_schedule_2",
-        start_field="hsem_batteries_enable_batteries_schedule_2_start",
-        end_field="hsem_batteries_enable_batteries_schedule_2_end",
-    )
+    return await validate_batteries_schedule_input(2, user_input)

--- a/custom_components/hsem/flows/batteries_schedule_3.py
+++ b/custom_components/hsem/flows/batteries_schedule_3.py
@@ -1,86 +1,27 @@
-import voluptuous as vol
-from homeassistant.helpers.selector import selector
+"""Config flow step for battery schedule 3.
 
-from custom_components.hsem.flows.batteries_schedule_1 import (
-    _resolve_usable_capacity_kwh,
-)
-from custom_components.hsem.utils.config_validator import validate_time_window
-from custom_components.hsem.utils.misc import (
-    calculate_recommended_threshold,
-    convert_to_float,
-    convert_to_int,
-    get_config_value,
+This module is a thin numbered wrapper around the shared helpers in
+:mod:`custom_components.hsem.flows.schedule_helpers`.  All schema
+construction and validation logic lives there.
+"""
+
+import voluptuous as vol
+
+from custom_components.hsem.flows.schedule_helpers import (
+    build_batteries_schedule_step_schema,
+    validate_batteries_schedule_input,
 )
 
 
 async def get_batteries_schedule_3_step_schema(
     config_entry, hass=None, user_input: dict | None = None
 ) -> vol.Schema:
-    """Return the data schema for the 'batteries_schedule' step."""
-
-    # Calculate recommended threshold as default if not already set
-    purchase_price = convert_to_float(
-        get_config_value(config_entry, "hsem_batteries_purchase_price") or 0.0
-    )
-    _cycles_3 = convert_to_int(
-        get_config_value(config_entry, "hsem_batteries_expected_cycles")
-    )
-    expected_cycles = _cycles_3 if _cycles_3 is not None else 6000
-    usable_capacity = _resolve_usable_capacity_kwh(hass, config_entry, user_input)
-    conversion_loss = convert_to_float(
-        get_config_value(config_entry, "hsem_batteries_conversion_loss") or 10.0
-    )
-
-    recommended = calculate_recommended_threshold(
-        purchase_price, expected_cycles, usable_capacity, conversion_loss
-    )
-
-    return vol.Schema(
-        {
-            vol.Required(
-                "hsem_batteries_enable_batteries_schedule_3",
-                default=get_config_value(
-                    config_entry, "hsem_batteries_enable_batteries_schedule_3"
-                ),
-            ): selector({"boolean": {}}),
-            vol.Required(
-                "hsem_batteries_enable_batteries_schedule_3_start",
-                default=get_config_value(
-                    config_entry, "hsem_batteries_enable_batteries_schedule_3_start"
-                ),
-            ): selector({"time": {}}),
-            vol.Required(
-                "hsem_batteries_enable_batteries_schedule_3_end",
-                default=get_config_value(
-                    config_entry, "hsem_batteries_enable_batteries_schedule_3_end"
-                ),
-            ): selector({"time": {}}),
-            vol.Required(
-                "hsem_batteries_enable_batteries_schedule_3_min_price_difference",
-                default=get_config_value(
-                    config_entry,
-                    "hsem_batteries_enable_batteries_schedule_3_min_price_difference",
-                )
-                or recommended,
-            ): selector(
-                {
-                    "number": {
-                        "min": 0,
-                        "max": 5,
-                        "step": 0.01,
-                        "mode": "box",
-                    }
-                }
-            ),
-        }
+    """Return the data schema for the batteries_schedule_3 flow step."""
+    return await build_batteries_schedule_step_schema(
+        3, config_entry, hass=hass, user_input=user_input
     )
 
 
 async def validate_batteries_schedule_3_input(user_input) -> dict[str, str]:
     """Validate user input for the battery schedule 3 step."""
-    return validate_time_window(
-        user_input,
-        enabled_field="hsem_batteries_enable_batteries_schedule_3",
-        start_field="hsem_batteries_enable_batteries_schedule_3_start",
-        end_field="hsem_batteries_enable_batteries_schedule_3_end",
-    )
+    return await validate_batteries_schedule_input(3, user_input)

--- a/custom_components/hsem/flows/ev.py
+++ b/custom_components/hsem/flows/ev.py
@@ -1,137 +1,32 @@
-import voluptuous as vol
-from homeassistant.helpers.selector import selector
+"""Config flow step for the primary EV charger.
 
-from custom_components.hsem.utils.config_validator import (
-    async_validate_entity_ids,
-    merge_errors,
+This module is a thin wrapper around the shared helpers in
+:mod:`custom_components.hsem.flows.ev_helpers`.  All schema construction
+and validation logic lives there.
+"""
+
+import voluptuous as vol
+
+from custom_components.hsem.flows.ev_helpers import (
+    build_ev_charger_schema,
+    validate_ev_charger_input,
 )
-from custom_components.hsem.utils.misc import get_config_value
 
 
 async def get_ev_step_schema(config_entry) -> vol.Schema:
-    """Return the data schema for the 'misc' step."""
-    return vol.Schema(
-        {
-            vol.Required(
-                "hsem_ev_second_enabled",
-                default=get_config_value(config_entry, "hsem_ev_second_enabled"),
-            ): selector({"boolean": {}}),
-            vol.Optional(
-                "hsem_ev_charger_status",
-                default=get_config_value(config_entry, "hsem_ev_charger_status"),
-            ): selector(
-                {
-                    "entity": {
-                        "domain": [
-                            "sensor",
-                            "switch",
-                            "input_boolean",
-                            "binary_sensor",
-                            "button",
-                        ]
-                    }
-                }
-            ),
-            vol.Optional(
-                "hsem_ev_charger_power",
-                default=get_config_value(config_entry, "hsem_ev_charger_power"),
-            ): selector({"entity": {"domain": "sensor"}}),
-            vol.Required(
-                "hsem_house_power_includes_ev_charger_power",
-                default=get_config_value(
-                    config_entry, "hsem_house_power_includes_ev_charger_power"
-                ),
-            ): selector({"boolean": {}}),
-            vol.Required(
-                "hsem_ev_charger_force_max_discharge_power",
-                default=get_config_value(
-                    config_entry, "hsem_ev_charger_force_max_discharge_power"
-                ),
-            ): selector({"boolean": {}}),
-            vol.Required(
-                "hsem_ev_charger_max_discharge_power",
-                default=get_config_value(
-                    config_entry, "hsem_ev_charger_max_discharge_power"
-                ),
-            ): selector(
-                {
-                    "number": {
-                        "min": 50,
-                        "max": 5000,
-                        "step": 1,
-                        "unit_of_measurement": "W",
-                        "mode": "slider",
-                    }
-                }
-            ),
-            vol.Optional(
-                "hsem_ev_soc",
-                default=get_config_value(config_entry, "hsem_ev_soc"),
-            ): selector(
-                {
-                    "entity": {
-                        "domain": ["sensor", "switch", "input_boolean", "input_number"]
-                    }
-                }
-            ),
-            vol.Optional(
-                "hsem_ev_soc_target",
-                default=get_config_value(config_entry, "hsem_ev_soc_target"),
-            ): selector(
-                {
-                    "entity": {
-                        "domain": ["sensor", "switch", "input_boolean", "input_number"]
-                    }
-                }
-            ),
-            vol.Optional(
-                "hsem_ev_connected",
-                default=get_config_value(config_entry, "hsem_ev_connected"),
-            ): selector(
-                {
-                    "entity": {
-                        "domain": [
-                            "sensor",
-                            "switch",
-                            "input_boolean",
-                            "button",
-                            "binary_sensor",
-                        ]
-                    }
-                }
-            ),
-            vol.Required(
-                "hsem_ev_allow_charge_past_target_soc",
-                default=get_config_value(
-                    config_entry, "hsem_ev_allow_charge_past_target_soc"
-                ),
-            ): selector({"boolean": {}}),
-        }
+    """Return the data schema for the primary EV charger flow step."""
+    return await build_ev_charger_schema(
+        config_entry,
+        prefix="hsem_ev",
+        include_primary_fields=True,
     )
 
 
 async def validate_ev_step_input(hass, user_input) -> dict[str, str]:
-    """Validate user input for the 'ev' step."""
-    required_errors: dict[str, str] = {
-        f: "required"
-        for f in (
-            "hsem_house_power_includes_ev_charger_power",
-            "hsem_ev_charger_max_discharge_power",
-            "hsem_ev_charger_force_max_discharge_power",
-            "hsem_ev_allow_charge_past_target_soc",
-        )
-        if f not in user_input
-    }
-    entity_errors = await async_validate_entity_ids(
+    """Validate user input for the primary EV charger flow step."""
+    return await validate_ev_charger_input(
         hass,
         user_input,
-        required_fields=[],
-        optional_fields=[
-            "hsem_ev_charger_status",
-            "hsem_ev_charger_power",
-            "hsem_ev_soc",
-            "hsem_ev_soc_target",
-            "hsem_ev_connected",
-        ],
+        prefix="hsem_ev",
+        extra_required_fields=["hsem_house_power_includes_ev_charger_power"],
     )
-    return merge_errors(required_errors, entity_errors)

--- a/custom_components/hsem/flows/ev_helpers.py
+++ b/custom_components/hsem/flows/ev_helpers.py
@@ -1,0 +1,198 @@
+"""Reusable schema factories and validators for EV config flow steps.
+
+The primary EV step (``flows/ev.py``) and the second EV step
+(``flows/ev_second.py``) share near-identical structure.  The differences are:
+
+- Field prefix: ``hsem_ev_`` vs ``hsem_ev_second_``.
+- The primary step has two extra top-level fields
+  (``hsem_ev_second_enabled`` and
+  ``hsem_house_power_includes_ev_charger_power``).
+- The required-fields list for validation differs slightly.
+
+This module parameterises both the schema builder and the validator so that
+``ev.py`` and ``ev_second.py`` each contain only a thin wrapper.
+
+Public API
+----------
+- :func:`build_ev_charger_schema` — async schema factory for one EV charger.
+- :func:`validate_ev_charger_input` — async validator for one EV charger.
+"""
+
+import voluptuous as vol
+from homeassistant.helpers.selector import selector
+
+from custom_components.hsem.utils.config_validator import (
+    async_validate_entity_ids,
+    merge_errors,
+)
+from custom_components.hsem.utils.misc import get_config_value
+
+# Domain lists reused for multiple fields — defined once to avoid repetition.
+_STATUS_DOMAINS = ["sensor", "switch", "input_boolean", "binary_sensor", "button"]
+_SOC_DOMAINS = ["sensor", "switch", "input_boolean", "input_number"]
+_CONNECTED_DOMAINS = ["sensor", "switch", "input_boolean", "button", "binary_sensor"]
+
+# Discharge-power slider selector — identical for both EV steps.
+_DISCHARGE_POWER_SELECTOR = selector(
+    {
+        "number": {
+            "min": 50,
+            "max": 5000,
+            "step": 1,
+            "unit_of_measurement": "W",
+            "mode": "slider",
+        }
+    }
+)
+
+
+async def build_ev_charger_schema(
+    config_entry,
+    prefix: str,
+    include_primary_fields: bool = False,
+) -> vol.Schema:
+    """Return the voluptuous schema for an EV charger config flow step.
+
+    Args:
+        config_entry: Active config entry; ``None`` for the initial config flow.
+        prefix: Field-name prefix, e.g. ``"hsem_ev"`` or ``"hsem_ev_second"``.
+        include_primary_fields: When ``True``, adds the two fields that only
+            appear in the primary EV step —
+            ``hsem_ev_second_enabled`` (enables the second-EV flow step) and
+            ``hsem_house_power_includes_ev_charger_power``.
+
+    Returns:
+        A ``vol.Schema`` for the EV charger flow step.
+    """
+    fields: dict = {}
+
+    if include_primary_fields:
+        fields[
+            vol.Required(
+                "hsem_ev_second_enabled",
+                default=get_config_value(config_entry, "hsem_ev_second_enabled"),
+            )
+        ] = selector({"boolean": {}})
+
+    fields[
+        vol.Optional(
+            f"{prefix}_charger_status",
+            default=get_config_value(config_entry, f"{prefix}_charger_status"),
+        )
+    ] = selector({"entity": {"domain": _STATUS_DOMAINS}})
+
+    fields[
+        vol.Optional(
+            f"{prefix}_charger_power",
+            default=get_config_value(config_entry, f"{prefix}_charger_power"),
+        )
+    ] = selector({"entity": {"domain": "sensor"}})
+
+    if include_primary_fields:
+        fields[
+            vol.Required(
+                "hsem_house_power_includes_ev_charger_power",
+                default=get_config_value(
+                    config_entry, "hsem_house_power_includes_ev_charger_power"
+                ),
+            )
+        ] = selector({"boolean": {}})
+
+    fields[
+        vol.Required(
+            f"{prefix}_charger_force_max_discharge_power",
+            default=get_config_value(
+                config_entry, f"{prefix}_charger_force_max_discharge_power"
+            ),
+        )
+    ] = selector({"boolean": {}})
+
+    fields[
+        vol.Required(
+            f"{prefix}_charger_max_discharge_power",
+            default=get_config_value(
+                config_entry, f"{prefix}_charger_max_discharge_power"
+            ),
+        )
+    ] = _DISCHARGE_POWER_SELECTOR
+
+    fields[
+        vol.Optional(
+            f"{prefix}_soc",
+            default=get_config_value(config_entry, f"{prefix}_soc"),
+        )
+    ] = selector({"entity": {"domain": _SOC_DOMAINS}})
+
+    fields[
+        vol.Optional(
+            f"{prefix}_soc_target",
+            default=get_config_value(config_entry, f"{prefix}_soc_target"),
+        )
+    ] = selector({"entity": {"domain": _SOC_DOMAINS}})
+
+    fields[
+        vol.Optional(
+            f"{prefix}_connected",
+            default=get_config_value(config_entry, f"{prefix}_connected"),
+        )
+    ] = selector({"entity": {"domain": _CONNECTED_DOMAINS}})
+
+    fields[
+        vol.Required(
+            f"{prefix}_allow_charge_past_target_soc",
+            default=get_config_value(
+                config_entry, f"{prefix}_allow_charge_past_target_soc"
+            ),
+        )
+    ] = selector({"boolean": {}})
+
+    return vol.Schema(fields)
+
+
+async def validate_ev_charger_input(
+    hass,
+    user_input: dict,
+    prefix: str,
+    extra_required_fields: list[str] | None = None,
+) -> dict[str, str]:
+    """Validate user input for an EV charger config flow step.
+
+    Checks that required boolean/numeric fields are present and that any
+    supplied entity IDs resolve to existing HA entities.
+
+    Args:
+        hass: Home Assistant instance used for entity existence lookups.
+        user_input: Dict of field name → value submitted by the user.
+        prefix: Field-name prefix, e.g. ``"hsem_ev"`` or ``"hsem_ev_second"``.
+        extra_required_fields: Additional required field names beyond the
+            standard set derived from *prefix*.  Use this for fields that
+            only exist in the primary EV step (e.g.
+            ``"hsem_house_power_includes_ev_charger_power"``).
+
+    Returns:
+        Dict mapping field names to translation error keys; empty on success.
+    """
+    standard_required = [
+        f"{prefix}_charger_max_discharge_power",
+        f"{prefix}_charger_force_max_discharge_power",
+        f"{prefix}_allow_charge_past_target_soc",
+    ]
+    all_required = standard_required + (extra_required_fields or [])
+
+    required_errors: dict[str, str] = {
+        f: "required" for f in all_required if f not in user_input
+    }
+
+    entity_errors = await async_validate_entity_ids(
+        hass,
+        user_input,
+        required_fields=[],
+        optional_fields=[
+            f"{prefix}_charger_status",
+            f"{prefix}_charger_power",
+            f"{prefix}_soc",
+            f"{prefix}_soc_target",
+            f"{prefix}_connected",
+        ],
+    )
+    return merge_errors(required_errors, entity_errors)

--- a/custom_components/hsem/flows/ev_second.py
+++ b/custom_components/hsem/flows/ev_second.py
@@ -1,126 +1,31 @@
-import voluptuous as vol
-from homeassistant.helpers.selector import selector
+"""Config flow step for the second EV charger.
 
-from custom_components.hsem.utils.config_validator import (
-    async_validate_entity_ids,
-    merge_errors,
+This module is a thin wrapper around the shared helpers in
+:mod:`custom_components.hsem.flows.ev_helpers`.  All schema construction
+and validation logic lives there.
+"""
+
+import voluptuous as vol
+
+from custom_components.hsem.flows.ev_helpers import (
+    build_ev_charger_schema,
+    validate_ev_charger_input,
 )
-from custom_components.hsem.utils.misc import get_config_value
 
 
 async def get_ev_second_step_schema(config_entry) -> vol.Schema:
-    """Return the data schema for the 'misc' step."""
-    return vol.Schema(
-        {
-            vol.Optional(
-                "hsem_ev_second_charger_status",
-                default=get_config_value(config_entry, "hsem_ev_second_charger_status"),
-            ): selector(
-                {
-                    "entity": {
-                        "domain": [
-                            "sensor",
-                            "switch",
-                            "input_boolean",
-                            "binary_sensor",
-                            "button",
-                        ]
-                    }
-                }
-            ),
-            vol.Optional(
-                "hsem_ev_second_charger_power",
-                default=get_config_value(config_entry, "hsem_ev_second_charger_power"),
-            ): selector({"entity": {"domain": "sensor"}}),
-            vol.Required(
-                "hsem_ev_second_charger_force_max_discharge_power",
-                default=get_config_value(
-                    config_entry, "hsem_ev_second_charger_force_max_discharge_power"
-                ),
-            ): selector({"boolean": {}}),
-            vol.Required(
-                "hsem_ev_second_charger_max_discharge_power",
-                default=get_config_value(
-                    config_entry, "hsem_ev_second_charger_max_discharge_power"
-                ),
-            ): selector(
-                {
-                    "number": {
-                        "min": 50,
-                        "max": 5000,
-                        "step": 1,
-                        "unit_of_measurement": "W",
-                        "mode": "slider",
-                    }
-                }
-            ),
-            vol.Optional(
-                "hsem_ev_second_soc",
-                default=get_config_value(config_entry, "hsem_ev_second_soc"),
-            ): selector(
-                {
-                    "entity": {
-                        "domain": ["sensor", "switch", "input_boolean", "input_number"]
-                    }
-                }
-            ),
-            vol.Optional(
-                "hsem_ev_second_soc_target",
-                default=get_config_value(config_entry, "hsem_ev_second_soc_target"),
-            ): selector(
-                {
-                    "entity": {
-                        "domain": ["sensor", "switch", "input_boolean", "input_number"]
-                    }
-                }
-            ),
-            vol.Optional(
-                "hsem_ev_second_connected",
-                default=get_config_value(config_entry, "hsem_ev_second_connected"),
-            ): selector(
-                {
-                    "entity": {
-                        "domain": [
-                            "sensor",
-                            "switch",
-                            "input_boolean",
-                            "button",
-                            "binary_sensor",
-                        ]
-                    }
-                }
-            ),
-            vol.Required(
-                "hsem_ev_second_allow_charge_past_target_soc",
-                default=get_config_value(
-                    config_entry, "hsem_ev_second_allow_charge_past_target_soc"
-                ),
-            ): selector({"boolean": {}}),
-        }
+    """Return the data schema for the second EV charger flow step."""
+    return await build_ev_charger_schema(
+        config_entry,
+        prefix="hsem_ev_second",
+        include_primary_fields=False,
     )
 
 
 async def validate_ev_second_step_input(hass, user_input) -> dict[str, str]:
-    """Validate user input for the 'ev_second' step."""
-    required_errors: dict[str, str] = {
-        f: "required"
-        for f in (
-            "hsem_ev_second_charger_max_discharge_power",
-            "hsem_ev_second_charger_force_max_discharge_power",
-            "hsem_ev_second_allow_charge_past_target_soc",
-        )
-        if f not in user_input
-    }
-    entity_errors = await async_validate_entity_ids(
+    """Validate user input for the second EV charger flow step."""
+    return await validate_ev_charger_input(
         hass,
         user_input,
-        required_fields=[],
-        optional_fields=[
-            "hsem_ev_second_charger_status",
-            "hsem_ev_second_charger_power",
-            "hsem_ev_second_soc",
-            "hsem_ev_second_soc_target",
-            "hsem_ev_second_connected",
-        ],
+        prefix="hsem_ev_second",
     )
-    return merge_errors(required_errors, entity_errors)

--- a/custom_components/hsem/flows/schedule_helpers.py
+++ b/custom_components/hsem/flows/schedule_helpers.py
@@ -1,0 +1,162 @@
+"""Reusable schema factory and validator for battery schedule config flow steps.
+
+All three schedule steps (1, 2, 3) share identical logic.  The only
+difference is the numeric suffix embedded in the config-entry key names.
+This module provides a single parameterised schema builder and a single
+parameterised validator so that ``batteries_schedule_{1,2,3}.py`` each
+contain only a thin numbered wrapper — removing the duplicated code.
+
+Public API
+----------
+- :func:`build_batteries_schedule_step_schema` — async schema factory.
+- :func:`validate_batteries_schedule_input` — async validator.
+- :func:`resolve_usable_capacity_kwh` — helper used by schema factories.
+"""
+
+import voluptuous as vol
+from homeassistant.helpers.selector import selector
+
+from custom_components.hsem.utils.config_validator import validate_time_window
+from custom_components.hsem.utils.misc import (
+    calculate_recommended_threshold,
+    convert_to_float,
+    convert_to_int,
+    get_config_value,
+)
+
+
+def resolve_usable_capacity_kwh(
+    hass,
+    config_entry,
+    user_input: dict | None = None,
+) -> float:
+    """Return the usable battery capacity in kWh for threshold preview calculations.
+
+    Resolves the live HA state of ``hsem_huawei_solar_batteries_rated_capacity``
+    (stored in Wh) and converts it to kWh.  Falls back to 10.0 kWh when the
+    entity is unavailable or the state cannot be parsed.
+
+    Priority for the entity-id string:
+    1. ``config_entry`` (options flow / existing config)
+    2. ``user_input`` (config flow — data from previous steps)
+    3. Built-in fallback: 10.0 kWh
+
+    Args:
+        hass: Home Assistant instance (may be None during initial config).
+        config_entry: Active config entry (may be None for new installs).
+        user_input: Optional dict of values collected in prior flow steps.
+
+    Returns:
+        Usable battery capacity in kWh.
+    """
+    rated_capacity_entity = get_config_value(
+        config_entry, "hsem_huawei_solar_batteries_rated_capacity"
+    ) or (
+        user_input.get("hsem_huawei_solar_batteries_rated_capacity")
+        if user_input
+        else None
+    )
+    if hass and rated_capacity_entity:
+        state = hass.states.get(rated_capacity_entity)
+        if state is not None:
+            rated_wh = convert_to_float(state.state)
+            if rated_wh and rated_wh > 0:
+                return rated_wh / 1000.0
+    return 10.0
+
+
+async def build_batteries_schedule_step_schema(
+    schedule_number: int,
+    config_entry,
+    hass=None,
+    user_input: dict | None = None,
+) -> vol.Schema:
+    """Return the voluptuous schema for a numbered battery schedule step.
+
+    Constructs schema keys by substituting *schedule_number* into the
+    standard ``hsem_batteries_enable_batteries_schedule_N*`` key pattern.
+
+    Args:
+        schedule_number: Integer suffix (1, 2, or 3) identifying the schedule.
+        config_entry: Active config entry; ``None`` for the initial config flow.
+        hass: Home Assistant instance; ``None`` when not yet available.
+        user_input: Optional dict of values from prior flow steps — used to
+            resolve the rated-capacity entity during first-time setup.
+
+    Returns:
+        A ``vol.Schema`` for the ``batteries_schedule_N`` flow step.
+    """
+    n = schedule_number
+    prefix = f"hsem_batteries_enable_batteries_schedule_{n}"
+
+    purchase_price = convert_to_float(
+        get_config_value(config_entry, "hsem_batteries_purchase_price") or 0.0
+    )
+    _cycles = convert_to_int(
+        get_config_value(config_entry, "hsem_batteries_expected_cycles")
+    )
+    expected_cycles = _cycles if _cycles is not None else 6000
+    usable_capacity = resolve_usable_capacity_kwh(hass, config_entry, user_input)
+    conversion_loss = convert_to_float(
+        get_config_value(config_entry, "hsem_batteries_conversion_loss") or 10.0
+    )
+
+    recommended = calculate_recommended_threshold(
+        purchase_price, expected_cycles, usable_capacity, conversion_loss
+    )
+
+    return vol.Schema(
+        {
+            vol.Required(
+                prefix,
+                default=get_config_value(config_entry, prefix),
+            ): selector({"boolean": {}}),
+            vol.Required(
+                f"{prefix}_start",
+                default=get_config_value(config_entry, f"{prefix}_start"),
+            ): selector({"time": {}}),
+            vol.Required(
+                f"{prefix}_end",
+                default=get_config_value(config_entry, f"{prefix}_end"),
+            ): selector({"time": {}}),
+            vol.Required(
+                f"{prefix}_min_price_difference",
+                default=get_config_value(config_entry, f"{prefix}_min_price_difference")
+                or recommended,
+            ): selector(
+                {
+                    "number": {
+                        "min": 0,
+                        "max": 5,
+                        "step": 0.01,
+                        "mode": "box",
+                    }
+                }
+            ),
+        }
+    )
+
+
+async def validate_batteries_schedule_input(
+    schedule_number: int,
+    user_input: dict,
+) -> dict[str, str]:
+    """Validate user input for a numbered battery schedule step.
+
+    Delegates to :func:`~custom_components.hsem.utils.config_validator.validate_time_window`
+    after deriving the correct field names from *schedule_number*.
+
+    Args:
+        schedule_number: Integer suffix (1, 2, or 3) identifying the schedule.
+        user_input: Dict of field name → value submitted by the user.
+
+    Returns:
+        Dict mapping field names to translation error keys; empty on success.
+    """
+    prefix = f"hsem_batteries_enable_batteries_schedule_{schedule_number}"
+    return validate_time_window(
+        user_input,
+        enabled_field=prefix,
+        start_field=f"{prefix}_start",
+        end_field=f"{prefix}_end",
+    )

--- a/tests/test_flow_helpers.py
+++ b/tests/test_flow_helpers.py
@@ -1,0 +1,559 @@
+"""Tests for the reusable schedule and EV config-flow helper modules.
+
+Covers:
+- :mod:`custom_components.hsem.flows.schedule_helpers`
+- :mod:`custom_components.hsem.flows.ev_helpers`
+
+Acceptance criteria from issue #313:
+- Schedule flows share one code path (via ``schedule_helpers``).
+- EV flows share one code path (via ``ev_helpers``).
+- Existing config migration still works (schema keys are unchanged).
+- Schema field names produced by the helpers match the original hard-coded names.
+- Validation behaviour is identical to the original numbered wrappers.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_hass(entity_states: dict | None = None) -> MagicMock:
+    """Build a minimal hass stub whose states.get() returns controlled values."""
+    hass = MagicMock()
+    entity_states = entity_states or {}
+
+    def _states_get(entity_id):
+        if entity_id in entity_states:
+            state = MagicMock()
+            state.state = entity_states[entity_id]
+            return state
+        return None
+
+    hass.states.get.side_effect = _states_get
+    return hass
+
+
+def _make_config_entry(overrides: dict | None = None) -> MagicMock:
+    """Build a config-entry stub backed by DEFAULT_CONFIG_VALUES."""
+    from custom_components.hsem.const import DEFAULT_CONFIG_VALUES
+
+    data = {**DEFAULT_CONFIG_VALUES, **(overrides or {})}
+    entry = MagicMock()
+    entry.options = {}
+    entry.data = data
+    return entry
+
+
+# ===========================================================================
+# schedule_helpers — build_batteries_schedule_step_schema
+# ===========================================================================
+
+
+class TestBuildBatteriesScheduleStepSchema:
+    """Schema factory produces correct fields for each schedule number."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("n", [1, 2, 3])
+    async def test_schema_contains_all_four_fields(self, n: int):
+        """All four expected keys must be present in the built schema."""
+        from custom_components.hsem.flows.schedule_helpers import (
+            build_batteries_schedule_step_schema,
+        )
+
+        schema = await build_batteries_schedule_step_schema(n, None)
+        keys = {str(k) for k in schema.schema}
+        prefix = f"hsem_batteries_enable_batteries_schedule_{n}"
+        assert prefix in keys
+        assert f"{prefix}_start" in keys
+        assert f"{prefix}_end" in keys
+        assert f"{prefix}_min_price_difference" in keys
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("n", [1, 2, 3])
+    async def test_schema_keys_match_original_numbered_wrappers(self, n: int):
+        """Schema keys produced by the helper must equal those of the original
+        numbered modules — ensuring no config migration is needed."""
+        # Import the numbered wrapper (which now delegates to the helper)
+        import importlib
+
+        from custom_components.hsem.flows.schedule_helpers import (
+            build_batteries_schedule_step_schema,
+        )
+
+        mod = importlib.import_module(
+            f"custom_components.hsem.flows.batteries_schedule_{n}"
+        )
+        getter = getattr(mod, f"get_batteries_schedule_{n}_step_schema")
+
+        schema_helper = await build_batteries_schedule_step_schema(n, None)
+        schema_wrapper = await getter(None)
+
+        keys_helper = {str(k) for k in schema_helper.schema}
+        keys_wrapper = {str(k) for k in schema_wrapper.schema}
+        assert keys_helper == keys_wrapper
+
+    @pytest.mark.asyncio
+    async def test_schema_default_falls_back_to_recommended_threshold(self):
+        """min_price_difference default uses recommended threshold when config value is 0."""
+        from custom_components.hsem.flows.schedule_helpers import (
+            build_batteries_schedule_step_schema,
+        )
+        from custom_components.hsem.utils.misc import calculate_recommended_threshold
+
+        # purchase_price=1000, cycles=6000, capacity=10 kWh, loss=10%
+        entry = _make_config_entry(
+            {
+                "hsem_batteries_purchase_price": 1000.0,
+                "hsem_batteries_expected_cycles": 6000,
+                "hsem_batteries_conversion_loss": 10.0,
+                # force min_price_difference to 0 so recommended kicks in
+                "hsem_batteries_enable_batteries_schedule_1_min_price_difference": 0.0,
+            }
+        )
+        schema = await build_batteries_schedule_step_schema(1, entry)
+        defaults = {str(k): k.default() for k in schema.schema if hasattr(k, "default")}
+        expected = calculate_recommended_threshold(1000.0, 6000, 10.0, 10.0)
+        assert defaults[
+            "hsem_batteries_enable_batteries_schedule_1_min_price_difference"
+        ] == pytest.approx(expected, abs=1e-6)
+
+    @pytest.mark.asyncio
+    async def test_rated_capacity_resolved_from_hass_state(self):
+        """resolve_usable_capacity_kwh uses the live HA state when available."""
+        from custom_components.hsem.flows.schedule_helpers import (
+            resolve_usable_capacity_kwh,
+        )
+
+        hass = _make_hass({"sensor.batteries_rated_capacity": "15000"})
+        entry = _make_config_entry()
+        capacity = resolve_usable_capacity_kwh(hass, entry)
+        assert capacity == pytest.approx(15.0)
+
+    @pytest.mark.asyncio
+    async def test_rated_capacity_falls_back_to_10kwh(self):
+        """resolve_usable_capacity_kwh returns 10.0 when HA state is unavailable."""
+        from custom_components.hsem.flows.schedule_helpers import (
+            resolve_usable_capacity_kwh,
+        )
+
+        capacity = resolve_usable_capacity_kwh(None, None)
+        assert capacity == pytest.approx(10.0)
+
+    @pytest.mark.asyncio
+    async def test_rated_capacity_falls_back_when_state_unparseable(self):
+        """resolve_usable_capacity_kwh returns 10.0 when state is not a number."""
+        from custom_components.hsem.flows.schedule_helpers import (
+            resolve_usable_capacity_kwh,
+        )
+
+        hass = _make_hass({"sensor.batteries_rated_capacity": "unavailable"})
+        entry = _make_config_entry()
+        capacity = resolve_usable_capacity_kwh(hass, entry)
+        assert capacity == pytest.approx(10.0)
+
+
+# ===========================================================================
+# schedule_helpers — validate_batteries_schedule_input
+# ===========================================================================
+
+
+class TestValidateBatteriesScheduleInput:
+    """Validator is identical in behaviour for all three schedule numbers."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("n", [1, 2, 3])
+    async def test_disabled_schedule_passes_with_invalid_times(self, n: int):
+        """Disabled schedule must skip time validation entirely."""
+        from custom_components.hsem.flows.schedule_helpers import (
+            validate_batteries_schedule_input,
+        )
+
+        prefix = f"hsem_batteries_enable_batteries_schedule_{n}"
+        errors = await validate_batteries_schedule_input(
+            n,
+            {
+                prefix: False,
+                f"{prefix}_start": "INVALID",
+                f"{prefix}_end": "INVALID",
+                f"{prefix}_min_price_difference": 0.0,
+            },
+        )
+        assert errors == {}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("n", [1, 2, 3])
+    async def test_zero_length_active_schedule_is_rejected(self, n: int):
+        """start == end when enabled must produce a base error."""
+        from custom_components.hsem.flows.schedule_helpers import (
+            validate_batteries_schedule_input,
+        )
+
+        prefix = f"hsem_batteries_enable_batteries_schedule_{n}"
+        errors = await validate_batteries_schedule_input(
+            n,
+            {
+                prefix: True,
+                f"{prefix}_start": "12:00:00",
+                f"{prefix}_end": "12:00:00",
+                f"{prefix}_min_price_difference": 0.0,
+            },
+        )
+        assert errors.get("base") == "start_time_equals_end_time"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("n", [1, 2, 3])
+    async def test_valid_cross_midnight_window_accepted(self, n: int):
+        """A valid cross-midnight window must pass with no errors."""
+        from custom_components.hsem.flows.schedule_helpers import (
+            validate_batteries_schedule_input,
+        )
+
+        prefix = f"hsem_batteries_enable_batteries_schedule_{n}"
+        errors = await validate_batteries_schedule_input(
+            n,
+            {
+                prefix: True,
+                f"{prefix}_start": "23:00:00",
+                f"{prefix}_end": "02:00:00",
+                f"{prefix}_min_price_difference": 0.0,
+            },
+        )
+        assert errors == {}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("n", [1, 2, 3])
+    async def test_invalid_time_format_rejected(self, n: int):
+        """An unparseable time string must produce an ``invalid_time_format`` error."""
+        from custom_components.hsem.flows.schedule_helpers import (
+            validate_batteries_schedule_input,
+        )
+
+        prefix = f"hsem_batteries_enable_batteries_schedule_{n}"
+        errors = await validate_batteries_schedule_input(
+            n,
+            {
+                prefix: True,
+                f"{prefix}_start": "not-a-time",
+                f"{prefix}_end": "09:00:00",
+                f"{prefix}_min_price_difference": 0.0,
+            },
+        )
+        assert errors.get(f"{prefix}_start") == "invalid_time_format"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("n", [1, 2, 3])
+    async def test_helper_output_matches_numbered_wrapper(self, n: int):
+        """Helper and numbered wrapper must return identical errors for the same input."""
+        import importlib
+
+        from custom_components.hsem.flows.schedule_helpers import (
+            validate_batteries_schedule_input,
+        )
+
+        mod = importlib.import_module(
+            f"custom_components.hsem.flows.batteries_schedule_{n}"
+        )
+        wrapper_validate = getattr(mod, f"validate_batteries_schedule_{n}_input")
+
+        prefix = f"hsem_batteries_enable_batteries_schedule_{n}"
+        user_input = {
+            prefix: True,
+            f"{prefix}_start": "08:00:00",
+            f"{prefix}_end": "08:00:00",
+            f"{prefix}_min_price_difference": 0.1,
+        }
+        errors_helper = await validate_batteries_schedule_input(n, user_input)
+        errors_wrapper = await wrapper_validate(user_input)
+        assert errors_helper == errors_wrapper
+
+
+# ===========================================================================
+# Legacy private alias — _resolve_usable_capacity_kwh
+# ===========================================================================
+
+
+class TestLegacyPrivateAlias:
+    """The legacy ``_resolve_usable_capacity_kwh`` re-export in batteries_schedule_1
+    must still work so that any external code that imports it continues to function."""
+
+    def test_alias_is_callable(self):
+        from custom_components.hsem.flows.batteries_schedule_1 import (
+            _resolve_usable_capacity_kwh,
+        )
+
+        assert callable(_resolve_usable_capacity_kwh)
+
+    def test_alias_returns_fallback(self):
+        from custom_components.hsem.flows.batteries_schedule_1 import (
+            _resolve_usable_capacity_kwh,
+        )
+
+        assert _resolve_usable_capacity_kwh(None, None) == pytest.approx(10.0)
+
+
+# ===========================================================================
+# ev_helpers — build_ev_charger_schema
+# ===========================================================================
+
+
+class TestBuildEvChargerSchema:
+    """Schema factory produces correct fields for primary and secondary EV steps."""
+
+    @pytest.mark.asyncio
+    async def test_primary_ev_schema_contains_all_fields(self):
+        """Primary EV schema must include the two extra primary-only boolean fields."""
+        from custom_components.hsem.flows.ev_helpers import build_ev_charger_schema
+
+        schema = await build_ev_charger_schema(
+            None, prefix="hsem_ev", include_primary_fields=True
+        )
+        keys = {str(k) for k in schema.schema}
+        # Extra primary fields
+        assert "hsem_ev_second_enabled" in keys
+        assert "hsem_house_power_includes_ev_charger_power" in keys
+        # Standard fields
+        assert "hsem_ev_charger_status" in keys
+        assert "hsem_ev_charger_power" in keys
+        assert "hsem_ev_charger_force_max_discharge_power" in keys
+        assert "hsem_ev_charger_max_discharge_power" in keys
+        assert "hsem_ev_soc" in keys
+        assert "hsem_ev_soc_target" in keys
+        assert "hsem_ev_connected" in keys
+        assert "hsem_ev_allow_charge_past_target_soc" in keys
+
+    @pytest.mark.asyncio
+    async def test_secondary_ev_schema_omits_primary_only_fields(self):
+        """Secondary EV schema must NOT include the primary-only fields."""
+        from custom_components.hsem.flows.ev_helpers import build_ev_charger_schema
+
+        schema = await build_ev_charger_schema(
+            None, prefix="hsem_ev_second", include_primary_fields=False
+        )
+        keys = {str(k) for k in schema.schema}
+        assert "hsem_ev_second_enabled" not in keys
+        assert "hsem_house_power_includes_ev_charger_power" not in keys
+        # Standard (second-prefixed) fields must be present
+        assert "hsem_ev_second_charger_status" in keys
+        assert "hsem_ev_second_charger_power" in keys
+        assert "hsem_ev_second_charger_force_max_discharge_power" in keys
+        assert "hsem_ev_second_charger_max_discharge_power" in keys
+        assert "hsem_ev_second_soc" in keys
+        assert "hsem_ev_second_soc_target" in keys
+        assert "hsem_ev_second_connected" in keys
+        assert "hsem_ev_second_allow_charge_past_target_soc" in keys
+
+    @pytest.mark.asyncio
+    async def test_primary_schema_keys_match_original_ev_step(self):
+        """Keys from the helper must exactly match those from the original ev.py."""
+        from custom_components.hsem.flows.ev import get_ev_step_schema
+        from custom_components.hsem.flows.ev_helpers import build_ev_charger_schema
+
+        schema_helper = await build_ev_charger_schema(
+            None, prefix="hsem_ev", include_primary_fields=True
+        )
+        schema_wrapper = await get_ev_step_schema(None)
+
+        keys_helper = {str(k) for k in schema_helper.schema}
+        keys_wrapper = {str(k) for k in schema_wrapper.schema}
+        assert keys_helper == keys_wrapper
+
+    @pytest.mark.asyncio
+    async def test_secondary_schema_keys_match_original_ev_second_step(self):
+        """Keys from the helper must exactly match those from the original ev_second.py."""
+        from custom_components.hsem.flows.ev_helpers import build_ev_charger_schema
+        from custom_components.hsem.flows.ev_second import get_ev_second_step_schema
+
+        schema_helper = await build_ev_charger_schema(
+            None, prefix="hsem_ev_second", include_primary_fields=False
+        )
+        schema_wrapper = await get_ev_second_step_schema(None)
+
+        keys_helper = {str(k) for k in schema_helper.schema}
+        keys_wrapper = {str(k) for k in schema_wrapper.schema}
+        assert keys_helper == keys_wrapper
+
+
+# ===========================================================================
+# ev_helpers — validate_ev_charger_input
+# ===========================================================================
+
+
+class TestValidateEvChargerInput:
+    """Validator enforces required fields and delegates entity lookups to HA."""
+
+    @pytest.mark.asyncio
+    async def test_primary_ev_missing_required_fields_produces_errors(self):
+        """Missing required boolean/numeric fields must each produce 'required'."""
+        from custom_components.hsem.flows.ev_helpers import validate_ev_charger_input
+
+        hass = _make_hass()
+        errors = await validate_ev_charger_input(
+            hass,
+            user_input={},
+            prefix="hsem_ev",
+            extra_required_fields=["hsem_house_power_includes_ev_charger_power"],
+        )
+        assert errors.get("hsem_ev_charger_max_discharge_power") == "required"
+        assert errors.get("hsem_ev_charger_force_max_discharge_power") == "required"
+        assert errors.get("hsem_ev_allow_charge_past_target_soc") == "required"
+        assert errors.get("hsem_house_power_includes_ev_charger_power") == "required"
+
+    @pytest.mark.asyncio
+    async def test_secondary_ev_missing_required_fields_produces_errors(self):
+        """Secondary EV required fields produce 'required' errors."""
+        from custom_components.hsem.flows.ev_helpers import validate_ev_charger_input
+
+        hass = _make_hass()
+        errors = await validate_ev_charger_input(
+            hass,
+            user_input={},
+            prefix="hsem_ev_second",
+        )
+        assert errors.get("hsem_ev_second_charger_max_discharge_power") == "required"
+        assert (
+            errors.get("hsem_ev_second_charger_force_max_discharge_power") == "required"
+        )
+        assert errors.get("hsem_ev_second_allow_charge_past_target_soc") == "required"
+
+    @pytest.mark.asyncio
+    async def test_valid_primary_ev_input_passes(self):
+        """All required fields present and no optional entities → no errors."""
+        from custom_components.hsem.flows.ev_helpers import validate_ev_charger_input
+
+        hass = _make_hass()
+        errors = await validate_ev_charger_input(
+            hass,
+            user_input={
+                "hsem_ev_charger_max_discharge_power": 2000,
+                "hsem_ev_charger_force_max_discharge_power": False,
+                "hsem_ev_allow_charge_past_target_soc": False,
+                "hsem_house_power_includes_ev_charger_power": True,
+            },
+            prefix="hsem_ev",
+            extra_required_fields=["hsem_house_power_includes_ev_charger_power"],
+        )
+        assert errors == {}
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_optional_entity_is_flagged(self):
+        """An optional entity that does not exist in HA must produce entity_not_found."""
+        from custom_components.hsem.flows.ev_helpers import validate_ev_charger_input
+
+        hass = _make_hass()  # no entities registered
+        errors = await validate_ev_charger_input(
+            hass,
+            user_input={
+                "hsem_ev_charger_max_discharge_power": 2000,
+                "hsem_ev_charger_force_max_discharge_power": False,
+                "hsem_ev_allow_charge_past_target_soc": False,
+                "hsem_house_power_includes_ev_charger_power": True,
+                "hsem_ev_charger_status": "sensor.ev_status_nonexistent",
+            },
+            prefix="hsem_ev",
+            extra_required_fields=["hsem_house_power_includes_ev_charger_power"],
+        )
+        assert errors.get("hsem_ev_charger_status") == "entity_not_found"
+
+    @pytest.mark.asyncio
+    async def test_primary_ev_validation_matches_original_ev_step(self):
+        """Helper and original ev.validate_ev_step_input must agree for the same input."""
+        from custom_components.hsem.flows.ev import validate_ev_step_input
+        from custom_components.hsem.flows.ev_helpers import validate_ev_charger_input
+
+        hass = _make_hass()
+        user_input = {
+            "hsem_ev_charger_max_discharge_power": 500,
+            "hsem_ev_charger_force_max_discharge_power": True,
+            "hsem_ev_allow_charge_past_target_soc": True,
+            "hsem_house_power_includes_ev_charger_power": False,
+        }
+        errors_helper = await validate_ev_charger_input(
+            hass,
+            user_input,
+            prefix="hsem_ev",
+            extra_required_fields=["hsem_house_power_includes_ev_charger_power"],
+        )
+        errors_wrapper = await validate_ev_step_input(hass, user_input)
+        assert errors_helper == errors_wrapper
+
+    @pytest.mark.asyncio
+    async def test_secondary_ev_validation_matches_original_ev_second_step(self):
+        """Helper and original ev_second.validate_ev_second_step_input must agree."""
+        from custom_components.hsem.flows.ev_helpers import validate_ev_charger_input
+        from custom_components.hsem.flows.ev_second import validate_ev_second_step_input
+
+        hass = _make_hass()
+        user_input = {
+            "hsem_ev_second_charger_max_discharge_power": 1000,
+            "hsem_ev_second_charger_force_max_discharge_power": False,
+            "hsem_ev_second_allow_charge_past_target_soc": False,
+        }
+        errors_helper = await validate_ev_charger_input(
+            hass, user_input, prefix="hsem_ev_second"
+        )
+        errors_wrapper = await validate_ev_second_step_input(hass, user_input)
+        assert errors_helper == errors_wrapper
+
+
+# ===========================================================================
+# Round-trip: all four flow keys survive voluptuous validation
+# ===========================================================================
+
+
+class TestSchemaRoundTrip:
+    """Valid user input must pass through the schema without voluptuous raising."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("n", [1, 2, 3])
+    async def test_schedule_schema_accepts_valid_input(self, n: int):
+        from custom_components.hsem.flows.schedule_helpers import (
+            build_batteries_schedule_step_schema,
+        )
+
+        prefix = f"hsem_batteries_enable_batteries_schedule_{n}"
+        schema = await build_batteries_schedule_step_schema(n, None)
+        valid_input = {
+            prefix: True,
+            f"{prefix}_start": "07:00:00",
+            f"{prefix}_end": "09:00:00",
+            f"{prefix}_min_price_difference": 0.05,
+        }
+        # Should not raise
+        result = schema(valid_input)
+        assert result[prefix] is True
+
+    @pytest.mark.asyncio
+    async def test_ev_primary_schema_accepts_valid_input(self):
+        from custom_components.hsem.flows.ev_helpers import build_ev_charger_schema
+
+        schema = await build_ev_charger_schema(
+            None, prefix="hsem_ev", include_primary_fields=True
+        )
+        valid_input = {
+            "hsem_ev_second_enabled": False,
+            "hsem_house_power_includes_ev_charger_power": True,
+            "hsem_ev_charger_force_max_discharge_power": False,
+            "hsem_ev_charger_max_discharge_power": 2000,
+            "hsem_ev_allow_charge_past_target_soc": False,
+        }
+        result = schema(valid_input)
+        assert result["hsem_ev_charger_max_discharge_power"] == 2000
+
+    @pytest.mark.asyncio
+    async def test_ev_secondary_schema_accepts_valid_input(self):
+        from custom_components.hsem.flows.ev_helpers import build_ev_charger_schema
+
+        schema = await build_ev_charger_schema(
+            None, prefix="hsem_ev_second", include_primary_fields=False
+        )
+        valid_input = {
+            "hsem_ev_second_charger_force_max_discharge_power": True,
+            "hsem_ev_second_charger_max_discharge_power": 1500,
+            "hsem_ev_second_allow_charge_past_target_soc": True,
+        }
+        result = schema(valid_input)
+        assert result["hsem_ev_second_charger_max_discharge_power"] == 1500


### PR DESCRIPTION
﻿## Summary

Deduplicates the HSEM schedule and EV config-flow modules by extracting two new shared helper files, satisfying [P2-01] #313.

---

## Problem

Before this change, identical logic was duplicated across five flow files:

| Pattern | Files | Duplication |
|---|---|---|
| Schedule schema builder | `batteries_schedule_1/2/3.py` | 3× identical `vol.Schema` construction |
| Schedule validator | `batteries_schedule_1/2/3.py` | 3× identical `validate_time_window` call |
| `_resolve_usable_capacity_kwh` | `batteries_schedule_1.py` (defined), `2.py` + `3.py` (imported from 1) | Single function incorrectly owned by a numbered module |
| EV schema builder | `ev.py` + `ev_second.py` | 2× near-identical `vol.Schema` construction |
| EV validator | `ev.py` + `ev_second.py` | 2× near-identical required-field + entity-existence checks |

Any bug fix or UI change to the schema had to be made in 3 (or 2) places simultaneously.

---

## Changes

### New: `flows/schedule_helpers.py`
- `resolve_usable_capacity_kwh(hass, config_entry, user_input)` — moved from `batteries_schedule_1.py`, now the single owner
- `build_batteries_schedule_step_schema(n, config_entry, ...)` — parameterised by schedule number; constructs the four-field schema for any `N`
- `validate_batteries_schedule_input(n, user_input)` — delegates to `validate_time_window` with the correct prefixed field names

### New: `flows/ev_helpers.py`
- `build_ev_charger_schema(config_entry, prefix, include_primary_fields)` — builds the EV charger schema; `include_primary_fields=True` adds the two primary-only fields (`hsem_ev_second_enabled`, `hsem_house_power_includes_ev_charger_power`)
- `validate_ev_charger_input(hass, user_input, prefix, extra_required_fields)` — validates required booleans/numerics and optional entity IDs

### Refactored: `flows/batteries_schedule_{1,2,3}.py`
Each is now a 10-line thin wrapper:
```python
async def get_batteries_schedule_N_step_schema(...) -> vol.Schema:
    return await build_batteries_schedule_step_schema(N, ...)

async def validate_batteries_schedule_N_input(user_input) -> dict[str, str]:
    return await validate_batteries_schedule_input(N, user_input)
```
`batteries_schedule_1.py` re-exports `_resolve_usable_capacity_kwh` as an alias for backward compatibility.

### Refactored: `flows/ev.py` and `flows/ev_second.py`
Each is now a thin wrapper calling the helper with the correct prefix and `include_primary_fields` flag.

### New: `tests/test_flow_helpers.py`
35 tests covering:
- Schema field names match the original hard-coded names (no config migration needed)
- Validation behaviour is identical between helper and numbered wrapper for all inputs
- `resolve_usable_capacity_kwh` correctly reads HA state, falls back to 10 kWh
- Legacy `_resolve_usable_capacity_kwh` alias remains callable
- Round-trip: valid inputs pass through `vol.Schema` without errors

---

## Acceptance criteria

- [x] Schedule flows share one code path (`schedule_helpers.py`)
- [x] EV flows share one code path (`ev_helpers.py`)
- [x] Existing config migration still works — all schema keys are identical to before
- [x] `_resolve_usable_capacity_kwh` backward-compat alias preserved in `batteries_schedule_1.py`
- [x] 35 new tests in `tests/test_flow_helpers.py` — all pass
- [x] No regressions: **1585 passed, 3 xfailed**
- [x] `tox -e lint` — **All checks passed!**

Fixes #313
