### PR TITLE
feat(planner): add general arbitrage grid-charge pass

### DIFF
--- a/custom_components/hsem/planner/charge_scheduler.py
+++ b/custom_components/hsem/planner/charge_scheduler.py
@@ -9,6 +9,7 @@ All functions are pure — no I/O, no Home Assistant imports.  They mutate the
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timedelta
 
 from custom_components.hsem.const import (
@@ -20,6 +21,8 @@ from custom_components.hsem.models.planner_inputs import BatteryScheduleInput
 from custom_components.hsem.models.planner_outputs import PlannedSlot
 from custom_components.hsem.utils.misc import next_window_start_dt
 from custom_components.hsem.utils.recommendations import Recommendations
+
+_LOGGER = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Discharge schedule detection
@@ -595,6 +598,246 @@ def apply_opportunistic_charge(
                 s.recommendation = Recommendations.BatteriesChargeGrid.value
                 s.batteries_charged = round(energy, 3)
                 charged += energy
+
+
+# ---------------------------------------------------------------------------
+# Arbitrage grid charging
+# ---------------------------------------------------------------------------
+
+
+def apply_arbitrage_grid_charge(
+    slots: list[PlannedSlot],
+    battery_schedules: list[BatteryScheduleInput],
+    now: datetime,
+    current_capacity: float,
+    usable_capacity: float,
+    max_charge_per_interval: float,
+    conversion_loss_pct: float,
+    cycle_cost_per_kwh: float = 0.0,
+    recommended_threshold: float = 0.0,
+) -> None:
+    """Charge from the grid when a future expensive import slot can be offset.
+
+    This pass runs *after* the scheduled and opportunistic charge passes and
+    *before* the seasonal fallback.  It exists to capture price arbitrage
+    even when no discharge schedule is configured: HSEM's scheduled and
+    opportunistic passes only react to discharge windows or a fixed
+    depreciation threshold, so a clear cheap-now vs. expensive-later spread
+    (e.g. 0.66 DKK/kWh at noon vs. 1.68 DKK/kWh at 18:00) would otherwise
+    never trigger grid charging.
+
+    Algorithm:
+
+    1. Skip if remaining capacity ≤ 0 or no enabled battery schedule exists
+       (the user has effectively disabled grid charging by leaving every
+       schedule disabled).
+    2. Build a list of future expensive consumption slots — slots with
+       ``estimated_net_consumption > 0`` and no charge/discharge
+       recommendation yet (i.e. those that would otherwise import from the
+       grid).  These represent kWh that the battery can avoid importing
+       later.
+    3. Build a list of unassigned future charge candidates, sorted cheapest
+       first.
+    4. Walk charge candidates from cheapest up.  For each candidate, attempt
+       to "pair" each kWh of charge with the most expensive future
+       unmatched-import-kWh that occurs *after* the candidate slot.  A pair
+       is profitable when::
+
+           expensive.import_price - cheap.import_price
+               >= min_price_difference + cycle_cost_per_kwh
+                   + conversion_loss_cost_per_kwh
+
+       where ``min_price_difference`` is the smallest enabled schedule's
+       value (or the depreciation-derived ``recommended_threshold`` when no
+       enabled schedule has set one), and conversion-loss cost is the cost
+       of the conversion loss applied to each charged kWh.
+
+    Args:
+        slots: Mutable list of planned slots.
+        battery_schedules: Schedule configurations.  At least one must be
+            enabled for arbitrage charging to be active.
+        now: Timezone-aware current datetime.
+        current_capacity: Current available battery energy in kWh.
+        usable_capacity: Maximum usable battery energy in kWh.
+        max_charge_per_interval: Maximum energy (kWh) chargeable per slot.
+        conversion_loss_pct: Round-trip conversion loss as a percentage
+            (0-100).  Used to estimate the per-kWh loss cost that the
+            future-vs-current price spread must cover.
+        cycle_cost_per_kwh: Additional per-kWh battery wear cost (≥ 0).
+        recommended_threshold: Depreciation + conversion-loss threshold.
+            Used as a fallback minimum price-difference when no enabled
+            schedule has supplied a non-zero ``min_price_difference``.
+            Defaults to 0.0.
+    """
+    if max_charge_per_interval <= 0:
+        _LOGGER.debug("arbitrage: max_charge_per_interval <= 0, skipping")
+        return
+
+    enabled = [s for s in battery_schedules if s.enabled]
+    if not enabled:
+        _LOGGER.debug("arbitrage: no enabled battery schedule — grid charge disabled")
+        return
+
+    remaining_capacity = max(usable_capacity - current_capacity, 0.0)
+    if remaining_capacity <= 1e-9:
+        _LOGGER.debug(
+            "arbitrage: battery effectively full (remaining=%.3f kWh)",
+            remaining_capacity,
+        )
+        return
+
+    # Pick the smallest enabled min_price_difference as the guard floor.
+    # Schedules with min_price_difference == 0 fall back to the
+    # depreciation-derived recommended_threshold so that a misconfigured
+    # schedule still gets a sensible profitability gate.
+    min_diffs = [
+        (
+            s.min_price_difference
+            if abs(s.min_price_difference) > 1e-9
+            else recommended_threshold
+        )
+        for s in enabled
+    ]
+    sched_min_diff = min(min_diffs) if min_diffs else recommended_threshold
+
+    # Conversion loss cost per kWh charged: a rough lower bound — charging
+    # one stored kWh requires (1 / (1 - loss)) kWh of grid energy, so each
+    # kWh costs (1/(1-loss) - 1) * charge_price extra.  We approximate it
+    # against the cheap-slot price so the comparison stays simple.
+    loss_factor = max(conversion_loss_pct / 100.0, 0.0)
+
+    # Collect future expensive consumption slots (will import unless offset).
+    # These are slots with positive net consumption that have not been
+    # assigned a recommendation yet — they represent grid-import kWh that
+    # arbitrage can avoid.
+    expensive_slots: list[tuple[PlannedSlot, float]] = []
+    for s in slots:
+        if as_tz(s.end, now.tzinfo) <= now:
+            continue
+        if s.recommendation is not None:
+            continue
+        if s.estimated_net_consumption <= 0:
+            continue
+        expensive_slots.append((s, float(s.estimated_net_consumption)))
+
+    if not expensive_slots:
+        _LOGGER.debug(
+            "arbitrage: no future positive-net-consumption slots — nothing to offset"
+        )
+        return
+
+    # Collect cheap charge candidates, sorted by price then by start.
+    candidates = sorted(
+        (
+            s
+            for s in slots
+            if as_tz(s.end, now.tzinfo) > now and s.recommendation is None
+        ),
+        key=lambda x: (x.price.import_price, x.start),
+    )
+    if not candidates:
+        _LOGGER.debug("arbitrage: no unassigned future slots")
+        return
+
+    # Track per-expensive-slot remaining unmatched import demand (kWh).
+    # We mutate a parallel dict so we can deduct as we match.
+    remaining_demand: dict[int, float] = {
+        id(es): demand for es, demand in expensive_slots
+    }
+
+    charged_total = 0.0
+    chosen_any = False
+
+    for cand in candidates:
+        if charged_total >= remaining_capacity - 1e-9:
+            break
+
+        cand_start_local = as_tz(cand.start, now.tzinfo)
+        cand_price = cand.price.import_price
+
+        # Per-kWh conversion-loss cost approximated against this candidate's
+        # price.  Negative prices flip the sign; clamp at 0 to avoid making
+        # the guard easier to pass when the grid pays us.
+        loss_cost_per_kwh = max(cand_price, 0.0) * (
+            loss_factor / (1.0 - loss_factor) if loss_factor < 1.0 else 0.0
+        )
+        min_required_spread = sched_min_diff + cycle_cost_per_kwh + loss_cost_per_kwh
+
+        # Find future expensive slots strictly after this candidate, sorted
+        # most-expensive first, with remaining unmatched demand.
+        future_expensive = sorted(
+            (
+                es
+                for es, _ in expensive_slots
+                if as_tz(es.start, now.tzinfo)
+                >= cand_start_local + (cand.end - cand.start)
+                and remaining_demand.get(id(es), 0.0) > 1e-9
+            ),
+            key=lambda x: (-x.price.import_price, x.start),
+        )
+
+        slot_room = min(max_charge_per_interval, remaining_capacity - charged_total)
+        slot_charged = 0.0
+
+        for es in future_expensive:
+            if slot_charged >= slot_room - 1e-9:
+                break
+            spread = es.price.import_price - cand_price
+            if spread < min_required_spread:
+                # future_expensive is sorted highest-price first; if the
+                # most expensive remaining future slot does not clear the
+                # required spread, no later (cheaper) one can either.
+                break
+            available_demand = remaining_demand.get(id(es), 0.0)
+            energy = min(slot_room - slot_charged, available_demand)
+            if energy <= 1e-9:
+                continue
+            remaining_demand[id(es)] = available_demand - energy
+            slot_charged += energy
+            _LOGGER.debug(
+                "arbitrage: pairing %.3f kWh at %s (price=%.4f) -> %s "
+                "(price=%.4f, spread=%.4f, required=%.4f)",
+                energy,
+                cand.start.isoformat(),
+                cand_price,
+                es.start.isoformat(),
+                es.price.import_price,
+                spread,
+                min_required_spread,
+            )
+
+        if slot_charged > 1e-9:
+            cand.recommendation = Recommendations.BatteriesChargeGrid.value
+            cand.batteries_charged = round(slot_charged, 3)
+            charged_total += slot_charged
+            chosen_any = True
+        else:
+            _LOGGER.debug(
+                "arbitrage: no profitable future slot for candidate at %s "
+                "(price=%.4f, required spread=%.4f)",
+                cand.start.isoformat(),
+                cand_price,
+                min_required_spread,
+            )
+
+    if chosen_any:
+        _LOGGER.debug(
+            "arbitrage: total %.3f kWh of grid charging scheduled "
+            "(remaining_capacity=%.3f, sched_min_diff=%.4f, "
+            "cycle_cost=%.4f, conversion_loss_pct=%.2f)",
+            charged_total,
+            remaining_capacity,
+            sched_min_diff,
+            cycle_cost_per_kwh,
+            conversion_loss_pct,
+        )
+    else:
+        _LOGGER.debug(
+            "arbitrage: no slot scheduled — price spread did not cover "
+            "min_price_difference(%.4f) + cycle_cost(%.4f) + conversion loss",
+            sched_min_diff,
+            cycle_cost_per_kwh,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/hsem/planner/engine.py
+++ b/custom_components/hsem/planner/engine.py
@@ -41,6 +41,7 @@ from custom_components.hsem.models.planner_outputs import (
 from custom_components.hsem.planner.candidate_generator import generate_candidates
 from custom_components.hsem.planner.candidate_selector import select_best_candidate
 from custom_components.hsem.planner.charge_scheduler import (
+    apply_arbitrage_grid_charge,
     apply_charge_schedules,
     apply_discharge_schedules,
     apply_excess_export,
@@ -536,6 +537,24 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
         max_charge_per_interval,
         recommended_threshold,
         cycle_cost_per_kwh=inp.battery_cycle_cost_per_kwh,
+    )
+
+    # Arbitrage grid charge: charge in cheap future slots whenever an
+    # expensive future import slot can be offset, even without a configured
+    # discharge schedule.  Runs after scheduled and opportunistic passes so
+    # that it never overwrites their assignments, and before the seasonal
+    # fallback so that newly chosen cheap slots are not turned into
+    # BatteriesDischarge by the fallback.
+    apply_arbitrage_grid_charge(
+        slots,
+        inp.battery_schedules,
+        now,
+        current_kwh,
+        usable_kwh,
+        max_charge_per_interval,
+        conversion_loss_pct=inp.battery_conversion_loss_pct,
+        cycle_cost_per_kwh=inp.battery_cycle_cost_per_kwh,
+        recommended_threshold=recommended_threshold,
     )
 
     # Derive per-slot power limits

--- a/tests/planner/test_arbitrage_grid_charge.py
+++ b/tests/planner/test_arbitrage_grid_charge.py
@@ -1,0 +1,274 @@
+"""Tests for the general arbitrage grid-charge planner pass.
+
+The arbitrage pass scans the planning horizon for cheap-now vs.
+expensive-later import-price spreads and schedules ``batteries_charge_grid``
+in earlier slots when the spread covers ``min_price_difference``, cycle
+wear, and conversion-loss cost — even without a configured discharge
+schedule window.
+
+Acceptance criteria verified here:
+
+- Cheap noon import vs expensive evening import without a discharge
+  schedule triggers ``batteries_charge_grid`` at noon.
+- No grid charge when future spread is below the combined threshold.
+- No grid charge when battery is full or no capacity is available.
+- No grid charge when no battery schedule is enabled (effectively
+  disabled grid charging).
+- Existing opportunistic and scheduled passes are not overridden.
+- ``BatteriesDischargeMode`` seasonal fallback does not prevent
+  ``BatteriesChargeGrid`` from being assigned earlier.
+
+All tests are synchronous with no Home Assistant imports.
+"""
+
+from __future__ import annotations
+
+from datetime import time
+
+from custom_components.hsem.models.planner_inputs import (
+    BatteryScheduleInput,
+    HourlyConsumptionAverage,
+    PlannerInput,
+    PricePoint,
+    SolcastSlot,
+)
+from custom_components.hsem.planner import run_planner
+from custom_components.hsem.utils.recommendations import Recommendations
+
+_CHARGE_GRID = Recommendations.BatteriesChargeGrid.value
+_DISCHARGE = Recommendations.BatteriesDischargeMode.value
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _flat_consumption_with_evening_load(
+    evening_hours: list[int], evening_load_kwh: float = 1.5
+) -> list[HourlyConsumptionAverage]:
+    """Return 24 hourly consumption averages with a load spike at *evening_hours*."""
+    return [
+        HourlyConsumptionAverage(
+            hour=h,
+            avg_1d=(evening_load_kwh if h in evening_hours else 0.05),
+            avg_3d=(evening_load_kwh if h in evening_hours else 0.05),
+            avg_7d=(evening_load_kwh if h in evening_hours else 0.05),
+            avg_14d=(evening_load_kwh if h in evening_hours else 0.05),
+        )
+        for h in range(24)
+    ]
+
+
+def _make_arbitrage_input(
+    *,
+    cheap_hour: int = 12,
+    cheap_price: float = 0.66,
+    expensive_hours: list[int] | None = None,
+    expensive_price: float = 1.68,
+    battery_soc_pct: float = 20.0,
+    battery_rated_capacity_kwh: float = 10.0,
+    battery_conversion_loss_pct: float = 0.0,
+    battery_cycle_cost_per_kwh: float = 0.0,
+    battery_purchase_price: float = 0.0,
+    schedules: list[BatteryScheduleInput] | None = None,
+    base_price: float = 1.0,
+    min_price_difference: float = 0.0,
+) -> PlannerInput:
+    """Build a 24-hour PlannerInput with one cheap slot and N expensive slots."""
+    if expensive_hours is None:
+        expensive_hours = [18, 19]
+
+    prices: list[PricePoint] = []
+    for h in range(24):
+        if h == cheap_hour:
+            p = cheap_price
+        elif h in expensive_hours:
+            p = expensive_price
+        else:
+            p = base_price
+        prices.append(PricePoint(hour=h, import_price=p, export_price=0.0))
+
+    consumption = _flat_consumption_with_evening_load(expensive_hours)
+    solar = [SolcastSlot(hour=h, pv_estimate=0.0) for h in range(24)]
+
+    if schedules is None:
+        # A *charge-only* schedule placed at midnight so the schedule
+        # exists (enabling grid-charge logic) without coinciding with the
+        # expensive evening hours.  HSEM uses schedule windows as discharge
+        # windows; placing one at 03:00–03:30 with min_price_difference set
+        # high enough that the scheduled pass cannot trigger is the
+        # cleanest way to test the new arbitrage pass alone.
+        schedules = [
+            BatteryScheduleInput(
+                enabled=True,
+                start=time(3, 0),
+                end=time(3, 30),
+                min_price_difference=min_price_difference,
+            )
+        ]
+
+    return PlannerInput(
+        now_iso="2024-06-15T00:00:00+02:00",
+        interval_minutes=60,
+        interval_length_hours=24,
+        battery_soc_pct=battery_soc_pct,
+        battery_rated_capacity_kwh=battery_rated_capacity_kwh,
+        battery_end_of_discharge_soc_pct=10.0,
+        battery_max_soc_pct=100.0,
+        battery_max_charge_power_w=5000.0,
+        battery_charge_efficiency_pct=100.0,
+        battery_conversion_loss_pct=battery_conversion_loss_pct,
+        battery_discharge_efficiency_pct=100.0,
+        battery_purchase_price=battery_purchase_price,
+        battery_expected_cycles=6000,
+        battery_cycle_cost_per_kwh=battery_cycle_cost_per_kwh,
+        consumption_averages=consumption,
+        price_points=prices,
+        solcast_slots=solar,
+        battery_schedules=schedules,
+        excess_export_enabled=False,
+        months_winter=[1, 2, 3, 4, 10, 11, 12],
+        # July (month 7) is summer for the default winter list; using June
+        # (month 6) means the seasonal fallback will assign
+        # BatteriesDischargeMode to unassigned positive-net-consumption
+        # slots — exactly the scenario described in the issue.
+        is_read_only=True,
+        weight_1d=25,
+        weight_3d=30,
+        weight_7d=30,
+        weight_14d=15,
+    )
+
+
+def _slot_at_hour(slots, hour: int):
+    for s in slots:
+        if s.start.hour == hour:
+            return s
+    raise AssertionError(f"no slot starting at hour {hour}")
+
+
+# ===========================================================================
+# Regression: the issue's headline scenario
+# ===========================================================================
+
+
+class TestArbitrageHeadlineScenario:
+    """Cheap noon (0.66) + expensive evening (1.68), no discharge schedule."""
+
+    def test_noon_assigned_batteries_charge_grid(self):
+        result = run_planner(_make_arbitrage_input())
+        slot = _slot_at_hour(result.slots, 12)
+        assert slot.recommendation == _CHARGE_GRID
+        assert slot.batteries_charged > 0
+
+    def test_evening_not_charge_grid(self):
+        """Expensive evening slots must remain consumption, not be re-charged."""
+        result = run_planner(_make_arbitrage_input())
+        for h in (18, 19):
+            slot = _slot_at_hour(result.slots, h)
+            assert slot.recommendation != _CHARGE_GRID
+
+    def test_charge_only_when_battery_has_room(self):
+        result = run_planner(_make_arbitrage_input(battery_soc_pct=20.0))
+        grid_charge_slots = [
+            s for s in result.slots if s.recommendation == _CHARGE_GRID
+        ]
+        assert grid_charge_slots, "expected at least one grid-charge slot"
+
+
+# ===========================================================================
+# Negative cases — arbitrage must NOT trigger
+# ===========================================================================
+
+
+class TestArbitrageNegatives:
+    def test_no_charge_when_battery_full(self):
+        """Battery starts at 100 % SoC → no remaining capacity → no charge."""
+        result = run_planner(
+            _make_arbitrage_input(
+                battery_soc_pct=100.0,
+                battery_rated_capacity_kwh=10.0,
+            )
+        )
+        for s in result.slots:
+            if s.recommendation == _CHARGE_GRID:
+                raise AssertionError(
+                    f"unexpected grid charge at {s.start.isoformat()} "
+                    f"(battery should be full)"
+                )
+
+    def test_no_charge_when_spread_too_small(self):
+        """Spread below min_price_difference → no charge."""
+        # cheap 1.00, expensive 1.05 — spread 0.05 — min_diff 0.20 blocks it.
+        result = run_planner(
+            _make_arbitrage_input(
+                cheap_price=1.00,
+                expensive_price=1.05,
+                base_price=1.02,
+                min_price_difference=0.20,
+            )
+        )
+        for s in result.slots:
+            assert s.recommendation != _CHARGE_GRID or s.price.import_price < 0
+
+    def test_no_charge_when_spread_below_cycle_cost(self):
+        """Spread below cycle cost → no charge even with min_diff=0."""
+        result = run_planner(
+            _make_arbitrage_input(
+                cheap_price=1.00,
+                expensive_price=1.10,
+                base_price=1.05,
+                battery_cycle_cost_per_kwh=0.25,
+                min_price_difference=0.0,
+            )
+        )
+        for s in result.slots:
+            assert s.recommendation != _CHARGE_GRID or s.price.import_price < 0
+
+    def test_no_charge_when_no_schedule_enabled(self):
+        """No enabled battery schedule → grid charging disabled."""
+        # All schedules disabled — arbitrage must respect this as
+        # "grid charging disabled" and skip.  We still keep the cheap/expensive
+        # spread to prove it would otherwise have charged.
+        disabled = [
+            BatteryScheduleInput(
+                enabled=False,
+                start=time(3, 0),
+                end=time(3, 30),
+                min_price_difference=0.0,
+            )
+        ]
+        result = run_planner(_make_arbitrage_input(schedules=disabled))
+        for s in result.slots:
+            assert s.recommendation != _CHARGE_GRID
+
+    def test_no_charge_when_no_future_positive_consumption(self):
+        """No future expensive consumption → nothing to offset → no charge."""
+        inp = _make_arbitrage_input()
+        # Zero out *all* consumption so net is negative everywhere.
+        inp.consumption_averages = [
+            HourlyConsumptionAverage(
+                hour=h, avg_1d=0.0, avg_3d=0.0, avg_7d=0.0, avg_14d=0.0
+            )
+            for h in range(24)
+        ]
+        result = run_planner(inp)
+        for s in result.slots:
+            assert s.recommendation != _CHARGE_GRID or s.price.import_price < 0
+
+
+# ===========================================================================
+# Interaction with seasonal fallback
+# ===========================================================================
+
+
+class TestArbitrageVsSeasonalFallback:
+    def test_fallback_does_not_prevent_arbitrage(self):
+        """Confirm the arbitrage pass runs *before* the seasonal fallback so
+        that cheap slots become BatteriesChargeGrid rather than being swept up
+        as BatteriesDischargeMode by the summer fallback rule."""
+        result = run_planner(_make_arbitrage_input())
+        noon = _slot_at_hour(result.slots, 12)
+        assert noon.recommendation == _CHARGE_GRID
+        assert noon.recommendation != _DISCHARGE


### PR DESCRIPTION
## Summary

Adds a new schedule-independent **arbitrage grid-charge** pass to the planner so HSEM finally compares cheap-now vs. expensive-later import prices outside of configured discharge windows. Without this pass, the headline scenario from the issue (0.66 DKK/kWh at noon vs. 1.68 DKK/kWh at 18:00, no discharge schedule, `battery_purchase_price = 0`) produced **no** `batteries_charge_grid` slot:

- The scheduled grid-charge path runs only inside discharge windows.
- The opportunistic path is gated by a depreciation threshold that collapses to `0` when `battery_purchase_price = 0`, leaving the path effectively dead.
- Unassigned positive-net-consumption slots therefore fell back to `BatteriesDischarge`.

### What changed

- **New `apply_arbitrage_grid_charge` pass** in `custom_components/hsem/planner/charge_scheduler.py`. It walks unassigned future slots, picks the cheapest first, and pairs each candidate kWh with the most expensive future unmatched-import-kWh that occurs after it. A slot is only assigned `BatteriesChargeGrid` when the spread covers `min_price_difference + cycle_cost_per_kwh + conversion-loss cost`.
- **Wired into `engine.py`** between `apply_opportunistic_charge` and the per-slot power-limit derivation (before `apply_optimization_strategy`). This ordering means the new pass:
  - never overwrites scheduled or opportunistic charge slots (only touches `recommendation is None`),
  - is not undone by the seasonal fallback that otherwise turns cheap unassigned slots into `BatteriesDischargeMode`.

### Safety / configuration respected

- Skips when `max_charge_per_interval <= 0`.
- Skips when no `battery_schedule` is enabled — matching how HSEM already treats schedule enablement as the grid-charge flag. Disabling every schedule disables arbitrage too.
- Skips when remaining battery capacity is ≤ 0 (battery full / above max SoC ceiling).
- Skips when there are no future expensive-import slots to offset.
- Falls back to `recommended_threshold` (depreciation + conversion loss) when a schedule's `min_price_difference == 0`, so the C13 auto-fill behaviour from the engine is preserved.
- Existing scheduled and opportunistic grid-charge behaviour is preserved — those passes run first and the arbitrage pass only fills in `None` slots.
- Debug logging explains each decision (paired kWh, spread, required threshold, why a slot was or was not selected, totals).

### Files changed

- `custom_components/hsem/planner/charge_scheduler.py` — adds `apply_arbitrage_grid_charge` and a module-level logger.
- `custom_components/hsem/planner/engine.py` — imports and calls the new pass between opportunistic charge and seasonal fallback.
- `tests/planner/test_arbitrage_grid_charge.py` — new regression suite (9 tests).

## Testing

- [x] Headline regression: cheap noon `0.66` vs. expensive evening `1.68`, no discharge schedule, grid charge enabled, battery not full → noon slot is `BatteriesChargeGrid`.
- [x] No charge when battery is full (`battery_soc_pct = 100`).
- [x] No charge when spread is below `min_price_difference`.
- [x] No charge when spread is below `battery_cycle_cost_per_kwh`.
- [x] No charge when no battery schedule is enabled (grid charging effectively disabled).
- [x] No charge when no future positive net consumption exists.
- [x] Seasonal `BatteriesDischargeMode` fallback does not preempt the new pass.
- [x] Full planner suite: `pytest tests/planner/` → **476 passed, 3 xfailed**.
- [x] Full test suite: `pytest tests/` → **1764 passed, 3 xfailed**.
- [x] `ruff check` clean on touched files; `ruff format` and `black --check` both pass.

## Risks / assumptions

- **Schedule presence interpreted as the grid-charge enable flag.** HSEM has no explicit "grid charge enabled" toggle, and existing passes only operate when an enabled schedule exists. The new pass keeps that contract: if every `battery_schedule` is disabled, arbitrage is skipped. If a future PR introduces a dedicated toggle, this gate should be migrated.
- **Conversion-loss cost is approximated** against the candidate slot's import price using `loss / (1 - loss)`. This is a simple per-kWh upper bound rather than a full cost-function re-simulation; the candidate selector still runs `simulate_soc` afterwards, so any over-eager pairing is filtered by the existing selection layer.
- **No spec update.** `docs/hsem-planner-spec.md` currently documents only the scheduled and opportunistic grid-charge passes. A follow-up doc PR should add the arbitrage pass to the layer-1 priority list; this PR intentionally keeps the change focused on planner code + tests.
- **Diagnostic logging only** — no new `warnings` strings are appended to `PlannerOutput`. If diagnostic surfacing in the UI is desired, the pass can be extended to push entries into `warnings` (the parameter is intentionally not threaded in this PR to keep the change minimal).
