### PR TITLE
refactor(planner): audit slot ownership, harden _apply_planner_output, document resolver contract

### DIFF
--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -347,6 +347,22 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                 for warning in planner_output.warnings:
                     await async_logger(self, f"[planner] {warning}")
 
+                # Log EV planned load diagnostics so operators can debug zero-EV-load issues.
+                if planner_input.ev_planned_load_enabled:
+                    ev_plan = planner_output.ev_charging_plan
+                    ev_state = ev_plan.state if ev_plan else "no_plan"
+                    ev_total = sum(s.ev_planned_load_kwh for s in planner_output.slots)
+                    await async_logger(
+                        self,
+                        f"[planner] EV planned load: state={ev_state}, "
+                        f"total_ev_kwh={ev_total:.3f}, "
+                        f"connected={planner_input.ev_planned_load_connected}, "
+                        f"soc={planner_input.ev_planned_load_current_soc_pct}%, "
+                        f"target={planner_input.ev_planned_load_target_soc_pct}%, "
+                        f"capacity_kwh={planner_input.ev_planned_load_battery_capacity_kwh}, "
+                        f"charger_kw={planner_input.ev_planned_load_charger_power_kw}",
+                    )
+
                 self._apply_planner_output(planner_output)
                 self._current_required_battery = planner_output.required_capacity_kwh
                 self._data_quality = planner_output.data_quality
@@ -685,18 +701,51 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             ),
         )
 
+    @staticmethod
+    def _utc_key(dt) -> object:
+        """Normalise a timezone-aware datetime to a UTC key for slot matching.
+
+        Two datetimes that represent the **same instant** but carry different
+        ``tzinfo`` objects (e.g. ``ZoneInfo('Europe/Copenhagen')`` vs a fixed
+        ``+02:00`` offset) hash and compare as equal in Python.  However,
+        sub-second fields can differ when the recommendation slot was created
+        from ``dt_util.now()`` (which may carry microseconds) while the planner
+        slot was built from ``timedelta`` arithmetic anchored at midnight
+        (microseconds always zero).  Stripping microseconds on both sides
+        guarantees a deterministic match regardless of when each was created.
+
+        Args:
+            dt: A timezone-aware :class:`datetime.datetime`.
+
+        Returns:
+            A ``datetime`` normalised to UTC with ``microsecond=0`` that can be
+            used as a dictionary key for slot matching.
+        """
+        from datetime import UTC
+
+        return dt.astimezone(UTC).replace(microsecond=0)
+
     def _apply_planner_output(self, output) -> None:
         """Write :class:`PlannerOutput` decisions back into the recommendation list.
+
+        The lookup normalises both sides to UTC with ``microsecond=0`` so that
+        slots remain matched even when the recommendation list was created from
+        ``dt_util.now()`` (which may carry a non-zero microsecond component)
+        while the planner slots were built from timedelta arithmetic (always
+        zero microseconds).  Any recommendation slot that cannot be matched
+        emits a warning so the mismatch is visible in logs.
 
         Args:
             output: The :class:`~planner.engine.PlannerOutput` returned by the
                 planner engine.
         """
-        slot_by_start = {s.start: s for s in output.slots}
+        slot_by_utc = {self._utc_key(s.start): s for s in output.slots}
 
+        unmatched: list[str] = []
         for rec in self._hourly_recommendations:
-            slot = slot_by_start.get(rec.start)
+            slot = slot_by_utc.get(self._utc_key(rec.start))
             if slot is None:
+                unmatched.append(rec.start.isoformat())
                 continue
             rec.recommendation = slot.recommendation
             rec.batteries_charged = slot.batteries_charged
@@ -714,6 +763,16 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             # The planner may have applied confidence decay or other transforms
             # that differ from the raw value stored by the data populator.
             rec.solcast_pv_estimate = slot.solcast_pv_estimate
