### PR TITLE
feat(planner): multi-EV solar allocation and charger efficiency AC-load domain

### DIFF
--- a/custom_components/hsem/planner/engine.py
+++ b/custom_components/hsem/planner/engine.py
@@ -289,25 +289,29 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
             )
 
     # -----------------------------------------------------------------------
-    # EV planned load injection (issue #396)
+    # EV planned load injection (issue #396, multi-EV follow-ups)
     # -----------------------------------------------------------------------
-    # Build EV charging plans for the primary and secondary EV independently,
-    # then sum their per-slot loads into slot.ev_planned_load_kwh BEFORE net
+    # Build EV charging plans for the primary and secondary EV in a
+    # deterministic order (primary first, then secondary), then sum their
+    # per-slot AC loads into slot.ev_planned_load_kwh BEFORE net
     # consumption is calculated.  This ensures:
     #   - Solar surplus is computed after EV demand is subtracted.
     #   - Battery solar-charge recommendations don't claim solar consumed by EVs.
     #   - No circular dependency: EV plans are built from raw inputs only.
     #
-    # Each EV is planned independently using the same pre-injection solar
-    # surplus estimate.  This is an intentional one-pass design; in practice
-    # the error is small because both EVs share the same solar forecast.
+    # Multi-EV solar allocation is *sequential*: the same mutable
+    # ``slot_solar_surplus`` list is threaded through both EV plans, and
+    # ``build_ev_charging_plan`` decrements each slot's entry by the amount
+    # of surplus it consumes.  This prevents both EVs from claiming the
+    # same solar kWh.
     ev_charging_plan: EVChargingPlan | None = None
     ev_second_charging_plan: EVChargingPlan | None = None
 
     # Accumulate combined EV planned load per slot (sum of both EVs).
     combined_ev_load = [0.0] * len(slots)
 
-    # Compute solar surplus ONCE before any EV injection (both EVs share it).
+    # Compute solar surplus ONCE before any EV injection (shared, mutable
+    # AC-domain budget).
     # IMPORTANT: estimated_net_consumption is still 0.0 here (populate_net_consumption
     # hasn't run yet), so surplus must be derived from the raw base fields:
     #   surplus = max(pv_estimate - avg_house_consumption, 0.0)

--- a/custom_components/hsem/planner/ev_planner.py
+++ b/custom_components/hsem/planner/ev_planner.py
@@ -33,12 +33,27 @@ from typing import Any
 class EVChargingSlot:
     """Per-slot EV charging plan entry.
 
+    Two distinct energy quantities are tracked for each slot:
+
+    - ``estimated_charged_kwh`` — energy *delivered* to the EV battery, the
+      value that counts toward the SoC target.
+    - ``ac_load_kwh`` — AC-side load drawn from PV or the grid, equal to
+      ``estimated_charged_kwh / (charger_efficiency_pct / 100)``.  This is
+      the value that enters the planner's energy balance and is used to
+      derive ``solar_surplus_kwh`` and ``import_needed_kwh``.
+
+    When ``charger_efficiency_pct == 100`` the two values are equal and
+    behaviour matches the legacy single-value model.
+
     Attributes:
         start: Timezone-aware start of the slot.
         end: Timezone-aware end of the slot.
-        estimated_charged_kwh: EV energy expected to charge in this slot.
-        solar_surplus_kwh: Solar surplus available after base house load.
-        import_needed_kwh: Grid import required for EV charging in this slot.
+        estimated_charged_kwh: EV energy delivered toward the SoC target.
+        ac_load_kwh: AC-side load drawn by the charger this slot.
+        solar_surplus_kwh: Solar surplus consumed by this EV in this slot
+            (AC domain, never exceeds the remaining shared surplus).
+        import_needed_kwh: Grid import required for EV charging in this slot
+            (AC domain).
         import_price: Import price for this slot (currency/kWh).
         estimated_cost: Estimated grid cost for EV charging this slot.
     """
@@ -46,6 +61,7 @@ class EVChargingSlot:
     start: datetime
     end: datetime
     estimated_charged_kwh: float = 0.0
+    ac_load_kwh: float = 0.0
     solar_surplus_kwh: float = 0.0
     import_needed_kwh: float = 0.0
     import_price: float = 0.0
@@ -57,6 +73,7 @@ class EVChargingSlot:
             "start": self.start.isoformat(),
             "end": self.end.isoformat(),
             "estimated_charged_kwh": round(self.estimated_charged_kwh, 3),
+            "ac_load_kwh": round(self.ac_load_kwh, 3),
             "solar_surplus_kwh": round(self.solar_surplus_kwh, 3),
             "import_needed_kwh": round(self.import_needed_kwh, 3),
             "import_price": round(self.import_price, 4),
