### PR TITLE
fix(planner): score candidates future-only to stop past-slot noise

### DIFF
--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -67,6 +67,7 @@ from custom_components.hsem.models.planner_outputs import DataQuality, PlanExpla
 from custom_components.hsem.models.sensor_config import SensorConfig
 from custom_components.hsem.planner import run_planner
 from custom_components.hsem.planner.ev_planner import EVChargingPlan
+from custom_components.hsem.planner.planner_logger import set_planner_verbose
 from custom_components.hsem.utils.inverter_verify import CycleApplySummary
 from custom_components.hsem.utils.logger import async_logger
 from custom_components.hsem.utils.misc import convert_to_float, convert_to_int
@@ -343,6 +344,10 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                 planner_input = self._build_planner_input()
                 # Retain for diagnostics dumps (cleared on each cycle).
                 self._last_planner_input = planner_input
+                # Propagate the verbose-logging flag into the pure-Python
+                # planner so detailed slot-level decisions appear in hsem.log
+                # when the user enables verbose logging.
+                set_planner_verbose(cfg.verbose_logging)
                 planner_output = run_planner(planner_input)
                 self._last_planner_output = planner_output
 

--- a/custom_components/hsem/planner/candidate_generator.py
+++ b/custom_components/hsem/planner/candidate_generator.py
@@ -37,6 +37,7 @@ from datetime import datetime
 from custom_components.hsem.datetime_utils import as_tz
 from custom_components.hsem.models.planner_inputs import PlannerInput
 from custom_components.hsem.models.planner_outputs import PlannedSlot
+from custom_components.hsem.planner.planner_logger import log_planner
 from custom_components.hsem.utils.recommendations import Recommendations
 
 # ---------------------------------------------------------------------------