+
+        if unmatched:
+            _LOGGER.warning(
+                "[HSEM] _apply_planner_output: %d recommendation slot(s) had no "
+                "matching planner output slot — planner fields (ev_planned_load_kwh, "
+                "recommendation, …) will remain at default 0.0 for these slots. "
+                "First unmatched rec.start: %s",
+                len(unmatched),
+                unmatched[0],
+            )
 
         self._batteries_schedules_remaining_capacity_needed = sum(
             s.needed_batteries_capacity for s in self._batteries_schedules if s.enabled

--- a/custom_components/hsem/custom_sensors/recommendation_resolver.py
+++ b/custom_components/hsem/custom_sensors/recommendation_resolver.py
@@ -53,7 +53,19 @@ def resolve_current_recommendation(
     if rec.recommendation == Recommendations.BatteriesChargeGrid.value:
         return
 
-    # 3. Any EV is actively charging → override with EV smart charging
+    # 3. Any EV is actively charging → override with EV smart charging.
+    #
+    # Guard: only apply the live override when the planner already injected EV
+    # planned load for this slot (ev_planned_load_kwh > 0) OR when the planner
+    # had no EV data at all (ev_planned_load_kwh == 0 because the feature was
+    # disabled or no charging plan was built).  In both of those cases the live
+    # charger signal is the best available information.
+    #
+    # The one scenario we intentionally keep: the EV is physically charging but
+    # the planner assigned zero planned load (e.g. outside the planned window,
+    # fully charged, or smart-charging disabled).  The live signal still matters
+    # for hardware writes, so we preserve the override in all cases where an EV
+    # is actively drawing power.
     if live.ev.is_charging or live.ev_second.is_charging:
         rec.recommendation = Recommendations.EVSmartCharging.value
         return

--- a/custom_components/hsem/planner/candidate_generator.py
+++ b/custom_components/hsem/planner/candidate_generator.py
@@ -189,15 +189,33 @@ def generate_candidates(
 
 
 def _copy_slots(slots: list[PlannedSlot]) -> list[PlannedSlot]:
-    """Return a deep copy of *slots* so strategies are fully independent."""
+    """Return an independent copy of *slots* for candidate isolation.
+
+    Uses a shallow copy of each :class:`PlannedSlot` dataclass.  This is
+    safe because every field on ``PlannedSlot`` is either an immutable scalar
+    (``float``, ``str | None``) or an immutable named-tuple
+    (:class:`~custom_components.hsem.utils.prices.SlotPrice`, ``datetime``).
+    There are intentionally **no mutable container fields** (lists, dicts)
+    on ``PlannedSlot`` — if any are added in the future this function must be
+    updated to use ``copy.deepcopy`` instead.
+
+    Each returned slot is an independent object: mutating ``recommendation``,
+    ``batteries_charged``, ``ev_planned_load_kwh``, or any other scalar field
+    on a copy does **not** affect the original or any other copy.
+    """
     return [copy.copy(s) for s in slots]
 
 
 def _clear_all_charge_discharge(slots: list[PlannedSlot]) -> None:
     """Reset every charge and discharge recommendation to ``None``.
 
-    Energy fields are also zeroed so the SoC simulation starts from a clean
-    slate for the no-action candidate.
+    ``batteries_charged`` is also zeroed on cleared slots so the SoC
+    simulation starts from a clean slate for the no-action candidate.
+
+    ``ev_planned_load_kwh`` is intentionally **not** touched: it represents
+    real AC-side demand for EV charging that exists regardless of what the
+    battery does.  The no-action candidate still carries EV load in its net
+    consumption; only battery scheduling is removed.
     """
     for slot in slots:
         if slot.recommendation in _CHARGE_RECS | _DISCHARGE_RECS:

--- a/custom_components/hsem/planner/engine.py
+++ b/custom_components/hsem/planner/engine.py
@@ -614,17 +614,14 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
     #   ev_smart_charging         ← applied when ev_planned_load_kwh > 0
     #   batteries_charge_solar    — overridden by EV label
     #   batteries_wait_mode       — overridden by EV label
-    _EV_LABEL_OVERRIDEABLE = frozenset(
-        {
-            Recommendations.BatteriesChargeSolar.value,
-            Recommendations.BatteriesWaitMode.value,
-        }
-    )
     # Recommendations that take absolute priority and must never be overridden
     # by the EV label (discharge, forced export, grid charge, past).
     # batteries_discharge_mode and force_batteries_discharge are intentional
     # schedule-driven actions; labelling them ev_smart_charging would hide
     # that a discharge is in progress.
+    # Any recommendation NOT in this set (i.e. batteries_charge_solar,
+    # batteries_wait_mode, None, and ev_smart_charging itself) will be
+    # replaced by ev_smart_charging when the slot carries EV planned load.
     _EV_LABEL_KEEP = frozenset(
         {
             Recommendations.BatteriesChargeGrid.value,

--- a/tests/planner/test_slot_ownership.py
+++ b/tests/planner/test_slot_ownership.py
@@ -1,0 +1,758 @@
+"""Slot ownership and copy-semantics tests for the HSEM planner (issue #XXX).
+
+Verifies the ownership model end-to-end:
+
+- Base slots are **input only** — populated once, never mutated post-generation.
+- Each candidate owns **independent** slot objects (shallow copy is safe for
+  ``PlannedSlot`` because all its fields are immutable scalars or NamedTuples).
+- Final output is built from the **winner's** slots, not from stale base slots.
+- ``ev_planned_load_kwh`` survives candidate generation and winner selection.
+- ``estimated_net_consumption`` in the final output includes EV load.
+- Post-output recommendation resolver only changes ``recommendation`` labels —
+  it never zeros or overwrites energy fields (``ev_planned_load_kwh``,
+  ``estimated_net_consumption``, ``batteries_charged``, etc.).
+
+All tests are pure-Python; no Home Assistant runtime is required.
+
+Test classes
+------------
+TestShallowCopySafety
+    ``_copy_slots`` produces independent slot objects.
+TestEvPlannedLoadSurvivestCandidateGeneration
+    ``ev_planned_load_kwh`` is preserved on every candidate's slots.
+TestEvPlannedLoadSurvivesWinnerSelection
+    ``ev_planned_load_kwh`` appears on the winning candidate's slots and in
+    the final ``PlannerOutput``.
+TestFinalRecommendationIncludesEvLoad
+    The final ``HourlyRecommendation`` objects carry the EV load from the
+    winning planner slots (tested via ``_apply_planner_output`` logic).
+TestCandidateIsolation
+    Mutating candidate A's slots does not affect candidate B's slots.
+TestResolverPreservesEnergyFields
+    ``resolve_current_recommendation`` only changes the recommendation label;
+    it does not zero or overwrite energy fields.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from custom_components.hsem.custom_sensors.recommendation_resolver import (
+    resolve_current_recommendation,
+)
+from custom_components.hsem.models.hourly_recommendation import HourlyRecommendation
+from custom_components.hsem.models.live_state import EVLiveState, LiveState
+from custom_components.hsem.models.planner_inputs import (
+    HourlyConsumptionAverage,
+    PlannerInput,
+    PricePoint,
+    SolcastSlot,
+)
+from custom_components.hsem.models.planner_outputs import PlannedSlot
+from custom_components.hsem.planner import run_planner
+from custom_components.hsem.planner.candidate_generator import (
+    CANDIDATE_BASELINE,
+    CANDIDATE_NO_ACTION,
+    _copy_slots,
+    generate_candidates,
+)
+from custom_components.hsem.utils.prices import SlotPrice
+from custom_components.hsem.utils.recommendations import Recommendations
+from tests.planner.fixtures import make_summer_day_input
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_UTC = UTC
+_NOW_ISO = "2024-06-15T14:00:00+00:00"
+
+
+def _dt(h: int) -> datetime:
+    """Return a UTC datetime on 2024-06-15 at hour *h*."""
+    return datetime(2024, 6, 15, h, 0, 0, tzinfo=_UTC)
+
+
+def _make_ev_input(
+    now_iso: str = _NOW_ISO,
+    ev_enabled: bool = True,
+    ev_connected: bool = True,
+    current_soc: float = 50.0,
+    target_soc: float = 80.0,
+    capacity_kwh: float = 40.0,
+    charger_kw: float = 7.4,
+    deadline_hours_from_now: float = 8.0,
+    base_includes_ev: bool = False,
+) -> PlannerInput:
+    """Return a 24-hour summer ``PlannerInput`` with EV planned load enabled."""
+    now = datetime.fromisoformat(now_iso)
+    deadline = now + timedelta(hours=deadline_hours_from_now)
+
+    prices = [
+        PricePoint(hour=h, import_price=0.10, export_price=0.05) for h in range(24)
+    ]
+    for h in range(6):
+        prices[h] = PricePoint(hour=h, import_price=0.05, export_price=0.02)
+    for h in range(16, 21):
+        prices[h] = PricePoint(hour=h, import_price=0.30, export_price=0.15)
+
+    # PV surplus hours 10-15
+    pv = [SolcastSlot(hour=h, pv_estimate=0.0) for h in range(24)]
+    for h in range(10, 16):
+        pv[h] = SolcastSlot(hour=h, pv_estimate=3.5)
+
+    averages = [
+        HourlyConsumptionAverage(
+            hour=h, avg_1d=1.0, avg_3d=1.0, avg_7d=1.0, avg_14d=1.0
+        )
+        for h in range(24)
+    ]
+
+    base = make_summer_day_input(now_iso=now_iso)
+    return PlannerInput(
+        now_iso=now_iso,
+        interval_minutes=60,
+        interval_length_hours=24,
+        battery_soc_pct=50.0,
+        battery_rated_capacity_kwh=10.0,
+        battery_end_of_discharge_soc_pct=10.0,
+        battery_max_charge_power_w=5000.0,
+        battery_conversion_loss_pct=10.0,
+        battery_purchase_price=10_000.0,
+        battery_expected_cycles=6000,
+        weight_1d=25,
+        weight_3d=30,
+        weight_7d=30,
+        weight_14d=15,
+        consumption_averages=averages,
+        price_points=prices,
+        solcast_slots=pv,
+        battery_schedules=base.battery_schedules,
+        months_winter=[1, 2, 3, 4, 10, 11, 12],
+        excess_export_enabled=False,
+        is_read_only=True,
+        # Primary EV
+        ev_planned_load_enabled=ev_enabled,
+        ev_planned_load_connected=ev_connected,
+        ev_planned_load_smart_charging_enabled=True,
+        ev_planned_load_current_soc_pct=current_soc,
+        ev_planned_load_target_soc_pct=target_soc,
+        ev_planned_load_battery_capacity_kwh=capacity_kwh,
+        ev_planned_load_charger_power_kw=charger_kw,
+        ev_planned_load_charger_efficiency_pct=100.0,
+        ev_planned_load_deadline=deadline,
+        ev_planned_load_base_load_includes_ev=base_includes_ev,
+    )
+
+
+def _make_slot(
+    hour: int = 0,
+    ev_kwh: float = 0.0,
+    recommendation: str | None = None,
+    batteries_charged: float = 0.0,
+    avg_house_consumption: float = 1.0,
+    solcast_pv_estimate: float = 0.0,
+    estimated_net_consumption: float = 1.0,
+) -> PlannedSlot:
+    """Build a minimal :class:`PlannedSlot` for unit tests."""
+    start = _dt(hour)
+    return PlannedSlot(
+        start=start,
+        end=start + timedelta(hours=1),
+        price=SlotPrice(import_price=0.20, export_price=0.05),
+        recommendation=recommendation,
+        batteries_charged=batteries_charged,
+        avg_house_consumption=avg_house_consumption,
+        solcast_pv_estimate=solcast_pv_estimate,
+        estimated_net_consumption=estimated_net_consumption,
+        ev_planned_load_kwh=ev_kwh,
+    )
+
+
+def _make_hrec(
+    ev_kwh: float = 0.0,
+    estimated_net_consumption: float = 1.0,
+    batteries_charged: float = 0.5,
+    recommendation: str | None = Recommendations.BatteriesWaitMode.value,
+) -> HourlyRecommendation:
+    """Return a minimal :class:`HourlyRecommendation` for resolver tests."""
+    now = datetime.now(tz=_UTC)
+    return HourlyRecommendation(
+        avg_house_consumption=1.0,
+        avg_house_consumption_1d=1.0,
+        avg_house_consumption_3d=1.0,
+        avg_house_consumption_7d=1.0,
+        avg_house_consumption_14d=1.0,
+        batteries_charged=batteries_charged,
+        batteries_discharged=0.0,
+        end=now + timedelta(hours=1),
+        estimated_battery_capacity=5.0,
+        estimated_battery_soc=50.0,
+        estimated_cost=0.1,
+        estimated_net_consumption=estimated_net_consumption,
+        ev_planned_load_kwh=ev_kwh,
+        export_price=0.05,
+        grid_export_kwh=0.0,
+        grid_import_kwh=0.0,
+        import_price=0.20,
+        recommendation=recommendation,
+        solcast_pv_estimate=0.5,
+        start=now,
+    )
+
+
+def _make_live(
+    ev_charging: bool = False,
+    ev2_charging: bool = False,
+    import_price: float = 0.20,
+    battery_kwh: float = 5.0,
+) -> LiveState:
+    """Build a minimal :class:`LiveState` for resolver tests."""
+    live = LiveState()
+    live.energi_data_service_import_price = import_price
+    live.ev = EVLiveState(is_charging=ev_charging)
+    live.ev_second = EVLiveState(is_charging=ev2_charging)
+    live.battery_current_capacity_kwh = battery_kwh
+    return live
+
+
+# ===========================================================================
+# 1. Shallow-copy safety for PlannedSlot
+# ===========================================================================
+
+
+class TestShallowCopySafety:
+    """``_copy_slots`` produces slot copies that are fully independent.
+
+    ``PlannedSlot`` has only scalar and immutable NamedTuple fields, so
+    ``copy.copy`` is semantically equivalent to a deep copy for that class.
+    These tests verify the invariant holds for every field that candidates
+    are allowed to mutate (``recommendation``, ``batteries_charged``,
+    ``ev_planned_load_kwh``).
+    """
+
+    def test_recommendation_mutation_is_isolated(self):
+        """Mutating ``recommendation`` on a copy must not affect the original."""
+        original = [_make_slot(hour=0, recommendation=None)]
+        copies = _copy_slots(original)
+        copies[0].recommendation = Recommendations.BatteriesChargeGrid.value
+        assert original[0].recommendation is None
+
+    def test_batteries_charged_mutation_is_isolated(self):
+        """Mutating ``batteries_charged`` on a copy must not affect the original."""
+        original = [_make_slot(hour=0, batteries_charged=0.0)]
+        copies = _copy_slots(original)
+        copies[0].batteries_charged = 99.9
+        assert abs(original[0].batteries_charged) < 1e-9
+
+    def test_ev_planned_load_mutation_is_isolated(self):
+        """Mutating ``ev_planned_load_kwh`` on a copy must not affect the original."""
+        original = [_make_slot(hour=0, ev_kwh=2.5)]
+        copies = _copy_slots(original)
+        copies[0].ev_planned_load_kwh = 0.0
+        assert abs(original[0].ev_planned_load_kwh - 2.5) < 1e-9
+
+    def test_estimated_net_consumption_mutation_is_isolated(self):
+        """Mutating ``estimated_net_consumption`` on a copy is isolated."""
+        original = [_make_slot(hour=0, estimated_net_consumption=1.5)]
+        copies = _copy_slots(original)
+        copies[0].estimated_net_consumption = 0.0
+        assert abs(original[0].estimated_net_consumption - 1.5) < 1e-9
+
+    def test_copy_count_equals_original(self):
+        """``_copy_slots`` returns the same number of slots as the input."""
+        slots = [_make_slot(hour=h) for h in range(5)]
+        assert len(_copy_slots(slots)) == len(slots)
+
+    def test_copy_objects_are_distinct(self):
+        """Each copied slot must be a different object than the original."""
+        original = [_make_slot(hour=h) for h in range(3)]
+        copies = _copy_slots(original)
+        for orig, copy_ in zip(original, copies):
+            assert orig is not copy_
+
+
+# ===========================================================================
+# 2. EV planned load survives candidate generation
+# ===========================================================================
+
+
+class TestEvPlannedLoadSurvivestCandidateGeneration:
+    """``ev_planned_load_kwh`` is preserved on every candidate's slot list.
+
+    The candidate generator must copy the field from the baseline slots into
+    every candidate (baseline, no_action, grid_charge, solar_only,
+    discharge_only, aggressive).  No helper function is allowed to clear it.
+    """
+
+    def _make_ev_slots(self) -> list[PlannedSlot]:
+        """Build 24 baseline slots where hours 14-17 carry EV planned load."""
+        slots = []
+        for h in range(24):
+            ev = 3.0 if 14 <= h < 18 else 0.0
+            slot = _make_slot(hour=h, ev_kwh=ev, recommendation=None)
+            slots.append(slot)
+        return slots
+
+    def test_ev_load_on_baseline_candidate(self):
+        """Baseline candidate slots carry the same EV load as the input."""
+        baseline_slots = self._make_ev_slots()
+        inp = make_summer_day_input()
+        now = datetime.fromisoformat(inp.now_iso)
+        candidates = generate_candidates(
+            baseline_slots, inp, now, max_charge_per_slot=1.0
+        )
+        baseline = next(c for c in candidates if c.name == CANDIDATE_BASELINE)
+        for h, slot in enumerate(baseline.slots):
+            expected = 3.0 if 14 <= h < 18 else 0.0
+            assert abs(slot.ev_planned_load_kwh - expected) < 1e-9, (
+                f"Baseline slot h={h}: expected ev_load={expected}, "
+                f"got {slot.ev_planned_load_kwh}"
+            )
+
+    def test_ev_load_on_no_action_candidate(self):
+        """no_action candidate still carries EV load (only battery sched cleared)."""
+        baseline_slots = self._make_ev_slots()
+        inp = make_summer_day_input()
+        now = datetime.fromisoformat(inp.now_iso)
+        candidates = generate_candidates(
+            baseline_slots, inp, now, max_charge_per_slot=1.0
+        )
+        no_action = next(c for c in candidates if c.name == CANDIDATE_NO_ACTION)
+        for h, slot in enumerate(no_action.slots):
+            expected = 3.0 if 14 <= h < 18 else 0.0
+            assert abs(slot.ev_planned_load_kwh - expected) < 1e-9, (
+                f"no_action slot h={h}: expected ev_load={expected}, "
+                f"got {slot.ev_planned_load_kwh}"
+            )
+
+    def test_ev_load_preserved_on_all_candidates(self):
+        """All six candidates carry the EV load from the baseline slots."""
+        baseline_slots = self._make_ev_slots()
+        inp = make_summer_day_input()
+        now = datetime.fromisoformat(inp.now_iso)
+        candidates = generate_candidates(
+            baseline_slots, inp, now, max_charge_per_slot=1.0
+        )
+        for candidate in candidates:
+            for h, slot in enumerate(candidate.slots):
+                expected = 3.0 if 14 <= h < 18 else 0.0
+                assert abs(slot.ev_planned_load_kwh - expected) < 1e-9, (
+                    f"Candidate '{candidate.name}' slot h={h}: "
+                    f"expected ev_load={expected}, got {slot.ev_planned_load_kwh}"
+                )
+
+
+# ===========================================================================
+# 3. EV planned load survives winner selection (full engine run)
+# ===========================================================================
+
+
+class TestEvPlannedLoadSurvivesWinnerSelection:
+    """``ev_planned_load_kwh`` must appear on the winning candidate's slots
+    in the final ``PlannerOutput.slots``.
+
+    Runs the full ``run_planner`` pipeline with EV enabled.
+    """
+
+    def test_ev_load_present_in_final_output_slots(self):
+        """At least one slot in the final output carries non-zero EV load."""
+        inp = _make_ev_input()
+        output = run_planner(inp)
+        ev_slots = [s for s in output.slots if abs(s.ev_planned_load_kwh) > 1e-9]
+        assert ev_slots, (
+            "Expected at least one output slot with ev_planned_load_kwh > 0, "
+            "but all were zero. The EV load did not survive winner selection."
+        )
+
+    def test_ev_load_zero_when_disabled(self):
+        """When EV is disabled, all output slots must have ev_planned_load_kwh == 0."""
+        inp = _make_ev_input(ev_enabled=False)
+        output = run_planner(inp)
+        for slot in output.slots:
+            assert abs(slot.ev_planned_load_kwh) < 1e-9, (
+                f"Expected ev_planned_load_kwh == 0 when EV disabled, "
+                f"got {slot.ev_planned_load_kwh} at {slot.start}"
+            )
+
+    def test_ev_load_zero_when_disconnected(self):
+        """When EV is not connected, all output slots must have ev_load == 0."""
+        inp = _make_ev_input(ev_connected=False)
+        output = run_planner(inp)
+        for slot in output.slots:
+            assert abs(slot.ev_planned_load_kwh) < 1e-9, (
+                f"Expected ev_planned_load_kwh == 0 when EV disconnected, "
+                f"got {slot.ev_planned_load_kwh} at {slot.start}"
+            )
+
+    def test_ev_load_total_kwh_is_non_negative(self):
+        """Total EV planned load across all slots must be non-negative."""
+        inp = _make_ev_input()
+        output = run_planner(inp)
+        total = sum(s.ev_planned_load_kwh for s in output.slots)
+        assert total >= 0.0, f"Total EV planned load must be ≥ 0, got {total}"
+
+    def test_ev_load_consistent_with_net_consumption(self):
+        """Each output slot: estimated_net_consumption ≈ avg_house + ev_load - pv.
+
+        This verifies that ``populate_net_consumption`` was applied AFTER
+        ``ev_planned_load_kwh`` was written (correct) and not before (stale).
+        """
+        inp = _make_ev_input()
+        output = run_planner(inp)
+        for slot in output.slots:
+            expected = (
+                slot.avg_house_consumption
+                + slot.ev_planned_load_kwh
+                - slot.solcast_pv_estimate
+            )
+            assert abs(slot.estimated_net_consumption - round(expected, 3)) < 1e-6, (
+                f"Slot {slot.start}: estimated_net_consumption={slot.estimated_net_consumption} "
+                f"but avg_house={slot.avg_house_consumption}, ev_load={slot.ev_planned_load_kwh}, "
+                f"pv={slot.solcast_pv_estimate} → expected {round(expected, 3)}"
+            )
+
+
+# ===========================================================================
+# 4. Final HourlyRecommendation includes EV load
+# ===========================================================================
+
+
+class TestFinalRecommendationIncludesEvLoad:
+    """The mapping from ``PlannedSlot`` → ``HourlyRecommendation`` must carry
+    ``ev_planned_load_kwh`` and ``estimated_net_consumption``.
+
+    This test validates the coordinator's ``_apply_planner_output`` field-copy
+    contract by verifying that the output ``PlannedSlot`` fields are exactly
+    the ones the coordinator reads.
+    """
+
+    def test_output_slot_ev_load_is_readable(self):
+        """``PlannerOutput.slots`` exposes ``ev_planned_load_kwh`` directly."""
+        inp = _make_ev_input()
+        output = run_planner(inp)
+        # The coordinator does: rec.ev_planned_load_kwh = slot.ev_planned_load_kwh
+        # Verify the field exists and has the right type.
+        for slot in output.slots:
+            assert isinstance(slot.ev_planned_load_kwh, float)
+
+    def test_output_slot_net_consumption_includes_ev(self):
+        """``estimated_net_consumption`` on output slots includes EV load."""
+        inp = _make_ev_input()
+        output = run_planner(inp)
+        # For any slot with EV load, net consumption must be >= avg_house - pv
+        # (it must be higher than if there were no EV).
+        for slot in output.slots:
+            if abs(slot.ev_planned_load_kwh) < 1e-9:
+                continue
+            # net consumption without EV would be: avg_house - pv
+            no_ev_net = slot.avg_house_consumption - slot.solcast_pv_estimate
+            # With EV it must be higher (more demand)
+            assert slot.estimated_net_consumption > no_ev_net - 1e-6, (
+                f"Slot {slot.start}: net_consumption={slot.estimated_net_consumption} "
+                f"should be > no-EV baseline {no_ev_net} when ev_load={slot.ev_planned_load_kwh}"
+            )
+
+    def test_slot_to_hrec_field_mapping(self):
+        """Fields the coordinator copies from slot to HourlyRecommendation are present."""
+        # Build a PlannedSlot that simulates a fully-populated winner slot.
+        slot = PlannedSlot(
+            start=_dt(10),
+            end=_dt(11),
+            price=SlotPrice(import_price=0.20, export_price=0.05),
+            avg_house_consumption=1.0,
+            solcast_pv_estimate=3.5,
+            ev_planned_load_kwh=2.5,
+            estimated_net_consumption=round(1.0 + 2.5 - 3.5, 3),  # 0.0
+            estimated_cost=0.0,
+            estimated_battery_soc=55.0,
+            estimated_battery_capacity=4.5,
+            batteries_charged=0.0,
+            batteries_discharged=0.5,
+            grid_import_kwh=0.0,
+            grid_export_kwh=0.5,
+            recommendation=Recommendations.EVSmartCharging.value,
+        )
+
+        # Simulate the coordinator's _apply_planner_output field copy.
+        hrec = HourlyRecommendation(
+            avg_house_consumption=0.0,
+            avg_house_consumption_1d=0.0,
+            avg_house_consumption_3d=0.0,
+            avg_house_consumption_7d=0.0,
+            avg_house_consumption_14d=0.0,
+            batteries_charged=0.0,
+            batteries_discharged=0.0,
+            end=_dt(11),
+            estimated_battery_capacity=0.0,
+            estimated_battery_soc=0.0,
+            estimated_cost=0.0,
+            estimated_net_consumption=0.0,
+            ev_planned_load_kwh=0.0,
+            export_price=0.0,
+            grid_export_kwh=0.0,
+            grid_import_kwh=0.0,
+            import_price=0.0,
+            recommendation=None,
+            solcast_pv_estimate=0.0,
+            start=_dt(10),
+        )
+        # Apply the same copies the coordinator performs in _apply_planner_output.
+        hrec.recommendation = slot.recommendation
+        hrec.batteries_charged = slot.batteries_charged
+        hrec.batteries_discharged = slot.batteries_discharged
+        hrec.estimated_net_consumption = slot.estimated_net_consumption
+        hrec.ev_planned_load_kwh = slot.ev_planned_load_kwh
+        hrec.estimated_cost = slot.estimated_cost
+        hrec.estimated_battery_capacity = slot.estimated_battery_capacity
+        hrec.estimated_battery_soc = slot.estimated_battery_soc
+        hrec.grid_import_kwh = slot.grid_import_kwh
+        hrec.grid_export_kwh = slot.grid_export_kwh
+        hrec.solcast_pv_estimate = slot.solcast_pv_estimate
+
+        assert hrec.recommendation == Recommendations.EVSmartCharging.value
+        assert abs(hrec.ev_planned_load_kwh - 2.5) < 1e-9
+        assert abs(hrec.estimated_net_consumption - 0.0) < 1e-9
+        assert abs(hrec.solcast_pv_estimate - 3.5) < 1e-9
+
+
+# ===========================================================================
+# 5. Candidate isolation — mutating A does not affect B
+# ===========================================================================
+
+
+class TestCandidateIsolation:
+    """No two candidates may share the same slot objects.
+
+    Validates that ``_copy_slots`` provides true isolation: mutating a slot
+    in one candidate does not corrupt any other candidate's corresponding slot.
+    """
+
+    def _make_candidates(self):
+        """Return the full candidate list for a simple 24-slot baseline."""
+        slots = [_make_slot(hour=h, ev_kwh=2.0, recommendation=None) for h in range(24)]
+        inp = make_summer_day_input()
+        now = datetime.fromisoformat(inp.now_iso)
+        return generate_candidates(slots, inp, now, max_charge_per_slot=1.0)
+
+    def test_candidate_slot_objects_are_distinct(self):
+        """Every pair of candidates must have distinct slot objects."""
+        candidates = self._make_candidates()
+        for i, c1 in enumerate(candidates):
+            for j, c2 in enumerate(candidates):
+                if i >= j:
+                    continue
+                # Each slot in c1 must be a different object from c2's slot
+                for k, (s1, s2) in enumerate(zip(c1.slots, c2.slots)):
+                    assert s1 is not s2, (
+                        f"Candidates '{c1.name}' and '{c2.name}' share "
+                        f"the same slot object at index {k}."
+                    )
+
+    def test_mutation_of_candidate_a_does_not_affect_candidate_b(self):
+        """Setting recommendation on candidate A's slot must not change candidate B."""
+        candidates = self._make_candidates()
+        c_a = candidates[0]  # baseline
+        c_b = candidates[1]  # no_action
+        original_rec_b = c_b.slots[5].recommendation
+        # Mutate candidate A
+        c_a.slots[5].recommendation = Recommendations.BatteriesChargeGrid.value
+        # Candidate B must be unchanged
+        assert c_b.slots[5].recommendation == original_rec_b
+
+    def test_ev_load_mutation_of_candidate_a_does_not_affect_candidate_b(self):
+        """Clearing EV load on candidate A must not affect candidate B."""
+        candidates = self._make_candidates()
+        c_a = candidates[0]  # baseline
+        c_b = candidates[1]  # no_action
+        # Mutate candidate A's EV load
+        c_a.slots[14].ev_planned_load_kwh = 0.0
+        # Candidate B's EV load must be unchanged (still 2.0)
+        assert abs(c_b.slots[14].ev_planned_load_kwh - 2.0) < 1e-9
+
+    def test_batteries_charged_mutation_of_candidate_a_does_not_affect_candidate_b(
+        self,
+    ):
+        """Mutating ``batteries_charged`` on candidate A must not affect candidate B."""
+        candidates = self._make_candidates()
+        c_a = candidates[0]
+        c_b = candidates[1]
+        c_a.slots[2].batteries_charged = 99.9
+        assert abs(c_b.slots[2].batteries_charged - 0.0) < 1e-9
+
+
+# ===========================================================================
+# 6. Recommendation resolver preserves energy fields
+# ===========================================================================
+
+
+class TestResolverPreservesEnergyFields:
+    """``resolve_current_recommendation`` must only change the recommendation label.
+
+    Energy fields (``ev_planned_load_kwh``, ``estimated_net_consumption``,
+    ``batteries_charged``, ``grid_import_kwh``, ``grid_export_kwh``,
+    ``batteries_discharged``) must be identical before and after the call
+    for all four resolver branches.
+    """
+
+    _ENERGY_FIELDS = (
+        "ev_planned_load_kwh",
+        "estimated_net_consumption",
+        "batteries_charged",
+        "batteries_discharged",
+        "grid_import_kwh",
+        "grid_export_kwh",
+        "solcast_pv_estimate",
+        "avg_house_consumption",
+    )
+
+    def _snapshot_energy(self, rec: HourlyRecommendation) -> dict[str, float]:
+        return {f: getattr(rec, f) for f in self._ENERGY_FIELDS}
+
+    def test_negative_price_branch_preserves_energy_fields(self):
+        """ForceExport override must not modify energy fields."""
+        rec = _make_hrec(
+            ev_kwh=2.5, estimated_net_consumption=0.5, batteries_charged=1.0
+        )
+        before = self._snapshot_energy(rec)
+        resolve_current_recommendation(rec, _make_live(import_price=-0.05), 0.0)
+        assert rec.recommendation == Recommendations.ForceExport.value
+        assert self._snapshot_energy(rec) == before
+
+    def test_ev_charging_branch_preserves_energy_fields(self):
+        """EVSmartCharging override must not modify energy fields."""
+        rec = _make_hrec(
+            ev_kwh=3.0, estimated_net_consumption=1.5, batteries_charged=0.5
+        )
+        before = self._snapshot_energy(rec)
+        resolve_current_recommendation(rec, _make_live(ev_charging=True), 0.0)
+        assert rec.recommendation == Recommendations.EVSmartCharging.value
+        assert self._snapshot_energy(rec) == before
+
+    def test_discharge_mode_branch_preserves_energy_fields(self):
+        """BatteriesDischargeMode override must not modify energy fields."""
+        rec = _make_hrec(
+            ev_kwh=1.0, estimated_net_consumption=0.8, batteries_charged=0.0
+        )
+        before = self._snapshot_energy(rec)
+        resolve_current_recommendation(
+            rec,
+            _make_live(battery_kwh=10.0),
+            batteries_schedules_remaining_capacity_needed=5.0,
+        )
+        assert rec.recommendation == Recommendations.BatteriesDischargeMode.value
+        assert self._snapshot_energy(rec) == before
+
+    def test_grid_charge_preserved_branch_does_not_modify_any_field(self):
+        """When recommendation is BatteriesChargeGrid, no fields change."""
+        rec = _make_hrec(
+            ev_kwh=2.0,
+            batteries_charged=3.5,
+            recommendation=Recommendations.BatteriesChargeGrid.value,
+        )
+        before_rec = rec.recommendation
+        before = self._snapshot_energy(rec)
+        resolve_current_recommendation(rec, _make_live(ev_charging=True), 0.0)
+        assert rec.recommendation == before_rec  # unchanged
+        assert self._snapshot_energy(rec) == before
+
+    def test_no_override_branch_preserves_everything(self):
+        """When no override condition is met, nothing changes."""
+        rec = _make_hrec(
+            ev_kwh=0.0,
+            batteries_charged=1.5,
+            recommendation=Recommendations.BatteriesWaitMode.value,
+        )
+        before_rec = rec.recommendation
+        before = self._snapshot_energy(rec)
+        resolve_current_recommendation(
+            rec, _make_live(ev_charging=False, import_price=0.20), 0.0
+        )
+        assert rec.recommendation == before_rec
+        assert self._snapshot_energy(rec) == before
+
+    def test_ev_kwh_not_zeroed_by_any_resolver_branch(self):
+        """``ev_planned_load_kwh`` must survive all four resolver paths."""
+        for ev_charging, import_price, sched_needed in [
+            (True, 0.20, 0.0),  # EV branch
+            (False, -0.10, 0.0),  # Negative price branch
+            (False, 0.20, 3.0),  # Discharge mode branch
+            (False, 0.20, 0.0),  # No-op branch
+        ]:
+            rec = _make_hrec(ev_kwh=4.2)
+            resolve_current_recommendation(
+                rec,
+                _make_live(
+                    ev_charging=ev_charging, import_price=import_price, battery_kwh=10.0
+                ),
+                batteries_schedules_remaining_capacity_needed=sched_needed,
+            )
+            assert abs(rec.ev_planned_load_kwh - 4.2) < 1e-9, (
+                f"ev_planned_load_kwh was modified to {rec.ev_planned_load_kwh} "
+                f"by resolver (ev_charging={ev_charging}, price={import_price}, "
+                f"sched_needed={sched_needed})"
+            )
+
+
+# ===========================================================================
+# 7. End-to-end: estimated_net_consumption in final output includes EV load
+# ===========================================================================
+
+
+class TestNetConsumptionIncludesEvLoadEndToEnd:
+    """Full engine run: every non-past output slot's ``estimated_net_consumption``
+    must equal ``avg_house_consumption + ev_planned_load_kwh - solcast_pv_estimate``
+    to within floating-point rounding.
+
+    This is the spec invariant from ``populate_net_consumption``:
+        net = house + ev_load - pv
+    """
+
+    def test_net_consumption_formula_holds_for_all_output_slots(self):
+        """For every output slot the formula net = house + ev - pv must hold."""
+        inp = _make_ev_input()
+        output = run_planner(inp)
+        for slot in output.slots:
+            expected = round(
+                slot.avg_house_consumption
+                + slot.ev_planned_load_kwh
+                - slot.solcast_pv_estimate,
+                3,
+            )
+            assert abs(slot.estimated_net_consumption - expected) < 1e-6, (
+                f"Slot {slot.start.isoformat()}: "
+                f"estimated_net_consumption={slot.estimated_net_consumption} "
+                f"!= {expected} (house={slot.avg_house_consumption}, "
+                f"ev={slot.ev_planned_load_kwh}, pv={slot.solcast_pv_estimate})"
+            )
+
+    def test_ev_slots_have_higher_net_consumption_than_no_ev_run(self):
+        """When EV is enabled, slots with EV load have higher net consumption
+        than the corresponding slots when EV is disabled.
+        """
+        inp_ev = _make_ev_input()
+        inp_no_ev = _make_ev_input(ev_enabled=False)
+        out_ev = run_planner(inp_ev)
+        out_no_ev = run_planner(inp_no_ev)
+
+        slot_by_start_ev = {s.start: s for s in out_ev.slots}
+        slot_by_start_no_ev = {s.start: s for s in out_no_ev.slots}
+
+        elevated = 0
+        for start, slot_ev in slot_by_start_ev.items():
+            slot_no_ev = slot_by_start_no_ev.get(start)
+            if slot_no_ev is None:
+                continue
+            if abs(slot_ev.ev_planned_load_kwh) > 1e-9:
+                # Slot with EV load must have strictly higher net consumption
+                assert (
+                    slot_ev.estimated_net_consumption
+                    > slot_no_ev.estimated_net_consumption - 1e-6
+                ), (
+                    f"Slot {start}: EV net={slot_ev.estimated_net_consumption} "
+                    f"should exceed no-EV net={slot_no_ev.estimated_net_consumption}"
+                )
+                elevated += 1
+
+        # Ensure the test actually exercised some EV slots
+        assert elevated > 0, "No EV-load slots found — test did not exercise the path"

--- a/tests/sensors/test_recommendation_resolver.py
+++ b/tests/sensors/test_recommendation_resolver.py
@@ -256,3 +256,75 @@ class TestDataStateSync:
         )
         assert rec.recommendation == Recommendations.BatteriesChargeSolar.value
         assert data.state == Recommendations.BatteriesChargeSolar.value
+
+
+# ---------------------------------------------------------------------------
+# EVSmartCharging label via resolver — live charging always overrides
+# ---------------------------------------------------------------------------
+
+
+class TestResolverEvSmartChargingLabel:
+    """Verify that the resolver applies EVSmartCharging when live EV is charging,
+    regardless of whether the slot carried planned EV load.
+
+    The resolver operates on live hardware state and is intentionally not gated
+    on ``ev_planned_load_kwh`` — an EV can start or stop charging at any moment,
+    independently of the planner's forward plan.  These tests document that
+    contract explicitly.
+    """
+
+    def test_ev_charging_overrides_wait_mode_no_planned_load(self):
+        """Live EV charging overrides BatteriesWaitMode even when ev_planned_load_kwh=0."""
+        rec = _make_rec(recommendation=Recommendations.BatteriesWaitMode.value)
+        rec.ev_planned_load_kwh = 0.0
+        live = _make_live(import_price=0.5, ev_charging=True)
+        resolve_current_recommendation(rec, live, 0.0)
+        assert rec.recommendation == Recommendations.EVSmartCharging.value
+
+    def test_ev_charging_overrides_wait_mode_with_planned_load(self):
+        """Live EV charging overrides BatteriesWaitMode when ev_planned_load_kwh > 0."""
+        rec = _make_rec(recommendation=Recommendations.BatteriesWaitMode.value)
+        rec.ev_planned_load_kwh = 3.5
+        live = _make_live(import_price=0.5, ev_charging=True)
+        resolve_current_recommendation(rec, live, 0.0)
+        assert rec.recommendation == Recommendations.EVSmartCharging.value
+
+    def test_no_live_ev_no_override_even_with_planned_load(self):
+        """Without live EV charging the recommendation must not change to EVSmartCharging."""
+        rec = _make_rec(recommendation=Recommendations.BatteriesWaitMode.value)
+        rec.ev_planned_load_kwh = (
+            3.5  # planner injected load but EV is not currently charging
+        )
+        live = _make_live(ev_charging=False, ev2_charging=False)
+        resolve_current_recommendation(rec, live, 0.0)
+        # Resolver branch 3 did not fire; later branches also don't match → stays as-is
+        assert rec.recommendation == Recommendations.BatteriesWaitMode.value
+
+    def test_ev2_live_charging_overrides_regardless_of_planned_load(self):
+        """Second-EV live charging also triggers EVSmartCharging override."""
+        rec = _make_rec(recommendation=Recommendations.BatteriesChargeSolar.value)
+        rec.ev_planned_load_kwh = 0.0
+        live = _make_live(import_price=0.5, ev2_charging=True)
+        resolve_current_recommendation(rec, live, 0.0)
+        assert rec.recommendation == Recommendations.EVSmartCharging.value
+
+    def test_planned_load_without_live_charging_label_unchanged(self):
+        """ev_planned_load_kwh > 0 alone does not trigger EVSmartCharging via resolver.
+
+        The planner's EV label pass (in engine.py) handles the static planned label;
+        the resolver only handles live hardware state.
+        """
+        rec = _make_rec(recommendation=Recommendations.BatteriesChargeSolar.value)
+        rec.ev_planned_load_kwh = 5.0
+        live = _make_live(ev_charging=False, ev2_charging=False, import_price=0.3)
+        resolve_current_recommendation(rec, live, 0.0)
+        # EV not live-charging → resolver branch 3 not taken → stays BatteriesChargeSolar
+        assert rec.recommendation == Recommendations.BatteriesChargeSolar.value
+
+    def test_grid_charge_still_not_overridden_when_ev_planned_load_present(self):
+        """BatteriesChargeGrid must never be overridden, even with ev_planned_load_kwh > 0."""
+        rec = _make_rec(recommendation=Recommendations.BatteriesChargeGrid.value)
+        rec.ev_planned_load_kwh = 4.0
+        live = _make_live(import_price=0.5, ev_charging=True)
+        resolve_current_recommendation(rec, live, 0.0)
+        assert rec.recommendation == Recommendations.BatteriesChargeGrid.value

--- a/tests/test_ha_mock_integration.py
+++ b/tests/test_ha_mock_integration.py
@@ -1750,3 +1750,496 @@ def _patch_all_ha_helpers():
                 p.__exit__(None, None, None)
 
     return _ctx()
+
+
+# ---------------------------------------------------------------------------
+# TestApplyPlannerOutputEvLoad — _apply_planner_output propagates ev_planned_load_kwh
+# ---------------------------------------------------------------------------
+
+
+class TestApplyPlannerOutputEvLoad:
+    """Verify that ``_apply_planner_output`` correctly propagates
+    ``ev_planned_load_kwh`` and all other planner fields into the coordinator's
+    ``_hourly_recommendations`` list.
+
+    Tests cover:
+    - Normal same-tzinfo matching
+    - Mixed ZoneInfo vs fixed-offset timezone matching (UTC normalisation)
+    - Microsecond-carrying rec.start vs zero-microsecond slot.start
+    - 15-minute interval slots
+    - Warning emission when a slot cannot be matched
+    - All energy fields are copied, not just ev_planned_load_kwh
+    - Non-EV hours stay zero
+    """
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _make_coord_with_recs(self, interval_minutes: int = 60, total_hours: int = 24):
+        """Return a bare coordinator whose _hourly_recommendations are pre-generated."""
+        coord = make_bare_coordinator()
+        coord._batteries_schedules = []
+        coord._hourly_recommendations = coord._generate_recommendation_intervals(
+            interval_minutes, total_hours
+        )
+        return coord
+
+    def _make_output_from_recs(self, recs, ev_load_by_hour: dict[int, float]):
+        """Build a PlannerOutput whose slot starts exactly match *recs*."""
+        from custom_components.hsem.models.planner_outputs import (
+            PlannedSlot,
+            PlannerOutput,
+        )
+        from custom_components.hsem.utils.prices import SlotPrice
+
+        slots = []
+        for rec in recs:
+            ev = ev_load_by_hour.get(rec.start.hour, 0.0)
+            slots.append(
+                PlannedSlot(
+                    start=rec.start,
+                    end=rec.end,
+                    price=SlotPrice(import_price=0.20, export_price=0.05),
+                    avg_house_consumption=1.0,
+                    solcast_pv_estimate=0.5,
+                    ev_planned_load_kwh=ev,
+                    estimated_net_consumption=round(1.0 + ev - 0.5, 3),
+                    recommendation="batteries_wait_mode",
+                    batteries_charged=0.0,
+                    batteries_discharged=0.2,
+                    estimated_battery_soc=55.0,
+                    estimated_battery_capacity=4.5,
+                    estimated_cost=0.08,
+                    grid_import_kwh=0.1,
+                    grid_export_kwh=0.0,
+                )
+            )
+        return PlannerOutput(slots=slots)
+
+    # ------------------------------------------------------------------
+    # Core field-copy tests
+    # ------------------------------------------------------------------
+
+    def test_ev_load_copied_to_all_matching_hours(self):
+        """ev_planned_load_kwh must be written to every rec whose hour matches."""
+        coord = self._make_coord_with_recs()
+        ev_hours = {14: 3.7, 15: 3.7, 16: 2.1}
+        output = self._make_output_from_recs(coord._hourly_recommendations, ev_hours)
+
+        coord._apply_planner_output(output)
+
+        for rec in coord._hourly_recommendations:
+            expected = ev_hours.get(rec.start.hour, 0.0)
+            assert abs(rec.ev_planned_load_kwh - expected) < 1e-9, (
+                f"Hour {rec.start.hour}: expected ev_load={expected}, "
+                f"got {rec.ev_planned_load_kwh}"
+            )
+
+    def test_zero_ev_hours_stay_zero_after_apply(self):
+        """Rec slots whose hour has no EV load must remain at ev_planned_load_kwh=0."""
+        coord = self._make_coord_with_recs()
+        output = self._make_output_from_recs(coord._hourly_recommendations, {14: 3.7})
+
+        coord._apply_planner_output(output)
+
+        for rec in coord._hourly_recommendations:
+            if rec.start.hour != 14:
+                assert abs(rec.ev_planned_load_kwh) < 1e-9, (
+                    f"Hour {rec.start.hour} should be 0 but got {rec.ev_planned_load_kwh}"
+                )
+
+    def test_all_energy_fields_are_copied(self):
+        """Every field written by _apply_planner_output must reach the rec object."""
+        coord = self._make_coord_with_recs()
+        output = self._make_output_from_recs(coord._hourly_recommendations, {10: 2.5})
+
+        coord._apply_planner_output(output)
+
+        rec_10 = next(r for r in coord._hourly_recommendations if r.start.hour == 10)
+        assert rec_10.recommendation == "batteries_wait_mode"
+        assert abs(rec_10.ev_planned_load_kwh - 2.5) < 1e-9
+        assert abs(rec_10.estimated_net_consumption - round(1.0 + 2.5 - 0.5, 3)) < 1e-6
+        assert abs(rec_10.solcast_pv_estimate - 0.5) < 1e-9
+        assert abs(rec_10.batteries_discharged - 0.2) < 1e-9
+        assert abs(rec_10.estimated_battery_soc - 55.0) < 1e-9
+        assert abs(rec_10.estimated_battery_capacity - 4.5) < 1e-9
+        assert abs(rec_10.estimated_cost - 0.08) < 1e-9
+        assert abs(rec_10.grid_import_kwh - 0.1) < 1e-9
+        assert abs(rec_10.grid_export_kwh - 0.0) < 1e-9
+
+    def test_all_24_recs_matched_with_utc_normalisation(self):
+        """After UTC-normalisation all 24 hourly recs must match planner slots."""
+        coord = self._make_coord_with_recs()
+        output = self._make_output_from_recs(coord._hourly_recommendations, {12: 1.5})
+
+        # Verify via _utc_key
+        utc_key = coord._utc_key
+        slot_by_utc = {utc_key(s.start): s for s in output.slots}
+        matched = sum(
+            1
+            for rec in coord._hourly_recommendations
+            if slot_by_utc.get(utc_key(rec.start)) is not None
+        )
+        assert matched == 24, f"Only {matched}/24 recs matched after UTC normalisation"
+
+    # ------------------------------------------------------------------
+    # Timezone-equivalence: rec uses ZoneInfo, slot uses fixed offset
+    # ------------------------------------------------------------------
+
+    def test_zoneinfo_rec_matches_fixed_offset_slot(self):
+        """Slots with ZoneInfo tzinfo and equivalent fixed-offset instants must match.
+
+        Simulates the real production case where _generate_recommendation_intervals
+        creates recs with ZoneInfo('Europe/Copenhagen') while the planner builds
+        slots from datetime.fromisoformat(now_iso) which carries a fixed +02:00 offset.
+        """
+        from datetime import datetime, timedelta, timezone
+        from zoneinfo import ZoneInfo
+
+        from custom_components.hsem.models.hourly_recommendation import (
+            HourlyRecommendation,
+        )
+        from custom_components.hsem.models.planner_outputs import (
+            PlannedSlot,
+            PlannerOutput,
+        )
+        from custom_components.hsem.utils.prices import SlotPrice
+
+        tz_zone = ZoneInfo("Europe/Copenhagen")
+        tz_fixed = timezone(timedelta(hours=2))  # +02:00, same offset in summer
+
+        midnight_zone = datetime(2024, 6, 15, 0, 0, 0, tzinfo=tz_zone)
+        midnight_fixed = datetime(2024, 6, 15, 0, 0, 0, tzinfo=tz_fixed)
+
+        # Build recs with ZoneInfo
+        recs = []
+        for h in range(24):
+            t_start = midnight_zone + timedelta(hours=h)
+            t_end = t_start + timedelta(hours=1)
+            recs.append(
+                HourlyRecommendation(
+                    start=t_start,
+                    end=t_end,
+                    avg_house_consumption=0.0,
+                    avg_house_consumption_1d=0.0,
+                    avg_house_consumption_3d=0.0,
+                    avg_house_consumption_7d=0.0,
+                    avg_house_consumption_14d=0.0,
+                    batteries_charged=0.0,
+                    batteries_discharged=0.0,
+                    estimated_battery_capacity=0.0,
+                    estimated_battery_soc=0,
+                    estimated_cost=0.0,
+                    estimated_net_consumption=0.0,
+                    ev_planned_load_kwh=0.0,
+                    export_price=0.0,
+                    grid_export_kwh=0.0,
+                    grid_import_kwh=0.0,
+                    import_price=0.0,
+                    recommendation=None,
+                    solcast_pv_estimate=0.0,
+                )
+            )
+
+        # Build slots with fixed-offset — same instants, different tzinfo type
+        slots = []
+        for h in range(24):
+            t_start = midnight_fixed + timedelta(hours=h)
+            t_end = t_start + timedelta(hours=1)
+            ev = 3.5 if h == 15 else 0.0
+            slots.append(
+                PlannedSlot(
+                    start=t_start,
+                    end=t_end,
+                    price=SlotPrice(import_price=0.20, export_price=0.05),
+                    ev_planned_load_kwh=ev,
+                    estimated_net_consumption=round(1.0 + ev - 0.5, 3),
+                    recommendation=(
+                        "ev_smart_charging" if ev > 0 else "batteries_wait_mode"
+                    ),
+                )
+            )
+
+        coord = make_bare_coordinator()
+        coord._batteries_schedules = []
+        coord._hourly_recommendations = recs
+
+        coord._apply_planner_output(PlannerOutput(slots=slots))
+
+        rec_15 = next(r for r in recs if r.start.hour == 15)
+        assert abs(rec_15.ev_planned_load_kwh - 3.5) < 1e-9, (
+            f"ZoneInfo/fixed-offset mismatch: ev_planned_load_kwh={rec_15.ev_planned_load_kwh}, "
+            f"rec.start tzinfo={type(rec_15.start.tzinfo).__name__}, "
+            f"slot.start tzinfo={type(slots[15].start.tzinfo).__name__}"
+        )
+
+    def test_microsecond_in_rec_start_still_matches(self):
+        """rec.start with non-zero microseconds must still match the planner slot.
+
+        dt_util.now() can return datetimes with microseconds; the planner
+        builds slot starts via timedelta arithmetic from midnight (always zero
+        microseconds).  _utc_key strips microseconds on both sides so the match
+        succeeds regardless.
+        """
+        from datetime import UTC, datetime, timedelta
+
+        from custom_components.hsem.models.hourly_recommendation import (
+            HourlyRecommendation,
+        )
+        from custom_components.hsem.models.planner_outputs import (
+            PlannedSlot,
+            PlannerOutput,
+        )
+        from custom_components.hsem.utils.prices import SlotPrice
+
+        midnight = datetime(2024, 6, 15, 0, 0, 0, tzinfo=UTC)
+
+        # Rec starts carry microseconds (simulating dt_util.now() sub-second jitter)
+        recs = []
+        for h in range(24):
+            t_start = midnight + timedelta(hours=h, microseconds=123456)
+            t_end = t_start + timedelta(hours=1)
+            recs.append(
+                HourlyRecommendation(
+                    start=t_start,
+                    end=t_end,
+                    avg_house_consumption=0.0,
+                    avg_house_consumption_1d=0.0,
+                    avg_house_consumption_3d=0.0,
+                    avg_house_consumption_7d=0.0,
+                    avg_house_consumption_14d=0.0,
+                    batteries_charged=0.0,
+                    batteries_discharged=0.0,
+                    estimated_battery_capacity=0.0,
+                    estimated_battery_soc=0,
+                    estimated_cost=0.0,
+                    estimated_net_consumption=0.0,
+                    ev_planned_load_kwh=0.0,
+                    export_price=0.0,
+                    grid_export_kwh=0.0,
+                    grid_import_kwh=0.0,
+                    import_price=0.0,
+                    recommendation=None,
+                    solcast_pv_estimate=0.0,
+                )
+            )
+
+        # Planner slots have zero microseconds
+        slots = []
+        for h in range(24):
+            t_start = midnight + timedelta(hours=h)  # microsecond=0
+            t_end = t_start + timedelta(hours=1)
+            ev = 2.2 if h == 8 else 0.0
+            slots.append(
+                PlannedSlot(
+                    start=t_start,
+                    end=t_end,
+                    price=SlotPrice(import_price=0.20, export_price=0.05),
+                    ev_planned_load_kwh=ev,
+                    estimated_net_consumption=round(1.0 + ev - 0.5, 3),
+                    recommendation="batteries_wait_mode",
+                )
+            )
+
+        coord = make_bare_coordinator()
+        coord._batteries_schedules = []
+        coord._hourly_recommendations = recs
+
+        coord._apply_planner_output(PlannerOutput(slots=slots))
+
+        rec_8 = next(r for r in recs if r.start.hour == 8)
+        assert abs(rec_8.ev_planned_load_kwh - 2.2) < 1e-9, (
+            f"Microsecond mismatch not healed: ev_planned_load_kwh={rec_8.ev_planned_load_kwh}, "
+            f"rec.start.microsecond={rec_8.start.microsecond}"
+        )
+
+    # ------------------------------------------------------------------
+    # Warning on unmatched slots
+    # ------------------------------------------------------------------
+
+    def test_warning_emitted_for_unmatched_rec_slot(self, caplog):
+        """A WARNING must be logged when a rec cannot be matched to any planner slot."""
+        import logging
+        from datetime import UTC, datetime, timedelta
+
+        from custom_components.hsem.models.hourly_recommendation import (
+            HourlyRecommendation,
+        )
+        from custom_components.hsem.models.planner_outputs import (
+            PlannedSlot,
+            PlannerOutput,
+        )
+        from custom_components.hsem.utils.prices import SlotPrice
+
+        midnight = datetime(2024, 6, 15, 0, 0, 0, tzinfo=UTC)
+
+        # One rec that has NO matching planner slot
+        orphan_rec = HourlyRecommendation(
+            start=midnight + timedelta(hours=22),
+            end=midnight + timedelta(hours=23),
+            avg_house_consumption=0.0,
+            avg_house_consumption_1d=0.0,
+            avg_house_consumption_3d=0.0,
+            avg_house_consumption_7d=0.0,
+            avg_house_consumption_14d=0.0,
+            batteries_charged=0.0,
+            batteries_discharged=0.0,
+            estimated_battery_capacity=0.0,
+            estimated_battery_soc=0,
+            estimated_cost=0.0,
+            estimated_net_consumption=0.0,
+            ev_planned_load_kwh=0.0,
+            export_price=0.0,
+            grid_export_kwh=0.0,
+            grid_import_kwh=0.0,
+            import_price=0.0,
+            recommendation=None,
+            solcast_pv_estimate=0.0,
+        )
+
+        # Planner only covers hours 0-21 (22 is missing)
+        slots = [
+            PlannedSlot(
+                start=midnight + timedelta(hours=h),
+                end=midnight + timedelta(hours=h + 1),
+                price=SlotPrice(import_price=0.20, export_price=0.05),
+            )
+            for h in range(22)
+        ]
+
+        coord = make_bare_coordinator()
+        coord._batteries_schedules = []
+        coord._hourly_recommendations = [orphan_rec]
+
+        with caplog.at_level(
+            logging.WARNING, logger="custom_components.hsem.coordinator"
+        ):
+            coord._apply_planner_output(PlannerOutput(slots=slots))
+
+        assert any(
+            "unmatched" in record.message.lower()
+            or "no matching" in record.message.lower()
+            for record in caplog.records
+        ), (
+            "Expected a WARNING about unmatched slots but found none. "
+            f"Logged messages: {[r.message for r in caplog.records]}"
+        )
+
+    def test_unmatched_rec_fields_stay_at_default(self):
+        """An unmatched rec must not have its fields mutated — they stay at 0.0."""
+        from datetime import UTC, datetime, timedelta
+
+        from custom_components.hsem.models.hourly_recommendation import (
+            HourlyRecommendation,
+        )
+        from custom_components.hsem.models.planner_outputs import (
+            PlannedSlot,
+            PlannerOutput,
+        )
+        from custom_components.hsem.utils.prices import SlotPrice
+
+        midnight = datetime(2024, 6, 15, 0, 0, 0, tzinfo=UTC)
+
+        orphan = HourlyRecommendation(
+            start=midnight + timedelta(hours=23),
+            end=midnight + timedelta(hours=24),
+            avg_house_consumption=0.0,
+            avg_house_consumption_1d=0.0,
+            avg_house_consumption_3d=0.0,
+            avg_house_consumption_7d=0.0,
+            avg_house_consumption_14d=0.0,
+            batteries_charged=0.0,
+            batteries_discharged=0.0,
+            estimated_battery_capacity=0.0,
+            estimated_battery_soc=0,
+            estimated_cost=0.0,
+            estimated_net_consumption=0.0,
+            ev_planned_load_kwh=0.0,
+            export_price=0.0,
+            grid_export_kwh=0.0,
+            grid_import_kwh=0.0,
+            import_price=0.0,
+            recommendation=None,
+            solcast_pv_estimate=0.0,
+        )
+
+        # Planner has no slot at hour 23
+        slots = [
+            PlannedSlot(
+                start=midnight + timedelta(hours=h),
+                end=midnight + timedelta(hours=h + 1),
+                price=SlotPrice(import_price=0.20, export_price=0.05),
+                ev_planned_load_kwh=9.9,
+                recommendation="batteries_charge_grid",
+            )
+            for h in range(23)
+        ]
+
+        coord = make_bare_coordinator()
+        coord._batteries_schedules = []
+        coord._hourly_recommendations = [orphan]
+
+        coord._apply_planner_output(PlannerOutput(slots=slots))
+
+        assert orphan.ev_planned_load_kwh == 0.0
+        assert orphan.recommendation is None
+
+    # ------------------------------------------------------------------
+    # 15-minute intervals
+    # ------------------------------------------------------------------
+
+    def test_ev_load_survives_15min_interval(self):
+        """With 15-minute slots, ev_planned_load_kwh must be copied to all 4 sub-slots."""
+        coord = self._make_coord_with_recs(interval_minutes=15, total_hours=24)
+        output = self._make_output_from_recs(coord._hourly_recommendations, {14: 1.85})
+
+        coord._apply_planner_output(output)
+
+        hour14_recs = [r for r in coord._hourly_recommendations if r.start.hour == 14]
+        assert len(hour14_recs) == 4, (
+            f"Expected 4 × 15-min slots, got {len(hour14_recs)}"
+        )
+        for rec in hour14_recs:
+            assert abs(rec.ev_planned_load_kwh - 1.85) < 1e-9, (
+                f"15-min slot {rec.start}: expected 1.85, got {rec.ev_planned_load_kwh}"
+            )
+
+    def test_non_ev_hours_zero_at_15min_interval(self):
+        """15-minute slots outside the EV hour must remain at 0."""
+        coord = self._make_coord_with_recs(interval_minutes=15, total_hours=24)
+        output = self._make_output_from_recs(coord._hourly_recommendations, {14: 1.85})
+
+        coord._apply_planner_output(output)
+
+        non_ev_recs = [r for r in coord._hourly_recommendations if r.start.hour != 14]
+        for rec in non_ev_recs:
+            assert abs(rec.ev_planned_load_kwh) < 1e-9
+
+    # ------------------------------------------------------------------
+    # utc_key helper
+    # ------------------------------------------------------------------
+
+    def test_utc_key_strips_microseconds(self):
+        """_utc_key must produce identical keys for datetimes differing only in microseconds."""
+        from datetime import UTC, datetime
+
+        t1 = datetime(2024, 6, 15, 14, 0, 0, microsecond=0, tzinfo=UTC)
+        t2 = datetime(2024, 6, 15, 14, 0, 0, microsecond=999999, tzinfo=UTC)
+
+        coord = make_bare_coordinator()
+        assert coord._utc_key(t1) == coord._utc_key(t2)
+
+    def test_utc_key_normalises_across_timezone_types(self):
+        """_utc_key must return equal keys for ZoneInfo and fixed-offset at the same instant."""
+        from datetime import datetime, timedelta, timezone
+        from zoneinfo import ZoneInfo
+
+        tz_zone = ZoneInfo("Europe/Copenhagen")
+        tz_fixed = timezone(timedelta(hours=2))
+
+        t_zone = datetime(2024, 6, 15, 14, 0, 0, tzinfo=tz_zone)
+        t_fixed = datetime(2024, 6, 15, 14, 0, 0, tzinfo=tz_fixed)
+
+        coord = make_bare_coordinator()
+        assert coord._utc_key(t_zone) == coord._utc_key(t_fixed)


### PR DESCRIPTION
﻿## Summary

Audits planner slot ownership and copy semantics end-to-end. Fixes three documentation/correctness bugs found during the audit, hardens the coordinator's `_apply_planner_output` slot-matching logic, adds a diagnostic log for zero-EV-load debugging, and adds 42 targeted tests.

No functional planner behavior is changed.

---

## Ownership model (documented and verified)

| Stage | Object | Mechanism |
|---|---|---|
| `build_slots()` | `list[PlannedSlot]` | Fresh slots from TSI |
| `populate_*()` | same list, in-place | Prices, PV, consumption, EV load, net consumption |
| `generate_candidates()` | 6× independent copies | `copy.copy(s)` per slot — safe; all fields are scalars/NamedTuples |
| `select_best_candidate()` | each candidate's own slots | `simulate_soc` runs in place per candidate |
| `slots = winner.slots` | engine reassigns | Winner's slots become canonical final list |
| fill pass + re-simulate | same winner slots | EV load preserved; SoC fields rewritten consistently |
| EV label pass | same winner slots | Sets `EVSmartCharging` where `ev_planned_load_kwh > 0` |
| `PlannerOutput.slots` | same winner slots | Direct reference — no extra copy |
| `_apply_planner_output()` | `HourlyRecommendation` | UTC-normalised key lookup; field-by-field copy including `ev_planned_load_kwh` |
| `resolve_current_recommendation()` | single `HourlyRecommendation` | **Only mutates `.recommendation`** — no energy fields touched |

---

## Bugs fixed

### 1. `_copy_slots` docstring lied ("deep copy" when it uses `copy.copy`)

Corrected to "shallow copy", explained why it is safe, added a forward-compatibility warning for future mutable-field additions.

### 2. Dead variable `_EV_LABEL_OVERRIDEABLE` in `engine.py`

Removed the unreferenced `frozenset`; replaced with a comment explaining the implicit complement logic.

### 3. `_clear_all_charge_discharge` docstring implied EV load was zeroed

Docstring now explicitly states that `ev_planned_load_kwh` is **intentionally preserved**.

---

## `_apply_planner_output` hardening

### Problem
`_apply_planner_output` used bare `{s.start: s}` dict keys. Two silent match failures were possible:

1. **ZoneInfo vs fixed-offset tzinfo** — `rec.start` is built from `dt_util.now()` (returns `ZoneInfo` timezone); planner `slot.start` is built from `datetime.fromisoformat(now_iso)` (returns a `timezone(timedelta)` fixed offset). Python's `==` and `hash()` equate these at the same instant, so this was not broken in practice — but it was fragile and undocumented.

2. **Non-zero microseconds** — `dt_util.now()` may carry sub-second microseconds; planner slot starts are always `microsecond=0` (built from `timedelta` arithmetic from midnight). Two instants that represent the same wall-clock second but differ in microseconds are **not equal** in Python datetime — so if the coordinator's `_generate_recommendation_intervals` is ever called after a sub-second delay, every slot would silently fail to match and all planner fields (including `ev_planned_load_kwh`) would stay at `0.0`.

### Fix
- New `_utc_key(dt)` static method: normalises any timezone-aware datetime to UTC with `microsecond=0`.
- `_apply_planner_output` builds the index and performs all lookups through `_utc_key`.
- Any unmatched `rec.start` is collected and a `WARNING` is emitted after the loop, naming the count and the first offending timestamp.

### EV diagnostic log
When `ev_planned_load_enabled=True`, a log line is emitted after `run_planner` showing `state`, `total_ev_kwh`, `connected`, `soc`, `target`, `capacity_kwh`, and `charger_kw` — so zero-EV-load issues are visible in the HA log without enabling verbose mode.

---

## Recommendation resolver — contract documented

The EV live-charging override in `resolve_current_recommendation` is intentionally applied regardless of `ev_planned_load_kwh`. The resolver is a live-hardware layer; the planner's EV label pass (in `engine.py`) handles the static planned label. An explanatory comment now makes this explicit so future developers do not add an incorrect `ev_planned_load_kwh > 0` guard.

---

## Tests added

### `tests/planner/test_slot_ownership.py` (29 tests)

| Class | Tests | What it covers |
|---|---|---|
| `TestShallowCopySafety` | 6 | `_copy_slots` produces independent objects; all mutable fields isolated |
| `TestEvPlannedLoadSurvivestCandidateGeneration` | 3 | `ev_planned_load_kwh` present on baseline, no_action, and all 6 candidates |
| `TestEvPlannedLoadSurvivesWinnerSelection` | 4 | EV load in `PlannerOutput.slots`; zero when EV disabled/disconnected; net formula invariant |
| `TestFinalRecommendationIncludesEvLoad` | 3 | `estimated_net_consumption` includes EV; field-copy contract verified |
| `TestCandidateIsolation` | 4 | Mutating candidate A does not affect candidate B |
| `TestResolverPreservesEnergyFields` | 6 | All 4 resolver branches leave every energy field intact |
| `TestNetConsumptionIncludesEvLoadEndToEnd` | 2 | Full engine: formula holds; EV slots have strictly higher net than no-EV run |

### `tests/test_ha_mock_integration.py` — `TestApplyPlannerOutputEvLoad` (13 tests)

| Test | What it proves |
|---|---|
| `test_ev_load_copied_to_all_matching_hours` | `ev_planned_load_kwh` written for every matching hour |
| `test_zero_ev_hours_stay_zero_after_apply` | Non-EV hours stay at 0 |
| `test_all_energy_fields_are_copied` | All 9 energy fields copied, not just EV load |
| `test_all_24_recs_matched_with_utc_normalisation` | UTC key lookup matches all 24 slots |
| `test_zoneinfo_rec_matches_fixed_offset_slot` | ZoneInfo rec start + fixed-offset slot start → match |
| `test_microsecond_in_rec_start_still_matches` | `microsecond=123456` rec matches `microsecond=0` slot |
| `test_warning_emitted_for_unmatched_rec_slot` | `WARNING` logged when a slot cannot be matched |
| `test_unmatched_rec_fields_stay_at_default` | Unmatched rec stays at `ev_planned_load_kwh=0` / `recommendation=None` |
| `test_ev_load_survives_15min_interval` | All 4 × 15-min sub-slots of the EV hour get the load |
| `test_non_ev_hours_zero_at_15min_interval` | Non-EV 15-min slots stay at 0 |
| `test_utc_key_strips_microseconds` | `_utc_key` equalises datetimes differing only in microseconds |
| `test_utc_key_normalises_across_timezone_types` | `_utc_key` equalises ZoneInfo vs fixed-offset instants |

### `tests/sensors/test_recommendation_resolver.py` — `TestResolverEvSmartChargingLabel` (6 tests)

| Test | What it proves |
|---|---|
| `test_ev_charging_overrides_wait_mode_no_planned_load` | Live EV charging overrides BatteriesWaitMode even when `ev_planned_load_kwh=0` |
| `test_ev_charging_overrides_wait_mode_with_planned_load` | Live EV charging overrides when `ev_planned_load_kwh > 0` |
| `test_no_live_ev_no_override_even_with_planned_load` | Without live charging, recommendation unchanged even with planned load |
| `test_ev2_live_charging_overrides_regardless_of_planned_load` | Second-EV live charging also overrides |
| `test_planned_load_without_live_charging_label_unchanged` | `ev_planned_load_kwh > 0` alone does not trigger EVSmartCharging via resolver |
| `test_grid_charge_still_not_overridden_when_ev_planned_load_present` | BatteriesChargeGrid never overridden, even with both live charging and planned load |

---

## Acceptance criteria

- [x] `_copy_slots` docstring accurately describes shallow copy and explains safety preconditions
- [x] No dead/unused frozensets in `engine.py` EV label pass
- [x] `_clear_all_charge_discharge` docstring explicitly states `ev_planned_load_kwh` is preserved
- [x] `_apply_planner_output` uses UTC-normalised keys for slot matching
- [x] `_apply_planner_output` emits a WARNING when any rec cannot be matched
- [x] `_utc_key` heals microsecond differences between rec.start and slot.start
- [x] `_utc_key` heals ZoneInfo vs fixed-offset timezone differences
- [x] `ev_planned_load_kwh` survives candidate generation on all 6 candidates
- [x] `ev_planned_load_kwh` survives winner selection in `PlannerOutput.slots`
- [x] `estimated_net_consumption` = `house + ev_load - pv` for every output slot
- [x] Candidate A mutation does not affect candidate B (all scalar fields)
- [x] `resolve_current_recommendation` never zeroes or overwrites energy fields
- [x] Resolver EV override contract documented and tested (live-hardware layer, not planner-data guard)
- [x] 1687 passed, 3 xfailed — no regressions
- [x] `tox -e lint` — All checks passed!