@@ -222,16 +239,34 @@ def build_ev_charging_plan(
     The current slot is scaled by its remaining duration, not the full
     slot width, to avoid over-counting energy in the partially elapsed slot.
 
+    Multi-EV solar allocation:
+        ``slot_solar_surplus_kwh`` is treated as a shared, mutable budget.
+        Whenever this EV consumes solar surplus in a slot, the matching
+        entry is decremented in place so that a later EV (planned in the
+        same pass) sees only what is left.  Callers wanting an
+        independent allocation must pass a copy of the surplus list.
+
+    Charger efficiency domain:
+        ``estimated_charged_kwh`` is the energy delivered to the EV
+        battery (counts toward the SoC target).  ``ac_load_kwh`` is the
+        AC-side load drawn from PV or the grid and equals
+        ``estimated_charged_kwh / (charger_efficiency_pct / 100)``.
+        ``solar_surplus_kwh`` and ``import_needed_kwh`` are reported in
+        the AC domain so the planner's energy balance and grid-import
+        accounting stay consistent.
+
     Args:
         inp: EV planner inputs.
         slots_start: List of slot start datetimes (same length as other lists).
         slots_end: List of slot end datetimes.
         slot_solar_surplus_kwh: Solar surplus available per slot (kWh, ≥ 0).
+            Mutated in place: surplus claimed by this EV is subtracted so
+            subsequent EVs share the remaining budget.
         slot_import_price: Import electricity price per slot.
 
     Returns:
         An :class:`EVChargingPlan` with state, charging slots, and a
-        ``planned_load_by_slot`` mapping.
+        ``planned_load_by_slot`` mapping (AC-domain load per slot).
     """
     plan = EVChargingPlan(
         ev_connected=inp.ev_connected,
@@ -307,6 +342,9 @@ def build_ev_charging_plan(
     remaining_energy = energy_needed
     selected: list[EVChargingSlot] = []
 
+    # Charger efficiency factor; clamp to >=1% so we never divide by zero.
+    eff_fraction = max(inp.charger_efficiency_pct, 1.0) / 100.0
+
     for i in ordered:
         if remaining_energy < 1e-9:
             break
@@ -331,37 +369,44 @@ def build_ev_charging_plan(
         max_charge = max_charge_energy_for_slot(
             avail_min, inp.charger_power_kw, inp.charger_efficiency_pct
         )
-        allocated = min(max_charge, remaining_energy)
-        if allocated < 1e-9:
+        delivered = min(max_charge, remaining_energy)
+        if delivered < 1e-9:
             continue
 
-        surplus = slot_solar_surplus_kwh[i]
-        solar_used = min(allocated, surplus)
-        import_needed = max(allocated - solar_used, 0.0)
+        # AC-side load drawn from PV/grid for this delivered energy.
+        ac_load = delivered / eff_fraction
+
+        # Solar surplus is a shared, AC-domain budget across EVs in this pass.
+        surplus = max(slot_solar_surplus_kwh[i], 0.0)
+        solar_used = min(ac_load, surplus)
+        import_needed = max(ac_load - solar_used, 0.0)
+        # Decrement the shared surplus so the next EV sees what is left.
+        slot_solar_surplus_kwh[i] = max(surplus - solar_used, 0.0)
+
         cost = import_needed * slot_import_price[i]
 
         ev_slot = EVChargingSlot(
             start=s_start,
             end=s_end,
-            estimated_charged_kwh=round(allocated, 3),
+            estimated_charged_kwh=round(delivered, 3),
+            ac_load_kwh=round(ac_load, 3),
             solar_surplus_kwh=round(solar_used, 3),
             import_needed_kwh=round(import_needed, 3),
             import_price=slot_import_price[i],
             estimated_cost=round(cost, 4),
         )
         selected.append(ev_slot)
-        remaining_energy -= allocated
+        remaining_energy -= delivered
 
     # Build output
     plan.charging_slots = selected
-    plan.planned_load_by_slot = {
-        s.start.isoformat(): s.estimated_charged_kwh for s in selected
-    }
+    # AC-domain load is what the planner injects into slot.ev_planned_load_kwh.
+    plan.planned_load_by_slot = {s.start.isoformat(): s.ac_load_kwh for s in selected}
 
-    # Identify current slot load
+    # Identify current slot load (AC-domain, matches planner injection)
     for s in selected:
         if s.start <= now_tz < s.end:
-            plan.current_slot_planned_load_kwh = s.estimated_charged_kwh
+            plan.current_slot_planned_load_kwh = s.ac_load_kwh
             break
 
     if selected:
@@ -397,5 +442,8 @@ def apply_ev_planned_load_to_slots(
         key = ev_slot.start.isoformat()
         for i, s in enumerate(slot_starts):
             if s.isoformat() == key:
-                slot_ev_planned_load_kwh[i] = ev_slot.estimated_charged_kwh
+                # Inject AC-domain load: this is what the house actually draws
+                # from PV/grid for this EV charging.  At 100 % efficiency this
+                # equals estimated_charged_kwh; below 100 % it is larger.
+                slot_ev_planned_load_kwh[i] = ev_slot.ac_load_kwh
                 break

--- a/docs/hsem-planner-spec.md
+++ b/docs/hsem-planner-spec.md
@@ -54,6 +54,30 @@ Positive `net_load_kwh` means the house needs energy.
 
 Negative `net_load_kwh` means there is PV surplus.
 
+When EV planned load integration is enabled, the planner injects an
+AC-domain `ev_planned_load_kwh` value into every slot **before** net
+consumption is calculated, and the effective net load becomes:
+
+```text
+effective_net_load_kwh = base_house_load_kwh + ev_planned_load_kwh - pv_kwh
+```
+
+Where:
+
+- `base_house_load_kwh` is the historical house consumption average for
+  the slot (or the user-provided baseline).  If
+  `base_load_includes_ev` is `True`, this baseline already covers EV
+  charging and `ev_planned_load_kwh` is **not** added again — it is
+  forced to zero to avoid double-counting.
+- `ev_planned_load_kwh` is the *AC-side* load drawn by every enabled
+  EV plan in this slot (see "EV planned load and charger efficiency"
+  below).
+- `pv_kwh` is the slot's PV estimate (`solcast_pv_estimate`).
+
+All downstream calculations — solar surplus, battery charge/discharge
+recommendations, candidate plans, cost function — operate on this
+post-injection `effective_net_load_kwh`.
+
 Battery and grid flows must satisfy:
 
 ```text
@@ -138,6 +162,75 @@ Example (90 % / 90 %): yield = 0.81, loss = 19 %.
   `1 − charge_eff × discharge_eff` when explicit efficiencies are set.
 - When both efficiencies are 100 %, the legacy `conversion_loss_pct` field drives
   the `conversion_loss_cost` term (backwards compatibility).
+
+## EV planned load and charger efficiency
+
+HSEM optionally plans charging for up to two electric vehicles before the
+home-battery planner runs.  The EV plan is built from raw inputs only
+(no dependency on battery decisions) and injects an AC-domain load into
+each slot's `ev_planned_load_kwh` field.
+
+### Two energy quantities per EV charging slot
+
+Each `EVChargingSlot` tracks two distinct energy values:
+
+| Field | Domain | Meaning |
+|---|---|---|
+| `estimated_charged_kwh` | EV battery (DC) | Energy delivered to the EV battery, counts toward the SoC target. |
+| `ac_load_kwh` | AC (PV/grid) | Load drawn by the charger from PV or grid. |
+
+The two are related by the charger efficiency:
+
+```text
+ac_load_kwh = estimated_charged_kwh / (charger_efficiency_pct / 100)
+```
+
+At `charger_efficiency_pct == 100`, `ac_load_kwh == estimated_charged_kwh`
+and behaviour is identical to the legacy single-value model.
+
+`solar_surplus_kwh`, `import_needed_kwh`, and `estimated_cost` on
+`EVChargingSlot` are all reported in the **AC domain** — they describe
+real-world PV consumption, grid import, and money spent.  The planner's
+injected `ev_planned_load_kwh` and the EV sensor's `current_slot_planned_load_kwh`
+also live in the AC domain.
+
+### Multi-EV solar allocation
+
+When both a primary and a secondary EV are enabled, their plans are
+built **sequentially** (primary first, then secondary) and share a
+single mutable solar-surplus budget per slot:
+
+1. The engine computes
+   `slot_solar_surplus[i] = max(pv_estimate[i] − avg_house_consumption[i], 0)`
+   for every slot.
+2. `build_ev_charging_plan` runs for the primary EV.  For every slot it
+   selects, it consumes `min(ac_load, slot_solar_surplus[i])` and
+   decrements `slot_solar_surplus[i]` in place by that amount.
+3. `build_ev_charging_plan` then runs for the secondary EV using the
+   same (now-decremented) list.
+
+This guarantees that two EVs cannot both report the same kWh of solar
+surplus, and that each EV's `solar_surplus_kwh` /
+`import_needed_kwh` / `estimated_cost` reflect what that EV actually
+consumes.  Combined `ev_planned_load_kwh` injected into planner slots
+remains correct (sum of AC loads).
+
+### Invariants for tests
+
+- At `charger_efficiency_pct == 100`, `ac_load_kwh == estimated_charged_kwh`
+  for every EV charging slot.
+- At `charger_efficiency_pct < 100`,
+  `ac_load_kwh == estimated_charged_kwh / (charger_efficiency_pct / 100)`
+  and `import_needed_kwh + solar_surplus_kwh == ac_load_kwh`.
+- The injected `slot.ev_planned_load_kwh` equals the sum of `ac_load_kwh`
+  across all enabled EV plans for that slot.
+- Two EVs sharing a single solar slot must not both claim the same
+  surplus: the sum of their `solar_surplus_kwh` values for the slot is
+  bounded above by the original pre-injection solar surplus.
+- When `base_load_includes_ev` is `True`, `slot.ev_planned_load_kwh`
+  remains zero regardless of the computed EV plan.
+- Effective net load identity holds for every slot:
+  `effective_net_load_kwh == base_house_load_kwh + ev_planned_load_kwh − pv_kwh`.
 
 ## SoC simulation
 

--- a/tests/planner/test_ev_planned_load.py
+++ b/tests/planner/test_ev_planned_load.py
@@ -487,14 +487,22 @@ class TestApplyEvPlannedLoad:
     def _make_plan(
         self, slots_kw: list[float], starts: list[datetime]
     ) -> EVChargingPlan:
-        """Build a minimal EVChargingPlan with one slot per start."""
+        """Build a minimal EVChargingPlan with one slot per start.
+
+        Each slot is treated as 100 %-efficient so AC load == delivered.
+        """
         from custom_components.hsem.planner.ev_planner import EVChargingSlot
 
         plan = EVChargingPlan()
         plan.state = "charging"
         for _i, (start, kw) in enumerate(zip(starts, slots_kw)):
             end = start + timedelta(hours=1)
-            ev_slot = EVChargingSlot(start=start, end=end, estimated_charged_kwh=kw)
+            ev_slot = EVChargingSlot(
+                start=start,
+                end=end,
+                estimated_charged_kwh=kw,
+                ac_load_kwh=kw,
+            )
             plan.charging_slots.append(ev_slot)
             plan.planned_load_by_slot[start.isoformat()] = kw
         return plan
@@ -992,3 +1000,432 @@ class TestEvSolarSurplusRegression:
             assert ev_slot.import_needed_kwh == pytest.approx(
                 ev_slot.estimated_charged_kwh, abs=0.01
             )
+
+
+# ---------------------------------------------------------------------------
+# TestMultiEvSolarAllocation
+# Two EVs sharing a single mutable solar-surplus budget per slot.
+# ---------------------------------------------------------------------------
+
+
+class TestMultiEvSolarAllocation:
+    """Sequential allocation of solar surplus across two EVs."""
+
+    def test_two_evs_share_limited_solar_surplus(self):
+        """Primary EV takes solar first; secondary gets only what's left.
+
+        Hand calculation
+        ----------------
+        Single 1-hour slot at 10:00 with:
+          slot solar surplus      = 4.0 kWh (AC, shared budget)
+          primary EV needs        = 3.0 kWh delivered, 100 % efficiency
+          secondary EV needs      = 3.0 kWh delivered, 100 % efficiency
+          charger power (both)    = 11 kW (max 11 kWh per slot)
+          import price            = 0.20 EUR/kWh
+
+        Primary plan (runs first):
+          delivered = min(11.0, 3.0) = 3.0 kWh
+          ac_load   = 3.0 / 1.0      = 3.0 kWh
+          solar     = min(3.0, 4.0)  = 3.0 kWh
+          import    = 0.0 kWh
+          cost      = 0.0 EUR
+          remaining slot surplus    = 4.0 − 3.0 = 1.0 kWh
+
+        Secondary plan (runs second, sees decremented surplus):
+          delivered = 3.0 kWh
+          ac_load   = 3.0 kWh
+          solar     = min(3.0, 1.0)  = 1.0 kWh
+          import    = 3.0 − 1.0      = 2.0 kWh
+          cost      = 2.0 × 0.20     = 0.40 EUR
+
+        Combined planner load injected into slot:
+          ev_planned_load_kwh = 3.0 + 3.0 = 6.0 kWh (AC domain)
+        """
+        now = _dt(9)  # 09:00, slot 10 is in future
+        deadline = now + timedelta(hours=4)
+
+        # Build a single-slot input where only hour 10 has surplus
+        starts = [_dt(h) for h in range(24)]
+        ends = [_dt(h) + timedelta(hours=1) for h in range(24)]
+        surplus = [0.0] * 24
+        surplus[10] = 4.0
+        prices = [0.20] * 24
+
+        primary_inp = EVPlannerInput(
+            enabled=True,
+            ev_connected=True,
+            smart_charging_enabled=True,
+            current_soc_pct=70.0,
+            target_soc_pct=73.0,  # 3 kWh / 100 kWh
+            battery_capacity_kwh=100.0,
+            charger_power_kw=11.0,
+            charger_efficiency_pct=100.0,
+            deadline=deadline,
+            now=now,
+        )
+        secondary_inp = EVPlannerInput(
+            enabled=True,
+            ev_connected=True,
+            smart_charging_enabled=True,
+            current_soc_pct=70.0,
+            target_soc_pct=73.0,  # 3 kWh / 100 kWh
+            battery_capacity_kwh=100.0,
+            charger_power_kw=11.0,
+            charger_efficiency_pct=100.0,
+            deadline=deadline,
+            now=now,
+        )
+
+        primary_plan = build_ev_charging_plan(
+            primary_inp, starts, ends, surplus, prices
+        )
+        # Capture surplus state between the two EV plans.
+        surplus_after_primary = list(surplus)
+        secondary_plan = build_ev_charging_plan(
+            secondary_inp, starts, ends, surplus, prices
+        )
+
+        # Primary should see the full 4.0 kWh surplus and consume 3.0 of it.
+        primary_slot_10 = next(
+            (s for s in primary_plan.charging_slots if s.start.hour == 10), None
+        )
+        assert primary_slot_10 is not None
+        assert primary_slot_10.estimated_charged_kwh == pytest.approx(3.0, abs=0.01)
+        assert primary_slot_10.ac_load_kwh == pytest.approx(3.0, abs=0.01)
+        assert primary_slot_10.solar_surplus_kwh == pytest.approx(3.0, abs=0.01)
+        assert primary_slot_10.import_needed_kwh == pytest.approx(0.0, abs=1e-9)
+        assert primary_slot_10.estimated_cost == pytest.approx(0.0, abs=1e-9)
+
+        # Surplus list at the point secondary started: 1.0 kWh remaining.
+        assert surplus_after_primary[10] == pytest.approx(1.0, abs=1e-9)
+
+        # Secondary should see 1.0 kWh remaining, consume 1.0 from solar, 2.0 grid.
+        secondary_slot_10 = next(
+            (s for s in secondary_plan.charging_slots if s.start.hour == 10), None
+        )
+        assert secondary_slot_10 is not None
+        assert secondary_slot_10.estimated_charged_kwh == pytest.approx(3.0, abs=0.01)
+        assert secondary_slot_10.ac_load_kwh == pytest.approx(3.0, abs=0.01)
+        assert secondary_slot_10.solar_surplus_kwh == pytest.approx(1.0, abs=0.01)
+        assert secondary_slot_10.import_needed_kwh == pytest.approx(2.0, abs=0.01)
+        assert secondary_slot_10.estimated_cost == pytest.approx(0.40, abs=1e-4)
+
+        # Surplus should now be drained for slot 10.
+        assert surplus[10] == pytest.approx(0.0, abs=1e-9)
+
+        # Combined AC load injected into the planner equals 6.0 kWh.
+        combined = primary_plan.planned_load_by_slot.get(
+            starts[10].isoformat(), 0.0
+        ) + secondary_plan.planned_load_by_slot.get(starts[10].isoformat(), 0.0)
+        assert combined == pytest.approx(6.0, abs=0.01)
+
+    def test_combined_solar_sum_bounded_by_original_surplus(self):
+        """Sum of two EVs' solar_surplus_kwh never exceeds the original budget.
+
+        With 2.0 kWh of slot surplus in the only solar slot and both EVs
+        wanting 2.0 kWh each (1 slot only available):
+          primary takes 2.0 solar
+          secondary sees 0.0 solar remaining → must use a grid slot
+          combined solar consumed by both = 2.0 (equal to original budget).
+        """
+        now = _dt(9)
+        deadline = now + timedelta(hours=4)
+        starts = [_dt(h) for h in range(24)]
+        ends = [_dt(h) + timedelta(hours=1) for h in range(24)]
+        surplus = [0.0] * 24
+        surplus[10] = 2.0
+        original_surplus = surplus[10]
+        prices = [0.10] * 24
+
+        inp_kwargs = dict(
+            enabled=True,
+            ev_connected=True,
+            smart_charging_enabled=True,
+            current_soc_pct=70.0,
+            target_soc_pct=72.0,  # 2 kWh / 100 kWh
+            battery_capacity_kwh=100.0,
+            charger_power_kw=11.0,
+            charger_efficiency_pct=100.0,
+            deadline=deadline,
+            now=now,
+        )
+
+        primary = build_ev_charging_plan(
+            EVPlannerInput(**inp_kwargs), starts, ends, surplus, prices
+        )
+        secondary = build_ev_charging_plan(
+            EVPlannerInput(**inp_kwargs), starts, ends, surplus, prices
+        )
+
+        # Sum each plan's solar_surplus across all slots — this is the
+        # actual solar consumed by each EV in this pass.
+        primary_solar = sum(s.solar_surplus_kwh for s in primary.charging_slots)
+        secondary_solar = sum(s.solar_surplus_kwh for s in secondary.charging_slots)
+
+        # Primary took all 2.0 kWh; secondary saw none.
+        assert primary_solar == pytest.approx(2.0, abs=0.01)
+        assert secondary_solar == pytest.approx(0.0, abs=1e-9)
+
+        # Bounded invariant: combined consumption <= original surplus.
+        combined_solar = primary_solar + secondary_solar
+        assert combined_solar <= original_surplus + 1e-6
+        assert combined_solar == pytest.approx(original_surplus, abs=0.01)
+
+    def test_engine_two_evs_share_solar_in_same_slot(self):
+        """End-to-end engine run: two enabled EVs share the same solar slot.
+
+        Hand calculation
+        ----------------
+        Single solar slot at hour 10:
+          house load  = 1.0 kWh, PV = 5.0 kWh → base surplus = 4.0 kWh.
+          Primary EV needs 3.0 kWh delivered (efficiency 100 %) → AC 3.0.
+          Secondary EV needs 3.0 kWh delivered (efficiency 100 %) → AC 3.0.
+
+        Sequential allocation:
+          Primary: solar 3.0, grid 0.0.
+          Secondary: solar 1.0, grid 2.0.
+          Combined ev_planned_load_kwh = 6.0 kWh injected into slot 10.
+
+        Effective net at hour 10:
+          1.0 (house) + 6.0 (combined EV) − 5.0 (PV) = 2.0 kWh (positive import).
+        """
+        now_iso = "2024-06-15T09:00:00+00:00"
+        from datetime import datetime as _dt2
+
+        now = _dt2.fromisoformat(now_iso)
+        deadline = now + timedelta(hours=6)
+
+        prices = [
+            PricePoint(hour=h, import_price=0.20, export_price=0.05) for h in range(24)
+        ]
+        pv = [SolcastSlot(hour=h, pv_estimate=0.0) for h in range(24)]
+        pv[10] = SolcastSlot(hour=10, pv_estimate=5.0)
+        averages = [
+            HourlyConsumptionAverage(
+                hour=h, avg_1d=1.0, avg_3d=1.0, avg_7d=1.0, avg_14d=1.0
+            )
+            for h in range(24)
+        ]
+
+        inp = PlannerInput(
+            now_iso=now_iso,
+            interval_minutes=60,
+            interval_length_hours=24,
+            battery_soc_pct=50.0,
+            battery_rated_capacity_kwh=10.0,
+            battery_end_of_discharge_soc_pct=10.0,
+            battery_max_soc_pct=90.0,
+            battery_max_charge_power_w=5000.0,
+            battery_max_discharge_power_w=5000.0,
+            battery_charge_efficiency_pct=95.0,
+            battery_conversion_loss_pct=5.0,
+            battery_discharge_efficiency_pct=95.0,
+            weight_1d=25,
+            weight_3d=30,
+            weight_7d=30,
+            weight_14d=15,
+            consumption_averages=averages,
+            price_points=prices,
+            solcast_slots=pv,
+            # Primary EV
+            ev_planned_load_enabled=True,
+            ev_planned_load_connected=True,
+            ev_planned_load_smart_charging_enabled=True,
+            ev_planned_load_current_soc_pct=70.0,
+            ev_planned_load_target_soc_pct=73.0,
+            ev_planned_load_battery_capacity_kwh=100.0,
+            ev_planned_load_charger_power_kw=11.0,
+            ev_planned_load_charger_efficiency_pct=100.0,
+            ev_planned_load_deadline=deadline,
+            ev_planned_load_base_load_includes_ev=False,
+            # Secondary EV (identical requirement)
+            ev_second_planned_load_enabled=True,
+            ev_second_planned_load_connected=True,
+            ev_second_planned_load_smart_charging_enabled=True,
+            ev_second_planned_load_current_soc_pct=70.0,
+            ev_second_planned_load_target_soc_pct=73.0,
+            ev_second_planned_load_battery_capacity_kwh=100.0,
+            ev_second_planned_load_charger_power_kw=11.0,
+            ev_second_planned_load_charger_efficiency_pct=100.0,
+            ev_second_planned_load_deadline=deadline,
+            ev_second_planned_load_base_load_includes_ev=False,
+        )
+        out = run_planner(inp)
+
+        assert out.ev_charging_plan is not None
+        assert out.ev_second_charging_plan is not None
+
+        prim_slot = next(
+            (s for s in out.ev_charging_plan.charging_slots if s.start.hour == 10),
+            None,
+        )
+        sec_slot = next(
+            (
+                s
+                for s in out.ev_second_charging_plan.charging_slots
+                if s.start.hour == 10
+            ),
+            None,
+        )
+        assert prim_slot is not None
+        assert sec_slot is not None
+        # Primary claimed 3.0 kWh of the 4.0 kWh surplus.
+        assert prim_slot.solar_surplus_kwh == pytest.approx(3.0, abs=0.01)
+        assert prim_slot.import_needed_kwh == pytest.approx(0.0, abs=0.01)
+        # Secondary saw only the leftover 1.0 kWh of surplus.
+        assert sec_slot.solar_surplus_kwh == pytest.approx(1.0, abs=0.01)
+        assert sec_slot.import_needed_kwh == pytest.approx(2.0, abs=0.01)
+        # Sum of solar consumed must not exceed pre-injection surplus (4.0 kWh).
+        assert (prim_slot.solar_surplus_kwh + sec_slot.solar_surplus_kwh) == (
+            pytest.approx(4.0, abs=0.01)
+        )
+
+        # Planner slot 10 should carry the combined AC load (6.0 kWh).
+        planner_slot_10 = next((s for s in out.slots if s.start.hour == 10), None)
+        assert planner_slot_10 is not None
+        assert planner_slot_10.ev_planned_load_kwh == pytest.approx(6.0, abs=0.01)
+        # Effective net: 1.0 (house) + 6.0 (EVs) − 5.0 (PV) = 2.0
+        assert planner_slot_10.estimated_net_consumption == pytest.approx(2.0, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# TestChargerEfficiencyAcLoad
+# Charger efficiency lives in the AC-load domain, not the delivered-energy
+# domain.  Delivered energy still counts toward the SoC target unchanged.
+# ---------------------------------------------------------------------------
+
+
+class TestChargerEfficiencyAcLoad:
+    """Charger efficiency raises AC load and grid import without inflating
+    delivered energy toward the SoC target."""
+
+    def test_charger_efficiency_80pct_increases_ac_load(self):
+        """80 % efficient charger draws 5.0 kWh AC to deliver 4.0 kWh to battery.
+
+        Hand calculation
+        ----------------
+        Single 1-hour slot, charger 5 kW @ 80 %, EV needs 4.0 kWh:
+          max delivered per slot = 5 kW × 1 h × 0.80 = 4.0 kWh
+          delivered              = min(4.0, 4.0) = 4.0 kWh
+          ac_load                = 4.0 / 0.80     = 5.0 kWh
+          solar surplus in slot  = 0.0
+          import_needed          = 5.0 − 0.0      = 5.0 kWh
+          cost                   = 5.0 × 0.20     = 1.0 EUR
+        Injected planner load (AC) = 5.0 kWh.
+        """
+        now = _dt(9)
+        deadline = now + timedelta(hours=2)
+        starts = [_dt(h) for h in range(24)]
+        ends = [_dt(h) + timedelta(hours=1) for h in range(24)]
+        surplus = [0.0] * 24
+        prices = [0.20] * 24
+
+        inp = EVPlannerInput(
+            enabled=True,
+            ev_connected=True,
+            smart_charging_enabled=True,
+            current_soc_pct=60.0,
+            target_soc_pct=64.0,  # 4 kWh / 100 kWh
+            battery_capacity_kwh=100.0,
+            charger_power_kw=5.0,
+            charger_efficiency_pct=80.0,
+            deadline=deadline,
+            now=now,
+        )
+        plan = build_ev_charging_plan(inp, starts, ends, surplus, prices)
+
+        assert len(plan.charging_slots) == 1
+        slot = plan.charging_slots[0]
+        assert slot.estimated_charged_kwh == pytest.approx(4.0, abs=0.01)
+        assert slot.ac_load_kwh == pytest.approx(5.0, abs=0.01)
+        assert slot.solar_surplus_kwh == pytest.approx(0.0, abs=1e-9)
+        assert slot.import_needed_kwh == pytest.approx(5.0, abs=0.01)
+        assert slot.estimated_cost == pytest.approx(1.0, abs=1e-4)
+        # Planner-injection value is the AC load, not delivered.
+        assert plan.planned_load_by_slot[slot.start.isoformat()] == pytest.approx(
+            5.0, abs=0.01
+        )
+        # AC = solar + import invariant.
+        assert (slot.solar_surplus_kwh + slot.import_needed_kwh) == pytest.approx(
+            slot.ac_load_kwh, abs=1e-6
+        )
+
+    def test_charger_efficiency_100pct_preserves_default_behavior(self):
+        """At 100 % efficiency, ac_load_kwh == estimated_charged_kwh (no regression).
+
+        Hand calculation
+        ----------------
+        Same setup but 100 % efficient: delivered == ac_load == 4.0 kWh.
+        Injected planner load equals delivered.  Locks in legacy behaviour.
+        """
+        now = _dt(9)
+        deadline = now + timedelta(hours=2)
+        starts = [_dt(h) for h in range(24)]
+        ends = [_dt(h) + timedelta(hours=1) for h in range(24)]
+        surplus = [0.0] * 24
+        prices = [0.20] * 24
+
+        inp = EVPlannerInput(
+            enabled=True,
+            ev_connected=True,
+            smart_charging_enabled=True,
+            current_soc_pct=60.0,
+            target_soc_pct=64.0,
+            battery_capacity_kwh=100.0,
+            charger_power_kw=5.0,
+            charger_efficiency_pct=100.0,
+            deadline=deadline,
+            now=now,
+        )
+        plan = build_ev_charging_plan(inp, starts, ends, surplus, prices)
+
+        assert len(plan.charging_slots) == 1
+        slot = plan.charging_slots[0]
+        assert slot.estimated_charged_kwh == pytest.approx(4.0, abs=0.01)
+        # The defining 100 %-efficiency invariant.
+        assert slot.ac_load_kwh == pytest.approx(slot.estimated_charged_kwh, abs=1e-9)
+        assert slot.import_needed_kwh == pytest.approx(4.0, abs=0.01)
+        assert plan.planned_load_by_slot[slot.start.isoformat()] == pytest.approx(
+            slot.estimated_charged_kwh, abs=1e-9
+        )
+
+    def test_charger_efficiency_partial_solar_with_loss(self):
+        """Efficiency < 100 % with partial solar: AC load is solar + grid in AC domain.
+
+        Hand calculation
+        ----------------
+        Slot has 3.0 kWh solar surplus (AC).  Charger 5 kW @ 80 %, EV needs
+        4.0 kWh delivered:
+          delivered     = 4.0 kWh
+          ac_load       = 4.0 / 0.80 = 5.0 kWh
+          solar_used    = min(5.0, 3.0) = 3.0 kWh
+          import_needed = 5.0 − 3.0    = 2.0 kWh
+        SoC target still receives 4.0 kWh.
+        """
+        now = _dt(9)
+        deadline = now + timedelta(hours=2)
+        starts = [_dt(h) for h in range(24)]
+        ends = [_dt(h) + timedelta(hours=1) for h in range(24)]
+        surplus = [0.0] * 24
+        surplus[9] = 3.0
+        prices = [0.20] * 24
+
+        inp = EVPlannerInput(
+            enabled=True,
+            ev_connected=True,
+            smart_charging_enabled=True,
+            current_soc_pct=60.0,
+            target_soc_pct=64.0,
+            battery_capacity_kwh=100.0,
+            charger_power_kw=5.0,
+            charger_efficiency_pct=80.0,
+            deadline=deadline,
+            now=now,
+        )
+        plan = build_ev_charging_plan(inp, starts, ends, surplus, prices)
+        assert len(plan.charging_slots) >= 1
+        slot = plan.charging_slots[0]
+        assert slot.estimated_charged_kwh == pytest.approx(4.0, abs=0.01)
+        assert slot.ac_load_kwh == pytest.approx(5.0, abs=0.01)
+        assert slot.solar_surplus_kwh == pytest.approx(3.0, abs=0.01)
+        assert slot.import_needed_kwh == pytest.approx(2.0, abs=0.01)


### PR DESCRIPTION
## Summary

Follow-ups to #397 that fix two correctness gaps in the EV planned-load
integration and align the planner spec with the new semantics. Branched
fresh from `main` (supersedes the closed PR #398, which was based on
the wrong branch).

1. **Multi-EV solar surplus is now allocated sequentially.** Previously
   each EV plan was built from the same pre-injection surplus snapshot,
   so two enabled EVs in the same solar slot would each report and use
   the full surplus — double-counting available PV. The planner now
   threads a shared, mutable `slot_solar_surplus` list through both EV
   plans in deterministic order (primary first, then secondary) and
   `build_ev_charging_plan` decrements it in place after each
   allocation. Per-EV `solar_surplus_kwh` / `import_needed_kwh` /
   `estimated_cost` now reflect what each EV actually consumes, and the
   combined planner AC load injected into slots remains correct.

2. **Charger efficiency is modelled in the AC-load domain.** Each
   `EVChargingSlot` now tracks two distinct values:

   - `estimated_charged_kwh` — energy *delivered* to the EV battery
     (counts toward the SoC target).
   - `ac_load_kwh = estimated_charged_kwh / (charger_efficiency / 100)`
     — AC-side load drawn from PV/grid.

   `ev_planned_load_kwh` injected into planner slots and the EV slot's
   `import_needed_kwh` are now in the AC domain, so a less-than-100 %
   charger correctly raises grid import and house load without
   inflating the energy reaching the SoC target. At 100 % efficiency
   the two values are equal and existing behaviour is preserved.

3. **`docs/hsem-planner-spec.md` updated** with the new
   `effective_net_load_kwh = base_house_load_kwh + ev_planned_load_kwh - pv_kwh`
   formula, an "EV planned load and charger efficiency" section
   describing the two energy quantities, the multi-EV sequential
   allocation rule, and matching test invariants.

4. **Hand-calculated tests added** in `tests/planner/test_ev_planned_load.py`:

   - `TestMultiEvSolarAllocation::test_two_evs_share_limited_solar_surplus`
     — two EVs need 3.0 kWh each in a slot with 4.0 kWh base surplus;
     primary gets 3.0 solar, secondary gets 1.0 solar + 2.0 grid,
     combined planner AC load = 6.0 kWh.
   - `TestMultiEvSolarAllocation::test_combined_solar_sum_bounded_by_original_surplus`
     — combined solar consumption across both EVs never exceeds the
     original pre-injection surplus.
   - `TestMultiEvSolarAllocation::test_engine_two_evs_share_solar_in_same_slot`
     — full engine run verifying combined ev_planned_load_kwh and
     effective net.
   - `TestChargerEfficiencyAcLoad::test_charger_efficiency_80pct_increases_ac_load`
     — 4.0 kWh delivered at 80 % charger efficiency yields ac_load 5.0,
     import 5.0, planner `ev_planned_load_kwh = 5.0`.
   - `TestChargerEfficiencyAcLoad::test_charger_efficiency_100pct_preserves_default_behavior`
     — locks in the legacy equality when efficiency is 100 %.
   - `TestChargerEfficiencyAcLoad::test_charger_efficiency_partial_solar_with_loss`
     — efficiency < 100 % combined with partial solar; AC load is
     consistent with solar + import.

   The existing single-EV solar test (`TestEvSolarSurplusRegression`)
   is unchanged and still passes.

## Test plan

- [x] `pytest tests/planner/test_ev_planned_load.py` — 43 passed (37
  existing + 6 new).
- [x] `pytest tests/` — 1628 passed, 3 xfailed (no regressions vs. base).
- [x] `black`, `ruff format`, `ruff check` clean for all changed files.

## Scope

No changes to inverter write logic, charge/discharge scheduling, SoC
simulation, or unrelated planner behaviour. EV planned load when no
secondary EV is configured behaves exactly as before, and the default
`charger_efficiency_pct = 100.0` keeps `ac_load_kwh == estimated_charged_kwh`.

---
🤖 *Generated by Computer*
