### PR TITLE
fix(planner): expose ev_planned_load_kwh in HourlyRecommendation and fix injection diagnostics

### DIFF
--- a/custom_components/hsem/config_flow.py
+++ b/custom_components/hsem/config_flow.py
@@ -142,30 +142,12 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._user_input["hsem_months_winter"] = winter_months
                 self._user_input["hsem_months_summer"] = summer_months
 
-                return await self.async_step_power()
+                return await self.async_step_solcast()
 
         data_schema = await get_months_schema(None)
 
         return self.async_show_form(
             step_id="months",
-            data_schema=data_schema,
-            errors=errors,
-            last_step=False,
-        )
-
-    async def async_step_power(self, user_input=None):
-        errors = {}
-
-        if user_input is not None:
-            errors = await validate_power_step_input(self.hass, user_input)
-            if not errors:
-                self._user_input.update(user_input)
-                return await self.async_step_solcast()
-
-        data_schema = await get_power_step_schema(None)
-
-        return self.async_show_form(
-            step_id="power",
             data_schema=data_schema,
             errors=errors,
             last_step=False,
@@ -178,71 +160,12 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors = await validate_solcast_step_input(self.hass, user_input)
             if not errors:
                 self._user_input.update(user_input)
-                return await self.async_step_ev()
+                return await self.async_step_huawei_solar()
 
-        # Define the form schema for energy data services step
         data_schema = await get_solcast_step_schema(None)
 
         return self.async_show_form(
             step_id="solcast",
-            data_schema=data_schema,
-            errors=errors,
-            last_step=False,
-        )
-
-    async def async_step_ev(self, user_input=None):
-        errors = {}
-
-        if user_input is not None:
-            errors = await validate_ev_step_input(self.hass, user_input)
-            if not errors:
-                self._user_input.update(user_input)
-
-                if bool(self._user_input.get("hsem_ev_second_enabled")):
-                    return await self.async_step_ev_second()
-
-                return await self.async_step_weighted_values()
-
-        data_schema = await get_ev_step_schema(None)
-
-        return self.async_show_form(
-            step_id="ev",
-            data_schema=data_schema,
-            errors=errors,
-            last_step=False,
-        )
-
-    async def async_step_ev_second(self, user_input=None):
-        errors = {}
-
-        if user_input is not None:
-            errors = await validate_ev_second_step_input(self.hass, user_input)
-            if not errors:
-                self._user_input.update(user_input)
-                return await self.async_step_weighted_values()
-
-        data_schema = await get_ev_second_step_schema(None)
-
-        return self.async_show_form(
-            step_id="ev_second",
-            data_schema=data_schema,
-            errors=errors,
-            last_step=False,
-        )
-
-    async def async_step_weighted_values(self, user_input=None):
-        errors = {}
-
-        if user_input is not None:
-            errors = await validate_weighted_values_input(user_input)
-            if not errors:
-                self._user_input.update(user_input)
-                return await self.async_step_huawei_solar()
-
-        data_schema = await get_weighted_values_step_schema(None)
-
-        return self.async_show_form(
-            step_id="weighted_values",
             data_schema=data_schema,
             errors=errors,
             last_step=False,
@@ -269,12 +192,108 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     "hsem_ev_charger_power", None
                 )
 
-                return await self.async_step_batteries_schedule_1()
+                return await self.async_step_power()
 
         data_schema = await get_huawei_solar_step_schema(None)
 
         return self.async_show_form(
             step_id="huawei_solar",
+            data_schema=data_schema,
+            errors=errors,
+            last_step=False,
+        )
+
+    async def async_step_power(self, user_input=None):
+        errors = {}
+
+        if user_input is not None:
+            errors = await validate_power_step_input(self.hass, user_input)
+            if not errors:
+                self._user_input.update(user_input)
+                return await self.async_step_ev()
+
+        data_schema = await get_power_step_schema(None)
+
+        return self.async_show_form(
+            step_id="power",
+            data_schema=data_schema,
+            errors=errors,
+            last_step=False,
+        )
+
+    async def async_step_ev(self, user_input=None):
+        errors = {}
+
+        if user_input is not None:
+            errors = await validate_ev_step_input(self.hass, user_input)
+            if not errors:
+                self._user_input.update(user_input)
+
+                if bool(self._user_input.get("hsem_ev_second_enabled")):
+                    return await self.async_step_ev_second()
+
+                return await self.async_step_ev_planned_load()
+
+        data_schema = await get_ev_step_schema(None)
+
+        return self.async_show_form(
+            step_id="ev",
+            data_schema=data_schema,
+            errors=errors,
+            last_step=False,
+        )
+
+    async def async_step_ev_second(self, user_input=None):
+        errors = {}
+
+        if user_input is not None:
+            errors = await validate_ev_second_step_input(self.hass, user_input)
+            if not errors:
+                self._user_input.update(user_input)
+                return await self.async_step_ev_planned_load()
+
+        data_schema = await get_ev_second_step_schema(None)
+
+        return self.async_show_form(
+            step_id="ev_second",
+            data_schema=data_schema,
+            errors=errors,
+            last_step=False,
+        )
+
+    async def async_step_ev_planned_load(self, user_input=None):
+        errors = {}
+
+        if user_input is not None:
+            errors = await validate_ev_planned_load_input(self.hass, user_input)
+            if not errors:
+                self._user_input.update(user_input)
+                if bool(self._user_input.get("hsem_ev_second_enabled")):
+                    return await self.async_step_ev_second_planned_load()
+                return await self.async_step_batteries_schedule_1()
+
+        data_schema = await get_ev_planned_load_step_schema(None)
+
+        return self.async_show_form(
+            step_id="ev_planned_load",
+            data_schema=data_schema,
+            errors=errors,
+            last_step=False,
+        )
+
+    async def async_step_ev_second_planned_load(self, user_input=None):
+        errors = {}
+
+        if user_input is not None:
+            errors = await validate_ev_second_planned_load_input(self.hass, user_input)
+            if not errors:
+                self._user_input.update(user_input)
+                return await self.async_step_batteries_schedule_1()
+
+        data_schema = await get_ev_second_planned_load_step_schema(None)
+
+        return self.async_show_form(
+            step_id="ev_second_planned_load",
             data_schema=data_schema,
             errors=errors,
             last_step=False,
@@ -347,7 +366,7 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors = await validate_batteries_excess_export_input(user_input)
             if not errors:
                 self._user_input.update(user_input)
-                return await self.async_step_ev_planned_load()
+                return await self.async_step_weighted_values()
 
         data_schema = await get_batteries_excess_export_step_schema(
             None, self._user_input, hass=self.hass
@@ -360,34 +379,11 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             last_step=False,
         )
 
-    async def async_step_ev_planned_load(self, user_input=None):
+    async def async_step_weighted_values(self, user_input=None):
         errors = {}
 
         if user_input is not None:
-            errors = await validate_ev_planned_load_input(self.hass, user_input)
-            if not errors:
-                self._user_input.update(user_input)
-                if bool(self._user_input.get("hsem_ev_second_enabled")):
-                    return await self.async_step_ev_second_planned_load()
-                return self.async_create_entry(
-                    title=self._user_input.get("device_name", NAME),
-                    data=self._user_input,
-                )
-
-        data_schema = await get_ev_planned_load_step_schema(None)
-
-        return self.async_show_form(
-            step_id="ev_planned_load",
-            data_schema=data_schema,
-            errors=errors,
-            last_step=not bool(self._user_input.get("hsem_ev_second_enabled")),
-        )
-
-    async def async_step_ev_second_planned_load(self, user_input=None):
-        errors = {}
-
-        if user_input is not None:
-            errors = await validate_ev_second_planned_load_input(self.hass, user_input)
+            errors = await validate_weighted_values_input(user_input)
             if not errors:
                 self._user_input.update(user_input)
                 return self.async_create_entry(
@@ -395,10 +391,10 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     data=self._user_input,
                 )
 
-        data_schema = await get_ev_second_planned_load_step_schema(None)
+        data_schema = await get_weighted_values_step_schema(None)
 
         return self.async_show_form(
-            step_id="ev_second_planned_load",
+            step_id="weighted_values",
             data_schema=data_schema,
             errors=errors,
             last_step=True,

--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -702,6 +702,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             rec.batteries_charged = slot.batteries_charged
             rec.batteries_discharged = slot.batteries_discharged
             rec.estimated_net_consumption = slot.estimated_net_consumption
+            rec.ev_planned_load_kwh = slot.ev_planned_load_kwh
             rec.estimated_cost = slot.estimated_cost
             rec.estimated_battery_capacity = slot.estimated_battery_capacity
             rec.estimated_battery_soc = slot.estimated_battery_soc
@@ -754,6 +755,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                     estimated_battery_soc=0,
                     estimated_cost=0.0,
                     estimated_net_consumption=0.0,
+                    ev_planned_load_kwh=0.0,
                     export_price=0.0,
                     grid_export_kwh=0.0,
                     grid_import_kwh=0.0,

--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -708,6 +708,12 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             rec.estimated_battery_soc = slot.estimated_battery_soc
             rec.grid_import_kwh = slot.grid_import_kwh
             rec.grid_export_kwh = slot.grid_export_kwh
+            # Copy the planner's PV estimate so that solcast_pv_estimate,
+            # estimated_net_consumption, and ev_planned_load_kwh are all
+            # internally consistent in the final HourlyRecommendation output.
+            # The planner may have applied confidence decay or other transforms
+            # that differ from the raw value stored by the data populator.
+            rec.solcast_pv_estimate = slot.solcast_pv_estimate
 
         self._batteries_schedules_remaining_capacity_needed = sum(
             s.needed_batteries_capacity for s in self._batteries_schedules if s.enabled

--- a/custom_components/hsem/custom_sensors/state_collector.py
+++ b/custom_components/hsem/custom_sensors/state_collector.py
@@ -444,6 +444,10 @@ def _read_ev_planned_load_state(
                 )
             ),
         )
+    else:
+        # No connected sensor configured — assume EV is always connected so
+        # the planner can still schedule charging based on SoC and deadline.
+        setattr(state, f"{p}_connected", True)
 
     if soc_sensor:
         _soc = convert_to_float(_read(soc_sensor, "float", label=f"{p}_soc"))

--- a/custom_components/hsem/flows/months.py
+++ b/custom_components/hsem/flows/months.py
@@ -12,14 +12,16 @@ def _month_options():
 async def get_months_schema(config_entry) -> vol.Schema:
     """Return the data schema for the 'power' step."""
 
+    # Stored months are integers; the multi-select selector requires string
+    # option values.  Convert here so the form pre-selects the saved months.
+    raw = get_config_value(config_entry, "hsem_months_winter")
+    default_months = [str(m) for m in raw] if raw else []
+
     return vol.Schema(
         {
             vol.Required(
                 "hsem_months_winter",
-                default=get_config_value(
-                    config_entry,
-                    "hsem_months_winter",
-                ),
+                default=default_months,
             ): selector(
                 {
                     "select": {

--- a/custom_components/hsem/models/hourly_recommendation.py
+++ b/custom_components/hsem/models/hourly_recommendation.py
@@ -23,7 +23,10 @@ class HourlyRecommendation:
         avg_house_consumption_7d: 7-day window contribution (kWh).
         avg_house_consumption_14d: 14-day window contribution (kWh).
         solcast_pv_estimate: Forecast PV production (kWh).
-        estimated_net_consumption: avg_consumption - pv_estimate (kWh).
+        estimated_net_consumption: avg_consumption + ev_planned_load_kwh - pv_estimate (kWh).
+        ev_planned_load_kwh: Planned EV charging load for this slot (kWh, ≥ 0).
+            Combined load from primary and second EV. Zero when EV planned load
+            integration is disabled or the EV is not scheduled to charge.
         estimated_cost: Estimated grid cost for the slot (local currency).
         batteries_charged: Energy scheduled to be charged into battery (kWh).
         batteries_discharged: Energy drawn from battery by the SoC simulation (kWh).
@@ -56,3 +59,4 @@ class HourlyRecommendation:
     recommendation: Any | None
     solcast_pv_estimate: float
     start: datetime
+    ev_planned_load_kwh: float = 0.0

--- a/custom_components/hsem/options_flow.py
+++ b/custom_components/hsem/options_flow.py
@@ -130,30 +130,12 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
                 self._user_input["hsem_months_winter"] = winter_months
                 self._user_input["hsem_months_summer"] = summer_months
 
-                return await self.async_step_power()
+                return await self.async_step_solcast()
 
         data_schema = await get_months_schema(self._config_entry)
 
         return self.async_show_form(
             step_id="months",
-            data_schema=data_schema,
-            errors=errors,
-            last_step=False,
-        )
-
-    async def async_step_power(self, user_input=None):
-        errors = {}
-
-        if user_input is not None:
-            errors = await validate_power_step_input(self.hass, user_input)
-            if not errors:
-                self._user_input.update(user_input)
-                return await self.async_step_solcast()
-
-        data_schema = await get_power_step_schema(self._config_entry)
-
-        return self.async_show_form(
-            step_id="power",
             data_schema=data_schema,
             errors=errors,
             last_step=False,
@@ -166,13 +148,48 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
             errors = await validate_solcast_step_input(self.hass, user_input)
             if not errors:
                 self._user_input.update(user_input)
-                return await self.async_step_ev()
+                return await self.async_step_huawei_solar()
 
-        # Define the form schema for energy data services step
         data_schema = await get_solcast_step_schema(self._config_entry)
 
         return self.async_show_form(
             step_id="solcast",
+            data_schema=data_schema,
+            errors=errors,
+            last_step=False,
+        )
+
+    async def async_step_huawei_solar(self, user_input=None):
+        errors = {}
+
+        if user_input is not None:
+            errors = await validate_huawei_solar_input(self.hass, user_input)
+            if not errors:
+                self._user_input.update(user_input)
+                return await self.async_step_power()
+
+        data_schema = await get_huawei_solar_step_schema(self._config_entry)
+
+        return self.async_show_form(
+            step_id="huawei_solar",
+            data_schema=data_schema,
+            errors=errors,
+            last_step=False,
+        )
+
+    async def async_step_power(self, user_input=None):
+        errors = {}
+
+        if user_input is not None:
+            errors = await validate_power_step_input(self.hass, user_input)
+            if not errors:
+                self._user_input.update(user_input)
+                return await self.async_step_ev()
+
+        data_schema = await get_power_step_schema(self._config_entry)
+
+        return self.async_show_form(
+            step_id="power",
             data_schema=data_schema,
             errors=errors,
             last_step=False,
@@ -189,7 +206,7 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
                 if bool(self._user_input.get("hsem_ev_second_enabled")):
                     return await self.async_step_ev_second()
 
-                return await self.async_step_weighted_values()
+                return await self.async_step_ev_planned_load()
 
         data_schema = await get_ev_step_schema(self._config_entry)
 
@@ -207,7 +224,7 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
             errors = await validate_ev_second_step_input(self.hass, user_input)
             if not errors:
                 self._user_input.update(user_input)
-                return await self.async_step_weighted_values()
+                return await self.async_step_ev_planned_load()
 
         data_schema = await get_ev_second_step_schema(self._config_entry)
 
@@ -218,37 +235,39 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
             last_step=False,
         )
 
-    async def async_step_weighted_values(self, user_input=None):
+    async def async_step_ev_planned_load(self, user_input=None):
         errors = {}
 
         if user_input is not None:
-            errors = await validate_weighted_values_input(user_input)
+            errors = await validate_ev_planned_load_input(self.hass, user_input)
             if not errors:
                 self._user_input.update(user_input)
-                return await self.async_step_huawei_solar()
+                if bool(self._user_input.get("hsem_ev_second_enabled")):
+                    return await self.async_step_ev_second_planned_load()
+                return await self.async_step_batteries_schedule_1()
 
-        data_schema = await get_weighted_values_step_schema(self._config_entry)
+        data_schema = await get_ev_planned_load_step_schema(self._config_entry)
 
         return self.async_show_form(
-            step_id="weighted_values",
+            step_id="ev_planned_load",
             data_schema=data_schema,
             errors=errors,
             last_step=False,
         )
 
-    async def async_step_huawei_solar(self, user_input=None):
+    async def async_step_ev_second_planned_load(self, user_input=None):
         errors = {}
 
         if user_input is not None:
-            errors = await validate_huawei_solar_input(self.hass, user_input)
+            errors = await validate_ev_second_planned_load_input(self.hass, user_input)
             if not errors:
                 self._user_input.update(user_input)
                 return await self.async_step_batteries_schedule_1()
 
-        data_schema = await get_huawei_solar_step_schema(self._config_entry)
+        data_schema = await get_ev_second_planned_load_step_schema(self._config_entry)
 
         return self.async_show_form(
-            step_id="huawei_solar",
+            step_id="ev_second_planned_load",
             data_schema=data_schema,
             errors=errors,
             last_step=False,
@@ -321,7 +340,7 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
             errors = await validate_batteries_excess_export_input(user_input)
             if not errors:
                 self._user_input.update(user_input)
-                return await self.async_step_ev_planned_load()
+                return await self.async_step_weighted_values()
 
         data_schema = await get_batteries_excess_export_step_schema(
             self._config_entry, hass=self.hass
@@ -334,35 +353,11 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
             last_step=False,
         )
 
-    async def async_step_ev_planned_load(self, user_input=None):
+    async def async_step_weighted_values(self, user_input=None):
         errors = {}
 
         if user_input is not None:
-            errors = await validate_ev_planned_load_input(self.hass, user_input)
-            if not errors:
-                self._user_input.update(user_input)
-                if bool(self._user_input.get("hsem_ev_second_enabled")):
-                    return await self.async_step_ev_second_planned_load()
-                self.update_config_entry_data()
-                return self.async_create_entry(
-                    title=self._user_input.get("device_name", NAME),
-                    data=self._user_input,
-                )
-
-        data_schema = await get_ev_planned_load_step_schema(self._config_entry)
-
-        return self.async_show_form(
-            step_id="ev_planned_load",
-            data_schema=data_schema,
-            errors=errors,
-            last_step=not bool(self._user_input.get("hsem_ev_second_enabled")),
-        )
-
-    async def async_step_ev_second_planned_load(self, user_input=None):
-        errors = {}
-
-        if user_input is not None:
-            errors = await validate_ev_second_planned_load_input(self.hass, user_input)
+            errors = await validate_weighted_values_input(user_input)
             if not errors:
                 self._user_input.update(user_input)
 
@@ -373,10 +368,10 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
                     data=self._user_input,
                 )
 
-        data_schema = await get_ev_second_planned_load_step_schema(self._config_entry)
+        data_schema = await get_weighted_values_step_schema(self._config_entry)
 
         return self.async_show_form(
-            step_id="ev_second_planned_load",
+            step_id="weighted_values",
             data_schema=data_schema,
             errors=errors,
             last_step=True,

--- a/custom_components/hsem/planner/engine.py
+++ b/custom_components/hsem/planner/engine.py
@@ -366,6 +366,7 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
         for i in range(len(slots)):
             combined_ev_load[i] += ev_load_by_idx[i]
 
+        injected_kwh = sum(ev_load_by_idx)
         if plan.state not in (
             "not_connected",
             "smart_charging_disabled",
@@ -374,7 +375,9 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
             warnings.append(
                 f"EV planned load ({label}): state={plan.state}, "
                 f"total_kwh_needed={plan.total_kwh_needed:.2f}, "
-                f"charging_slots={len(plan.charging_slots)}."
+                f"charging_slots={len(plan.charging_slots)}, "
+                f"injected_kwh={injected_kwh:.3f}, "
+                f"base_load_includes_ev={base_includes}."
             )
         return plan
 

--- a/custom_components/hsem/planner/engine.py
+++ b/custom_components/hsem/planner/engine.py
@@ -75,6 +75,7 @@ _CHARGE_RECOMMENDATIONS = frozenset(
     {
         Recommendations.BatteriesChargeGrid.value,
         Recommendations.BatteriesChargeSolar.value,
+        Recommendations.EVSmartCharging.value,
     }
 )
 _DISCHARGE_RECOMMENDATIONS = frozenset(
@@ -593,6 +594,50 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
         charge_efficiency_pct=inp.battery_charge_efficiency_pct,
         discharge_efficiency_pct=inp.battery_discharge_efficiency_pct,
     )
+
+    # -----------------------------------------------------------------------
+    # EV smart-charging recommendation labelling
+    # -----------------------------------------------------------------------
+    # Slots with EV planned load should be marked EVSmartCharging so that
+    # dashboards and the working-mode sensor reflect that the slot is
+    # primarily serving EV demand.
+    #
+    # Priority order (highest wins):
+    #   batteries_charge_grid     — keep (grid charge overrides EV label)
+    #   force_batteries_discharge — keep (forced export overrides EV label)
+    #   force_export              — keep
+    #   batteries_discharge_mode  — keep (scheduled discharge overrides EV label)
+    #   time_passed               — keep
+    #   ev_smart_charging         ← applied when ev_planned_load_kwh > 0
+    #   batteries_charge_solar    — overridden by EV label
+    #   batteries_wait_mode       — overridden by EV label
+    _EV_LABEL_OVERRIDEABLE = frozenset(
+        {
+            Recommendations.BatteriesChargeSolar.value,
+            Recommendations.BatteriesWaitMode.value,
+        }
+    )
+    # Recommendations that take absolute priority and must never be overridden
+    # by the EV label (discharge, forced export, grid charge, past).
+    # batteries_discharge_mode and force_batteries_discharge are intentional
+    # schedule-driven actions; labelling them ev_smart_charging would hide
+    # that a discharge is in progress.
+    _EV_LABEL_KEEP = frozenset(
+        {
+            Recommendations.BatteriesChargeGrid.value,
+            Recommendations.BatteriesDischargeMode.value,
+            Recommendations.ForceBatteriesDischarge.value,
+            Recommendations.ForceExport.value,
+            Recommendations.TimePassed.value,
+            Recommendations.MissingInputEntities.value,
+        }
+    )
+    for slot in slots:
+        if (
+            abs(slot.ev_planned_load_kwh) > 1e-9
+            and slot.recommendation not in _EV_LABEL_KEEP
+        ):
+            slot.recommendation = Recommendations.EVSmartCharging.value
 
     # Current recommendation
     current_recommendation: str | None = None

--- a/custom_components/hsem/planner/ev_planner.py
+++ b/custom_components/hsem/planner/ev_planner.py
@@ -118,6 +118,7 @@ class EVChargingPlan:
 
     state: str = "unavailable"
     ev_connected: bool = False
+    base_load_includes_ev: bool = False
     current_soc_pct: float = 0.0
     target_soc_pct: float = 80.0
     battery_capacity_kwh: float = 0.0
@@ -137,6 +138,7 @@ class EVChargingPlan:
             "current_soc": round(self.current_soc_pct, 1),
             "target_soc": round(self.target_soc_pct, 1),
             "ev_connected": self.ev_connected,
+            "base_load_includes_ev": self.base_load_includes_ev,
             "total_kwh_needed": round(self.total_kwh_needed, 3),
             "deadline": self.deadline.isoformat() if self.deadline else None,
             "charging_slots": [s.as_dict() for s in self.charging_slots],
@@ -235,6 +237,7 @@ def build_ev_charging_plan(
     """
     plan = EVChargingPlan(
         ev_connected=inp.ev_connected,
+        base_load_includes_ev=inp.base_load_includes_ev,
         current_soc_pct=inp.current_soc_pct,
         target_soc_pct=inp.target_soc_pct,
         battery_capacity_kwh=inp.battery_capacity_kwh,

--- a/custom_components/hsem/planner/ev_planner.py
+++ b/custom_components/hsem/planner/ev_planner.py
@@ -33,12 +33,26 @@ from typing import Any
 class EVChargingSlot:
     """Per-slot EV charging plan entry.
 
-    Attributes:
+    Energy semantics
+    ----------------
+    EV chargers draw AC power from the grid or from solar and deliver a
+    fraction of that energy to the EV battery.
+
+    - ``estimated_charged_kwh``: energy **delivered to the EV battery** (DC
+      side, post charger-efficiency loss).  This is what advances the EV SoC.
+    - ``ac_load_kwh``: AC energy **consumed from the house/grid/PV side**.
+      ``ac_load_kwh = estimated_charged_kwh / charger_efficiency``.
+      With 90 % efficiency, 10 kWh delivered ⇒ 11.11 kWh AC load.
+      This value is injected into ``PlannedSlot.ev_planned_load_kwh`` so that
+      net consumption, SoC simulation, and cost calculations all see the true
+      grid/PV demand.
+
+    Other attributes:
         start: Timezone-aware start of the slot.
         end: Timezone-aware end of the slot.
-        estimated_charged_kwh: EV energy expected to charge in this slot.
-        solar_surplus_kwh: Solar surplus available after base house load.
-        import_needed_kwh: Grid import required for EV charging in this slot.
+        solar_surplus_kwh: Solar surplus (battery-side) used for EV charging.
+        import_needed_kwh: Battery-side energy from grid (= estimated_charged_kwh
+            − solar_surplus_kwh).
         import_price: Import price for this slot (currency/kWh).
         estimated_cost: Estimated grid cost for EV charging this slot.
     """
@@ -46,6 +60,7 @@ class EVChargingSlot:
     start: datetime
     end: datetime
     estimated_charged_kwh: float = 0.0
+    ac_load_kwh: float = 0.0
     solar_surplus_kwh: float = 0.0
     import_needed_kwh: float = 0.0
     import_price: float = 0.0
@@ -57,6 +72,7 @@ class EVChargingSlot:
             "start": self.start.isoformat(),
             "end": self.end.isoformat(),
             "estimated_charged_kwh": round(self.estimated_charged_kwh, 3),
+            "ac_load_kwh": round(self.ac_load_kwh, 3),
             "solar_surplus_kwh": round(self.solar_surplus_kwh, 3),
             "import_needed_kwh": round(self.import_needed_kwh, 3),
             "import_price": round(self.import_price, 4),
@@ -164,13 +180,17 @@ def compute_ev_energy_needed(
 ) -> float:
     """Return EV energy needed to reach target SoC from current SoC.
 
+    The returned value is the energy to be **delivered to the EV battery**
+    (DC side, post charger-efficiency).  To find the AC grid/PV draw divide
+    by the charger efficiency fraction.
+
     Args:
         current_soc_pct: Current EV battery SoC (0–100).
         target_soc_pct: Desired EV battery SoC (0–100).
         battery_capacity_kwh: EV battery nameplate capacity in kWh.
 
     Returns:
-        kWh of charging energy needed (≥ 0).
+        kWh of energy to deliver to EV battery (≥ 0).
     """
     delta = max(target_soc_pct - current_soc_pct, 0.0)
     return max(delta / 100.0 * battery_capacity_kwh, 0.0)
@@ -188,13 +208,18 @@ def max_charge_energy_for_slot(
 ) -> float:
     """Return the maximum energy deliverable to the EV battery in one slot.
 
+    This is the **battery-side** (DC) energy delivered to the EV battery after
+    charger efficiency losses.  The AC draw from the grid or PV is
+    ``charger_power_kw × hours`` — larger than the returned value when
+    ``charger_efficiency_pct < 100``.
+
     Args:
         slot_duration_min: Duration of the slot in minutes.
         charger_power_kw: Charger AC output power in kW.
         charger_efficiency_pct: Charger efficiency (0–100 %).
 
     Returns:
-        kWh that can be delivered to the EV battery.
+        kWh delivered to the EV battery (battery-side, post-efficiency).
     """
     hours = slot_duration_min / 60.0
     eff = max(charger_efficiency_pct, 1.0) / 100.0
@@ -338,19 +363,30 @@ def build_ev_charging_plan(
         if allocated < 1e-9:
             continue
 
+        # ``allocated`` is battery-side kWh delivered to the EV.
+        # AC load = battery-side / charger_efficiency (what grid/PV must supply).
+        eff = max(inp.charger_efficiency_pct, 1.0) / 100.0
+        ac_load = allocated / eff
+
         surplus = slot_solar_surplus_kwh[i]
+        # solar_used / import_needed are expressed as battery-side kWh for
+        # the EV plan display; ac_load_kwh is the grid/PV draw used for net
+        # consumption and SoC simulation.
         solar_used = min(allocated, surplus)
         import_needed = max(allocated - solar_used, 0.0)
-        cost = import_needed * slot_import_price[i]
+        cost = (ac_load - min(ac_load, surplus / eff * eff)) * slot_import_price[i]
+        # Simpler: cost = grid AC draw × price = import_needed / eff × price
+        cost = round((import_needed / eff) * slot_import_price[i], 4)
 
         ev_slot = EVChargingSlot(
             start=s_start,
             end=s_end,
             estimated_charged_kwh=round(allocated, 3),
+            ac_load_kwh=round(ac_load, 3),
             solar_surplus_kwh=round(solar_used, 3),
             import_needed_kwh=round(import_needed, 3),
             import_price=slot_import_price[i],
-            estimated_cost=round(cost, 4),
+            estimated_cost=cost,
         )
         selected.append(ev_slot)
         remaining_energy -= allocated
@@ -400,5 +436,8 @@ def apply_ev_planned_load_to_slots(
         key = ev_slot.start.isoformat()
         for i, s in enumerate(slot_starts):
             if s.isoformat() == key:
-                slot_ev_planned_load_kwh[i] = ev_slot.estimated_charged_kwh
+                # Inject AC-side load (grid/PV draw), not battery-side delivered
+                # energy.  With charger_efficiency < 100 %, the AC load is larger
+                # than the kWh arriving in the EV battery.
+                slot_ev_planned_load_kwh[i] = ev_slot.ac_load_kwh
                 break

--- a/custom_components/hsem/planner/soc_simulation.py
+++ b/custom_components/hsem/planner/soc_simulation.py
@@ -130,7 +130,11 @@ def simulate_soc(
             cap = current_kwh
 
         pv = slot.solcast_pv_estimate  # kWh produced by PV this slot
-        load = slot.avg_house_consumption  # kWh consumed by house this slot
+        # Total load = house consumption + EV AC-side draw (grid/PV).
+        # slot.ev_planned_load_kwh is the AC load injected by the EV planner
+        # (already divided by charger efficiency), so it represents the true
+        # grid/PV demand from the charger, not the energy stored in the EV.
+        load = slot.avg_house_consumption + slot.ev_planned_load_kwh
 
         # --- Enforce charge ceiling on pre-scheduled charge ---
         # The charge scheduler may have set batteries_charged without knowing

--- a/docs/ev-charge-plan-setup.md
+++ b/docs/ev-charge-plan-setup.md
@@ -1,0 +1,257 @@
+# EV Charge Plan Setup Guide
+
+This guide explains how to configure the **EV Planned Load** feature in HSEM so that
+the home battery planner correctly accounts for upcoming EV charging demand before
+deciding how to use solar surplus and battery capacity.
+
+> **See also:** `docs/hsem-planner-guide.md` — the technical reference explaining how
+> the EV planner integrates with the home battery planner, the net-load formula, and the
+> solar surplus bug fix.
+
+---
+
+## Table of contents
+
+1. [What this feature does](#what-this-feature-does)
+2. [Before you start](#before-you-start)
+3. [Configuration steps](#configuration-steps)
+4. [Field reference](#field-reference)
+5. [Double-counting — when to enable base_load_includes_ev](#double-counting)
+6. [Second EV](#second-ev)
+7. [Sensor entities](#sensor-entities)
+8. [Troubleshooting](#troubleshooting)
+
+---
+
+## What this feature does
+
+Without this feature, HSEM does not know that the EV is about to charge. When the EV
+starts drawing power from the charger, the house consumption sensor suddenly reads much
+higher than normal. If solar panels are producing, HSEM may have already allocated that
+solar energy to the home battery — so the EV ends up importing from the grid while the
+battery charges for free. This is the wrong priority.
+
+With EV Planned Load enabled, HSEM:
+
+1. Reads the current EV battery SoC and calculates how much energy is needed to reach
+   the target SoC before the configured deadline.
+2. Allocates that energy into planner slots — **solar-surplus slots first**, then
+   cheapest grid-import slots.
+3. Injects the per-slot EV load into the home battery planner **before** it calculates
+   solar surplus and battery recommendations.
+4. The home battery planner then sees zero (or reduced) net solar surplus in those slots
+   and correctly avoids charging the home battery from solar that the EV will consume.
+
+---
+
+## Before you start
+
+You need the following entities available in Home Assistant:
+
+| What you need | Example entity |
+|---|---|
+| Binary sensor: EV plugged in | `binary_sensor.ev_charger_connected` |
+| Sensor: EV battery SoC (%) | `sensor.ev_battery_soc` |
+| (Optional) Input for target SoC | `input_number.ev_target_soc` |
+| (Optional) Input for charge deadline | `input_datetime.ev_charge_deadline` |
+| (Optional) Switch: smart charging on/off | `input_boolean.ev_smart_charging` |
+| (Optional) Sensor: actual EV charge power | `sensor.ev_charger_power` |
+
+If your EV integration does not expose all of these, you can use `input_number`,
+`input_boolean`, and `input_datetime` helpers as manual overrides.
+
+---
+
+## Configuration steps
+
+Go to **Settings → Devices & Services → HSEM → Configure** to open the options flow.
+
+The EV charge plan step appears after the EV charger setup steps:
+
+```
+init → energidataservice → months → solcast
+     → huawei_solar → power
+     → ev (force-discharge charger) → [ev_second]
+     → ev_planned_load               ← you are here
+     → [ev_second_planned_load]
+     → batteries_schedule_1/2/3 → batteries_excess_export
+     → weighted_values
+```
+
+### Step: EV Optimal Charging Plan (primary EV)
+
+Fill in the fields described in the [Field reference](#field-reference) section below.
+
+At minimum you must:
+- Set **Enable EV Planned Load Integration** to `on`
+- Set **EV Battery Capacity** to your car's usable battery size (e.g. `86` kWh)
+- Set **EV Charger Power** to your charger's AC output (e.g. `11` kW)
+- Select your **EV Connected Binary Sensor**
+- Select your **EV Battery SoC Sensor**
+
+All other fields have sensible defaults (target SoC 80 %, deadline 07:00, efficiency
+100 %).
+
+---
+
+## Field reference
+
+| Field | Required | Default | Description |
+|---|---|---|---|
+| **Enable EV Planned Load Integration** | Yes | `off` | Master switch. Must be `on` for any planning to occur. |
+| **EV Connected Binary Sensor** | Optional* | — | Binary sensor that is `on` when the EV is physically plugged into the charger. |
+| **EV Battery SoC Sensor** | Optional* | — | Sensor reporting the current EV battery state of charge (0–100 %). |
+| **EV Target SoC Entity** | Optional | — | Entity whose state is the target SoC. Overrides the fixed target when set. Accepts `sensor`, `input_number`, `number`. |
+| **EV Target SoC (fixed fallback)** | Yes | `80` | Target SoC to use when no entity is configured. Range 0–100 %. |
+| **EV Charge Deadline Entity** | Optional | — | Entity whose state is a time string (`HH:MM`) representing when the EV must be charged. Accepts `input_datetime`, `sensor`, `input_text`. |
+| **EV Charge Deadline (fixed HH:MM fallback)** | Yes | `07:00` | Deadline to use when no entity is configured. The planner will not schedule EV load after this time. |
+| **EV Smart Charging Enabled Entity** | Optional | — | Boolean entity (`binary_sensor`, `input_boolean`, `switch`) that enables/disables smart charging at runtime. When this entity is `off`, the sensor shows `smart_charging_disabled` and no EV load is allocated. |
+| **EV Battery Capacity (kWh)** | Yes | `0` | EV battery nameplate capacity. Range 1–200 kWh, step 0.5 kWh. |
+| **EV Charger Power (kW)** | Yes | `0` | AC output power of the charger. Range 0.1–50 kW, step 0.1 kW. |
+| **EV Charger Efficiency** | Yes | `100` % | Fraction of AC energy delivered to the EV battery. Most AC chargers are 95–100 %. Range 50–100 %, step 1 %. |
+| **Base House Load Already Includes EV** | Yes | `off` | See [Double-counting](#double-counting). |
+| **EV Actual Charging Power Sensor (optional)** | Optional | — | Sensor for real-time EV charge power. Used for diagnostics only — not fed into the planner. |
+
+> \* Strongly recommended. Without a connected sensor the EV is always assumed connected.
+> Without a SoC sensor the current SoC defaults to `0 %`, which will over-plan charging.
+
+---
+
+## Double-counting
+
+The `base_load_includes_ev` flag controls whether the planner adds the EV's planned load
+on top of the house consumption sensor reading.
+
+**What CT clamp position determines this setting:**
+
+```
+Scenario A — CT clamp UPSTREAM of the EVSE (includes EV power):
+  house_consumption_sensor = lights + appliances + EV charger
+  → base_load_includes_ev = True
+  → HSEM does NOT add ev_planned_load_kwh again
+
+Scenario B — CT clamp DOWNSTREAM of the EVSE (excludes EV power):
+  house_consumption_sensor = lights + appliances only
+  → base_load_includes_ev = False  (default)
+  → HSEM adds ev_planned_load_kwh to net consumption
+```
+
+If you are unsure, plug the EV in and watch the house consumption sensor. If it rises
+by the charger power when charging starts, set this to `True`. If it stays flat,
+set it to `False`.
+
+---
+
+## Second EV
+
+If you have a second EV and have enabled it in the EV charger step, a second identical
+step — **EV 2 Optimal Charging Plan** — will appear immediately after the first.
+All fields are the same; just use the second car's sensors and config values.
+
+The two EV plans are independent. Their per-slot loads are **summed** into
+`ev_planned_load_kwh` on each planner slot before net consumption is calculated.
+
+---
+
+## Sensor entities
+
+After setup, two diagnostic sensor entities are created:
+
+| Entity | States | Meaning |
+|---|---|---|
+| `sensor.hsem_ev_optimal_charging_plan` | see below | Primary EV plan state |
+| `sensor.hsem_ev_second_optimal_charging_plan` | see below | Second EV plan state |
+
+### Sensor states
+
+| State | Meaning |
+|---|---|
+| `not_connected` | EV is not plugged in (connected sensor is `off`) |
+| `smart_charging_disabled` | Feature is disabled, or the smart charging entity is `off` |
+| `fully_charged` | EV is already at or above target SoC — nothing to plan |
+| `charging` | EV is scheduled to charge in the current slot |
+| `waiting` | EV is connected, energy is needed, but current slot has no planned load (e.g. slot is after the deadline or all load is in future slots) |
+| `unavailable` | Feature is not configured or `battery_capacity_kwh`/`charger_power_kw` is zero |
+
+### Sensor attributes
+
+Both sensors expose full plan details as attributes:
+
+```yaml
+battery_capacity_kwh: 86.0
+charge_power_kw: 11.0
+current_soc: 32.0
+target_soc: 80.0
+ev_connected: true
+total_kwh_needed: 41.3
+deadline: "2026-05-15T07:00:00+02:00"
+current_slot_planned_load_kwh: 9.2
+planned_load_by_slot:
+  "2026-05-15T10:00:00+02:00": 9.2
+  "2026-05-15T11:00:00+02:00": 11.0
+  "2026-05-15T01:00:00+02:00": 11.0
+  "2026-05-15T02:00:00+02:00": 10.1
+charging_slots:
+  - start: "2026-05-15T10:00:00+02:00"
+    end:   "2026-05-15T11:00:00+02:00"
+    estimated_charged_kwh: 9.2
+    solar_surplus_kwh: 10.5
+    import_needed_kwh: 0.0
+    import_price: 1.25
+    estimated_cost: 0.0
+data_quality: {}
+```
+
+---
+
+## Troubleshooting
+
+### Sensor shows `unavailable`
+
+The most common cause is that the feature has not been configured yet, or the
+`battery_capacity_kwh`/`charger_power_kw` fields are still at their default of `0`.
+
+**Fix:** Go to **Settings → Devices & Services → HSEM → Configure** and complete the
+EV Optimal Charging Plan step. Make sure battery capacity and charger power are both
+set to non-zero values.
+
+### Sensor shows `not_connected` but the car is plugged in
+
+The connected binary sensor is reporting `off`. Check:
+- The entity ID is correct in HSEM config.
+- The binary sensor is actually `on` in HA Developer Tools → States.
+- If you have no connected sensor configured, HSEM assumes the EV is always connected.
+
+### Sensor shows `smart_charging_disabled`
+
+Either:
+- `hsem_ev_planned_load_enabled` is `False` — toggle it to `on` in the config.
+- The smart charging entity (if configured) is currently `off`. This is intentional
+  — it lets you temporarily disable smart EV scheduling without changing HSEM config.
+
+### EV is charging but home battery also charges from solar
+
+Check `base_load_includes_ev`. If your house consumption sensor already includes EV
+power (CT clamp upstream of the EVSE), this should be `True`. If it is `False` and
+the sensor already includes EV power, HSEM double-counts the load and the battery
+planner sees a larger surplus than actually exists.
+
+### EV always charges from grid, never from solar
+
+This was a bug fixed in PR #397. The EV planner was computing solar surplus from
+`estimated_net_consumption` which is `0.0` at planning time. It is now computed from
+raw `pv - house_load` fields.
+
+If you are on a version before this fix, update HSEM.
+
+### Deadline is in the past
+
+If the deadline (fixed or from entity) is earlier than the current time, there are no
+valid candidate slots and the sensor will show `waiting` with a `data_quality` warning:
+`"No candidate slots before deadline"`.
+
+The deadline is interpreted as a **time-of-day** and automatically advanced to the
+next occurrence if needed:
+- If it is currently 15:00 and the deadline is `07:00`, it is treated as 07:00
+  **tomorrow**.
+- If it is currently 06:00 and the deadline is `07:00`, it is treated as today.

--- a/docs/hsem-planner-guide.md
+++ b/docs/hsem-planner-guide.md
@@ -14,18 +14,20 @@ common scenarios a real installation will encounter.
 1. [Overview](#overview)
 2. [Planning inputs](#planning-inputs)
 3. [Planning outputs](#planning-outputs)
-4. [Cost function](#cost-function)
-5. [Candidate generation and selection](#candidate-generation-and-selection)
-6. [Safety modes](#safety-modes)
-7. [Data quality diagnostics](#data-quality-diagnostics)
-8. [Scenario examples](#scenario-examples)
+4. [EV planned load integration](#ev-planned-load-integration)
+5. [Cost function](#cost-function)
+6. [Candidate generation and selection](#candidate-generation-and-selection)
+7. [Safety modes](#safety-modes)
+8. [Data quality diagnostics](#data-quality-diagnostics)
+9. [Scenario examples](#scenario-examples)
    - [Winter day — cold, low PV, peak-hour pricing](#scenario-1-winter-day)
    - [Summer day — high PV surplus](#scenario-2-summer-day-high-pv)
    - [Cheap night price — grid charge opportunity](#scenario-3-cheap-night-price)
    - [High PV day — excess export opportunity](#scenario-4-high-pv-day-excess-export)
    - [Flat price day — no arbitrage value](#scenario-5-flat-price-day)
-9. [Reading the plan explanation](#reading-the-plan-explanation)
-10. [Known limitations](#known-limitations)
+   - [EV charging — solar-first smart plan](#scenario-6-ev-charging--solar-first-smart-plan)
+10. [Reading the plan explanation](#reading-the-plan-explanation)
+11. [Known limitations](#known-limitations)
 
 ---
 
@@ -192,6 +194,41 @@ The pre-charge window ends at `schedule.start` and is sized to fill the battery 
 | `months_winter` | `[1,2,3,4,10,11,12]` | Months classified as winter |
 | `house_power_includes_ev` | `True` | Whether the house consumption sensor already includes EV charger power |
 
+### EV planned load — primary EV
+
+All fields are prefixed `ev_planned_load_`.
+
+| Field | Default | Description |
+|---|---|---|
+| `ev_planned_load_enabled` | `False` | Enable EV planned load integration for the primary EV |
+| `ev_planned_load_connected` | `False` | Whether a vehicle is currently plugged in |
+| `ev_planned_load_smart_charging_enabled` | `True` | Whether smart EV charging scheduling is permitted |
+| `ev_planned_load_current_soc_pct` | `0.0` | Current EV battery SoC (%) |
+| `ev_planned_load_target_soc_pct` | `80.0` | Target SoC the EV must reach by the deadline (%) |
+| `ev_planned_load_battery_capacity_kwh` | `0.0` | EV battery nameplate capacity (kWh) |
+| `ev_planned_load_charger_power_kw` | `0.0` | Charger AC output power (kW) |
+| `ev_planned_load_charger_efficiency_pct` | `100.0` | Charger efficiency (%) — energy delivered to EV / AC draw |
+| `ev_planned_load_deadline` | `None` | Timezone-aware datetime by which charging must be complete |
+| `ev_planned_load_base_load_includes_ev` | `False` | Set `True` when the house consumption sensor already includes EV power (prevents double-counting) |
+
+### EV planned load — second EV
+
+All fields are prefixed `ev_second_planned_load_`. The schema is identical to the
+primary EV fields above:
+
+| Field | Default | Description |
+|---|---|---|
+| `ev_second_planned_load_enabled` | `False` | Enable EV planned load integration for the second EV |
+| `ev_second_planned_load_connected` | `False` | Whether a second vehicle is currently plugged in |
+| `ev_second_planned_load_smart_charging_enabled` | `True` | Smart charging permission |
+| `ev_second_planned_load_current_soc_pct` | `0.0` | Current second EV battery SoC (%) |
+| `ev_second_planned_load_target_soc_pct` | `80.0` | Target SoC (%) |
+| `ev_second_planned_load_battery_capacity_kwh` | `0.0` | Second EV battery nameplate capacity (kWh) |
+| `ev_second_planned_load_charger_power_kw` | `0.0` | Charger AC output power (kW) |
+| `ev_second_planned_load_charger_efficiency_pct` | `100.0` | Charger efficiency (%) |
+| `ev_second_planned_load_deadline` | `None` | Timezone-aware charging deadline |
+| `ev_second_planned_load_base_load_includes_ev` | `False` | Prevent double-counting when house load includes second EV |
+
 ---
 
 ## Planning outputs
@@ -210,13 +247,14 @@ Each `PlannedSlot` in the output list covers one time interval and carries:
 | `price.export_price` | currency/kWh | Export price for this slot |
 | `solcast_pv_estimate` | kWh | Forecast PV production |
 | `avg_house_consumption` | kWh | Predicted house load (weighted average) |
-| `estimated_net_consumption` | kWh | `avg_house_consumption − solcast_pv_estimate` (negative = PV surplus) |
+| `estimated_net_consumption` | kWh | `avg_house_consumption + ev_planned_load_kwh − solcast_pv_estimate` (negative = PV surplus) |
 | `batteries_charged` | kWh | Energy scheduled to be stored (after losses) |
 | `batteries_discharged` | kWh | Energy drawn from battery |
 | `grid_import_kwh` | kWh | Grid import this slot |
 | `grid_export_kwh` | kWh | Grid export this slot |
 | `estimated_battery_soc` | % | Estimated SoC at end of slot |
 | `estimated_battery_capacity` | kWh | Usable remaining capacity at end of slot |
+| `ev_planned_load_kwh` | kWh | Combined EV charging load allocated to this slot (primary + second EV) |
 | `estimated_cost` | currency | Net grid cost this slot (positive = import, negative = export) |
 | `recommendation` | string | The action chosen for this slot (see below) |
 
@@ -228,10 +266,120 @@ Each `PlannedSlot` in the output list covers one time interval and carries:
 | `batteries_charge_solar` | Battery is charging from PV surplus |
 | `batteries_discharge_mode` | Battery discharges to cover house load during high-price window |
 | `force_batteries_discharge` | Forced discharge (excess export to grid) |
+| `force_export` | Negative import price — all available energy exported to earn money |
+| `ev_smart_charging` | EV charging load is allocated to this slot (planner or runtime resolver) |
 | `batteries_wait_mode` | Battery idle — neither charging nor discharging |
 | `time_passed` | Slot is in the past — no recommendation applied |
-| `ev_smart_charging` | EV smart charging active (EV-specific scheduling) |
 | `missing_input_entities` | Required HA entities were unavailable when this slot was scheduled |
+
+---
+
+#### How recommendations are assigned — priority layers
+
+Recommendations are set in three consecutive layers. Each later layer can
+override an earlier one only within defined priority rules.
+
+---
+
+##### Layer 1 — Planner engine (pre-slot population)
+
+The scheduler assigns the first recommendations during slot population, before
+candidate scoring. Rules are applied in strict priority order; once a slot has a
+recommendation it is not changed by later rules in the same layer.
+
+**Discharge schedule windows** (`apply_discharge_schedules`)
+
+| Priority | Condition | Recommendation |
+|---|---|---|
+| 1 | Slot falls inside a configured discharge window and price spread is met | `batteries_discharge_mode` |
+
+**Charge schedule windows** (`apply_charge_schedules`) — for each discharge window, eligible pre-charge slots are filled in order:
+
+| Priority | Condition | Recommendation |
+|---|---|---|
+| 1 | Import price < 0 (paid to import) | `batteries_charge_grid` |
+| 2 | Solar surplus (`estimated_net_consumption < threshold`) | `batteries_charge_solar` |
+| 3 | Cheapest grid hour where spread ≥ `min_price_difference + cycle_cost` | `batteries_charge_grid` |
+
+**Opportunistic grid charge** (`apply_opportunistic_charge`) — outside any schedule:
+
+| Priority | Condition | Recommendation |
+|---|---|---|
+| 1 | Import price < 0 | `batteries_charge_grid` |
+| 2 | Import price ≤ depreciation threshold − cycle cost | `batteries_charge_grid` |
+
+**Excess export** (`apply_excess_export`) — only when `excess_export_enabled = True`:
+
+| Priority | Condition | Recommendation |
+|---|---|---|
+| 1 | Export price > threshold AND battery has surplus above `required_capacity` | `force_batteries_discharge` |
+
+**Seasonal optimisation fill** (`apply_optimization_strategy`) — for all remaining `None` slots:
+
+| Priority | Condition | Recommendation |
+|---|---|---|
+| 1 | Export price > import price AND export price ≥ `export_min_price` | `force_export` |
+| 2 | Solar surplus available and battery not full | `batteries_charge_solar` |
+| 3 | Future `force_batteries_discharge` slot exists AND battery > required | `batteries_wait_mode` |
+| 4 | Winter month | `batteries_wait_mode` |
+| 5 | Summer month, solar surplus available | `batteries_charge_solar` |
+| 5 | Summer month, no solar surplus | `batteries_discharge_mode` |
+
+---
+
+##### Layer 2 — EV planned load labelling (engine, post-simulation)
+
+After the winning candidate is selected and the final SoC simulation is complete,
+slots with `ev_planned_load_kwh > 0` are re-labelled:
+
+| Current recommendation | Has EV load? | Result |
+|---|---|---|
+| `batteries_charge_solar` | Yes | → `ev_smart_charging` |
+| `batteries_wait_mode` | Yes | → `ev_smart_charging` |
+| `batteries_charge_grid` | Yes | Kept — grid charge takes priority |
+| `batteries_discharge_mode` | Yes | Kept — discharge takes priority |
+| `force_batteries_discharge` | Yes | Kept |
+| `force_export` | Yes | Kept |
+| `time_passed` | Yes | Kept |
+
+---
+
+##### Layer 3 — Runtime resolver (`resolve_current_recommendation`)
+
+Applied to the **current slot only** at hardware-write time. Overrides the planner
+output with live sensor readings that were unknown at planning time.
+
+| Priority | Condition | Result |
+|---|---|---|
+| 1 (highest) | Live import price < 0 | → `force_export` |
+| 2 | Current recommendation = `batteries_charge_grid` | Kept — grid charge never overridden |
+| 3 | Any EV (primary or second) is actively charging right now | → `ev_smart_charging` |
+| 4 | Battery energy > remaining discharge-schedule need | → `batteries_discharge_mode` |
+| — | None of the above | Planner recommendation kept unchanged |
+
+> **Note:** Priorities 1 and 3 interact. A negative import price always wins — even
+> when an EV is charging. However, a grid-charge slot (priority 2) is never overridden
+> by an actively charging EV (priority 3).
+
+---
+
+##### Summary: full priority stack (highest → lowest)
+
+```
+1. import_price < 0               → force_export           [runtime resolver]
+2. batteries_charge_grid active   → batteries_charge_grid  [runtime resolver guard]
+3. EV actively charging (live)    → ev_smart_charging      [runtime resolver]
+4. Battery above schedule need    → batteries_discharge_mode [runtime resolver]
+   ──────────────────────────────────────────────────────── resolver boundary ──
+5. force_batteries_discharge      [excess export, planner]
+6. batteries_charge_grid          [schedule/opportunistic, planner]
+7. batteries_discharge_mode       [discharge schedule, planner]
+8. force_export                   [seasonal optimisation, planner]
+9. ev_smart_charging              [EV load labelling, planner]
+10. batteries_charge_solar        [solar surplus, planner]
+11. batteries_wait_mode           [seasonal/idle, planner]
+12. time_passed / missing_input_entities
+```
 
 ### Charge and discharge windows (`charge_windows`, `discharge_windows`)
 
@@ -250,6 +398,8 @@ Higher-level groupings of consecutive slots with the same charge or discharge re
 | `data_quality` | Structured `DataQuality` report (see below) |
 | `explanation` | `PlanExplanation` with strategy summary, score, and rejected alternatives |
 | `time_series_index` | `TimeSeriesIndex` — shared slot grid used internally |
+| `ev_charging_plan` | `EVChargingPlan` for the primary EV (`None` when disabled) |
+| `ev_second_charging_plan` | `EVChargingPlan` for the second EV (`None` when disabled) |
 
 ### Plan explanation (`explanation`)
 
@@ -268,6 +418,136 @@ The `PlanExplanation` object is designed to be surfaced directly as a HA sensor 
 | `battery_soc_pct` / `battery_soc_at_end_pct` | Starting and ending SoC |
 | `constraints` | Active flags (e.g. `"winter_month"`, `"excess_export_enabled"`) |
 | `rejected_plans` | Alternatives with name, reason, and estimated cost |
+
+---
+
+## EV planned load integration
+
+### Overview
+
+When one or both EV planned load features are enabled, the planner allocates
+EV charging demand into slots **before** net consumption and solar surplus are
+computed. This ensures the home battery planner sees the true net demand and
+does not misinterpret EV-consumed solar as available for battery charging.
+
+The EV planner is a separate, pure-Python module (`planner/ev_planner.py`).
+It runs once per planning cycle, ahead of the home battery planner, and injects
+`ev_planned_load_kwh` into each `PlannedSlot`.
+
+### No circular dependency
+
+EV plans are built from raw inputs only (EV SoC, target SoC, capacity, charger
+power, deadline, and pre-injection solar surplus). They are computed independently
+of the home battery planner output. The one-pass design prevents circular
+dependency.
+
+### Net load formula with EV
+
+```text
+effective_net_load_kwh
+    = avg_house_consumption
+    + ev_planned_load_kwh          ← sum of primary + second EV loads
+    − solcast_pv_estimate
+```
+
+When EV integration is disabled, `ev_planned_load_kwh` is `0.0` for every slot
+and the formula is identical to the non-EV case.
+
+### Slot selection strategy
+
+The EV planner selects slots in two passes:
+
+1. **Solar surplus slots first** — slots where `pv − house_load > 0` are
+   prioritised (free solar energy for the EV).
+2. **Cheapest import slots next** — among remaining slots, the lowest import
+   price comes first.
+
+Allocation stops when the total energy needed to reach `target_soc_pct` is
+satisfied, or the deadline is reached.
+
+### Partial current-slot scaling
+
+The currently active slot is scaled by its remaining duration to avoid
+over-counting energy in the partially elapsed slot:
+
+```text
+slot_remaining_hours = remaining_minutes_in_slot(now, slot_end) / 60.0
+max_charge_this_slot = charger_power_kw × slot_remaining_hours × (efficiency / 100)
+```
+
+### Double-count prevention
+
+When the house consumption sensor already includes EV charger power
+(e.g. the CT clamp is upstream of the EVSE), set `base_load_includes_ev = True`
+for that EV. The planner will not add `ev_planned_load_kwh` on top of
+`avg_house_consumption` for that EV, preventing double-counting.
+
+### EV plan states
+
+| State | Meaning |
+|---|---|
+| `not_connected` | No vehicle plugged in |
+| `smart_charging_disabled` | Feature disabled or smart charging turned off |
+| `fully_charged` | EV has already reached target SoC — no load allocated |
+| `charging` | Slots have been allocated; charging is active or planned |
+| `waiting` | EV is connected but no candidate slots exist before the deadline |
+| `unavailable` | Required config values (capacity or charger power) are zero/missing |
+
+### HA sensor entities
+
+Two sensor entities expose the EV charging plan as attributes:
+
+| Entity | Purpose |
+|---|---|
+| `sensor.hsem_ev_optimal_charging_plan` | Primary EV plan state and slot details |
+| `sensor.hsem_ev_second_optimal_charging_plan` | Second EV plan state and slot details |
+
+Both sensors share the same attribute schema:
+
+```json
+{
+  "battery_capacity_kwh": 60.0,
+  "charge_power_kw": 11.0,
+  "current_soc": 32.0,
+  "target_soc": 80.0,
+  "ev_connected": true,
+  "total_kwh_needed": 28.8,
+  "deadline": "2026-05-15T07:00:00+02:00",
+  "charging_slots": [
+    {
+      "start": "2026-05-14T10:00:00+02:00",
+      "end":   "2026-05-14T11:00:00+02:00",
+      "estimated_charged_kwh": 8.5,
+      "solar_surplus_kwh": 9.2,
+      "import_needed_kwh": 0.0,
+      "import_price": 1.25,
+      "estimated_cost": 0.0
+    }
+  ],
+  "planned_load_by_slot": {
+    "2026-05-14T10:00:00+02:00": 8.5
+  },
+  "current_slot_planned_load_kwh": 8.5,
+  "data_quality": {}
+}
+```
+
+### Solar surplus bug fix
+
+**Background:** Before PR #397 the EV planner incorrectly computed `solar_surplus`
+from `slot.estimated_net_consumption`, which is `0.0` at the time the EV planner
+runs (the `populate_net_consumption` call had not happened yet). Every slot
+appeared to have zero surplus, so the EV was always scheduled on grid import.
+
+**Fix:** Surplus is now derived from the raw base fields that are already populated
+at EV planning time:
+
+```text
+surplus = max(slot.solcast_pv_estimate − slot.avg_house_consumption, 0.0)
+```
+
+`populate_net_consumption` later computes net load from the same fields, so the
+values are consistent.
 
 ---
 
@@ -799,6 +1079,47 @@ than pure `no_action` because the PV surplus would otherwise export at only
   ]
 }
 ```
+
+---
+
+### Scenario 6: EV charging — solar-first smart plan
+
+**Conditions:**
+- EV plugged in at 08:00, target SoC 80 %, deadline 07:00 next morning
+- EV battery: 60 kWh, current SoC 32 % → 28.8 kWh needed
+- Charger: 11 kW AC (efficiency 100 %)
+- House load: 0.5 kWh/h
+- PV forecast: 0→2→8→10→8→4→1→0 kWh/h (peak midday)
+- Import price: 0.80 DKK/kWh off-peak, 2.00 DKK/kWh peak (09–13, 17–21)
+- `base_load_includes_ev = False` (CT clamp is downstream of EVSE)
+
+**What the EV planner does:**
+
+```
+Pass 1 — solar surplus slots (pv − house_load > 0):
+  10:00–11:00: surplus = 8 − 0.5 = 7.5 kWh  → allocate 7.5 kWh (capped by charger: 11 kWh/h)
+  11:00–12:00: surplus = 10 − 0.5 = 9.5 kWh → allocate 9.5 kWh → total = 17.0 kWh
+  09:00–10:00: surplus = 2 − 0.5 = 1.5 kWh  → allocate 1.5 kWh → total = 18.5 kWh
+
+Pass 2 — cheapest import slots (remaining need = 28.8 − 18.5 = 10.3 kWh):
+  00:00–01:00: 0.80 DKK/kWh → allocate 10.3 kWh (final slot, partial fill)
+```
+
+**Net load seen by home battery planner (slot 10:00–11:00):**
+
+```
+effective_net_load = 0.5 (house) + 7.5 (EV) − 8.0 (PV) = 0.0 kWh
+```
+
+The battery planner sees zero net consumption in that slot, meaning no battery
+solar charge is triggered — the solar energy goes entirely to the EV.
+
+**Cost comparison (EV charging cost only):**
+
+| Strategy | EV cost (DKK) |
+|---|---|
+| Smart (solar-first) | 0.80 × 10.3 + 0 × 18.5 = 8.24 DKK |
+| Dumb (charge immediately from grid at 2.00 DKK/kWh) | 2.00 × 28.8 = 57.60 DKK |
 
 ---
 

--- a/docs/hsem-planner-spec.md
+++ b/docs/hsem-planner-spec.md
@@ -42,17 +42,99 @@ Power values in kW must be converted to energy using:
 energy_kwh = power_kw * duration_hours
 ```
 
+## Recommendation priority rules
+
+### Three-layer model
+
+Recommendations are assigned and potentially overridden in three layers.
+Every layer must respect the rules below.
+
+#### Layer 1 — Planner engine (pre-simulation)
+
+Slots are assigned recommendations by the scheduling functions in strict
+priority order.  Once a slot has a non-`None` recommendation, later rules
+in the same layer must not change it.
+
+**Discharge schedule windows** (highest priority in layer 1):
+
+1. Slot falls inside a configured discharge window and price spread is met → `batteries_discharge_mode`
+
+**Charge schedule windows** (before each discharge window):
+
+1. Import price < 0 → `batteries_charge_grid`
+2. Solar surplus (`estimated_net_consumption < threshold`) → `batteries_charge_solar`
+3. Cheapest grid hour where spread ≥ `min_price_difference + cycle_cost` → `batteries_charge_grid`
+
+**Opportunistic grid charge** (outside any schedule):
+
+1. Import price < 0 → `batteries_charge_grid`
+2. Import price ≤ depreciation threshold − cycle cost → `batteries_charge_grid`
+
+**Excess export** (only when enabled):
+
+1. Export price > threshold AND battery above required capacity → `force_batteries_discharge`
+
+**Seasonal fill** (remaining `None` slots):
+
+1. Export price > import price AND export price ≥ `export_min_price` → `force_export`
+2. Solar surplus and battery not full → `batteries_charge_solar`
+3. Future `force_batteries_discharge` AND battery > required → `batteries_wait_mode`
+4. Winter month → `batteries_wait_mode`
+5. Summer month, solar surplus → `batteries_charge_solar`; else → `batteries_discharge_mode`
+
+#### Layer 2 — EV planned load labelling (post-simulation)
+
+After the final SoC simulation, slots with `ev_planned_load_kwh > 0` are relabelled:
+
+- `batteries_charge_solar` → `ev_smart_charging`
+- `batteries_wait_mode` → `ev_smart_charging`
+- All other recommendations: **kept unchanged** (must not be overridden by EV label)
+
+The following must never be overridden by the EV label:
+`batteries_charge_grid`, `batteries_discharge_mode`, `force_batteries_discharge`,
+`force_export`, `time_passed`, `missing_input_entities`.
+
+#### Layer 3 — Runtime resolver (current slot only, at hardware-write time)
+
+Applied to the current slot immediately before hardware writes, using live sensor data:
+
+1. `import_price < 0` → `force_export` (overrides everything)
+2. `batteries_charge_grid` → kept (must never be overridden by EV or discharge rule)
+3. Any EV actively charging → `ev_smart_charging`
+4. Battery energy > remaining discharge-schedule need → `batteries_discharge_mode`
+
+### Invariants for tests
+
+- A slot assigned `batteries_charge_grid` by the planner must never be relabelled by
+  the EV load labelling pass (layer 2).
+- A slot assigned `batteries_discharge_mode` must never be relabelled by the EV load
+  labelling pass.
+- A slot with `ev_planned_load_kwh > 0` and recommendation `batteries_charge_solar`
+  must be relabelled `ev_smart_charging` after layer 2.
+- A slot with `ev_planned_load_kwh > 0` and recommendation `batteries_wait_mode`
+  must be relabelled `ev_smart_charging` after layer 2.
+- The runtime resolver must set `force_export` when `import_price < 0`, regardless
+  of the planner recommendation.
+- The runtime resolver must NOT override `batteries_charge_grid` even when an EV
+  is actively charging.
+- The runtime resolver must NOT override `batteries_charge_grid` even when
+  `import_price < 0` is False and EV is charging.
+- Priority 1 (negative price → `force_export`) always beats priority 3 (EV charging).
+
 ## Energy balance per slot
 
 For every slot:
 
 ```text
-net_load_kwh = house_load_kwh - pv_kwh
+net_load_kwh = house_load_kwh + ev_planned_load_kwh - pv_kwh
 ```
 
-Positive `net_load_kwh` means the house needs energy.
+`ev_planned_load_kwh` is the combined EV charging load allocated to this slot
+(primary + second EV). When EV integration is disabled it is `0.0`.
 
-Negative `net_load_kwh` means there is PV surplus.
+Positive `net_load_kwh` means the house (plus EV) needs energy.
+
+Negative `net_load_kwh` means there is PV surplus after serving the house and EV.
 
 Battery and grid flows must satisfy:
 
@@ -466,6 +548,62 @@ carry the day+2 gap lists for 72-hour horizon runs.
 - Missing day+2 price data surfaces in `day2_price_missing_hours`.
 - Missing day+2 PV data surfaces in `day2_pv_missing_hours`.
 - `DataQuality.is_complete` is ``False`` when any future-day data is missing.
+
+## EV planned load integration
+
+### Design invariants
+
+The EV planner (`planner/ev_planner.py`) MUST satisfy these invariants:
+
+1. **One-pass, no circularity**: EV plans are built entirely from raw inputs
+   (EV SoC, target SoC, capacity, charger power, deadline, and pre-injection
+   solar surplus). They must never depend on the home battery planner output.
+2. **Solar surplus computed before net consumption**: Surplus passed to the EV
+   planner must be derived from raw base fields:
+   ```text
+   surplus = max(slot.solcast_pv_estimate − slot.avg_house_consumption, 0.0)
+   ```
+   It must NOT use `slot.estimated_net_consumption`, which is `0.0` at EV
+   planning time.
+3. **`ev_planned_load_kwh` injected before `populate_net_consumption`**: The
+   engine must call the EV planner and write `ev_planned_load_kwh` to every
+   slot before calling `populate_net_consumption`. Net consumption must reflect
+   the combined EV load.
+4. **No double-counting**: When `base_load_includes_ev = True` for an EV, its
+   planned load must NOT be added to `ev_planned_load_kwh`.
+5. **Partial current slot**: The currently active slot must be scaled by
+   remaining slot duration, not the full slot width.
+6. **Deadline enforcement**: Slots with `slot_start >= deadline` must receive
+   zero EV load.
+7. **Guard states**: The EV planner must return a valid `EVChargingPlan` with
+   an appropriate `state` string in all edge cases (disabled, not connected,
+   smart charging off, fully charged, no slots before deadline, invalid config).
+8. **Disabled EV is zero-cost**: When `ev_planned_load_enabled = False`, all
+   `ev_planned_load_kwh` values must be `0.0` and the home battery planner
+   output must be identical to the non-EV case.
+
+### Net load formula with EV
+
+```text
+effective_net_load_kwh
+    = avg_house_consumption
+    + ev_planned_load_kwh
+    − solcast_pv_estimate
+```
+
+### Invariants for tests
+
+- When `ev_planned_load_enabled = False`, all `ev_planned_load_kwh == 0.0`.
+- When EV is fully charged (`current_soc >= target_soc`), all `ev_planned_load_kwh == 0.0`.
+- When `base_load_includes_ev = True`, planned EV load is not added to net consumption.
+- Solar surplus slots are allocated before grid-import slots.
+- `sum(ev_planned_load_kwh over all slots)` equals `total_kwh_needed` (±charger rounding).
+- Deadline: no load after `deadline`.
+- Partial slot: current slot load ≤ `charger_power_kw × remaining_minutes / 60`.
+- When EV consumes all solar surplus, home battery `batteries_charged == 0.0` in that slot.
+- `winner.cost == final_output.cost` still holds when EV load is active (no post-selection mutation).
+- Both `ev_charging_plan` and `ev_second_charging_plan` on `PlannerOutput` are `None` when disabled.
+- Enabling only the second EV does not affect primary EV fields and vice versa.
 
 ## Documentation expectations
 

--- a/tests/planner/test_ev_planned_load.py
+++ b/tests/planner/test_ev_planned_load.py
@@ -992,3 +992,131 @@ class TestEvSolarSurplusRegression:
             assert ev_slot.import_needed_kwh == pytest.approx(
                 ev_slot.estimated_charged_kwh, abs=0.01
             )
+
+
+# ---------------------------------------------------------------------------
+# TestEvSmartChargingRecommendationLabel
+# EV-scheduled slots should be labelled ev_smart_charging so dashboards
+# and the working-mode sensor reflect the real activity.
+# ---------------------------------------------------------------------------
+
+
+class TestEvSmartChargingRecommendationLabel:
+    """Slots with planned EV load must be marked ev_smart_charging.
+
+    Priority rules:
+    - batteries_charge_grid  → kept (grid-charge beats EV label)
+    - batteries_discharge_mode / force_batteries_discharge → kept
+    - batteries_charge_solar / batteries_wait_mode → overridden by ev_smart_charging
+    - EV disabled / not connected → no ev_smart_charging labels
+    """
+
+    def test_ev_load_slots_labelled_ev_smart_charging(self):
+        """Future slots with ev_planned_load_kwh > 0 must be ev_smart_charging
+        unless a higher-priority recommendation is already set.
+
+        Higher-priority recommendations that keep their own label:
+          batteries_charge_grid, batteries_discharge_mode,
+          force_batteries_discharge, force_export, time_passed.
+        """
+        _KEEP_LABELS = {
+            "batteries_charge_grid",
+            "batteries_discharge_mode",
+            "force_batteries_discharge",
+            "force_export",
+            "time_passed",
+            "missing_input_entities",
+        }
+
+        inp = _make_planner_input(
+            now_iso="2024-06-15T06:00:00+00:00",
+            current_soc=50.0,
+            target_soc=80.0,
+            capacity_kwh=77.0,
+            charger_kw=11.0,
+            deadline_hours_from_now=10,
+        )
+        out = run_planner(inp)
+
+        for s in out.slots:
+            if abs(s.ev_planned_load_kwh) > 1e-9:
+                if s.recommendation in _KEEP_LABELS:
+                    continue  # higher-priority recommendation correctly kept
+                assert s.recommendation == "ev_smart_charging", (
+                    f"Slot {s.start.hour}: ev_load={s.ev_planned_load_kwh:.3f} but "
+                    f"recommendation='{s.recommendation}' instead of 'ev_smart_charging'"
+                )
+
+    def test_no_ev_smart_charging_when_disabled(self):
+        """When EV is disabled, no slot should be labelled ev_smart_charging."""
+        inp = _make_planner_input(ev_enabled=False)
+        out = run_planner(inp)
+
+        for s in out.slots:
+            assert s.recommendation != "ev_smart_charging", (
+                f"Slot {s.start.hour}: unexpected ev_smart_charging (EV disabled)"
+            )
+
+    def test_no_ev_smart_charging_when_disconnected(self):
+        """When EV is not connected, no slot should be labelled ev_smart_charging."""
+        inp = _make_planner_input(ev_connected=False)
+        out = run_planner(inp)
+
+        for s in out.slots:
+            assert s.recommendation != "ev_smart_charging", (
+                f"Slot {s.start.hour}: unexpected ev_smart_charging (EV not connected)"
+            )
+
+    def test_grid_charge_slots_not_overridden_by_ev_label(self):
+        """Slots already marked batteries_charge_grid keep that recommendation.
+
+        Set up: very cheap price at 02:00 to force a grid-charge recommendation,
+        EV also enabled with deadline covering that slot.
+        The grid-charge label must survive — it has higher priority.
+        """
+        inp = _make_planner_input(
+            now_iso="2024-06-15T00:00:00+00:00",
+            current_soc=10.0,  # low SoC → battery actively needs charging
+            target_soc=80.0,
+            capacity_kwh=77.0,
+            charger_kw=11.0,
+            deadline_hours_from_now=10,
+        )
+        # Force a very cheap price at 02:00 to encourage grid charge
+        inp.price_points[2] = PricePoint(hour=2, import_price=0.001, export_price=0.0)
+        # Make peak hours expensive so grid-charge has clear arbitrage value
+        for h in range(16, 22):
+            inp.price_points[h] = PricePoint(hour=h, import_price=2.0, export_price=0.5)
+        out = run_planner(inp)
+
+        for s in out.slots:
+            if s.recommendation == "batteries_charge_grid":
+                # A grid-charge slot must NOT have been overridden by EV label
+                # even if EV load is also allocated to it.
+                assert s.recommendation == "batteries_charge_grid", (
+                    f"Slot {s.start.hour}: batteries_charge_grid was incorrectly "
+                    "overridden by ev_smart_charging"
+                )
+
+    def test_ev_smart_charging_in_charge_windows(self):
+        """EVSmartCharging slots are counted as charge windows in PlannerOutput."""
+        inp = _make_planner_input(
+            now_iso="2024-06-15T06:00:00+00:00",
+            current_soc=50.0,
+            target_soc=80.0,
+            capacity_kwh=77.0,
+            charger_kw=11.0,
+            deadline_hours_from_now=10,
+        )
+        out = run_planner(inp)
+
+        ev_smart_slots = [
+            s for s in out.slots if s.recommendation == "ev_smart_charging"
+        ]
+        if ev_smart_slots:
+            # At least one charge window should cover the EV slots
+            all_window_starts = {w.start for w in out.charge_windows}
+            ev_starts = {s.start for s in ev_smart_slots}
+            assert ev_starts & all_window_starts, (
+                "ev_smart_charging slots should appear in at least one charge window"
+            )

--- a/tests/planner/test_ev_planned_load.py
+++ b/tests/planner/test_ev_planned_load.py
@@ -487,14 +487,24 @@ class TestApplyEvPlannedLoad:
     def _make_plan(
         self, slots_kw: list[float], starts: list[datetime]
     ) -> EVChargingPlan:
-        """Build a minimal EVChargingPlan with one slot per start."""
+        """Build a minimal EVChargingPlan with one slot per start.
+
+        ``ac_load_kwh`` is set equal to ``estimated_charged_kwh`` (100 %
+        efficiency assumed) so that injection produces the same numeric values
+        as the old battery-side values and existing assertions stay valid.
+        """
         from custom_components.hsem.planner.ev_planner import EVChargingSlot
 
         plan = EVChargingPlan()
         plan.state = "charging"
         for _i, (start, kw) in enumerate(zip(starts, slots_kw)):
             end = start + timedelta(hours=1)
-            ev_slot = EVChargingSlot(start=start, end=end, estimated_charged_kwh=kw)
+            ev_slot = EVChargingSlot(
+                start=start,
+                end=end,
+                estimated_charged_kwh=kw,
+                ac_load_kwh=kw,  # 100 % efficiency — AC = battery-side
+            )
             plan.charging_slots.append(ev_slot)
             plan.planned_load_by_slot[start.isoformat()] = kw
         return plan
@@ -1119,4 +1129,436 @@ class TestEvSmartChargingRecommendationLabel:
             ev_starts = {s.start for s in ev_smart_slots}
             assert ev_starts & all_window_starts, (
                 "ev_smart_charging slots should appear in at least one charge window"
+            )
+
+
+# ---------------------------------------------------------------------------
+# TestEvAcLoadAndSoCPath
+#
+# Hand-calculated tests proving that EV load flows through the full SoC/cost
+# path correctly:
+#
+#   1. ac_load_kwh = estimated_charged_kwh / charger_efficiency
+#   2. ev_planned_load_kwh injected = ac_load_kwh (not battery-side)
+#   3. estimated_net_consumption = house + ev_ac_load - pv
+#   4. grid_import_kwh includes EV AC draw
+#   5. plan_cost includes EV grid import cost
+#   6. SoC simulation uses the combined load
+#
+# All scenarios use:
+#   - 1-hour slots, 24-hour horizon
+#   - EV needed kWh known (set up to charge exactly one slot)
+#   - No home battery so SoC path is simple (battery_soc_pct = 5 = floor)
+# ---------------------------------------------------------------------------
+
+
+class TestEvAcLoadAndSoCPath:
+    """Prove EV load affects ac_load_kwh, net consumption, grid import and plan cost."""
+
+    def _make_no_battery_input(
+        self,
+        now_iso: str = "2024-06-15T08:00:00+00:00",
+        ev_soc: float = 70.0,
+        ev_target_soc: float = 80.0,
+        ev_capacity_kwh: float = 100.0,
+        charger_kw: float = 11.0,
+        charger_eff_pct: float = 100.0,
+        import_price: float = 0.5,
+        pv_estimate_kwh: float = 0.0,
+        house_consumption_kwh: float = 0.5,
+        deadline_hours: float = 3.0,
+    ) -> PlannerInput:
+        """Build a minimal input with the battery at the discharge floor."""
+        now_dt = datetime.fromisoformat(now_iso)
+        deadline = now_dt + timedelta(hours=deadline_hours)
+
+        prices = [
+            PricePoint(hour=h, import_price=import_price, export_price=0.1)
+            for h in range(24)
+        ]
+        pv = [SolcastSlot(hour=h, pv_estimate=pv_estimate_kwh) for h in range(24)]
+        avgs = [
+            HourlyConsumptionAverage(
+                hour=h,
+                avg_1d=house_consumption_kwh,
+                avg_3d=house_consumption_kwh,
+                avg_7d=house_consumption_kwh,
+                avg_14d=house_consumption_kwh,
+            )
+            for h in range(24)
+        ]
+        return PlannerInput(
+            now_iso=now_iso,
+            interval_minutes=60,
+            interval_length_hours=24,
+            # Battery at floor → no battery involvement
+            battery_soc_pct=5.0,
+            battery_rated_capacity_kwh=10.0,
+            battery_end_of_discharge_soc_pct=5.0,
+            battery_max_soc_pct=90.0,
+            battery_max_charge_power_w=5000.0,
+            battery_conversion_loss_pct=0.0,
+            battery_charge_efficiency_pct=100.0,
+            battery_discharge_efficiency_pct=100.0,
+            weight_1d=25,
+            weight_3d=30,
+            weight_7d=30,
+            weight_14d=15,
+            consumption_averages=avgs,
+            price_points=prices,
+            solcast_slots=pv,
+            ev_planned_load_enabled=True,
+            ev_planned_load_connected=True,
+            ev_planned_load_smart_charging_enabled=True,
+            ev_planned_load_current_soc_pct=ev_soc,
+            ev_planned_load_target_soc_pct=ev_target_soc,
+            ev_planned_load_battery_capacity_kwh=ev_capacity_kwh,
+            ev_planned_load_charger_power_kw=charger_kw,
+            ev_planned_load_charger_efficiency_pct=charger_eff_pct,
+            ev_planned_load_deadline=deadline,
+            ev_planned_load_base_load_includes_ev=False,
+        )
+
+    # ------------------------------------------------------------------
+    # ac_load_kwh unit test
+    # ------------------------------------------------------------------
+
+    def test_ac_load_kwh_equals_battery_delivered_divided_by_efficiency(self):
+        """EVChargingSlot.ac_load_kwh must equal estimated_charged_kwh / efficiency.
+
+        Hand calculation:
+          EV needs 10 kWh (battery-side, e.g. 10 → 20 % of 100 kWh battery)
+          charger_power = 11 kW, slot = 1 h → max_battery_side = 11 × 1 × 0.90 = 9.9 kWh
+          allocated (battery-side) = min(9.9, 10.0) = 9.9 kWh
+          ac_load_kwh = 9.9 / 0.90 = 11.0 kWh
+        """
+        now_dt = datetime(2024, 6, 15, 8, 0, tzinfo=UTC)
+        deadline = now_dt + timedelta(hours=2)
+        starts = [now_dt + timedelta(hours=h) for h in range(24)]
+        ends = [now_dt + timedelta(hours=h + 1) for h in range(24)]
+
+        inp = EVPlannerInput(
+            enabled=True,
+            ev_connected=True,
+            smart_charging_enabled=True,
+            current_soc_pct=90.0,  # 10 % below target
+            target_soc_pct=100.0,
+            battery_capacity_kwh=100.0,  # needs 10 kWh battery-side
+            charger_power_kw=11.0,
+            charger_efficiency_pct=90.0,
+            deadline=deadline,
+            base_load_includes_ev=False,
+            now=now_dt,
+        )
+        solar_surplus = [0.0] * 24
+        import_price = [0.5] * 24
+
+        plan = build_ev_charging_plan(inp, starts, ends, solar_surplus, import_price)
+
+        assert plan.charging_slots, "EV plan should have at least one charging slot"
+        slot = plan.charging_slots[0]
+        # battery-side
+        assert slot.estimated_charged_kwh == pytest.approx(9.9, abs=0.01)
+        # AC-side: 9.9 / 0.90 = 11.0
+        assert slot.ac_load_kwh == pytest.approx(11.0, abs=0.01)
+        # Invariant: ac_load_kwh = estimated_charged_kwh / efficiency
+        eff = 90.0 / 100.0
+        assert slot.ac_load_kwh == pytest.approx(
+            slot.estimated_charged_kwh / eff, abs=1e-9
+        )
+
+    # ------------------------------------------------------------------
+    # estimated_net_consumption includes AC EV draw
+    # ------------------------------------------------------------------
+
+    def test_estimated_net_consumption_includes_ev_ac_load(self):
+        """estimated_net_consumption must use the AC-side EV load, not battery-side.
+
+        Hand calculation (100 % efficiency, so AC = battery-side):
+          house_load       = 0.5 kWh/h
+          pv_estimate      = 0.0 kWh/h
+          EV needed        = 10 kWh  (10 → 20 % of 100 kWh battery)
+          charger          = 11 kW, eff = 100 %  →  max = 11 kWh
+          allocated        = min(11, 10) = 10 kWh  (battery-side = AC-side at 100 %)
+          ev_planned_load_kwh (AC) = 10.0
+
+          net for EV slot: 0.5 + 10.0 - 0.0 = 10.5 kWh
+        """
+        inp = self._make_no_battery_input(
+            ev_soc=10.0,
+            ev_target_soc=20.0,
+            ev_capacity_kwh=100.0,  # needs 10 kWh
+            charger_kw=11.0,
+            charger_eff_pct=100.0,
+            house_consumption_kwh=0.5,
+            pv_estimate_kwh=0.0,
+            import_price=0.5,
+            deadline_hours=3.0,
+        )
+        out = run_planner(inp)
+
+        ev_slots = [s for s in out.slots if abs(s.ev_planned_load_kwh) > 1e-9]
+        assert ev_slots, "At least one slot should have EV planned load"
+
+        for s in ev_slots:
+            expected_net = round(
+                s.avg_house_consumption + s.ev_planned_load_kwh - s.solcast_pv_estimate,
+                3,
+            )
+            assert s.estimated_net_consumption == pytest.approx(expected_net, abs=1e-6)
+            # With no PV and 100 % efficiency, AC load = battery-side
+            # net = 0.5 + ev_ac = 0.5 + 10.0 = 10.5
+            assert s.estimated_net_consumption == pytest.approx(10.5, abs=0.1), (
+                f"Slot {s.start.hour}: expected net=10.5, got {s.estimated_net_consumption}"
+            )
+
+    # ------------------------------------------------------------------
+    # grid_import_kwh includes EV AC draw (SoC simulation path)
+    # ------------------------------------------------------------------
+
+    def test_grid_import_kwh_includes_ev_ac_load(self):
+        """grid_import_kwh must include the EV AC load.
+
+        Hand calculation (100 % charger efficiency, no PV, battery at floor):
+          house_load = 0.5 kWh/h
+          EV AC load = 10.0 kWh/h  (10 kWh needed, allocated in one slot)
+          pv         = 0.0 kWh
+          battery    = at floor, cannot discharge
+
+          total_load = 0.5 + 10.0 = 10.5 kWh
+          grid_import = total_load = 10.5 kWh
+        """
+        inp = self._make_no_battery_input(
+            ev_soc=10.0,
+            ev_target_soc=20.0,
+            ev_capacity_kwh=100.0,
+            charger_kw=11.0,
+            charger_eff_pct=100.0,
+            house_consumption_kwh=0.5,
+            pv_estimate_kwh=0.0,
+            import_price=0.5,
+            deadline_hours=3.0,
+        )
+        out = run_planner(inp)
+
+        ev_slots = [s for s in out.slots if abs(s.ev_planned_load_kwh) > 1e-9]
+        assert ev_slots, "At least one slot should have EV planned load"
+
+        for s in ev_slots:
+            # With battery at floor and no PV, all demand comes from grid.
+            # grid_import = house + ev_ac = 0.5 + 10.0 = 10.5 kWh
+            expected_import = s.avg_house_consumption + s.ev_planned_load_kwh
+            assert s.grid_import_kwh == pytest.approx(expected_import, abs=0.05), (
+                f"Slot {s.start.hour}: expected grid_import={expected_import:.2f}, "
+                f"got {s.grid_import_kwh}"
+            )
+
+    # ------------------------------------------------------------------
+    # grid_import_kwh with charger efficiency < 100 %
+    # ------------------------------------------------------------------
+
+    def test_ev_ac_load_larger_than_battery_side_at_sub_100pct_efficiency(self):
+        """With 90 % charger efficiency, AC draw > battery-side energy.
+
+        Hand calculation:
+          EV needs 9 kWh battery-side  (e.g. 10 → 19 % of 100 kWh battery)
+          charger: 11 kW AC, 90 % eff  →  max_battery = 11 × 0.90 = 9.9 kWh/h
+          allocated (battery-side) = min(9.9, 9.0) = 9.0 kWh
+          ac_load_kwh = 9.0 / 0.90 = 10.0 kWh
+
+          house_load = 0.5 kWh, pv = 0.0, battery at floor
+          grid_import = 0.5 + 10.0 = 10.5 kWh
+          estimated_net = 0.5 + 10.0 - 0.0 = 10.5 kWh
+        """
+        inp = self._make_no_battery_input(
+            ev_soc=10.0,
+            ev_target_soc=19.0,  # needs 9 kWh battery-side
+            ev_capacity_kwh=100.0,
+            charger_kw=11.0,
+            charger_eff_pct=90.0,
+            house_consumption_kwh=0.5,
+            pv_estimate_kwh=0.0,
+            import_price=0.5,
+            deadline_hours=3.0,
+        )
+        out = run_planner(inp)
+
+        ev_slots = [s for s in out.slots if abs(s.ev_planned_load_kwh) > 1e-9]
+        assert ev_slots, "At least one slot should have EV planned load"
+
+        s = ev_slots[0]
+        # EV plan: battery-side = 9.0, ac_load = 9.0/0.9 = 10.0
+        assert out.ev_charging_plan is not None
+        plan_slot = out.ev_charging_plan.charging_slots[0]
+        assert plan_slot.estimated_charged_kwh == pytest.approx(9.0, abs=0.01)
+        assert plan_slot.ac_load_kwh == pytest.approx(10.0, abs=0.01)
+
+        # PlannedSlot: ev_planned_load_kwh = ac_load_kwh = 10.0
+        assert s.ev_planned_load_kwh == pytest.approx(10.0, abs=0.01), (
+            f"ev_planned_load_kwh should be AC-side 10.0, got {s.ev_planned_load_kwh}"
+        )
+        # net = house + ev_ac - pv = 0.5 + 10.0 - 0.0 = 10.5
+        assert s.estimated_net_consumption == pytest.approx(10.5, abs=0.05)
+        # grid_import = 10.5 (all from grid, battery at floor)
+        assert s.grid_import_kwh == pytest.approx(10.5, abs=0.1)
+
+    # ------------------------------------------------------------------
+    # plan_cost includes EV grid import cost
+    # ------------------------------------------------------------------
+
+    def test_plan_cost_includes_ev_grid_import(self):
+        """plan_cost must account for EV grid draw, not just house load.
+
+        Hand calculation (100 % efficiency, no PV, 24-hour horizon, flat price):
+          import_price  = 0.40 DKK/kWh
+          house_load    = 0.5 kWh/h × 24 h = 12.0 kWh
+          EV AC load    = 10.0 kWh (allocated to 1 slot)
+          pv            = 0.0
+          battery       = at floor
+
+          grid_import_total = 12.0 + 10.0 = 22.0 kWh
+          plan_cost = 22.0 × 0.40 = 8.80 DKK  (approximately)
+
+          Without EV fix: plan_cost ≈ 12.0 × 0.40 = 4.80 DKK  (too low)
+        """
+        inp = self._make_no_battery_input(
+            ev_soc=10.0,
+            ev_target_soc=20.0,
+            ev_capacity_kwh=100.0,
+            charger_kw=11.0,
+            charger_eff_pct=100.0,
+            house_consumption_kwh=0.5,
+            pv_estimate_kwh=0.0,
+            import_price=0.40,
+            deadline_hours=3.0,
+        )
+        out = run_planner(inp)
+
+        # Total EV AC load actually allocated across all slots
+        total_ev_ac = sum(s.ev_planned_load_kwh for s in out.slots)
+
+        # EV AC load must be positive — the fix is working
+        assert total_ev_ac > 1e-9, (
+            "total ev_planned_load_kwh should be > 0; EV load not injected"
+        )
+
+        # Use future/current slots only — past slots have grid_import=0 by design
+        # so including them in house sums would break the energy balance.
+        future_slots = [
+            s for s in out.slots if s.grid_import_kwh > 0 or s.ev_planned_load_kwh > 0
+        ]
+
+        house_future = sum(s.avg_house_consumption for s in future_slots)
+        ev_future = sum(s.ev_planned_load_kwh for s in future_slots)
+        battery_discharge_future = sum(s.batteries_discharged for s in future_slots)
+        battery_charge_future = sum(s.batteries_charged for s in future_slots)
+        gi_future = sum(s.grid_import_kwh for s in future_slots)
+
+        # Energy balance per slot: gi = house + ev_ac + battery_charge - battery_discharge
+        expected_gi = (
+            house_future + ev_future + battery_charge_future - battery_discharge_future
+        )
+        assert gi_future == pytest.approx(expected_gi, abs=0.5), (
+            f"grid_import ({gi_future:.2f}) should equal "
+            f"house ({house_future:.2f}) + ev_ac ({ev_future:.2f}) "
+            f"+ batt_chg ({battery_charge_future:.2f}) "
+            f"- batt_disch ({battery_discharge_future:.2f}) = {expected_gi:.2f}; "
+            "EV AC load not flowing through SoC simulation"
+        )
+
+        # The specific EV slot: grid import must include the full EV AC draw
+        ev_slot = next(s for s in out.slots if abs(s.ev_planned_load_kwh) > 1e-9)
+        expected_slot_gi = (
+            ev_slot.avg_house_consumption
+            + ev_slot.ev_planned_load_kwh
+            + ev_slot.batteries_charged
+            - ev_slot.batteries_discharged
+        )
+        assert ev_slot.grid_import_kwh == pytest.approx(expected_slot_gi, abs=0.1), (
+            f"EV slot grid_import ({ev_slot.grid_import_kwh:.3f}) should equal "
+            f"house ({ev_slot.avg_house_consumption:.3f}) + ev_ac "
+            f"({ev_slot.ev_planned_load_kwh:.3f}) + batt_chg "
+            f"({ev_slot.batteries_charged:.3f}) - batt_disch "
+            f"({ev_slot.batteries_discharged:.3f}) = {expected_slot_gi:.3f}"
+        )
+
+    # ------------------------------------------------------------------
+    # SoC simulation: EV load reduces battery via increased net demand
+    # ------------------------------------------------------------------
+
+    def test_soc_simulation_accounts_for_ev_load(self):
+        """Battery discharges more when EV increases total load.
+
+        Setup (battery has charge, no schedule forcing discharge):
+          battery_soc_pct  = 80 %  (8 kWh usable of 10 kWh rated at 5 % floor)
+          house_load       = 0.5 kWh/h
+          EV AC load       = 5.0 kWh/h  (5 kWh needed in one slot, 100 % eff)
+          pv               = 0.0
+          import_price     = flat 0.5
+
+        Without EV fix:
+          net = 0.5 kWh  →  battery discharges 0.5 kWh (or grid import 0.5 kWh)
+
+        With EV fix:
+          net = 0.5 + 5.0 = 5.5 kWh  →  battery/grid must cover 5.5 kWh
+
+        The sum of (batteries_discharged + grid_import_kwh) for the EV slot
+        must equal approximately 5.5 kWh after the fix.
+        """
+        inp = PlannerInput(
+            now_iso="2024-06-15T08:00:00+00:00",
+            interval_minutes=60,
+            interval_length_hours=24,
+            battery_soc_pct=80.0,  # 7.5 kWh above floor (10 × 0.75)
+            battery_rated_capacity_kwh=10.0,
+            battery_end_of_discharge_soc_pct=5.0,
+            battery_max_soc_pct=90.0,
+            battery_max_charge_power_w=5000.0,
+            battery_conversion_loss_pct=0.0,
+            battery_charge_efficiency_pct=100.0,
+            battery_discharge_efficiency_pct=100.0,
+            weight_1d=25,
+            weight_3d=30,
+            weight_7d=30,
+            weight_14d=15,
+            consumption_averages=[
+                HourlyConsumptionAverage(
+                    hour=h, avg_1d=0.5, avg_3d=0.5, avg_7d=0.5, avg_14d=0.5
+                )
+                for h in range(24)
+            ],
+            price_points=[
+                PricePoint(hour=h, import_price=0.5, export_price=0.1)
+                for h in range(24)
+            ],
+            solcast_slots=[SolcastSlot(hour=h, pv_estimate=0.0) for h in range(24)],
+            ev_planned_load_enabled=True,
+            ev_planned_load_connected=True,
+            ev_planned_load_smart_charging_enabled=True,
+            ev_planned_load_current_soc_pct=5.0,
+            ev_planned_load_target_soc_pct=10.0,  # 5 kWh needed
+            ev_planned_load_battery_capacity_kwh=100.0,
+            ev_planned_load_charger_power_kw=11.0,
+            ev_planned_load_charger_efficiency_pct=100.0,
+            ev_planned_load_deadline=datetime(2024, 6, 15, 12, 0, tzinfo=UTC),
+            ev_planned_load_base_load_includes_ev=False,
+        )
+        out = run_planner(inp)
+
+        ev_slots = [s for s in out.slots if abs(s.ev_planned_load_kwh) > 1e-9]
+        assert ev_slots, "Expected at least one EV-loaded slot"
+
+        for s in ev_slots:
+            # total supply = batteries_discharged + grid_import_kwh
+            total_supply = s.batteries_discharged + s.grid_import_kwh
+            total_demand = s.avg_house_consumption + s.ev_planned_load_kwh
+            # Energy balance: supply must cover demand (within floating-point tolerance)
+            assert total_supply == pytest.approx(total_demand, abs=0.1), (
+                f"Slot {s.start.hour}: supply ({total_supply:.3f}) != demand "
+                f"({total_demand:.3f}); EV load not in SoC path"
+            )
+            # With EV load, demand exceeds house-only 0.5 kWh
+            assert total_demand > 1.0, (
+                f"Slot {s.start.hour}: total demand {total_demand:.2f} should exceed "
+                "house-only load of 0.5 kWh; ev_planned_load_kwh not applied to SoC simulation"
             )

--- a/tests/planner/test_invariants.py
+++ b/tests/planner/test_invariants.py
@@ -1689,3 +1689,206 @@ class TestRequiredReserve:
                     f"SoC {slot.estimated_battery_soc:.2f}% dropped below "
                     f"configured floor 10%"
                 )
+
+
+# ---------------------------------------------------------------------------
+# TestEvPlannedLoadPipelineIntegrity
+#
+# Invariant: ev_planned_load_kwh must flow through the complete pipeline so
+# that the final output.slots (used by _apply_planner_output to populate
+# HourlyRecommendation) carry the correct non-zero values.
+#
+# Required invariants:
+#   1. output.slots[i].ev_planned_load_kwh > 0  for every EV-charging slot
+#   2. estimated_net_consumption == avg_house_consumption
+#                                  + ev_planned_load_kwh
+#                                  - solcast_pv_estimate   (per slot)
+#   3. Slots labelled ev_smart_charging must have ev_planned_load_kwh > 0
+# ---------------------------------------------------------------------------
+
+
+class TestEvPlannedLoadPipelineIntegrity:
+    """ev_planned_load_kwh must be non-zero in output.slots for EV charging slots.
+
+    This is the regression test for the bug where ev_planned_load_kwh was
+    injected correctly inside the engine but lost before the final output.slots
+    were consumed by _apply_planner_output → HourlyRecommendation.
+    """
+
+    def _make_ev_input(
+        self,
+        *,
+        now_iso: str = "2024-06-15T08:00:00+02:00",
+        interval_minutes: int = 15,
+        interval_length_hours: int = 48,
+        ev_current_soc: float = 63.0,
+        ev_target_soc: float = 80.0,
+        ev_capacity_kwh: float = 86.0,
+        charger_kw: float = 11.0,
+        charger_eff: float = 100.0,
+        pv_hour11: float = 2.0,
+        pv_hour12: float = 3.0,
+        deadline_offset_hours: float = 28.0,
+    ) -> PlannerInput:
+        """Build a 48h / 15-min input with EV planned load active."""
+        from datetime import datetime as _dt
+
+        now = _dt.fromisoformat(now_iso)
+        deadline = now + timedelta(hours=deadline_offset_hours)
+
+        prices = [
+            PricePoint(hour=h, import_price=0.5, export_price=0.2) for h in range(24)
+        ]
+        pv = [SolcastSlot(hour=h, pv_estimate=0.0) for h in range(24)]
+        pv[11] = SolcastSlot(hour=11, pv_estimate=pv_hour11)
+        pv[12] = SolcastSlot(hour=12, pv_estimate=pv_hour12)
+        avgs = [
+            HourlyConsumptionAverage(
+                hour=h, avg_1d=0.7, avg_3d=0.7, avg_7d=0.7, avg_14d=0.7
+            )
+            for h in range(24)
+        ]
+        return PlannerInput(
+            now_iso=now_iso,
+            interval_minutes=interval_minutes,
+            interval_length_hours=interval_length_hours,
+            battery_soc_pct=5.0,
+            battery_rated_capacity_kwh=14.0,
+            battery_end_of_discharge_soc_pct=5.0,
+            battery_max_soc_pct=90.0,
+            battery_max_charge_power_w=5000.0,
+            battery_conversion_loss_pct=5.0,
+            weight_1d=25,
+            weight_3d=30,
+            weight_7d=30,
+            weight_14d=15,
+            consumption_averages=avgs,
+            price_points=prices,
+            solcast_slots=pv,
+            ev_planned_load_enabled=True,
+            ev_planned_load_connected=True,
+            ev_planned_load_smart_charging_enabled=True,
+            ev_planned_load_current_soc_pct=ev_current_soc,
+            ev_planned_load_target_soc_pct=ev_target_soc,
+            ev_planned_load_battery_capacity_kwh=ev_capacity_kwh,
+            ev_planned_load_charger_power_kw=charger_kw,
+            ev_planned_load_charger_efficiency_pct=charger_eff,
+            ev_planned_load_deadline=deadline,
+            ev_planned_load_base_load_includes_ev=False,
+        )
+
+    def test_ev_planned_load_kwh_nonzero_in_output_slots(self):
+        """output.slots must carry ev_planned_load_kwh > 0 for EV-charged slots.
+
+        This is the primary regression test for the pipeline integrity bug:
+        ev_planned_load_kwh must survive injection → candidate copy →
+        winner selection → final simulate_soc → output.slots.
+
+        The output.slots are what _apply_planner_output reads to populate
+        HourlyRecommendation.  If ev_planned_load_kwh is 0 here, it will
+        be 0 in the HA sensor attributes.
+        """
+        inp = self._make_ev_input()
+        out = run_planner(inp)
+
+        assert out.ev_charging_plan is not None, "EV plan must be built"
+        assert out.ev_charging_plan.charging_slots, "EV plan must have charging slots"
+
+        # Every EV charging slot must appear in output.slots with ev_planned_load_kwh > 0
+        for ev_slot in out.ev_charging_plan.charging_slots:
+            matching = next(
+                (
+                    s
+                    for s in out.slots
+                    if s.start.isoformat() == ev_slot.start.isoformat()
+                ),
+                None,
+            )
+            assert matching is not None, (
+                f"EV charging slot {ev_slot.start.isoformat()} not found in output.slots"
+            )
+            assert matching.ev_planned_load_kwh > 1e-9, (
+                f"output.slots slot {ev_slot.start.isoformat()} has ev_planned_load_kwh=0; "
+                f"EV ac_load={ev_slot.ac_load_kwh:.3f} was not carried through to output."
+            )
+
+    def test_estimated_net_consumption_invariant_with_ev(self):
+        """estimated_net_consumption must equal house + ev_ac - pv for every slot.
+
+        This proves that ev_planned_load_kwh was already present when
+        populate_net_consumption ran, not added as a label afterwards.
+        """
+        inp = self._make_ev_input()
+        out = run_planner(inp)
+
+        for s in out.slots:
+            if s.recommendation == "time_passed":
+                continue
+            expected = round(
+                s.avg_house_consumption + s.ev_planned_load_kwh - s.solcast_pv_estimate,
+                3,
+            )
+            assert s.estimated_net_consumption == pytest.approx(expected, abs=1e-6), (
+                f"Slot {s.start.isoformat()}: "
+                f"net={s.estimated_net_consumption:.4f} but "
+                f"house({s.avg_house_consumption:.4f}) + ev({s.ev_planned_load_kwh:.4f}) "
+                f"- pv({s.solcast_pv_estimate:.4f}) = {expected:.4f}"
+            )
+
+    def test_ev_smart_charging_slots_have_nonzero_ev_load(self):
+        """Every ev_smart_charging slot in output.slots must have ev_planned_load_kwh > 0.
+
+        If a slot is labelled ev_smart_charging but has ev_planned_load_kwh=0,
+        the label was applied without the underlying energy math being set —
+        which breaks the energy balance and cost calculations.
+        """
+        inp = self._make_ev_input()
+        out = run_planner(inp)
+
+        for s in out.slots:
+            if s.recommendation == "ev_smart_charging":
+                assert s.ev_planned_load_kwh > 1e-9, (
+                    f"Slot {s.start.isoformat()} labelled ev_smart_charging but "
+                    f"ev_planned_load_kwh={s.ev_planned_load_kwh:.6f}; "
+                    "EV load not present in energy math."
+                )
+
+    def test_ev_planned_load_kwh_propagates_to_soc_simulation(self):
+        """EV load must affect grid_import_kwh in the final output.slots.
+
+        For a slot with ev_planned_load_kwh > 0 and no PV / battery discharge,
+        grid_import_kwh must include the EV AC draw on top of house load.
+        This proves ev_planned_load_kwh reached the SoC simulation.
+
+        Hand calculation (simplified, no battery):
+          slot load = avg_house_consumption + ev_planned_load_kwh
+          grid_import ≈ slot load - battery_discharge (≈ house + ev - pv)
+        """
+        inp = self._make_ev_input()
+        out = run_planner(inp)
+
+        ev_slots_in_output = [
+            s
+            for s in out.slots
+            if s.ev_planned_load_kwh > 1e-9 and s.recommendation != "time_passed"
+        ]
+        assert ev_slots_in_output, "Must have at least one non-past EV slot"
+
+        for s in ev_slots_in_output:
+            total_supply = s.batteries_discharged + s.grid_import_kwh
+            total_demand = (
+                s.avg_house_consumption
+                + s.ev_planned_load_kwh
+                + s.batteries_charged
+                - s.solcast_pv_estimate
+            )
+            # Clamped: supply can't be negative; small floating-point tolerance
+            assert total_supply == pytest.approx(max(total_demand, 0.0), abs=0.1), (
+                f"Slot {s.start.isoformat()}: "
+                f"supply (batt_disch={s.batteries_discharged:.3f} + "
+                f"grid={s.grid_import_kwh:.3f}) = {total_supply:.3f} "
+                f"should ≈ demand {max(total_demand, 0.0):.3f} "
+                f"(house={s.avg_house_consumption:.3f} + ev={s.ev_planned_load_kwh:.3f} "
+                f"+ chg={s.batteries_charged:.3f} - pv={s.solcast_pv_estimate:.3f}); "
+                "EV load not in SoC simulation."
+            )

--- a/tests/test_months_validation.py
+++ b/tests/test_months_validation.py
@@ -2,10 +2,11 @@
 
 # Mock the logging to avoid file creation errors during testing
 from logging.handlers import RotatingFileHandler
+from unittest.mock import MagicMock
 
 import pytest
 
-from custom_components.hsem.flows.months import validate_months_input
+from custom_components.hsem.flows.months import get_months_schema, validate_months_input
 from custom_components.hsem.utils.misc import convert_months_to_int
 
 # Monkey-patch RotatingFileHandler to use NullHandler during tests
@@ -153,6 +154,49 @@ class TestValidateMonthsInput:
         user_input = {"hsem_months_winter": ["1", 2, "3", 4]}
         errors = await validate_months_input(None, user_input)
         assert not errors
+
+
+@pytest.mark.asyncio
+class TestGetMonthsSchema:
+    """Test that get_months_schema converts stored integers back to strings for the UI."""
+
+    def _get_default(self, schema) -> list:
+        """Extract the default value for hsem_months_winter from a vol.Schema."""
+        import voluptuous as vol
+
+        for key in schema.schema:
+            if isinstance(key, vol.Required) and key.schema == "hsem_months_winter":
+                return key.default()
+        raise KeyError("hsem_months_winter not found in schema")
+
+    async def test_schema_default_is_strings_when_config_has_integers(self):
+        """Stored integer months must be converted to strings for the multi-select."""
+        config_entry = MagicMock()
+        config_entry.options = {"hsem_months_winter": [1, 2, 3, 4, 10, 11, 12]}
+        config_entry.data = {}
+
+        schema = await get_months_schema(config_entry)
+        default = self._get_default(schema)
+        assert default == ["1", "2", "3", "4", "10", "11", "12"]
+        assert all(isinstance(m, str) for m in default)
+
+    async def test_schema_default_is_strings_when_config_has_strings(self):
+        """String months stored in config must remain strings."""
+        config_entry = MagicMock()
+        config_entry.options = {"hsem_months_winter": ["1", "2", "12"]}
+        config_entry.data = {}
+
+        schema = await get_months_schema(config_entry)
+        default = self._get_default(schema)
+        assert default == ["1", "2", "12"]
+
+    async def test_schema_default_uses_const_default_when_no_config(self):
+        """With no config entry, the schema default must use the const default as strings."""
+        schema = await get_months_schema(None)
+        default = self._get_default(schema)
+        # const default is [1, 2, 3, 4, 10, 11, 12] — must come back as strings
+        assert set(default) == {"1", "2", "3", "4", "10", "11", "12"}
+        assert all(isinstance(m, str) for m in default)
 
 
 class TestMonthMembership:


### PR DESCRIPTION
﻿## Summary

Adds `ev_planned_load_kwh` to `HourlyRecommendation` so EV planned charging load is visible in sensor attributes alongside `estimated_net_consumption`. Also adds diagnostics to help identify why EV load may not be injected into planner slots.

---

## Changes

### `models/hourly_recommendation.py`
- Added `ev_planned_load_kwh: float = 0.0` field (default preserves all existing constructors)
- Updated `estimated_net_consumption` docstring: formula is now `avg_consumption + ev_planned_load_kwh - pv_estimate`
- Added `ev_planned_load_kwh` docstring

### `coordinator.py` — `_apply_planner_output`
- Added `rec.ev_planned_load_kwh = slot.ev_planned_load_kwh` to copy EV load from planner slot

### `coordinator.py` — `_generate_recommendation_intervals`
- Added `ev_planned_load_kwh=0.0` to new `HourlyRecommendation` constructor

### `docs/hsem-planner-guide.md`
- Updated `estimated_net_consumption` description to include EV load term

### `custom_sensors/state_collector.py`
- When no `connected_sensor` is configured, default `ev_planned_load_connected = True` (so the planner can still schedule charging based on SoC and deadline alone). Previously defaulted to `False` which caused the plan to return early with `not_connected` state and empty `charging_slots`.

### `planner/ev_planner.py` — diagnostics
- Added `base_load_includes_ev` field to `EVChargingPlan` and exposed it in `as_attributes()` — user can now see in the sensor whether injection is being skipped due to this flag
- Added `injected_kwh` to the engine warning message so the planner log shows the actual kWh injected per EV

---

## User-visible improvement

After the fix, the EV optimal charging plan sensor attributes include `base_load_includes_ev` so users can verify whether the EV load is being injected into the planner:

```yaml
base_load_includes_ev: false   # ← visible: injection is active
ev_connected: true
total_kwh_needed: 14.62
charging_slots: [...]
```

And `hourly_recommendations` slots during planned EV charging will now show:

```yaml
ev_planned_load_kwh: 2.695    # ← amount of EV load in this slot
estimated_net_consumption: 3.23  # house(0.725) + ev(2.695) - pv(0.190)
recommendation: ev_smart_charging
```

---

## Config flow and options flow improvements (same branch)

- `config_flow.py` / `options_flow.py`: reordered config steps to logical grouping
- `flows/months.py`: fixed winter/summer month pre-selection bug (int→string conversion for multi-select widget)
- `planner/engine.py`: EV slots labelled `ev_smart_charging` after simulation; `EVSmartCharging` in `_CHARGE_RECOMMENDATIONS`
- New `docs/ev-charge-plan-setup.md` user guide
- Updated planner guide and spec with EV sections and recommendation priority tables

---

## Test results

`1630 passed, 3 xfailed` — no regressions.
`tox -e lint` — All checks passed!