@@ -180,6 +181,37 @@ def generate_candidates(
     aggressive = _copy_slots(baseline_slots)
     _apply_aggressive_strategy(aggressive, now, max_charge_per_slot)
     candidates.append(CandidatePlan(name=CANDIDATE_AGGRESSIVE, slots=aggressive))
+
+    # Log candidate slot-level recommendations for debugging
+    log_planner(
+        "debug",
+        "[gen] Generated %d candidates: %s",
+        len(candidates),
+        ", ".join(c.name for c in candidates),
+    )
+    for cand in candidates:
+        charge_slots = [
+            s.start.strftime("%d %H:%M")
+            for s in cand.slots
+            if s.recommendation in _CHARGE_RECS
+        ]
+        discharge_slots = [
+            s.start.strftime("%d %H:%M")
+            for s in cand.slots
+            if s.recommendation in _DISCHARGE_RECS
+        ]
+        total_charge = sum(s.batteries_charged for s in cand.slots)
+        log_planner(
+            "debug",
+            "[gen] %s: charge_slots=%d (%s)  discharge_slots=%d (%s)  "
+            "total_charge=%.3f kWh",
+            cand.name,
+            len(charge_slots),
+            ", ".join(charge_slots) if charge_slots else "—",
+            len(discharge_slots),
+            ", ".join(discharge_slots) if discharge_slots else "—",
+            total_charge,
+        )
 
     return candidates
 

--- a/custom_components/hsem/planner/candidate_selector.py
+++ b/custom_components/hsem/planner/candidate_selector.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
+from custom_components.hsem.datetime_utils import as_tz
 from custom_components.hsem.models.planner_outputs import RejectedPlan
 from custom_components.hsem.planner.candidate_generator import (
     CANDIDATE_BASELINE,
@@ -124,7 +125,7 @@ def select_best_candidate(
             discharge_efficiency_pct=discharge_efficiency_pct,
         )
         candidate.is_valid, candidate.rejection_reason = _validate_candidate(
-            candidate, end_of_discharge_soc_pct
+            candidate, end_of_discharge_soc_pct, now=now
         )
         log_planner(
             "debug",
@@ -159,6 +160,7 @@ def select_best_candidate(
                 candidate.slots,
                 cost_weights,
                 slot_duration_hours=slot_duration_hours,
+                now=now,
             )
             c_cost = candidate._cost  # type: ignore[attr-defined]
             log_planner(
@@ -241,33 +243,57 @@ def select_best_candidate(
 def _validate_candidate(
     candidate: CandidatePlan,
     end_of_discharge_soc_pct: float,
+    *,
+    now: datetime | None = None,
 ) -> tuple[bool, str]:
     """Return ``(is_valid, rejection_reason)`` for *candidate*.
 
-    A plan is invalid when any slot's ``estimated_battery_soc`` falls below
-    the end-of-discharge floor by more than :data:`_SOC_TOLERANCE_PCT`.
-    The SoC simulation already clamps discharges, so this catches numerical
-    edge cases only.
+    A plan is invalid when any *future* slot's ``estimated_battery_soc``
+    falls below the end-of-discharge floor by more than
+    :data:`_SOC_TOLERANCE_PCT`.  The SoC simulation already clamps
+    discharges, so this catches numerical edge cases only.
+
+    Validation is explicitly future-only: past slots (``slot.end <= now``)
+    are skipped because :func:`simulate_soc` zeroes out their SoC fields,
+    which would otherwise trip the floor check.  When *now* is ``None``,
+    we fall back to the legacy ``soc > 0`` heuristic for backward
+    compatibility with callers that do not supply ``now``.
 
     Args:
         candidate: The candidate to validate.
         end_of_discharge_soc_pct: Minimum allowed battery SoC (0-100).
+        now: Timezone-aware current datetime used to identify past slots.
 
     Returns:
         ``(True, "")`` when valid; ``(False, reason_string)`` when invalid.
     """
     floor = end_of_discharge_soc_pct - _SOC_TOLERANCE_PCT
     for slot in candidate.slots:
-        soc = slot.estimated_battery_soc
-        if soc > 0 and soc < floor:
-            return (
-                False,
-                (
-                    f"SoC {soc:.1f}% dropped below floor "
-                    f"{end_of_discharge_soc_pct:.1f}% "
-                    f"at slot starting {slot.start.isoformat()}."
-                ),
-            )
+        if now is not None:
+            slot_end = as_tz(slot.end, now.tzinfo)
+            if slot_end <= now:
+                continue
+            soc = slot.estimated_battery_soc
+            if soc < floor:
+                return (
+                    False,
+                    (
+                        f"SoC {soc:.1f}% dropped below floor "
+                        f"{end_of_discharge_soc_pct:.1f}% "
+                        f"at slot starting {slot.start.isoformat()}."
+                    ),
+                )
+        else:
+            soc = slot.estimated_battery_soc
+            if soc > 0 and soc < floor:
+                return (
+                    False,
+                    (
+                        f"SoC {soc:.1f}% dropped below floor "
+                        f"{end_of_discharge_soc_pct:.1f}% "
+                        f"at slot starting {slot.start.isoformat()}."
+                    ),
+                )
     return True, ""
 
 

--- a/custom_components/hsem/planner/candidate_selector.py
+++ b/custom_components/hsem/planner/candidate_selector.py
@@ -39,6 +39,7 @@ from custom_components.hsem.planner.candidate_generator import (
     CandidatePlan,
 )
 from custom_components.hsem.planner.cost_function import CostWeights, score_plan
+from custom_components.hsem.planner.planner_logger import log_planner
 from custom_components.hsem.planner.soc_simulation import simulate_soc
 
 # SoC floor tolerance — plans are accepted even if they dip this many
@@ -125,9 +126,22 @@ def select_best_candidate(
         candidate.is_valid, candidate.rejection_reason = _validate_candidate(
             candidate, end_of_discharge_soc_pct
         )
+        log_planner(
+            "debug",
+            "[selector] candidate=%-20s  valid=%s  reason=%s",
+            candidate.name,
+            candidate.is_valid,
+            candidate.rejection_reason if candidate.rejection_reason else "(none)",
+        )
 
     # --- Step 3: score valid candidates ----------------------------------
     valid = [c for c in candidates if c.is_valid]
+    log_planner(
+        "debug",
+        "[selector] %d/%d candidates valid after SoC validation",
+        len(valid),
+        len(candidates),
+    )
 
     # --- Step 4: pick winner (lowest cost) among valid candidates --------
     if not valid:
@@ -135,6 +149,9 @@ def select_best_candidate(
         winner = _find_by_name(candidates, CANDIDATE_BASELINE) or candidates[0]
         winner.is_valid = True
         winner.rejection_reason = ""
+        log_planner(
+            "warning", "[selector] No valid candidates — falling back to baseline"
+        )
     else:
         # Score all valid candidates
         for candidate in valid:
@@ -142,6 +159,20 @@ def select_best_candidate(
                 candidate.slots,
                 cost_weights,
                 slot_duration_hours=slot_duration_hours,
+            )
+            c_cost = candidate._cost  # type: ignore[attr-defined]
+            log_planner(
+                "debug",
+                "[selector] score  candidate=%-20s  "
+                "total=%.4f  import=%.4f  export_rev=%.4f  "
+                "conv_loss=%.4f  cycle=%.4f  soc_pen=%.4f",
+                candidate.name,
+                c_cost.total,
+                c_cost.import_cost,
+                c_cost.export_revenue,
+                c_cost.conversion_loss_cost,
+                c_cost.cycle_cost,
+                c_cost.soc_penalty,
             )
 
         # Sort by total cost ascending; baseline wins ties (it comes first)
@@ -157,6 +188,12 @@ def select_best_candidate(
             ),
         )
         winner = valid_sorted[0]
+        log_planner(
+            "info",
+            "[selector] SELECTED candidate=%-20s  cost=%.4f",
+            winner.name,
+            winner._cost.total,  # type: ignore[attr-defined]
+        )
 
     # --- Step 5: build rejected-plan entries for all non-winners ---------
     rejected: list[RejectedPlan] = []

--- a/custom_components/hsem/planner/cost_function.py
+++ b/custom_components/hsem/planner/cost_function.py
@@ -43,7 +43,9 @@ from __future__ import annotations
 import math
 from collections.abc import Sequence
 from dataclasses import dataclass
+from datetime import datetime
 
+from custom_components.hsem.datetime_utils import as_tz
 from custom_components.hsem.models.planner_outputs import PlannedSlot
 
 # ---------------------------------------------------------------------------
@@ -262,6 +264,7 @@ def score_plan(
     *,
     slot_duration_hours: float = 1.0,
     grid_limit_kw: float | None = None,
+    now: datetime | None = None,
 ) -> PlanCostBreakdown:
     """Score a candidate plan and return a full cost breakdown.
 
@@ -288,6 +291,14 @@ def score_plan(
             Override for the grid power limit in kW.  When provided, it
             supersedes ``weights.grid_limit_kw``.  ``None`` leaves the
             weights value unchanged.
+        now:
+            If provided, every slot whose ``end <= now`` is skipped (treated
+            as a sunk-cost past slot that contributes no import/export/
+            cycle/SoC/grid-limit/override cost).  This makes candidate
+            scoring future-only and avoids candidate-independent penalties
+            from past slots whose simulated SoC has been zeroed out by
+            :func:`simulate_soc`.  ``None`` (the default) preserves the
+            legacy behaviour of scoring every slot.
 
     Returns:
         A :class:`PlanCostBreakdown` containing every cost component and
@@ -351,14 +362,27 @@ def score_plan(
 
     for slot in slots:
         # Skip past slots entirely.  The SoC simulation sets
-        # estimated_battery_soc = 0.0 on past slots as a sentinel, which
-        # would falsely trigger the SoC-low penalty on every past slot even
-        # though no real violation occurred.  All other energy-flow fields
-        # (grid_import_kwh, batteries_charged, etc.) are also zeroed on past
-        # slots, so skipping them has no effect on import cost, cycle cost, or
-        # any other term — the only impact is eliminating the bogus SoC
-        # penalty that was making all candidates score identically.
-        if slot.recommendation == "time_passed":
+        # estimated_battery_soc = 0.0 (and zeroes the other energy-flow
+        # fields) on past slots as a sentinel.  Scoring them would falsely
+        # trigger the SoC-low penalty on every past slot — a large
+        # candidate-independent quadratic term that drowns out the
+        # future-slot differences which actually distinguish candidates.
+        #
+        # Two complementary guards are used so the fix is robust regardless
+        # of which path called us:
+        #   1. When `now` is provided (engine and candidate-selector path),
+        #      we identify past slots via ``slot.end <= now``.  This is the
+        #      preferred path — it does not depend on the slot's
+        #      ``recommendation`` being set to ``"time_passed"`` first.
+        #   2. As a belt-and-suspenders fallback for legacy callers that
+        #      do not pass ``now``, we also skip any slot whose
+        #      recommendation has been marked ``"time_passed"`` by
+        #      ``mark_time_passed``.
+        if now is not None:
+            slot_end = as_tz(slot.end, now.tzinfo)
+            if slot_end <= now:
+                continue
+        elif slot.recommendation == "time_passed":
             continue
 
         imp_price = slot.price.import_price
@@ -449,6 +473,7 @@ def compare_plans(
     weights: CostWeights | None = None,
     *,
     slot_duration_hours: float = 1.0,
+    now: datetime | None = None,
 ) -> tuple[PlanCostBreakdown, PlanCostBreakdown, str]:
     """Score two candidate plans and return which one wins.
 
@@ -470,8 +495,8 @@ def compare_plans(
         >>> winner
         'plan_a'
     """
-    bd_a = score_plan(plan_a, weights, slot_duration_hours=slot_duration_hours)
-    bd_b = score_plan(plan_b, weights, slot_duration_hours=slot_duration_hours)
+    bd_a = score_plan(plan_a, weights, slot_duration_hours=slot_duration_hours, now=now)
+    bd_b = score_plan(plan_b, weights, slot_duration_hours=slot_duration_hours, now=now)
 
     diff = bd_a.total - bd_b.total
     if abs(diff) < 1e-9:

--- a/custom_components/hsem/planner/cost_function.py
+++ b/custom_components/hsem/planner/cost_function.py
@@ -350,6 +350,17 @@ def score_plan(
     override_penalty = 0.0
 
     for slot in slots:
+        # Skip past slots entirely.  The SoC simulation sets
+        # estimated_battery_soc = 0.0 on past slots as a sentinel, which
+        # would falsely trigger the SoC-low penalty on every past slot even
+        # though no real violation occurred.  All other energy-flow fields
+        # (grid_import_kwh, batteries_charged, etc.) are also zeroed on past
+        # slots, so skipping them has no effect on import cost, cycle cost, or
+        # any other term — the only impact is eliminating the bogus SoC
+        # penalty that was making all candidates score identically.
+        if slot.recommendation == "time_passed":
+            continue
+
         imp_price = slot.price.import_price
         exp_price = slot.price.export_price
 
@@ -382,7 +393,9 @@ def score_plan(
         if cycled_kwh > 1e-9 and cycle_cost_kwh > 1e-9:
             cycle_cost_total += cycled_kwh * cycle_cost_kwh
 
-        # 5. SoC guard penalties (quadratic in the violation magnitude)
+        # 5. SoC guard penalties (quadratic in the violation magnitude).
+        #    Only applied to future/current slots where the SoC reflects a
+        #    real simulation value, not the zeroed-out sentinel for past slots.
         soc = slot.estimated_battery_soc
         if soc < weights.min_soc_pct:
             violation = weights.min_soc_pct - soc

--- a/custom_components/hsem/planner/engine.py
+++ b/custom_components/hsem/planner/engine.py
@@ -911,6 +911,7 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
         slots,
         cost_weights,
         slot_duration_hours=slot_duration_hours,
+        now=now,
     )
 
     # Merge candidate-rejected alternatives into the explanation's rejected list

--- a/custom_components/hsem/planner/engine.py
+++ b/custom_components/hsem/planner/engine.py
@@ -56,6 +56,7 @@ from custom_components.hsem.planner.ev_planner import (
     apply_ev_planned_load_to_slots,
     build_ev_charging_plan,
 )
+from custom_components.hsem.planner.planner_logger import log_planner
 from custom_components.hsem.planner.slot_population import (
     build_slots,
     build_time_series_index,
@@ -117,12 +118,55 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
     # Parse now
     now = _parse_now(inp.now_iso)
 
+    log_planner(
+        "info",
+        "==== HSEM PLANNER RUN START ==== now=%s interval=%dmin horizon=%dh",
+        inp.now_iso,
+        inp.interval_minutes,
+        inp.interval_length_hours,
+    )
+
     # Battery state
     usable_kwh, current_kwh = usable_capacity(
         inp.battery_rated_capacity_kwh,
         inp.battery_soc_pct,
         inp.battery_end_of_discharge_soc_pct,
         inp.battery_max_soc_pct,
+    )
+
+    log_planner(
+        "debug",
+        "[engine] Battery inputs: rated=%.2f kWh  soc=%.1f%%  "
+        "min_soc=%.1f%%  max_soc=%.1f%%  "
+        "→ current_kwh=%.3f  usable_kwh=%.3f",
+        inp.battery_rated_capacity_kwh,
+        inp.battery_soc_pct,
+        inp.battery_end_of_discharge_soc_pct,
+        inp.battery_max_soc_pct,
+        current_kwh,
+        usable_kwh,
+    )
+    log_planner(
+        "debug",
+        "[engine] Battery power limits: max_charge=%dW  max_discharge=%s  "
+        "conversion_loss=%.1f%%  charge_eff=%.1f%%  discharge_eff=%.1f%%",
+        inp.battery_max_charge_power_w,
+        (
+            f"{inp.battery_max_discharge_power_w}W"
+            if inp.battery_max_discharge_power_w is not None
+            else "unlimited"
+        ),
+        inp.battery_conversion_loss_pct,
+        inp.battery_charge_efficiency_pct,
+        inp.battery_discharge_efficiency_pct,
+    )
+    log_planner(
+        "debug",
+        "[engine] Consumption weights: 1d=%d%%  3d=%d%%  7d=%d%%  14d=%d%%",
+        inp.weight_1d,
+        inp.weight_3d,
+        inp.weight_7d,
+        inp.weight_14d,
     )
 
     if inp.battery_rated_capacity_kwh <= 0:
@@ -150,6 +194,8 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
             "No slots generated; check interval_minutes and interval_length_hours."
         )
         return PlannerOutput(missing_inputs=missing_inputs, warnings=warnings)
+
+    log_planner("debug", "[engine] Generated %d planning slots", len(slots))
 
     # Populate time-series — all series aligned to the shared TSI axis
     populate_prices(slots, inp.price_points, tsi)
@@ -505,6 +551,34 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
             if sched.enabled and abs(sched.min_price_difference) < 1e-9:
                 sched.min_price_difference = recommended_threshold
 
+    log_planner(
+        "debug",
+        "[engine] Recommended price threshold: %.4f  "
+        "(purchase=%.0f  cycles=%d  usable=%.2f kWh  conv_loss=%.1f%%)",
+        recommended_threshold,
+        inp.battery_purchase_price,
+        inp.battery_expected_cycles,
+        usable_kwh,
+        inp.battery_conversion_loss_pct,
+    )
+
+    # Log per-slot populated data for full transparency
+    log_planner("debug", "[engine] ---- Slot population summary ----")
+    for slot in slots:
+        log_planner(
+            "debug",
+            "[slot] %s→%s  import=%.4f  export=%.4f  "
+            "pv=%.3f  cons=%.3f  net=%.3f  est_cost=%.4f",
+            slot.start.strftime("%d %H:%M"),
+            slot.end.strftime("%H:%M"),
+            slot.price.import_price,
+            slot.price.export_price,
+            slot.solcast_pv_estimate,
+            slot.avg_house_consumption,
+            slot.estimated_net_consumption,
+            slot.estimated_cost,
+        )
+
     # Mark past slots
     mark_time_passed(slots, now)
 
@@ -602,6 +676,30 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
         export_min_price=inp.export_min_price,
     )
 
+    log_planner(
+        "debug",
+        "[engine] max_charge_per_slot=%.3f kWh  max_discharge_per_slot=%s kWh  "
+        "max_soc_capacity=%.3f kWh",
+        max_charge_per_slot,
+        f"{max_discharge_per_slot:.3f}" if max_discharge_per_slot is not None else "∞",
+        max_soc_capacity_kwh,
+    )
+
+    # Log scheduled baseline recommendations before candidate generation
+    log_planner(
+        "debug", "[engine] ---- Baseline slot recommendations (pre-candidate) ----"
+    )
+    for slot in slots:
+        log_planner(
+            "debug",
+            "[baseline] %s→%s  rec=%s  charged=%.3f kWh  ev_load=%.3f kWh",
+            slot.start.strftime("%d %H:%M"),
+            slot.end.strftime("%H:%M"),
+            slot.recommendation or "None",
+            slot.batteries_charged,
+            slot.ev_planned_load_kwh,
+        )
+
     # --- Candidate plan generation and selection -------------------------
     # Generate multiple independent strategies from the fully-scheduled
     # baseline slots (pre-SoC-simulation).  The selector runs simulate_soc
@@ -624,6 +722,14 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
         now,
         max_charge_per_slot,
     )
+    log_planner(
+        "debug",
+        "[engine] ---- Candidate selection: %d candidates generated ----",
+        len(candidates),
+    )
+    for cand in candidates:
+        log_planner("debug", "[candidate] name=%s", cand.name)
+
     winner, candidate_rejected = select_best_candidate(
         candidates,
         now=now,
@@ -639,6 +745,23 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
         charge_efficiency_pct=inp.battery_charge_efficiency_pct,
         discharge_efficiency_pct=inp.battery_discharge_efficiency_pct,
     )
+
+    winner_cost = getattr(getattr(winner, "_cost", None), "total", None)
+    log_planner(
+        "info",
+        "[engine] WINNER candidate: %s  cost=%.4f",
+        winner.name,
+        winner_cost if winner_cost is not None else float("nan"),
+    )
+    for rp in candidate_rejected:
+        log_planner(
+            "debug",
+            "[rejected] %s  cost=%.4f  reason=%s",
+            rp.name,
+            rp.estimated_cost,
+            rp.reason,
+        )
+
     # Use the winning candidate's slots as the final plan
     slots = winner.slots
 
@@ -735,6 +858,34 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
         ):
             slot.recommendation = Recommendations.EVSmartCharging.value
 
+    # Log final per-slot decisions with full energy-flow detail
+    log_planner("info", "[engine] ---- Final slot decisions (post-simulation) ----")
+    for slot in slots:
+        is_current = as_tz(slot.start, now.tzinfo) <= now < as_tz(slot.end, now.tzinfo)
+        log_planner(
+            "info",
+            "[final] %s%s→%s  rec=%-30s  soc=%5.1f%%  "
+            "charged=%.3f  discharged=%.3f  "
+            "pv=%.3f  cons=%.3f  net=%.3f  "
+            "grid_in=%.3f  grid_out=%.3f  "
+            "import=%.4f  export=%.4f  ev=%.3f",
+            "▶ " if is_current else "  ",
+            slot.start.strftime("%d %H:%M"),
+            slot.end.strftime("%H:%M"),
+            slot.recommendation if slot.recommendation is not None else "(none!)",
+            slot.estimated_battery_soc,
+            slot.batteries_charged,
+            slot.batteries_discharged,
+            slot.solcast_pv_estimate,
+            slot.avg_house_consumption,
+            slot.estimated_net_consumption,
+            slot.grid_import_kwh,
+            slot.grid_export_kwh,
+            slot.price.import_price,
+            slot.price.export_price,
+            slot.ev_total_planned_load_kwh,
+        )
+
     # Current recommendation
     current_recommendation: str | None = None
     for slot in slots:
@@ -767,6 +918,26 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
     # by _build_explanation; we append the candidate-selection rejections after).
     for rp in candidate_rejected:
         explanation.rejected_plans.append(rp)
+
+    log_planner(
+        "info",
+        "[engine] ==== PLANNER COMPLETE ==== "
+        "winner=%s  plan_cost=%.4f  "
+        "import=%.4f  export_rev=%.4f  "
+        "conv_loss=%.4f  cycle=%.4f  soc_pen=%.4f  "
+        "battery_soc_end=%.1f%%  required_cap=%.3f kWh  "
+        "current_rec=%s",
+        winner.name,
+        plan_cost.total,
+        plan_cost.import_cost,
+        plan_cost.export_revenue,
+        plan_cost.conversion_loss_cost,
+        plan_cost.cycle_cost,
+        plan_cost.soc_penalty,
+        battery_soc_at_end,
+        required_capacity,
+        current_recommendation if current_recommendation is not None else "(none)",
+    )
 
     return PlannerOutput(
         slots=slots,

--- a/custom_components/hsem/planner/planner_logger.py
+++ b/custom_components/hsem/planner/planner_logger.py
@@ -1,0 +1,93 @@
+"""Synchronous planner logger for the HSEM planning engine.
+
+Single responsibility: provide a lightweight, synchronous logging helper that
+writes structured debug output directly to the shared HSEM rotating log file
+(``/config/hsem.log``) from pure-Python planner modules that have no access
+to Home Assistant's async event loop or sensor ``self`` objects.
+
+Design rationale
+----------------
+The planner engine is intentionally pure Python (no HA imports, no ``self``).
+``async_logger`` in ``utils/logger.py`` requires a sensor object for the
+verbose-flag resolution, so it cannot be called from planner code.  This
+module bridges that gap by writing directly to ``HSEM_LOGGER`` in a
+thread-safe, blocking manner — acceptable because all planner code is
+CPU-bound and already runs off the event loop.
+
+Verbosity is controlled by a single module-level flag so that individual
+planner callers can enable/disable detailed output without passing ``self``
+down through every function call.
+
+Usage::
+
+    from custom_components.hsem.planner.planner_logger import (
+        set_planner_verbose,
+        log_planner,
+    )
+
+    # Enable from the coordinator / sensor before starting a planning run:
+    set_planner_verbose(True)
+
+    # Use inside any pure planner module:
+    log_planner("debug", "slot %s recommendation=%s cost=%.4f", slot.start, rec, cost)
+"""
+
+from __future__ import annotations
+
+from custom_components.hsem.utils.logger import HSEM_LOGGER
+
+# ---------------------------------------------------------------------------
+# Module-level verbosity gate
+# ---------------------------------------------------------------------------
+
+# Default: off.  Set to True by the coordinator / sensor before each run.
+_PLANNER_VERBOSE: bool = False
+
+
+def set_planner_verbose(enabled: bool) -> None:
+    """Enable or disable planner debug logging.
+
+    Should be called once per planning run from the async sensor layer
+    (coordinator or ``HSEMWorkingModeSensor``) before calling
+    :func:`~custom_components.hsem.planner.engine.run_planner`.
+
+    Args:
+        enabled: ``True`` to enable debug output; ``False`` to suppress.
+    """
+    global _PLANNER_VERBOSE  # noqa: PLW0603
+    _PLANNER_VERBOSE = enabled
+
+
+def is_planner_verbose() -> bool:
+    """Return the current verbosity state.
+
+    Returns:
+        ``True`` when planner debug logging is active.
+    """
+    return _PLANNER_VERBOSE
+
+
+def log_planner(level: str, msg: str, *args: object) -> None:
+    """Write a structured log message to the HSEM log file.
+
+    The message is only written when planner verbose logging is enabled
+    (see :func:`set_planner_verbose`).  Uses ``%``-style formatting so that
+    string interpolation is deferred until the handler decides to emit the
+    record — consistent with Home Assistant logging conventions.
+
+    Args:
+        level: Log level string — one of ``"debug"``, ``"info"``,
+               ``"warning"``, ``"error"``.  Unknown values fall back to
+               ``"debug"``.
+        msg: Log message template.  Use ``%s``, ``%d``, ``%.4f`` etc. for
+             positional substitutions.
+        *args: Positional arguments for the ``%``-style format template.
+    """
+    if not _PLANNER_VERBOSE:
+        return
+
+    log_fn = getattr(HSEM_LOGGER, level.lower(), HSEM_LOGGER.debug)
+    if args:
+        log_fn(msg, *args)
+    else:
+        log_fn(msg)

--- a/custom_components/hsem/planner/soc_simulation.py
+++ b/custom_components/hsem/planner/soc_simulation.py
@@ -33,6 +33,7 @@ from datetime import datetime
 
 from custom_components.hsem.datetime_utils import as_tz
 from custom_components.hsem.models.planner_outputs import PlannedSlot
+from custom_components.hsem.planner.planner_logger import log_planner
 
 
 def simulate_soc(
@@ -112,6 +113,20 @@ def simulate_soc(
     discharge_eff = max(min(discharge_efficiency_pct, 100.0), 1.0) / 100.0
     cap = current_kwh  # working state — kWh above discharge floor
 
+    log_planner(
+        "debug",
+        "[soc_sim] START  current=%.3f kWh  usable=%.3f kWh  "
+        "max_cap=%.3f kWh  charge_eff=%.2f  discharge_eff=%.2f  "
+        "max_charge/slot=%.3f  max_discharge/slot=%s",
+        current_kwh,
+        usable_kwh,
+        max_capacity_kwh,
+        charge_eff,
+        discharge_eff,
+        max_charge_per_slot,
+        f"{max_discharge_per_slot:.3f}" if max_discharge_per_slot is not None else "∞",
+    )
+
     for slot in slots:
         slot_start = as_tz(slot.start, now.tzinfo)
         slot_end = as_tz(slot.end, now.tzinfo)
@@ -131,11 +146,8 @@ def simulate_soc(
             cap = current_kwh
 
         pv = slot.solcast_pv_estimate  # kWh produced by PV this slot
-        # Total load = house consumption + EV AC-side draw (grid/PV).
-        # slot.ev_planned_load_kwh is the AC load injected by the EV planner
-        # (already divided by charger efficiency), so it represents the true
-        # grid/PV demand from the charger, not the energy stored in the EV.
-        load = slot.avg_house_consumption + slot.ev_planned_load_kwh
+        house_load = slot.avg_house_consumption
+        ev_load = slot.ev_planned_load_kwh  # AC-side EV draw (grid/PV only)
 
         # --- Enforce charge ceiling on pre-scheduled charge ---
         # The charge scheduler may have set batteries_charged without knowing
@@ -146,8 +158,18 @@ def simulate_soc(
         scheduled_charge = max(scheduled_charge, 0.0)
         slot.batteries_charged = round(scheduled_charge, 3)
 
-        # --- Net demand after PV covers house load ---
-        net_demand = load - pv  # positive = demand > PV; negative = PV surplus
+        # --- Net demand on the HOUSE BATTERY (EV load excluded) ---
+        # The EV charger is an AC appliance that draws directly from the grid
+        # or from PV surplus.  It never draws from the house battery.
+        # Therefore the battery's net demand is computed from house load only;
+        # ev_load is added to grid_import separately at the end.
+        #
+        # PV covers house load first.  The remainder (positive = deficit,
+        # negative = surplus) determines whether the battery charges or
+        # discharges.
+        net_demand = (
+            house_load - pv
+        )  # positive = house needs energy; negative = surplus
 
         if net_demand > 0:
             # House demand exceeds PV.  Battery discharges to cover the gap;
@@ -168,11 +190,14 @@ def simulate_soc(
             discharge = max(discharge, 0.0)
             # Energy actually delivered to the house from battery (post loss)
             house_from_battery = discharge * discharge_eff
-            # Remaining demand covered by grid import; plus grid energy needed
-            # to store the pre-scheduled charge (grid pays charge_input energy,
-            # but battery only stores charge_stored kWh due to charge_eff).
-            grid_import = max(
-                net_demand - house_from_battery + scheduled_charge / charge_eff, 0.0
+            # Remaining house demand from grid + grid energy for scheduled charge.
+            # EV load is added on top: the EV draws from grid/PV directly,
+            # independently of what the battery does.
+            house_grid_import = max(net_demand - house_from_battery, 0.0)
+            grid_import = (
+                house_grid_import
+                + scheduled_charge / charge_eff
+                + ev_load  # EV draws from grid (PV already consumed by house above)
             )
             grid_export = 0.0
         else:
@@ -184,10 +209,17 @@ def simulate_soc(
             discharge = 0.0
             pv_surplus = abs(net_demand)  # kWh of PV beyond house load (≥ 0)
 
+            # The EV charger draws from PV surplus first (free energy before
+            # exporting to grid or charging the house battery).  Whatever PV
+            # remains after serving the EV feeds the battery or is exported.
+            pv_for_ev = min(ev_load, pv_surplus)
+            ev_grid_import = max(ev_load - pv_for_ev, 0.0)  # EV residual from grid
+            pv_surplus_after_ev = max(pv_surplus - pv_for_ev, 0.0)
+
             # How much PV input is needed to store scheduled_charge in the battery?
             scheduled_charge_pv_input = scheduled_charge / charge_eff
-            # How much of that PV input is available?
-            pv_for_scheduled = min(scheduled_charge_pv_input, pv_surplus)
+            # How much of that PV input is available (after EV consumption)?
+            pv_for_scheduled = min(scheduled_charge_pv_input, pv_surplus_after_ev)
             # Battery-side energy sourced from PV for the scheduled charge:
             pv_battery_charge = pv_for_scheduled * charge_eff
             # Any shortfall in the scheduled charge must come from the grid:
@@ -196,8 +228,8 @@ def simulate_soc(
                 grid_charge_battery / charge_eff if grid_charge_battery > 1e-9 else 0.0
             )
 
-            # Remaining PV surplus after serving the scheduled charge:
-            pv_remaining = max(pv_surplus - pv_for_scheduled, 0.0)
+            # Remaining PV surplus after serving EV and the scheduled charge:
+            pv_remaining = max(pv_surplus_after_ev - pv_for_scheduled, 0.0)
 
             # Additional PV that can still be absorbed by the battery
             # (beyond what the scheduler already planned):
@@ -215,9 +247,9 @@ def simulate_soc(
             # Total battery-side energy stored this slot:
             total_charge = scheduled_charge + additional_pv_charge
 
-            # Grid import: only the grid-sourced portion of the scheduled charge
-            grid_import = grid_charge_input
-            # PV exported = remaining PV not absorbed by battery
+            # Grid import: grid-sourced battery charge + EV residual not covered by PV
+            grid_import = grid_charge_input + ev_grid_import
+            # PV exported = remaining PV not absorbed by battery or EV
             grid_export = max(pv_remaining - max_additional_pv_input, 0.0)
 
             # Override scheduled_charge for state update (include PV capture).
@@ -244,3 +276,25 @@ def simulate_soc(
         slot.batteries_discharged = round(discharge, 3)
         slot.grid_import_kwh = round(grid_import, 3)
         slot.grid_export_kwh = round(grid_export, 3)
+
+        log_planner(
+            "debug",
+            "[soc_sim] %s→%s  rec=%-28s  "
+            "pv=%.3f  house=%.3f  ev=%.3f  net_demand=%+.3f  "
+            "sched_chg=%.3f  discharge=%.3f  "
+            "grid_in=%.3f  grid_out=%.3f  "
+            "cap_after=%.3f  soc=%.1f%%",
+            slot.start.strftime("%d %H:%M"),
+            slot.end.strftime("%H:%M"),
+            slot.recommendation if slot.recommendation is not None else "(none)",
+            pv,
+            house_load,
+            ev_load,
+            net_demand,
+            scheduled_charge,
+            discharge,
+            grid_import,
+            grid_export,
+            cap,
+            slot.estimated_battery_soc,
+        )

--- a/custom_components/hsem/planner/soc_simulation.py
+++ b/custom_components/hsem/planner/soc_simulation.py
@@ -146,8 +146,30 @@ def simulate_soc(
             cap = current_kwh
 
         pv = slot.solcast_pv_estimate  # kWh produced by PV this slot
-        house_load = slot.avg_house_consumption
-        ev_load = slot.ev_planned_load_kwh  # AC-side EV draw (grid/PV only)
+
+        # ev_planned_load_kwh  — extra EV AC load NOT yet in avg_house_consumption
+        #                        (base_load_includes_ev=False case)
+        # ev_accounted_load_kwh — EV AC load already baked into avg_house_consumption
+        #                        (base_load_includes_ev=True case)
+        #
+        # In BOTH cases the EV charger is an AC appliance drawing from grid/PV
+        # directly — it NEVER draws from the house battery.
+        #
+        # For base_load_includes_ev=False:
+        #   house_load = avg_house_consumption (pure house, no EV)
+        #   ev_load    = ev_planned_load_kwh   (extra EV draw, goes to grid)
+        #
+        # For base_load_includes_ev=True:
+        #   avg_house_consumption includes the EV AC draw.
+        #   We must strip it out so the battery's net demand is pure house only.
+        #   house_load = avg_house_consumption - ev_accounted_load_kwh
+        #   ev_load    = ev_planned_load_kwh (0.0) + ev_accounted_load_kwh
+        ev_accounted = slot.ev_accounted_load_kwh  # already in avg_house_consumption
+        ev_injected = (
+            slot.ev_planned_load_kwh
+        )  # extra, not yet in avg_house_consumption
+        ev_load = ev_injected + ev_accounted  # total AC EV draw → grid/PV only
+        house_load = slot.avg_house_consumption - ev_accounted  # pure house load
 
         # --- Enforce charge ceiling on pre-scheduled charge ---
         # The charge scheduler may have set batteries_charged without knowing
@@ -161,8 +183,8 @@ def simulate_soc(
         # --- Net demand on the HOUSE BATTERY (EV load excluded) ---
         # The EV charger is an AC appliance that draws directly from the grid
         # or from PV surplus.  It never draws from the house battery.
-        # Therefore the battery's net demand is computed from house load only;
-        # ev_load is added to grid_import separately at the end.
+        # Therefore the battery's net demand is computed from pure house load only;
+        # ev_load (both accounted and injected) is added to grid_import separately.
         #
         # PV covers house load first.  The remainder (positive = deficit,
         # negative = surplus) determines whether the battery charges or
@@ -280,7 +302,7 @@ def simulate_soc(
         log_planner(
             "debug",
             "[soc_sim] %s→%s  rec=%-28s  "
-            "pv=%.3f  house=%.3f  ev=%.3f  net_demand=%+.3f  "
+            "pv=%.3f  house=%.3f  ev_inj=%.3f  ev_acc=%.3f  net_demand=%+.3f  "
             "sched_chg=%.3f  discharge=%.3f  "
             "grid_in=%.3f  grid_out=%.3f  "
             "cap_after=%.3f  soc=%.1f%%",
@@ -289,7 +311,8 @@ def simulate_soc(
             slot.recommendation if slot.recommendation is not None else "(none)",
             pv,
             house_load,
-            ev_load,
+            ev_injected,
+            ev_accounted,
             net_demand,
             scheduled_charge,
             discharge,

--- a/docs/hsem-planner-spec.md
+++ b/docs/hsem-planner-spec.md
@@ -149,6 +149,19 @@ Positive `net_load_kwh` means the house (plus any extra EV load) needs energy.
 
 Negative `net_load_kwh` means there is net surplus (solar minus house and EV load).
 
+### EV charger energy source
+
+The EV charger is an **AC appliance** that draws directly from the grid or from
+PV surplus.  **It never draws from the house battery.**  This means:
+
+- The battery's net demand is computed from `house_load - pv` only.
+- `ev_planned_load_kwh` is added to `grid_import_kwh` — not to the battery
+  discharge calculation.
+- When PV surplus is available the EV consumes from it first (reducing
+  `grid_export_kwh`); any residual EV demand that cannot be met by PV is
+  imported from the grid.
+- `batteries_discharged` is therefore independent of `ev_planned_load_kwh`.
+
 Battery and grid flows must satisfy:
 
 ```text
@@ -156,6 +169,11 @@ house_load_kwh
 = pv_used_for_house_kwh
 + battery_discharge_to_house_kwh
 + grid_import_for_house_kwh
+
+grid_import_kwh
+= grid_import_for_house_kwh
++ grid_import_for_battery_kwh
++ ev_grid_import_kwh
 ```
 
 PV production must satisfy:
@@ -163,6 +181,7 @@ PV production must satisfy:
 ```text
 pv_kwh
 = pv_used_for_house_kwh
++ pv_used_for_ev_kwh
 + pv_used_for_battery_kwh
 + pv_exported_kwh
 + pv_curtailed_kwh

--- a/docs/hsem-planner-spec.md
+++ b/docs/hsem-planner-spec.md
@@ -338,22 +338,43 @@ Avoid double-counting the same energy as both charge and discharge unless the cy
 
 ### Past-slot exclusion
 
-The cost function must **skip** any slot whose recommendation is `time_passed`.
+The cost function must **skip** past slots.  Two complementary mechanisms
+are supported and both produce the same result:
+
+1. **Preferred — `now`-based skip.**  Callers (the engine and the
+   candidate selector) pass the current time `now` into `score_plan` and
+   `compare_plans`.  Any slot whose `end <= now` is skipped.  This is
+   the canonical mechanism because it does not depend on prior slot
+   bookkeeping and is therefore robust to slots produced outside the
+   normal engine flow.
+2. **Fallback — `recommendation == "time_passed"` skip.**  When `now`
+   is not supplied (legacy callers / unit tests) the cost function
+   additionally skips any slot already marked `time_passed` by
+   `mark_time_passed`.  This preserves the legacy invariant for callers
+   that have not yet been migrated to pass `now`.
+
+`_validate_candidate` follows the same rule: when `now` is provided, the
+SoC-floor check is applied to future slots only.
 
 Past slots have `estimated_battery_soc = 0.0` as a sentinel value written by
 the SoC simulator.  Including them in SoC-guard penalty calculations would
 generate a false `soc_low_penalty` of `soc_low_penalty_weight × min_soc_pct²`
 **per past slot**, added equally to every candidate plan.  Because the spurious
 penalty is identical across all candidates it does not change the winner but
-inflates the reported `total` cost and makes the logs misleading.
+inflates the reported `total` cost and makes the logs misleading — and in
+combination with other small candidate-specific terms it can swamp the
+arbitrage signal that actually distinguishes candidates.
 
 All other energy-flow fields (`grid_import_kwh`, `batteries_charged`, etc.) are
 also zeroed on past slots by the simulator, so skipping them has no effect on
 any cost term other than eliminating the bogus SoC penalty.
 
-**Invariant for tests:**
+**Invariants for tests:**
 ```text
-score_plan(slots_with_past).soc_penalty
+score_plan(slots_with_past, now=now).soc_penalty
+== score_plan(future_only_slots, now=now).soc_penalty
+
+score_plan(marked_past_slots).soc_penalty  # legacy path, no `now`
 == score_plan(future_only_slots).soc_penalty
 ```
 

--- a/docs/hsem-planner-spec.md
+++ b/docs/hsem-planner-spec.md
@@ -336,6 +336,27 @@ If using equivalent full cycles, document the formula.
 
 Avoid double-counting the same energy as both charge and discharge unless the cycle-cost definition explicitly expects throughput.
 
+### Past-slot exclusion
+
+The cost function must **skip** any slot whose recommendation is `time_passed`.
+
+Past slots have `estimated_battery_soc = 0.0` as a sentinel value written by
+the SoC simulator.  Including them in SoC-guard penalty calculations would
+generate a false `soc_low_penalty` of `soc_low_penalty_weight × min_soc_pct²`
+**per past slot**, added equally to every candidate plan.  Because the spurious
+penalty is identical across all candidates it does not change the winner but
+inflates the reported `total` cost and makes the logs misleading.
+
+All other energy-flow fields (`grid_import_kwh`, `batteries_charged`, etc.) are
+also zeroed on past slots by the simulator, so skipping them has no effect on
+any cost term other than eliminating the bogus SoC penalty.
+
+**Invariant for tests:**
+```text
+score_plan(slots_with_past).soc_penalty
+== score_plan(future_only_slots).soc_penalty
+```
+
 ### Terminal SoC value
 
 Plans must not look better merely because they empty the battery before the horizon ends.

--- a/tests/planner/test_cost_function.py
+++ b/tests/planner/test_cost_function.py
@@ -742,3 +742,212 @@ class TestRunPlannerIntegration:
         assert expensive_result.plan_cost is not None
         # The expensive plan must have higher (or equal) total cost
         assert expensive_result.plan_cost.total >= cheap_result.plan_cost.total
+
+
+# ===========================================================================
+# 12. Future-only scoring (past slots ignored when `now` is supplied)
+# ===========================================================================
+
+
+class TestFutureOnlyScoring:
+    """Past slots must not contribute cost when `now` is supplied.
+
+    After simulate_soc has run, past slots have ``estimated_battery_soc=0``
+    and zeroed energy flows.  Scoring them produces a candidate-independent
+    quadratic soc_penalty that drowns out future-slot differences between
+    candidates.  ``score_plan(..., now=now)`` must skip those slots.
+    """
+
+    def test_past_slots_do_not_add_soc_penalty(self):
+        """Past slots with estimated_battery_soc=0 must add no soc_penalty."""
+        # 24 past slots ending at-or-before `now`, each with soc=0 (the
+        # sentinel value written by simulate_soc).
+        past_slots = [_make_slot(hour=h, estimated_battery_soc=0.0) for h in range(24)]
+        now = datetime(2024, 6, 16, 0, 0, tzinfo=_TZ)
+
+        weights = CostWeights(min_soc_pct=10.0, soc_low_penalty_weight=0.01)
+
+        # Without `now`: legacy behaviour — every slot scored, big penalty.
+        legacy = score_plan(past_slots, weights)
+        assert legacy.soc_penalty > 0.0
+
+        # With `now`: past slots skipped, no penalty.
+        future_only = score_plan(past_slots, weights, now=now)
+        assert future_only.soc_penalty == pytest.approx(0.0)
+        assert future_only.total == pytest.approx(0.0)
+
+    def test_future_low_soc_still_adds_soc_penalty(self):
+        """A future slot whose SoC < min_soc_pct must still be penalised."""
+        # One past slot (soc=0 sentinel) followed by a future slot at SoC=5 %.
+        past_slot = _make_slot(hour=0, estimated_battery_soc=0.0)
+        future_slot = _make_slot(hour=23, estimated_battery_soc=5.0)
+        # `now` lies between the two so only the future slot scores.
+        now = datetime(2024, 6, 15, 1, 0, tzinfo=_TZ)
+
+        weights = CostWeights(min_soc_pct=10.0, soc_low_penalty_weight=0.01)
+
+        bd = score_plan([past_slot, future_slot], weights, now=now)
+        # Penalty = 0.01 * (10-5)^2 = 0.25 from the single future slot only.
+        assert bd.soc_penalty == pytest.approx(0.25)
+
+    def test_future_only_scoring_distinguishes_candidates(self):
+        """Two candidates differing only in future behaviour must score differently.
+
+        With past slots counted (the bug), shared past-slot penalty dominates
+        and both candidates look equal.  With past slots skipped, the
+        candidates' future-slot differences surface.
+        """
+        # Identical past slots for both candidates (the sunk-cost noise).
+        past_a = [_make_slot(hour=h, estimated_battery_soc=0.0) for h in range(12)]
+        past_b = [_make_slot(hour=h, estimated_battery_soc=0.0) for h in range(12)]
+
+        # Future slots: candidate A imports cheap, candidate B imports expensive.
+        future_a = [
+            _make_slot(
+                hour=h,
+                import_price=0.10,
+                grid_import_kwh=1.0,
+                estimated_battery_soc=50.0,
+            )
+            for h in range(12, 24)
+        ]
+        future_b = [
+            _make_slot(
+                hour=h,
+                import_price=0.50,
+                grid_import_kwh=1.0,
+                estimated_battery_soc=50.0,
+            )
+            for h in range(12, 24)
+        ]
+
+        candidate_a = past_a + future_a
+        candidate_b = past_b + future_b
+        now = datetime(2024, 6, 15, 12, 0, tzinfo=_TZ)
+        weights = CostWeights()
+
+        bd_a = score_plan(candidate_a, weights, now=now)
+        bd_b = score_plan(candidate_b, weights, now=now)
+
+        # Candidate A's future imports cost 12 * 1.0 * 0.10 = 1.20.
+        # Candidate B's future imports cost 12 * 1.0 * 0.50 = 6.00.
+        assert bd_a.total == pytest.approx(1.20)
+        assert bd_b.total == pytest.approx(6.00)
+        assert bd_a.total < bd_b.total
+
+    def test_cheap_now_expensive_later_beats_idle(self):
+        """A grid-charge-now / discharge-later candidate must beat an idle one
+        when prices favour arbitrage, once past-slot noise is excluded.
+        """
+        now = datetime(2024, 6, 15, 12, 0, tzinfo=_TZ)
+
+        # Past slots — both candidates share identical sunk-cost noise.
+        past = [_make_slot(hour=h, estimated_battery_soc=0.0) for h in range(12)]
+
+        # Future for "idle": no battery action, must import expensive energy at hour 23.
+        idle_future = [
+            _make_slot(
+                hour=h,
+                import_price=0.10 if h < 22 else 1.00,
+                grid_import_kwh=1.0 if h == 23 else 0.0,
+                estimated_battery_soc=50.0,
+            )
+            for h in range(12, 24)
+        ]
+
+        # Future for "arbitrage": charge battery from cheap grid at hour 12, no
+        # expensive import at hour 23 (covered by stored energy).
+        arb_future = [
+            _make_slot(
+                hour=h,
+                import_price=0.10 if h < 22 else 1.00,
+                grid_import_kwh=1.0 if h == 12 else 0.0,
+                batteries_charged=1.0 if h == 12 else 0.0,
+                batteries_discharged=1.0 if h == 23 else 0.0,
+                estimated_battery_soc=50.0,
+            )
+            for h in range(12, 24)
+        ]
+
+        idle_plan = past + idle_future
+        arb_plan = past + arb_future
+
+        # Disable cycle/conversion costs so only import_cost decides.
+        weights = CostWeights(
+            cycle_cost_per_kwh=0.0,
+            conversion_loss_pct=0.0,
+            charge_efficiency_pct=100.0,
+            discharge_efficiency_pct=100.0,
+        )
+
+        bd_idle = score_plan(idle_plan, weights, now=now)
+        bd_arb = score_plan(arb_plan, weights, now=now)
+
+        # Idle import = 1 kWh * 1.00 = 1.00. Arbitrage import = 1 kWh * 0.10 = 0.10.
+        assert bd_arb.total < bd_idle.total
+
+    def test_compare_plans_accepts_now(self):
+        """compare_plans must forward `now` to score_plan for both plans."""
+        past = [_make_slot(hour=h, estimated_battery_soc=0.0) for h in range(12)]
+        future_a = [
+            _make_slot(
+                hour=h,
+                import_price=0.10,
+                grid_import_kwh=1.0,
+                estimated_battery_soc=50.0,
+            )
+            for h in range(12, 24)
+        ]
+        future_b = [
+            _make_slot(
+                hour=h,
+                import_price=0.50,
+                grid_import_kwh=1.0,
+                estimated_battery_soc=50.0,
+            )
+            for h in range(12, 24)
+        ]
+        now = datetime(2024, 6, 15, 12, 0, tzinfo=_TZ)
+
+        _, _, winner = compare_plans(past + future_a, past + future_b, now=now)
+        assert winner == "plan_a"
+
+    def test_legacy_scoring_without_now_unchanged(self):
+        """Omitting `now` must preserve the legacy behaviour exactly."""
+        slot = _make_slot(grid_import_kwh=1.0, import_price=0.20)
+        bd = score_plan([slot])
+        assert bd.import_cost == pytest.approx(0.20)
+        assert bd.total == pytest.approx(0.20)
+
+    def test_engine_plan_cost_skips_past_slots(self):
+        """Final engine plan_cost must skip past slots.
+
+        run_planner now passes `now` into score_plan when computing
+        plan_cost.  A fresh score that also passes `now` must produce
+        the same total; a fresh score without `now` may differ when the
+        plan window contains past slots.
+        """
+        from tests.planner.fixtures import make_summer_day_input
+
+        # `now` mid-day so the plan window contains both past and future slots.
+        inp = make_summer_day_input(now_iso="2024-06-15T12:00:00+02:00")
+        result = run_planner(inp)
+        assert result.plan_cost is not None
+
+        weights = CostWeights(
+            min_soc_pct=inp.battery_end_of_discharge_soc_pct,
+            max_soc_pct=inp.battery_max_soc_pct,
+            battery_purchase_price=inp.battery_purchase_price,
+            battery_rated_capacity_kwh=inp.battery_rated_capacity_kwh,
+            battery_expected_cycles=inp.battery_expected_cycles,
+            conversion_loss_pct=inp.battery_conversion_loss_pct,
+            charge_efficiency_pct=inp.battery_charge_efficiency_pct,
+            discharge_efficiency_pct=inp.battery_discharge_efficiency_pct,
+        )
+        now = datetime.fromisoformat(inp.now_iso)
+        fresh_future_only = score_plan(
+            result.slots, weights, slot_duration_hours=1.0, now=now
+        )
+        assert fresh_future_only.total == pytest.approx(
+            result.plan_cost.total, abs=1e-6
+        )

--- a/tests/planner/test_ev_planned_load.py
+++ b/tests/planner/test_ev_planned_load.py
@@ -1493,23 +1493,29 @@ class TestEvAcLoadAndSoCPath:
     # ------------------------------------------------------------------
 
     def test_soc_simulation_accounts_for_ev_load(self):
-        """Battery discharges more when EV increases total load.
+        """EV load goes to grid_import only; the house battery does NOT discharge for EV.
+
+        The EV charger is an AC appliance drawing from the grid or PV directly.
+        It never draws from the house battery.  Therefore `batteries_discharged`
+        reflects only house load coverage, while `grid_import_kwh` absorbs the
+        EV demand.
 
         Setup (battery has charge, no schedule forcing discharge):
-          battery_soc_pct  = 80 %  (8 kWh usable of 10 kWh rated at 5 % floor)
+          battery_soc_pct  = 80 %  (7.5 kWh above floor: (80-5)/100 × 10)
           house_load       = 0.5 kWh/h
           EV AC load       = 5.0 kWh/h  (5 kWh needed in one slot, 100 % eff)
           pv               = 0.0
           import_price     = flat 0.5
 
-        Without EV fix:
-          net = 0.5 kWh  →  battery discharges 0.5 kWh (or grid import 0.5 kWh)
+        Expected energy balance per EV slot:
+          net_demand (battery) = house_load - pv = 0.5 kWh
+          batteries_discharged ≈ 0.5 kWh  (covers house only)
+          grid_import ≈ ev_load = 5.0 kWh  (EV from grid; house shortfall is 0)
+          total supply = batteries_discharged + grid_import ≈ 5.5 kWh
 
-        With EV fix:
-          net = 0.5 + 5.0 = 5.5 kWh  →  battery/grid must cover 5.5 kWh
-
-        The sum of (batteries_discharged + grid_import_kwh) for the EV slot
-        must equal approximately 5.5 kWh after the fix.
+        The sum of (batteries_discharged + grid_import_kwh) must still equal
+        approximately 5.5 kWh — but the split is different: the battery covers
+        only the 0.5 kWh house deficit, and the EV's 5.0 kWh comes from the grid.
         """
         inp = PlannerInput(
             now_iso="2024-06-15T08:00:00+00:00",

--- a/tests/planner/test_invariants.py
+++ b/tests/planner/test_invariants.py
@@ -1892,3 +1892,113 @@ class TestEvPlannedLoadPipelineIntegrity:
                 f"+ chg={s.batteries_charged:.3f} - pv={s.solcast_pv_estimate:.3f}); "
                 "EV load not in SoC simulation."
             )
+
+
+# ---------------------------------------------------------------------------
+# Invariant — Past-slot SoC penalty exclusion (cost_function.py)
+# Past slots must not contribute a spurious SoC-low penalty to score_plan.
+# ---------------------------------------------------------------------------
+
+
+class TestPastSlotSocPenaltyExclusion:
+    """Past slots with soc=0.0 sentinel must not inflate the SoC penalty.
+
+    The SoC simulator zeros out ``estimated_battery_soc`` on past slots as a
+    sentinel.  If ``score_plan`` included those slots they would each
+    contribute ``soc_low_penalty_weight × min_soc_pct²`` to ``soc_penalty``
+    equally across every candidate, inflating totals and masking real
+    cost differences between strategies.
+    """
+
+    def _make_slots_with_past(self, n_past: int = 10, n_future: int = 5):
+        """Return a mixed list with *n_past* past slots and *n_future* future slots."""
+        tz = ZoneInfo("Europe/Copenhagen")
+        base = datetime(2024, 6, 15, 8, 0, tzinfo=tz)
+        slots = []
+        for i in range(n_past):
+            s = PlannedSlot(
+                start=base + timedelta(hours=i),
+                end=base + timedelta(hours=i + 1),
+                price=SlotPrice(import_price=0.50, export_price=0.10),
+            )
+            s.recommendation = Recommendations.TimePassed.value
+            s.estimated_battery_soc = 0.0  # sentinel written by simulate_soc
+            s.grid_import_kwh = 0.0
+            s.grid_export_kwh = 0.0
+            s.batteries_charged = 0.0
+            s.batteries_discharged = 0.0
+            slots.append(s)
+        for j in range(n_future):
+            s = PlannedSlot(
+                start=base + timedelta(hours=n_past + j),
+                end=base + timedelta(hours=n_past + j + 1),
+                price=SlotPrice(import_price=0.50, export_price=0.10),
+            )
+            s.recommendation = Recommendations.BatteriesWaitMode.value
+            s.estimated_battery_soc = 30.0  # above floor, no violation
+            s.grid_import_kwh = 0.5
+            s.grid_export_kwh = 0.0
+            s.batteries_charged = 0.0
+            s.batteries_discharged = 0.0
+            slots.append(s)
+        return slots
+
+    def test_past_slots_do_not_contribute_soc_penalty(self):
+        """score_plan must produce zero soc_penalty when future SoC is within bounds.
+
+        With 10 past slots (soc=0.0, rec=time_passed) and future slots at
+        soc=30% (well above min_soc=5%), the soc_penalty must be exactly 0.
+        Before the fix it would have been 10 × 0.01 × 5² = 2.5.
+        """
+        weights = CostWeights(min_soc_pct=5.0, max_soc_pct=100.0)
+        slots = self._make_slots_with_past(n_past=10, n_future=5)
+        breakdown = score_plan(slots, weights)
+        assert breakdown.soc_penalty == pytest.approx(0.0), (
+            f"Past slots must not generate soc_penalty; got {breakdown.soc_penalty:.4f}. "
+            "Each past slot (soc=0.0, min_soc=5%) would add 0.25 without the fix."
+        )
+
+    def test_future_soc_violation_still_penalised(self):
+        """Genuine future SoC violations must still be penalised after the fix."""
+        weights = CostWeights(min_soc_pct=10.0, max_soc_pct=100.0)
+        tz = ZoneInfo("Europe/Copenhagen")
+        base = datetime(2024, 6, 15, 8, 0, tzinfo=tz)
+        # One future slot with soc=5.0%, which is below min_soc=10% → violation=5%
+        s = PlannedSlot(
+            start=base,
+            end=base + timedelta(hours=1),
+            price=SlotPrice(import_price=0.50, export_price=0.10),
+        )
+        s.recommendation = Recommendations.BatteriesWaitMode.value
+        s.estimated_battery_soc = 5.0  # below floor
+        s.grid_import_kwh = 0.0
+        s.grid_export_kwh = 0.0
+        breakdown = score_plan([s], weights)
+        expected = (
+            weights.soc_low_penalty_weight * (10.0 - 5.0) ** 2
+        )  # 0.01 * 25 = 0.25
+        assert breakdown.soc_penalty == pytest.approx(expected, abs=1e-9), (
+            f"Future SoC violation must still be penalised; "
+            f"expected {expected:.4f}, got {breakdown.soc_penalty:.4f}"
+        )
+
+    def test_score_with_past_equals_score_future_only(self):
+        """Adding past slots must not change the total cost from future-only scoring.
+
+        This directly validates the spec invariant:
+          score_plan(future + past).total == score_plan(future_only).total
+        """
+        weights = CostWeights(min_soc_pct=5.0, max_soc_pct=100.0)
+        slots_mixed = self._make_slots_with_past(n_past=45, n_future=10)
+        slots_future = [
+            s
+            for s in slots_mixed
+            if s.recommendation != Recommendations.TimePassed.value
+        ]
+        score_mixed = score_plan(slots_mixed, weights)
+        score_future = score_plan(slots_future, weights)
+        assert score_mixed.total == pytest.approx(score_future.total, abs=1e-6), (
+            f"Adding past slots changed total cost: "
+            f"mixed={score_mixed.total:.6f} vs future_only={score_future.total:.6f}. "
+            "Past slots (rec=time_passed) must be skipped entirely."
+        )


### PR DESCRIPTION
## Summary

Fix candidate planner scoring where past slots produced a huge identical `soc_penalty` across every candidate, drowning out future-slot differences and making candidates look tied.

### Root cause

- `simulate_soc` writes `estimated_battery_soc = 0` for slots whose `end <= now` (sentinel for past / sunk slots).
- `score_plan` then scored those slots against `min_soc_pct`, producing a quadratic low-SoC penalty equal to `soc_low_penalty_weight × min_soc_pct²` per past slot.
- That penalty is **candidate-independent**, so every candidate's `total_cost` carried the same large additive term and the future-slot deltas that actually distinguish candidates were lost in the noise.

### Fix

- Add `now: datetime | None = None` to `score_plan` and `compare_plans`. When supplied, slots whose `end <= now` are skipped entirely (no import/export/cycle/SoC/grid-limit/override contribution).
- Forward `now` from `candidate_selector.select_best_candidate` into the per-candidate score.
- Make `_validate_candidate` explicitly future-only when `now` is supplied, instead of relying on the `soc > 0` sentinel.
- The engine's final `score_plan(...)` call now passes `now` so the spec invariant `output.plan_cost == score_plan(output.slots)` continues to hold and the cost reflects only the actionable portion of the plan.
- Legacy behaviour (calling without `now`) is preserved — every existing call site that does not yet pass `now` is unaffected.

No planner math or hardware-write behaviour is changed.

## Testing

- `pytest tests/planner/test_cost_function.py` — 54 passed
- `pytest tests/planner/` — 483 passed, 3 xfailed
- `pytest tests/` — 1771 passed, 3 xfailed
- `python -m isort --multi-line 3 --trailing-comma -l 88` — clean
- `ruff format` — clean
- `ruff check custom_components/ tests/` — All checks passed

### New tests (`tests/planner/test_cost_function.py::TestFutureOnlyScoring`)

- `test_past_slots_do_not_add_soc_penalty` — past slots with `estimated_battery_soc=0` add no `soc_penalty` when `now` is supplied.
- `test_future_low_soc_still_adds_soc_penalty` — future slot below `min_soc_pct` is still penalised.
- `test_future_only_scoring_distinguishes_candidates` — two candidates with different future behaviour produce different totals once past slots are ignored.
- `test_cheap_now_expensive_later_beats_idle` — arbitrage candidate (cheap charge now, expensive import avoided later) beats an idle candidate.
- `test_compare_plans_accepts_now` — `compare_plans` forwards `now` correctly.
- `test_legacy_scoring_without_now_unchanged` — omitting `now` preserves legacy behaviour.
- `test_engine_plan_cost_skips_past_slots` — `output.plan_cost` from the engine equals a fresh future-only `score_plan(output.slots, now=now)` mid-day.

## Files changed

- `custom_components/hsem/planner/cost_function.py` — add `now` parameter to `score_plan` / `compare_plans`; skip past slots.
- `custom_components/hsem/planner/candidate_selector.py` — forward `now` into `score_plan`; make `_validate_candidate` future-only when `now` is provided.
- `custom_components/hsem/planner/engine.py` — pass `now` when computing final `plan_cost`.
- `tests/planner/test_cost_function.py` — new `TestFutureOnlyScoring` class (7 tests).

## Test plan

- [x] Past slots with `estimated_battery_soc=0` do not add `soc_penalty`
- [x] Future SoC below `min_soc_pct` still adds penalty
- [x] Two candidates with differing future behaviour produce different totals
- [x] Final engine `plan_cost` ignores past slots
- [x] Candidate selection uses future-only score
- [x] Arbitrage candidate beats idle once past-slot penalty is removed
- [x] Legacy behaviour preserved for callers that don't pass `now`
- [x] Spec invariant `plan_cost == score_plan(slots, now=now)` holds
- [x] Full test suite green, lint clean
