### PR TITLE
feat(planner): split PlanCostBreakdown into total_cost/score; add terminal_soc_value; fix EV charge window to one midnight crossing

### DIFF
--- a/custom_components/hsem/planner/candidate_selector.py
+++ b/custom_components/hsem/planner/candidate_selector.py
@@ -187,6 +187,27 @@ def select_best_candidate(
                 c_cost.terminal_soc_value,
             )
 
+            # Diagnostic: surface the candidate's terminal SoC trajectory so
+            # it is obvious WHY a given candidate's terminal_soc_value has the
+            # value it does.  When two candidates have identical term_soc it
+            # means they converge to the same end-of-horizon SoC; this trail
+            # makes that visible without needing a debugger.
+            _future_tail = [s for s in candidate.slots if s.end > now][-3:]
+            if _future_tail:
+                trail = "  ".join(
+                    f"{s.start.strftime('%d %H:%M')}→{s.end.strftime('%H:%M')} "
+                    f"rec={s.recommendation or '(none)'}  "
+                    f"cap={s.estimated_battery_capacity:.3f}  "
+                    f"soc={s.estimated_battery_soc:.1f}%"
+                    for s in _future_tail
+                )
+                log_planner(
+                    "debug",
+                    "[selector] tail   candidate=%-20s  %s",
+                    candidate.name,
+                    trail,
+                )
+
         # Sort by selector score ascending; baseline wins ties (it comes first)
         valid_sorted = sorted(
             valid,

--- a/custom_components/hsem/planner/candidate_selector.py
+++ b/custom_components/hsem/planner/candidate_selector.py
@@ -63,6 +63,7 @@ def select_best_candidate(
     slot_duration_hours: float,
     charge_efficiency_pct: float = 100.0,
     discharge_efficiency_pct: float = 100.0,
+    replacement_price_per_kwh: float | None = None,
 ) -> tuple[CandidatePlan, list[RejectedPlan]]:
     """Score all candidates, validate them, and return the best one.
 
@@ -101,12 +102,18 @@ def select_best_candidate(
         discharge_efficiency_pct:
             Discharge-side efficiency (0-100 %).  Forwarded to
             :func:`~soc_simulation.simulate_soc`.  Defaults to 100 %.
+        replacement_price_per_kwh:
+            Currency-per-kWh price used by :func:`~cost_function.score_plan`
+            to evaluate the terminal-SoC opportunity cost (issue #413).
+            A conservative choice is the average future import price across
+            the horizon.  ``None`` disables the terminal-SoC term.
 
     Returns:
         A ``(winner, rejected_plans)`` tuple where *winner* is the
-        :class:`CandidatePlan` with the lowest valid total cost and
-        *rejected_plans* lists every non-selected candidate with an
-        explanation of why it was not chosen.
+        :class:`CandidatePlan` with the lowest valid selector
+        :attr:`~cost_function.PlanCostBreakdown.score` and *rejected_plans*
+        lists every non-selected candidate with an explanation of why it
+        was not chosen.
     """
     # --- Step 1 & 2: simulate and validate each candidate ---------------
     for candidate in candidates:
@@ -160,27 +167,31 @@ def select_best_candidate(
                 cost_weights,
                 slot_duration_hours=slot_duration_hours,
                 now=now,
+                initial_battery_kwh=current_kwh,
+                replacement_price_per_kwh=replacement_price_per_kwh,
             )
             c_cost = candidate._cost  # type: ignore[attr-defined]
             log_planner(
                 "debug",
                 "[selector] score  candidate=%-20s  "
-                "total=%.4f  import=%.4f  export_rev=%.4f  "
-                "conv_loss=%.4f  cycle=%.4f  soc_pen=%.4f",
+                "score=%.4f  total_cost=%.4f  import=%.4f  export_rev=%.4f  "
+                "conv_loss=%.4f  cycle=%.4f  soc_pen=%.4f  term_soc=%.4f",
                 candidate.name,
-                c_cost.total,
+                c_cost.score,
+                c_cost.total_cost,
                 c_cost.import_cost,
                 c_cost.export_revenue,
                 c_cost.conversion_loss_cost,
                 c_cost.cycle_cost,
                 c_cost.soc_penalty,
+                c_cost.terminal_soc_value,
             )
 
-        # Sort by total cost ascending; baseline wins ties (it comes first)
+        # Sort by selector score ascending; baseline wins ties (it comes first)
         valid_sorted = sorted(
             valid,
             key=lambda c: (
-                c._cost.total,  # type: ignore[attr-defined]
+                c._cost.score,  # type: ignore[attr-defined]
                 # Stable tie-break: baseline index is 0, so it wins ties
                 next(
                     (i for i, x in enumerate(candidates) if x is c),
@@ -191,9 +202,10 @@ def select_best_candidate(
         winner = valid_sorted[0]
         log_planner(
             "info",
-            "[selector] SELECTED candidate=%-20s  cost=%.4f",
+            "[selector] SELECTED candidate=%-20s  score=%.4f  total_cost=%.4f",
             winner.name,
-            winner._cost.total,  # type: ignore[attr-defined]
+            winner._cost.score,  # type: ignore[attr-defined]
+            winner._cost.total_cost,  # type: ignore[attr-defined]
         )
 
     # --- Step 5: build rejected-plan entries for all non-winners ---------
@@ -206,28 +218,33 @@ def select_best_candidate(
         if not candidate.is_valid:
             reason = candidate.rejection_reason
         else:
-            winner_cost = getattr(getattr(winner, "_cost", None), "total", float("inf"))
-            candidate_cost = getattr(
-                getattr(candidate, "_cost", None), "total", float("inf")
+            winner_score = getattr(
+                getattr(winner, "_cost", None), "score", float("inf")
             )
-            diff = round(candidate_cost - winner_cost, 4)
+            candidate_score = getattr(
+                getattr(candidate, "_cost", None), "score", float("inf")
+            )
+            diff = round(candidate_score - winner_score, 4)
             if diff > 1e-6:
                 reason = (
-                    f"Higher cost than selected plan "
-                    f"({candidate_cost:.4f} vs {winner_cost:.4f}; "
+                    f"Higher selector score than selected plan "
+                    f"({candidate_score:.4f} vs {winner_score:.4f}; "
                     f"Δ = +{diff:.4f})."
                 )
             else:
                 reason = (
-                    f"Tied or marginally worse cost "
-                    f"({candidate_cost:.4f}); baseline preferred."
+                    f"Tied or marginally worse score "
+                    f"({candidate_score:.4f}); baseline preferred."
                 )
 
         rejected.append(
             RejectedPlan(
                 name=candidate.name,
                 reason=reason,
-                estimated_cost=getattr(getattr(candidate, "_cost", None), "total", 0.0),
+                # estimated_cost surfaces the selector score so dashboards
+                # and tests sort rejected plans the same way the selector
+                # ranked them.
+                estimated_cost=getattr(getattr(candidate, "_cost", None), "score", 0.0),
             )
         )
 

--- a/custom_components/hsem/planner/cost_function.py
+++ b/custom_components/hsem/planner/cost_function.py
@@ -1,13 +1,23 @@
-"""Plan cost function for the HSEM planner (issue #295).
+"""Plan cost function for the HSEM planner (issues #295, #413).
 
 This module scores a candidate plan (a fully-populated list of
 :class:`~custom_components.hsem.models.planner_outputs.PlannedSlot` objects)
-as a single numeric value.  **Lower cost is better**, so the planner can
-choose between alternatives by picking the plan with the minimum score.
+and exposes two distinct aggregate numbers:
+
+- :attr:`PlanCostBreakdown.total_cost` — the **real-money outcome** of the
+  plan within the horizon.  Sum of grid import cost minus export revenue
+  plus battery cycle (depreciation) cost plus round-trip conversion loss
+  cost.  Auditable; directly comparable to an electricity bill.
+- :attr:`PlanCostBreakdown.score` — the **selector objective**.  Equals
+  ``total_cost`` plus every synthetic penalty (SoC guard, grid limit,
+  override) plus the terminal-SoC opportunity cost.  The candidate selector
+  picks the plan with the **lowest score**, not the lowest money cost.
 
 Cost components
 ---------------
-The cost function aggregates seven independently-tunable penalty terms:
+The cost function aggregates eight independently-tunable terms:
+
+Money terms (sum to ``total_cost``):
 
 1. **Import cost** — energy imported from the grid × import price.
 2. **Export revenue** — energy exported to the grid × export price
@@ -17,6 +27,9 @@ The cost function aggregates seven independently-tunable penalty terms:
    proxy for its opportunity cost.
 4. **Battery cycle cost** — depreciation per kWh cycled, derived from the
    battery's purchase price, rated capacity, and expected lifetime cycles.
+
+Selector-only terms (added on top of ``total_cost`` to produce ``score``):
+
 5. **SoC penalties** — quadratic penalty when the end-of-slot SoC is too low
    (below the configured ``min_soc_pct`` guard) or too high (above the
    configured ``max_soc_pct`` guard), multiplied by a configurable weight.
@@ -25,6 +38,12 @@ The cost function aggregates seven independently-tunable penalty terms:
 7. **Override penalty** — per-slot cost added for any slot whose recommendation
    was forced by an override (e.g. read-only mode, manual schedule).  Penalises
    plans that deviate from the hardware's natural optimal state.
+8. **Terminal SoC value** — opportunity cost of the change in battery energy
+   over the horizon, priced at ``replacement_price_per_kwh``.  A plan that
+   ends the horizon with *more* stored energy than it started with receives a
+   *credit* (negative term that reduces ``score``); a plan that empties the
+   battery pays a *penalty* (positive term that increases ``score``).
+   Computed as ``(initial_kwh − final_kwh) × replacement_price_per_kwh``.
 
 All monetary values are in the caller's local currency (e.g. DKK or EUR).
 
@@ -36,6 +55,15 @@ Design constraints
 - **Float-safe** — NaN prices are treated as 0.0 rather than propagating.
 - **Immutable input** — slots are *never* mutated; the function is a pure
   read-only scan.
+- **Money / selector split** — ``total_cost`` never includes synthetic
+  penalties; ``score`` always does.  The selector minimises ``score``.
+
+Backward compatibility
+----------------------
+:attr:`PlanCostBreakdown.total` is preserved as a deprecated alias for
+``score`` so existing code and tests that compared plans by ``.total``
+keep selecting the same winner.  New code should use ``total_cost`` (money)
+or ``score`` (selector) explicitly.
 """
 
 from __future__ import annotations
@@ -150,7 +178,14 @@ class CostWeights:
 class PlanCostBreakdown:
     """Per-term breakdown of the cost computed by :func:`score_plan`.
 
-    Useful for debugging, logging, and surfacing in the plan explanation.
+    Two aggregate numbers are exposed:
+
+    - :attr:`total_cost` — sum of money terms only.  Auditable; comparable
+      to a real electricity bill.  Computed as
+      ``import_cost − export_revenue + cycle_cost + conversion_loss_cost``.
+    - :attr:`score` — selector objective.  Equals ``total_cost`` plus all
+      synthetic penalties and the terminal-SoC opportunity cost.  The
+      candidate selector minimises this value.
 
     Attributes:
         import_cost:
@@ -158,21 +193,40 @@ class PlanCostBreakdown:
         export_revenue:
             Total revenue from grid exports across all slots (≥ 0).
             This is a *positive* value representing earned money; it is
-            *subtracted* from the total cost in :attr:`total`.
+            *subtracted* from :attr:`total_cost`.
         conversion_loss_cost:
             Opportunity cost of energy lost in round-trip battery cycles.
         cycle_cost:
             Battery depreciation cost (kWh cycled × cost per kWh).
         soc_penalty:
             Quadratic SoC guard penalty (too-low + too-high violations).
+            Selector-only — does not enter :attr:`total_cost`.
         grid_limit_penalty:
             Penalty for exceeding the configured grid power limit.
+            Selector-only — does not enter :attr:`total_cost`.
         override_penalty:
-            Penalty for forced-override slots.
+            Penalty for forced-override slots.  Selector-only.
+        terminal_soc_value:
+            Opportunity cost of the change in stored battery energy across
+            the horizon, priced at ``replacement_price_per_kwh``.  Negative
+            (credit) when the plan ends with *more* stored energy than it
+            started with; positive (penalty) when the plan empties the
+            battery.  Selector-only — does not enter :attr:`total_cost`.
+        total_cost:
+            Money outcome of the plan in the horizon.  Equal to
+            ``import_cost − export_revenue + cycle_cost + conversion_loss_cost``.
+            Auditable; does **not** include any synthetic penalties.
+        score:
+            Selector objective.  Equal to
+            ``total_cost + soc_penalty + grid_limit_penalty
+            + override_penalty + terminal_soc_value``.
+            **Lower is better.**  The candidate selector picks the plan
+            with the lowest score.
         total:
-            Sum of all terms: ``import_cost − export_revenue
-            + conversion_loss_cost + cycle_cost + soc_penalty
-            + grid_limit_penalty + override_penalty``.
+            Deprecated alias for :attr:`score`, preserved so older code
+            and tests that compared plans by ``.total`` keep selecting the
+            same winner.  New code should use :attr:`total_cost` or
+            :attr:`score` explicitly.
     """
 
     import_cost: float = 0.0
@@ -182,6 +236,10 @@ class PlanCostBreakdown:
     soc_penalty: float = 0.0
     grid_limit_penalty: float = 0.0
     override_penalty: float = 0.0
+    terminal_soc_value: float = 0.0
+    total_cost: float = 0.0
+    score: float = 0.0
+    # Deprecated alias for ``score``; kept for backward compatibility.
     total: float = 0.0
 
 
@@ -254,6 +312,46 @@ def _resolve_cycle_cost(weights: CostWeights) -> float:
 
 
 # ---------------------------------------------------------------------------
+# Terminal-SoC helper
+# ---------------------------------------------------------------------------
+
+
+def _final_battery_kwh(
+    slots: Sequence[PlannedSlot],
+    now: datetime | None,
+) -> float:
+    """Return the estimated stored battery energy (kWh) at end of horizon.
+
+    Scans *slots* in reverse and returns the ``estimated_battery_capacity``
+    value of the last slot that is still in the future.
+
+    The SoC simulator writes ``estimated_battery_capacity`` as the remaining
+    usable energy above the discharge floor at the *end* of each slot.  Past
+    slots have this field zeroed as a sentinel, so we must explicitly skip
+    them when picking the horizon's terminal SoC.
+
+    Args:
+        slots: Ordered list of planned slots.
+        now: Timezone-aware current datetime.  When provided, slots with
+            ``slot.end <= now`` are skipped.  When ``None``, slots whose
+            recommendation equals the ``TimePassed`` sentinel are skipped.
+
+    Returns:
+        Remaining battery energy above the discharge floor (kWh) at the end
+        of the last future slot, or ``0.0`` when no future slot exists.
+    """
+    _time_passed_value = Recommendations.TimePassed.value
+    for slot in reversed(slots):
+        if now is not None:
+            if slot.end <= now:
+                continue
+        elif slot.recommendation == _time_passed_value:
+            continue
+        return slot.estimated_battery_capacity
+    return 0.0
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -265,6 +363,8 @@ def score_plan(
     slot_duration_hours: float = 1.0,
     grid_limit_kw: float | None = None,
     now: datetime | None = None,
+    initial_battery_kwh: float | None = None,
+    replacement_price_per_kwh: float | None = None,
 ) -> PlanCostBreakdown:
     """Score a candidate plan and return a full cost breakdown.
 
@@ -283,6 +383,21 @@ def score_plan(
     way, including past slots in the SoC-guard penalty would generate a
     false ``soc_low_penalty`` because the simulator zeros
     ``estimated_battery_soc`` on past slots as a sentinel value.
+
+    Two aggregate numbers are returned (issue #413):
+
+    - ``total_cost`` — money outcome only.  Equals
+      ``import_cost − export_revenue + cycle_cost + conversion_loss_cost``.
+    - ``score`` — selector objective.  Equals ``total_cost`` plus all
+      synthetic penalties (SoC guard, grid limit, override) and the
+      terminal-SoC opportunity cost.  The candidate selector minimises
+      this value.
+
+    Terminal-SoC accounting (the spec-mandated
+    ``terminal_soc_penalty_or_credit`` term) is enabled when both
+    ``initial_battery_kwh`` and ``replacement_price_per_kwh`` are provided.
+    It prevents the selector from preferring plans that look "cheap" only
+    because they empty the battery before the end of the horizon.
 
     Args:
         slots:
@@ -305,10 +420,23 @@ def score_plan(
             ``end`` is at or before *now* is skipped.  When ``None`` the
             fallback sentinel check (``recommendation == TimePassed``) is
             used instead.
+        initial_battery_kwh:
+            Energy stored above the discharge floor (kWh) at the start of
+            the horizon.  Required (together with
+            ``replacement_price_per_kwh``) to enable terminal-SoC accounting.
+            ``None`` disables the term.
+        replacement_price_per_kwh:
+            Currency-per-kWh price used to value the change in stored
+            battery energy across the horizon.  A conservative choice is the
+            *average future import price* across the planning horizon.
+            Required (together with ``initial_battery_kwh``) to enable
+            terminal-SoC accounting.  ``None`` disables the term.
 
     Returns:
-        A :class:`PlanCostBreakdown` containing every cost component and
-        the total score.  **Lower total = better plan.**
+        A :class:`PlanCostBreakdown` containing every cost component, the
+        money ``total_cost``, and the selector ``score``.
+        **Lower ``score`` = better plan** (this is what the selector
+        minimises).
 
     Examples:
         >>> from datetime import datetime
@@ -329,7 +457,11 @@ def score_plan(
         >>> bd = score_plan([slot])
         >>> bd.import_cost
         0.2
-        >>> bd.total
+        >>> bd.total_cost
+        0.2
+        >>> bd.score
+        0.2
+        >>> bd.total  # deprecated alias for score
         0.2
     """
     if weights is None:
@@ -444,15 +576,41 @@ def score_plan(
         if _is_override_slot(slot) and abs(weights.override_penalty_per_slot) > 1e-9:
             override_penalty += weights.override_penalty_per_slot
 
-    total = (
-        import_cost
-        - export_revenue
-        + conversion_loss_cost
-        + cycle_cost_total
+    # 8. Terminal-SoC opportunity cost (selector-only).
+    #
+    # Plans that end the horizon with more stored battery energy than they
+    # started with receive a credit (terminal_soc_value < 0, reducing score).
+    # Plans that empty the battery pay a penalty (terminal_soc_value > 0,
+    # increasing score).  This implements the spec-mandated
+    # ``terminal_soc_penalty_or_credit`` term and prevents the selector from
+    # preferring plans that look cheap only because they drained the battery.
+    #
+    # The term is computed only when both inputs are provided so unit tests
+    # that call score_plan without horizon context keep behaving as before.
+    terminal_soc_value = 0.0
+    if (
+        initial_battery_kwh is not None
+        and replacement_price_per_kwh is not None
+        and abs(replacement_price_per_kwh) > 1e-9
+    ):
+        final_battery_kwh = _final_battery_kwh(slots, now)
+        delta_kwh = initial_battery_kwh - final_battery_kwh
+        terminal_soc_value = delta_kwh * replacement_price_per_kwh
+
+    # ``total_cost`` is money only — never includes synthetic penalties.
+    total_cost = import_cost - export_revenue + conversion_loss_cost + cycle_cost_total
+
+    # ``score`` is the selector objective.  It adds every synthetic penalty
+    # and the terminal-SoC opportunity cost on top of ``total_cost``.
+    score = (
+        total_cost
         + soc_penalty
         + grid_limit_penalty
         + override_penalty
+        + terminal_soc_value
     )
+
+    score_rounded = round(score, 6)
 
     return PlanCostBreakdown(
         import_cost=round(import_cost, 6),
@@ -462,7 +620,11 @@ def score_plan(
         soc_penalty=round(soc_penalty, 6),
         grid_limit_penalty=round(grid_limit_penalty, 6),
         override_penalty=round(override_penalty, 6),
-        total=round(total, 6),
+        terminal_soc_value=round(terminal_soc_value, 6),
+        total_cost=round(total_cost, 6),
+        score=score_rounded,
+        # ``total`` is a deprecated alias for ``score`` (issue #413).
+        total=score_rounded,
     )
 
 
@@ -472,31 +634,56 @@ def compare_plans(
     weights: CostWeights | None = None,
     *,
     slot_duration_hours: float = 1.0,
+    now: datetime | None = None,
+    initial_battery_kwh: float | None = None,
+    replacement_price_per_kwh: float | None = None,
 ) -> tuple[PlanCostBreakdown, PlanCostBreakdown, str]:
     """Score two candidate plans and return which one wins.
+
+    The winner is the plan with the lower :attr:`PlanCostBreakdown.score`
+    (selector objective).  When the scores tie within ``1e-9``, the winner
+    is ``"tie"``.
 
     Args:
         plan_a: First candidate plan (list of slots).
         plan_b: Second candidate plan (list of slots).
         weights: Shared cost weights applied to both plans.
         slot_duration_hours: Duration of each slot in hours.
+        now: Forwarded to :func:`score_plan`.
+        initial_battery_kwh: Forwarded to :func:`score_plan` to enable
+            terminal-SoC accounting.
+        replacement_price_per_kwh: Forwarded to :func:`score_plan` to enable
+            terminal-SoC accounting.
 
     Returns:
         A three-tuple ``(breakdown_a, breakdown_b, winner)`` where
-        ``winner`` is either ``"plan_a"`` or ``"plan_b"`` (the plan
-        with the lower total cost).  When both plans have identical scores
-        within floating-point tolerance (``< 1e-9``), ``winner`` is
-        ``"tie"``.
+        ``winner`` is either ``"plan_a"`` or ``"plan_b"`` (the plan with
+        the lower selector score).  ``"tie"`` when both plans are
+        equivalent within floating-point tolerance.
 
     Examples:
         >>> bd_a, bd_b, winner = compare_plans(cheap_slots, expensive_slots)
         >>> winner
         'plan_a'
     """
-    bd_a = score_plan(plan_a, weights, slot_duration_hours=slot_duration_hours)
-    bd_b = score_plan(plan_b, weights, slot_duration_hours=slot_duration_hours)
+    bd_a = score_plan(
+        plan_a,
+        weights,
+        slot_duration_hours=slot_duration_hours,
+        now=now,
+        initial_battery_kwh=initial_battery_kwh,
+        replacement_price_per_kwh=replacement_price_per_kwh,
+    )
+    bd_b = score_plan(
+        plan_b,
+        weights,
+        slot_duration_hours=slot_duration_hours,
+        now=now,
+        initial_battery_kwh=initial_battery_kwh,
+        replacement_price_per_kwh=replacement_price_per_kwh,
+    )
 
-    diff = bd_a.total - bd_b.total
+    diff = bd_a.score - bd_b.score
     if abs(diff) < 1e-9:
         winner = "tie"
     elif diff < 0:

--- a/custom_components/hsem/planner/engine.py
+++ b/custom_components/hsem/planner/engine.py
@@ -25,6 +25,7 @@ Design notes
 
 from __future__ import annotations
 
+import math
 from datetime import datetime
 
 from custom_components.hsem.datetime_utils import as_tz
@@ -716,6 +717,33 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
     )
     slot_duration_hours = inp.interval_minutes / 60.0
 
+    # Replacement price for the terminal-SoC opportunity cost term (issue #413).
+    # We use the *average future import price* across the horizon as a
+    # conservative, deterministic proxy: stored battery energy at end-of-
+    # horizon is valued at what it would cost on average to buy that energy
+    # back from the grid.  Past slots (recommendation == TimePassed) are
+    # excluded so the value reflects the actual decision window.
+    _future_import_prices = [
+        s.price.import_price
+        for s in slots
+        if as_tz(s.end, now.tzinfo) > now and not math.isnan(s.price.import_price)
+    ]
+    replacement_price_per_kwh: float | None = (
+        sum(_future_import_prices) / len(_future_import_prices)
+        if _future_import_prices
+        else None
+    )
+    log_planner(
+        "debug",
+        "[engine] terminal-SoC replacement price: %s  (avg of %d future slots)",
+        (
+            f"{replacement_price_per_kwh:.4f}"
+            if replacement_price_per_kwh is not None
+            else "(none — no future slots)"
+        ),
+        len(_future_import_prices),
+    )
+
     candidates = generate_candidates(
         slots,
         inp,
@@ -744,19 +772,22 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
         slot_duration_hours=slot_duration_hours,
         charge_efficiency_pct=inp.battery_charge_efficiency_pct,
         discharge_efficiency_pct=inp.battery_discharge_efficiency_pct,
+        replacement_price_per_kwh=replacement_price_per_kwh,
     )
 
-    winner_cost = getattr(getattr(winner, "_cost", None), "total", None)
+    winner_score = getattr(getattr(winner, "_cost", None), "score", None)
+    winner_total_cost = getattr(getattr(winner, "_cost", None), "total_cost", None)
     log_planner(
         "info",
-        "[engine] WINNER candidate: %s  cost=%.4f",
+        "[engine] WINNER candidate: %s  score=%.4f  total_cost=%.4f",
         winner.name,
-        winner_cost if winner_cost is not None else float("nan"),
+        winner_score if winner_score is not None else float("nan"),
+        winner_total_cost if winner_total_cost is not None else float("nan"),
     )
     for rp in candidate_rejected:
         log_planner(
             "debug",
-            "[rejected] %s  cost=%.4f  reason=%s",
+            "[rejected] %s  score=%.4f  reason=%s",
             rp.name,
             rp.estimated_cost,
             rp.reason,
@@ -907,11 +938,17 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
     # The spec invariant requires: output.plan_cost == score_plan(output.slots).
     # Because we re-ran simulate_soc above, the slot fields are now fully
     # consistent with the final recommendations and this score is authoritative.
+    # The terminal-SoC opportunity cost (issue #413) uses the same
+    # ``current_kwh`` initial value and average-future-import replacement
+    # price that the selector used, so the final score is identical to the
+    # winning candidate's score for the same slots.
     plan_cost = score_plan(
         slots,
         cost_weights,
         slot_duration_hours=slot_duration_hours,
         now=now,
+        initial_battery_kwh=current_kwh,
+        replacement_price_per_kwh=replacement_price_per_kwh,
     )
 
     # Merge candidate-rejected alternatives into the explanation's rejected list
@@ -923,18 +960,20 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
     log_planner(
         "info",
         "[engine] ==== PLANNER COMPLETE ==== "
-        "winner=%s  plan_cost=%.4f  "
+        "winner=%s  score=%.4f  total_cost=%.4f  "
         "import=%.4f  export_rev=%.4f  "
-        "conv_loss=%.4f  cycle=%.4f  soc_pen=%.4f  "
+        "conv_loss=%.4f  cycle=%.4f  soc_pen=%.4f  term_soc=%.4f  "
         "battery_soc_end=%.1f%%  required_cap=%.3f kWh  "
         "current_rec=%s",
         winner.name,
-        plan_cost.total,
+        plan_cost.score,
+        plan_cost.total_cost,
         plan_cost.import_cost,
         plan_cost.export_revenue,
         plan_cost.conversion_loss_cost,
         plan_cost.cycle_cost,
         plan_cost.soc_penalty,
+        plan_cost.terminal_soc_value,
         battery_soc_at_end,
         required_capacity,
         current_recommendation if current_recommendation is not None else "(none)",

--- a/custom_components/hsem/planner/ev_planner.py
+++ b/custom_components/hsem/planner/ev_planner.py
@@ -21,7 +21,7 @@ from synchronous test code.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 # ---------------------------------------------------------------------------
@@ -231,6 +231,74 @@ def remaining_minutes_in_slot(now: datetime, slot_end: datetime) -> float:
     return max((slot_end - now).total_seconds() / 60.0, 0.0)
 
 
+def _max_planning_horizon_end(now: datetime) -> datetime:
+    """Return the latest instant the EV planner is allowed to schedule into.
+
+    The EV charging window is **always** rooted at ``now`` and may span at
+    most **one midnight crossing**, i.e. it may extend into tomorrow but
+    must not reach into the day after tomorrow.  Concretely, the returned
+    value is the local-midnight that starts the day after tomorrow — the
+    first instant the planner must NOT touch.
+
+    Examples (with ``now`` in Europe/Copenhagen):
+
+    - ``now = 2024-06-15 14:00`` → returns ``2024-06-17 00:00``.
+      Window allows today afternoon + all of tomorrow.  One midnight crossed
+      (the today→tomorrow boundary at 2024-06-16 00:00).
+    - ``now = 2024-06-15 23:55`` → returns ``2024-06-17 00:00``.
+      Window of ~24 h 5 min, still one midnight crossing.
+    - ``now = 2024-06-15 00:00`` → returns ``2024-06-17 00:00``.
+      Exactly 48 h window, one midnight crossing.
+
+    The returned instant uses ``now``'s timezone so "midnight" refers to the
+    user's local time, not UTC.  Across DST transitions ``replace(hour=0)``
+    pins the local clock value as a user would expect.
+
+    Args:
+        now: Timezone-aware current datetime.
+
+    Returns:
+        Timezone-aware datetime for the start of the day after tomorrow in
+        ``now``'s timezone.  Slots starting at or after this instant must be
+        excluded from the EV charging plan.
+    """
+    return (now + timedelta(days=2)).replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def _effective_deadline(
+    now: datetime,
+    user_deadline: datetime | None,
+) -> datetime:
+    """Return the deadline the EV planner will actually use.
+
+    The effective deadline is the **earlier** of:
+
+    - The user-configured ``user_deadline`` (if any), and
+    - The "one-midnight-crossing" horizon cap from
+      :func:`_max_planning_horizon_end`.
+
+    When the user has not set a deadline, the horizon cap is used directly.
+
+    This guarantees the EV charging window is at most ``[now, end-of-tomorrow]``
+    even when the planner's overall slot horizon extends to 48 h or 72 h.
+    Without this clamp the EV scheduler would spread charging across multiple
+    days, which is not what users expect from a "must be done by 17:00 tomorrow"
+    deadline.
+
+    Args:
+        now: Timezone-aware current datetime.
+        user_deadline: User-configured charging deadline, or ``None``.
+
+    Returns:
+        Timezone-aware datetime.  EV slots starting at or after this instant
+        must not be selected.
+    """
+    horizon_cap = _max_planning_horizon_end(now)
+    if user_deadline is None:
+        return horizon_cap
+    return min(user_deadline, horizon_cap)
+
+
 def build_ev_charging_plan(
     inp: EVPlannerInput,
     slots_start: list[datetime],
@@ -310,24 +378,37 @@ def build_ev_charging_plan(
         plan.state = "fully_charged"
         return plan
 
-    # --- Candidate slot filtering (before deadline) ---
-    # Find the current slot index (first slot that contains now or is in future)
+    # --- Candidate slot filtering (before effective deadline) ---
+    #
+    # The "effective deadline" is the earlier of the user-configured
+    # deadline and the one-midnight-crossing horizon cap (end of tomorrow
+    # in ``now``'s timezone).  This guarantees the EV charging window stays
+    # rooted at ``now`` and never reaches into the day after tomorrow, even
+    # when the planner's overall slot horizon extends to 48 h or 72 h.
+    # See ``_effective_deadline`` for details.
     now_tz = inp.now
-    deadline = inp.deadline
+    effective_deadline = _effective_deadline(now_tz, inp.deadline)
+    # We surface a diagnostic in ``plan.data_quality`` only when the cap
+    # actually changed the deadline — otherwise the field is noise.
+    deadline_clamped = inp.deadline is not None and effective_deadline < inp.deadline
 
     candidate_indices: list[int] = []
     for i, (s_start, s_end) in enumerate(zip(slots_start, slots_end)):
         # Skip past slots
         if s_end <= now_tz:
             continue
-        # Skip slots beyond deadline
-        if deadline is not None and s_start >= deadline:
+        # Skip slots starting at or beyond the effective deadline.
+        # ``effective_deadline`` is always non-None by construction.
+        if s_start >= effective_deadline:
             break
         candidate_indices.append(i)
 
     if not candidate_indices:
         plan.state = "waiting"
         plan.data_quality = {"warning": "No candidate slots before deadline"}
+        if deadline_clamped:
+            plan.data_quality["effective_deadline"] = effective_deadline.isoformat()
+            plan.data_quality["deadline_clamped"] = True
         return plan
 
     # --- Two-pass slot selection ---
@@ -362,11 +443,15 @@ def build_ev_charging_plan(
         else:
             avail_min = slot_duration_minutes(s_start, s_end)
 
-        # Clamp to deadline
-        if deadline is not None and s_end > deadline:
+        # Clamp to the effective deadline (one-midnight-crossing horizon
+        # cap, possibly tightened further by the user-configured deadline).
+        if s_end > effective_deadline:
             avail_min = min(
                 avail_min,
-                max((deadline - max(s_start, now_tz)).total_seconds() / 60.0, 0.0),
+                max(
+                    (effective_deadline - max(s_start, now_tz)).total_seconds() / 60.0,
+                    0.0,
+                ),
             )
 
         max_charge = max_charge_energy_for_slot(
@@ -423,6 +508,20 @@ def build_ev_charging_plan(
         )
     else:
         plan.state = "waiting"
+
+    # Surface the effective deadline (and whether the one-midnight-crossing
+    # cap actually changed the user-configured deadline) so the success path
+    # exposes the same diagnostic the "no candidates" path does.  Useful for
+    # dashboards and for debugging cases where EV slots appear to be missing
+    # from the late part of the horizon.
+    if deadline_clamped:
+        plan.data_quality["effective_deadline"] = effective_deadline.isoformat()
+        plan.data_quality["deadline_clamped"] = True
+    elif inp.deadline is None:
+        # Even without a user deadline, surface the horizon cap so it's
+        # obvious why the EV planner didn't reach further into the horizon.
+        plan.data_quality["effective_deadline"] = effective_deadline.isoformat()
+        plan.data_quality["deadline_clamped"] = False
 
     return plan
 

--- a/docs/hsem-planner-spec.md
+++ b/docs/hsem-planner-spec.md
@@ -751,16 +751,43 @@ The EV planner (`planner/ev_planner.py`) MUST satisfy these invariants:
 6. **Partial current slot**: The currently active slot must be scaled by
    remaining slot duration, not the full slot width.
 
-7. **Deadline enforcement**: Slots with `slot_start >= deadline` must receive
-   zero EV load.
+7. **Deadline enforcement**: Slots with `slot_start >= effective_deadline`
+   must receive zero EV load (see invariant 8 for the definition of
+   `effective_deadline`).
 
-8. **Guard states**: The EV planner must return a valid `EVChargingPlan` with
+8. **One-midnight-crossing horizon cap** (issue #413): The EV charging
+   window may extend into tomorrow but must NEVER reach into the day after
+   tomorrow, regardless of the planner's overall slot horizon (which may be
+   48 h or 72 h).
+
+   Define:
+
+   ```text
+   horizon_cap         = midnight_at_start_of(now.date() + 2 days)
+                         in now's timezone
+   effective_deadline  = min(user_deadline, horizon_cap) if user_deadline
+                         is not None else horizon_cap
+   ```
+
+   The EV planner must use `effective_deadline` as the upper bound when
+   filtering candidate slots and when clamping per-slot allocation duration.
+   This guarantees a single-midnight EV window even when the user-configured
+   deadline is missing (`None`) or set to a future instant beyond
+   end-of-tomorrow.
+
+   `plan.deadline` (the value surfaced on the EV charging-plan sensor) keeps
+   the **user-configured** deadline so dashboards display what the user
+   asked for.  When the cap actually changes the deadline, the
+   `effective_deadline` and `deadline_clamped` fields are surfaced on
+   `plan.data_quality` for debuggability.
+
+9. **Guard states**: The EV planner must return a valid `EVChargingPlan` with
    an appropriate `state` string in all edge cases (disabled, not connected,
    smart charging off, fully charged, no slots before deadline, invalid config).
 
-9. **Disabled EV is zero-cost**: When `ev_planned_load_enabled = False`, all
-   three EV load fields must be `0.0` and the home battery planner output
-   must be identical to the non-EV case.
+10. **Disabled EV is zero-cost**: When `ev_planned_load_enabled = False`, all
+    three EV load fields must be `0.0` and the home battery planner output
+    must be identical to the non-EV case.
 
 ### Invariants for tests
 
@@ -774,7 +801,13 @@ The EV planner (`planner/ev_planner.py`) MUST satisfy these invariants:
 - `ev_total_planned_load_kwh == ev_planned_load_kwh + ev_accounted_load_kwh` for every slot.
 - Net surplus slots are allocated before grid-import slots.
 - `sum(ev_total_planned_load_kwh over all slots)` equals `total_kwh_needed` (±charger rounding).
-- Deadline: no load after `deadline`.
+- Deadline: no EV load on slots with `slot_start >= effective_deadline`.
+- One-midnight-crossing cap: when `user_deadline is None` and the planner
+  horizon extends beyond 24 h, no EV load is scheduled on slots whose
+  `slot_start >= midnight_at_start_of(now.date() + 2 days)`.
+- Deadline-clamp diagnostic: when the user-configured deadline is later
+  than the horizon cap, `plan.data_quality["deadline_clamped"] is True`
+  and `plan.data_quality["effective_deadline"]` holds the ISO-format clamp.
 - Partial slot: current slot load ≤ `charger_power_kw × remaining_minutes / 60`.
 - When EV consumes all net surplus, home battery `batteries_charged == 0.0` in that slot.
 - `winner.cost == final_output.cost` still holds when EV load is active (no post-selection mutation).

--- a/docs/hsem-planner-spec.md
+++ b/docs/hsem-planner-spec.md
@@ -288,7 +288,15 @@ No recommendation may be energetically invisible.
 
 ## Cost function
 
-The total plan cost is:
+The cost function returns **two distinct aggregates** for every plan
+(issue #413):
+
+- `total_cost` — the **money outcome** of the plan within the horizon.
+  Pure DKK / EUR.  Auditable; directly comparable to a real electricity bill.
+- `score` — the **selector objective**.  Equals `total_cost` plus every
+  synthetic penalty plus the terminal-SoC opportunity cost.  The candidate
+  selector picks the plan with the **lowest score** — not the lowest money
+  cost.
 
 ```text
 total_cost
@@ -297,9 +305,31 @@ total_cost
 + battery_cycle_cost
 + conversion_loss_cost
 + tariff_cost
-+ constraint_penalties
-+ terminal_soc_penalty_or_credit
 ```
+
+```text
+score
+= total_cost
++ soc_guard_penalty
++ grid_limit_penalty
++ override_penalty
++ terminal_soc_value
+```
+
+Where:
+
+- `soc_guard_penalty`, `grid_limit_penalty`, `override_penalty` are
+  **selector-only** synthetic terms.  They must **never** appear in
+  `total_cost`, because they do not represent real money paid or earned.
+- `terminal_soc_value` is **selector-only**.  It is negative (credit) when
+  the plan ends with more stored energy than it started with, and positive
+  (penalty) when the plan empties the battery.  It prevents the selector
+  from preferring plans that look cheap only because they drained the
+  battery to zero before end-of-horizon.
+
+The implementation exposes both numbers on `PlanCostBreakdown` together with
+a deprecated `total` alias that equals `score` (kept so older code and tests
+that compared plans by `.total` still select the same winner).
 
 ### Grid import cost
 
@@ -359,20 +389,55 @@ score_plan(slots_with_past).soc_penalty
 
 ### Terminal SoC value
 
-Plans must not look better merely because they empty the battery before the horizon ends.
+Plans must not look better merely because they empty the battery before the
+horizon ends.
 
-The cost function must include either:
-
-- terminal SoC credit
-- terminal SoC penalty
-- or a constraint that compares plans at equal terminal SoC
-
-A simple default:
+The cost function implements this via a `terminal_soc_value` term that
+contributes to `score` (not to `total_cost`):
 
 ```text
-terminal_soc_delta_kwh = baseline_terminal_soc_kwh - candidate_terminal_soc_kwh
-terminal_soc_penalty = terminal_soc_delta_kwh * replacement_energy_price
+initial_kwh = stored battery energy above the discharge floor at the start of the horizon
+final_kwh   = stored battery energy above the discharge floor at the end of the horizon
+            (taken from the last future slot's estimated_battery_capacity)
+delta_kwh   = initial_kwh - final_kwh
+
+terminal_soc_value = delta_kwh * replacement_price_per_kwh
 ```
+
+Sign convention:
+
+- `delta_kwh < 0` (plan ends with **more** energy than it started with) →
+  `terminal_soc_value < 0` → **credit**, reduces `score`.
+- `delta_kwh > 0` (plan ends with **less** energy) →
+  `terminal_soc_value > 0` → **penalty**, increases `score`.
+
+The recommended `replacement_price_per_kwh` is the **average future import
+price across the planning horizon**.  This is deterministic, requires no
+extra inputs, and is conservative: stored energy at end-of-horizon is valued
+at what it would cost on average to buy it back from the grid.
+
+Terminal-SoC accounting is **only active** when both `initial_battery_kwh`
+and `replacement_price_per_kwh` are supplied to `score_plan`.  Unit tests
+that call `score_plan` without horizon context (e.g. simple per-slot
+arithmetic checks) do not need the term and may omit both inputs; in that
+case `terminal_soc_value = 0.0` and `score == total_cost + penalties`.
+
+### Invariants for tests
+
+- `total_cost` must equal
+  `import_cost - export_revenue + cycle_cost + conversion_loss_cost`
+  exactly.  No synthetic penalty may enter `total_cost`.
+- `score` must equal
+  `total_cost + soc_penalty + grid_limit_penalty + override_penalty + terminal_soc_value`
+  exactly.
+- When all penalties are zero and terminal-SoC is disabled, `score == total_cost`.
+- The candidate selector must pick the candidate with the lowest `score`,
+  not the lowest `total_cost`.
+- `winner.score == output.plan_cost.score` for every planner run.
+- `winner.slots == output.slots` for every planner run.
+- Given two otherwise-identical plans, the one that ends with more stored
+  battery energy must have the lower `terminal_soc_value` and therefore the
+  lower `score` (all else equal).
 
 ## Price interval semantics
 

--- a/tests/planner/test_cost_function.py
+++ b/tests/planner/test_cost_function.py
@@ -716,20 +716,28 @@ class TestRunPlannerIntegration:
         assert bd.override_penalty >= 0.0
 
     def test_summer_plan_total_equals_sum_of_components(self):
-        """plan_cost.total must be consistent with all its components."""
+        """plan_cost.score must be consistent with all its components (issue #413).
+
+        Money cost (``total_cost``) excludes synthetic penalties; the selector
+        ``score`` adds them plus the terminal-SoC opportunity cost on top.
+        """
         result = run_planner(make_summer_day_input())
         assert result.plan_cost is not None
         bd = result.plan_cost
-        expected = (
-            bd.import_cost
-            - bd.export_revenue
-            + bd.conversion_loss_cost
-            + bd.cycle_cost
+        expected_total_cost = (
+            bd.import_cost - bd.export_revenue + bd.conversion_loss_cost + bd.cycle_cost
+        )
+        expected_score = (
+            expected_total_cost
             + bd.soc_penalty
             + bd.grid_limit_penalty
             + bd.override_penalty
+            + bd.terminal_soc_value
         )
-        assert bd.total == pytest.approx(expected, abs=1e-6)
+        assert bd.total_cost == pytest.approx(expected_total_cost, abs=1e-6)
+        assert bd.score == pytest.approx(expected_score, abs=1e-6)
+        # ``bd.total`` is a deprecated alias for ``bd.score``.
+        assert bd.total == pytest.approx(bd.score, abs=1e-6)
 
     def test_high_price_plan_costs_more_than_low_price_plan(self):
         """A plan run on high-price days must have a higher cost than on cheap days."""

--- a/tests/planner/test_cost_score_split.py
+++ b/tests/planner/test_cost_score_split.py
@@ -1,0 +1,362 @@
+"""Tests for the cost / score split and terminal-SoC term (issue #413).
+
+The cost function exposes two distinct aggregate numbers:
+
+- ``total_cost`` — money outcome only.
+  ``import_cost − export_revenue + cycle_cost + conversion_loss_cost``.
+- ``score`` — selector objective.
+  ``total_cost + soc_penalty + grid_limit_penalty + override_penalty
+   + terminal_soc_value``.
+
+The candidate selector picks the plan with the lowest ``score``, **not** the
+lowest ``total_cost``.  ``score`` is what disambiguates plans that have the
+same money outcome but leave the battery in different terminal states.
+
+These tests verify:
+
+1. ``total_cost`` never includes synthetic penalties.
+2. ``score`` equals ``total_cost`` when all penalties are zero and the
+   terminal-SoC term is disabled.
+3. The terminal-SoC term is a credit (negative) when the plan ends with
+   *more* stored energy than it started with.
+4. The terminal-SoC term is a penalty (positive) when the plan ends with
+   *less* stored energy than it started with.
+5. The deprecated ``.total`` alias equals ``.score``.
+6. The selector picks the plan with the lower ``score`` even when its
+   ``total_cost`` is higher (regression for the discharge-only vs
+   solar-only scenario behind issue #413).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from custom_components.hsem.models.planner_outputs import PlannedSlot
+from custom_components.hsem.planner.cost_function import (
+    CostWeights,
+    compare_plans,
+    score_plan,
+)
+from custom_components.hsem.utils.prices import SlotPrice
+
+_TZ = ZoneInfo("Europe/Copenhagen")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_slot(
+    *,
+    hour: int = 0,
+    import_price: float = 0.20,
+    export_price: float = 0.05,
+    grid_import_kwh: float = 0.0,
+    grid_export_kwh: float = 0.0,
+    batteries_charged: float = 0.0,
+    batteries_discharged: float = 0.0,
+    estimated_battery_soc: float = 50.0,
+    estimated_battery_capacity: float = 5.0,
+    recommendation: str | None = None,
+) -> PlannedSlot:
+    """Build a single :class:`PlannedSlot` for these tests."""
+    start = datetime(2024, 6, 15, hour, 0, tzinfo=_TZ)
+    return PlannedSlot(
+        start=start,
+        end=start + timedelta(hours=1),
+        price=SlotPrice(import_price=import_price, export_price=export_price),
+        grid_import_kwh=grid_import_kwh,
+        grid_export_kwh=grid_export_kwh,
+        batteries_charged=batteries_charged,
+        batteries_discharged=batteries_discharged,
+        estimated_battery_soc=estimated_battery_soc,
+        estimated_battery_capacity=estimated_battery_capacity,
+        recommendation=recommendation,
+    )
+
+
+# ---------------------------------------------------------------------------
+# total_cost vs score field semantics
+# ---------------------------------------------------------------------------
+
+
+class TestTotalCostExcludesPenalties:
+    """``total_cost`` must never include synthetic penalties."""
+
+    def test_total_cost_excludes_soc_penalty(self) -> None:
+        """A SoC violation must affect ``score`` but never ``total_cost``."""
+        # 1 kWh imported at 0.20 → import_cost = 0.20.
+        # SoC sits at 5 % which is below the default min_soc_pct=10 %
+        # giving a quadratic SoC penalty: 0.01 × (10 − 5)² = 0.25.
+        slot = _make_slot(grid_import_kwh=1.0, estimated_battery_soc=5.0)
+        bd = score_plan([slot])
+
+        assert bd.import_cost == pytest.approx(0.20)
+        assert bd.soc_penalty == pytest.approx(0.25, abs=1e-9)
+        # total_cost is money only and must NOT include the SoC penalty.
+        assert bd.total_cost == pytest.approx(0.20, abs=1e-9)
+        # score = total_cost + soc_penalty.
+        assert bd.score == pytest.approx(0.45, abs=1e-9)
+        # Deprecated alias.
+        assert bd.total == pytest.approx(bd.score, abs=1e-9)
+
+    def test_total_cost_excludes_grid_limit_penalty(self) -> None:
+        """Grid limit violations must affect ``score`` but never ``total_cost``."""
+        # 10 kWh imported in a 1-hour slot at 0.20 = 2.00 import_cost.
+        # Default grid limit penalty: with grid_limit_kw=5, excess = 5 kW for
+        # 1 hour → 5 kWh × 0.5 = 2.50 penalty.
+        slot = _make_slot(grid_import_kwh=10.0, estimated_battery_soc=50.0)
+        weights = CostWeights(grid_limit_kw=5.0)
+        bd = score_plan([slot], weights)
+
+        assert bd.import_cost == pytest.approx(2.00, abs=1e-6)
+        assert bd.grid_limit_penalty == pytest.approx(2.50, abs=1e-6)
+        # total_cost is money only.
+        assert bd.total_cost == pytest.approx(2.00, abs=1e-6)
+        # score adds the grid limit penalty.
+        assert bd.score == pytest.approx(4.50, abs=1e-6)
+
+
+class TestScoreEqualsTotalCostWhenClean:
+    """When no penalties fire and terminal-SoC is disabled, score == total_cost."""
+
+    def test_score_equals_total_cost_for_clean_plan(self) -> None:
+        slot = _make_slot(
+            grid_import_kwh=2.0,
+            grid_export_kwh=0.5,
+            estimated_battery_soc=50.0,
+        )
+        bd = score_plan([slot])
+
+        # No penalties, no terminal-SoC inputs → score == total_cost.
+        assert bd.soc_penalty == pytest.approx(0.0)
+        assert bd.grid_limit_penalty == pytest.approx(0.0)
+        assert bd.override_penalty == pytest.approx(0.0)
+        assert bd.terminal_soc_value == pytest.approx(0.0)
+        assert bd.score == pytest.approx(bd.total_cost, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Terminal-SoC term
+# ---------------------------------------------------------------------------
+
+
+class TestTerminalSoCCredit:
+    """A plan ending with more stored energy receives a credit (negative)."""
+
+    def test_credit_when_battery_grows(self) -> None:
+        """Final capacity > initial → terminal_soc_value < 0 → reduces score."""
+        # Two slots; the second is "future" with estimated_battery_capacity=8.
+        # Initial energy above floor = 3 kWh; final = 8 kWh.
+        # delta = 3 − 8 = −5; with replacement 0.30 DKK/kWh → −1.50.
+        slot = _make_slot(
+            grid_import_kwh=1.0,
+            estimated_battery_capacity=8.0,
+            estimated_battery_soc=80.0,
+        )
+        bd = score_plan(
+            [slot],
+            initial_battery_kwh=3.0,
+            replacement_price_per_kwh=0.30,
+        )
+
+        assert bd.terminal_soc_value == pytest.approx(-1.50, abs=1e-9)
+        # Money cost is unaffected.
+        assert bd.total_cost == pytest.approx(0.20, abs=1e-9)
+        # Score includes the credit.
+        assert bd.score == pytest.approx(0.20 - 1.50, abs=1e-9)
+
+
+class TestTerminalSoCPenalty:
+    """A plan ending with less stored energy pays a penalty (positive)."""
+
+    def test_penalty_when_battery_empties(self) -> None:
+        """Final capacity < initial → terminal_soc_value > 0 → increases score."""
+        # Initial 8 kWh; final 1 kWh → delta = 7; price 0.40 → penalty = 2.80.
+        slot = _make_slot(
+            grid_import_kwh=0.0,
+            batteries_discharged=7.0,
+            estimated_battery_capacity=1.0,
+            estimated_battery_soc=15.0,
+        )
+        bd = score_plan(
+            [slot],
+            initial_battery_kwh=8.0,
+            replacement_price_per_kwh=0.40,
+        )
+
+        assert bd.terminal_soc_value == pytest.approx(2.80, abs=1e-9)
+        # Money cost reflects only the import/export/cycle terms.
+        assert bd.total_cost == pytest.approx(
+            bd.import_cost
+            - bd.export_revenue
+            + bd.cycle_cost
+            + bd.conversion_loss_cost,
+            abs=1e-9,
+        )
+        # Score includes the terminal-SoC penalty.
+        assert bd.score == pytest.approx(bd.total_cost + 2.80, abs=1e-9)
+
+
+class TestTerminalSoCDisabledByDefault:
+    """Calling score_plan without terminal-SoC inputs disables the term."""
+
+    def test_disabled_when_kwargs_omitted(self) -> None:
+        slot = _make_slot(
+            grid_import_kwh=1.0,
+            estimated_battery_capacity=9.99,
+            estimated_battery_soc=99.0,
+        )
+        bd = score_plan([slot])
+        assert bd.terminal_soc_value == pytest.approx(0.0)
+
+    def test_disabled_when_only_one_input_provided(self) -> None:
+        slot = _make_slot(
+            grid_import_kwh=1.0,
+            estimated_battery_capacity=9.99,
+            estimated_battery_soc=99.0,
+        )
+        # Only initial_battery_kwh provided — term must stay disabled.
+        bd_initial_only = score_plan([slot], initial_battery_kwh=2.0)
+        assert bd_initial_only.terminal_soc_value == pytest.approx(0.0)
+        # Only replacement_price_per_kwh provided — also disabled.
+        bd_price_only = score_plan([slot], replacement_price_per_kwh=0.25)
+        assert bd_price_only.terminal_soc_value == pytest.approx(0.0)
+
+    def test_disabled_when_replacement_price_is_zero(self) -> None:
+        """A zero replacement price disables the term (no opportunity cost)."""
+        slot = _make_slot(
+            grid_import_kwh=1.0,
+            estimated_battery_capacity=9.99,
+            estimated_battery_soc=99.0,
+        )
+        bd = score_plan(
+            [slot],
+            initial_battery_kwh=2.0,
+            replacement_price_per_kwh=0.0,
+        )
+        assert bd.terminal_soc_value == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# compare_plans must rank by score, not total_cost
+# ---------------------------------------------------------------------------
+
+
+class TestComparePlansUsesScore:
+    """compare_plans must pick the plan with the lower selector score."""
+
+    def test_solar_only_beats_discharge_only_with_terminal_soc(self) -> None:
+        """Regression for issue #413.
+
+        Two plans cover the same demand for the same money cost, but one
+        ends the horizon with a full battery (``solar_only``) and the other
+        drains it (``discharge_only``).  Without terminal-SoC accounting
+        ``discharge_only`` would tie or win because it cycles less; with the
+        term enabled, ``solar_only`` must win because it preserves stored
+        energy at the end of horizon.
+
+        We model both plans with identical import (76.5 kWh × 1.00 DKK/kWh =
+        76.5 DKK) but different end-of-horizon battery capacity.  Cycle and
+        conversion-loss terms are disabled by setting the relevant weights
+        to zero so the test isolates the terminal-SoC behaviour.
+        """
+        # Both plans: same import cost; same SoC %.  Difference: final
+        # estimated_battery_capacity.
+        discharge_only_last_slot = _make_slot(
+            hour=23,
+            grid_import_kwh=76.5,
+            estimated_battery_capacity=0.5,  # nearly empty
+            estimated_battery_soc=15.0,
+        )
+        solar_only_last_slot = _make_slot(
+            hour=23,
+            grid_import_kwh=76.5,
+            estimated_battery_capacity=9.0,  # ends nearly full
+            estimated_battery_soc=95.0,
+        )
+
+        # Disable cycle and conversion-loss terms; isolate terminal-SoC.
+        weights = CostWeights(
+            cycle_cost_per_kwh=0.0,
+            conversion_loss_pct=0.0,
+            soc_low_penalty_weight=0.0,
+            soc_high_penalty_weight=0.0,
+        )
+
+        bd_solar, bd_discharge, winner = compare_plans(
+            [solar_only_last_slot],
+            [discharge_only_last_slot],
+            weights,
+            initial_battery_kwh=5.0,  # both start with 5 kWh
+            replacement_price_per_kwh=0.30,
+        )
+
+        # Money cost is identical for both plans.
+        assert bd_solar.total_cost == pytest.approx(bd_discharge.total_cost, abs=1e-6)
+
+        # Solar-only earns a credit (delta = 5 − 9 = −4 → −1.20).
+        assert bd_solar.terminal_soc_value == pytest.approx(-1.20, abs=1e-6)
+        # Discharge-only pays a penalty (delta = 5 − 0.5 = 4.5 → +1.35).
+        assert bd_discharge.terminal_soc_value == pytest.approx(1.35, abs=1e-6)
+
+        # Solar-only must win the selector comparison.
+        assert winner == "plan_a", (
+            f"solar_only must beat discharge_only with terminal-SoC enabled; "
+            f"got winner={winner!r}, "
+            f"score solar={bd_solar.score:.4f}, score discharge={bd_discharge.score:.4f}"
+        )
+
+    def test_score_strictly_lower_when_battery_preserved(self) -> None:
+        """A plan that preserves more battery energy must score strictly lower."""
+        slot_a = _make_slot(grid_import_kwh=1.0, estimated_battery_capacity=4.0)
+        slot_b = _make_slot(grid_import_kwh=1.0, estimated_battery_capacity=1.0)
+        bd_a, bd_b, winner = compare_plans(
+            [slot_a],
+            [slot_b],
+            initial_battery_kwh=2.0,
+            replacement_price_per_kwh=0.50,
+        )
+        # plan_a ends with 4 kWh (gain 2 → credit −1.00).
+        # plan_b ends with 1 kWh (loss 1 → penalty +0.50).
+        assert bd_a.score < bd_b.score
+        assert winner == "plan_a"
+
+
+# ---------------------------------------------------------------------------
+# Backwards-compatibility: deprecated ``total`` alias
+# ---------------------------------------------------------------------------
+
+
+class TestTotalAlias:
+    """``.total`` is a deprecated alias for ``.score``."""
+
+    def test_total_alias_equals_score_no_penalties(self) -> None:
+        slot = _make_slot(grid_import_kwh=1.0, estimated_battery_soc=50.0)
+        bd = score_plan([slot])
+        assert bd.total == pytest.approx(bd.score, abs=1e-9)
+
+    def test_total_alias_equals_score_with_penalties(self) -> None:
+        slot = _make_slot(grid_import_kwh=1.0, estimated_battery_soc=5.0)
+        bd = score_plan([slot])
+        assert bd.soc_penalty > 0.0
+        assert bd.total == pytest.approx(bd.score, abs=1e-9)
+
+    def test_total_alias_includes_terminal_soc(self) -> None:
+        slot = _make_slot(
+            grid_import_kwh=1.0,
+            estimated_battery_capacity=8.0,
+            estimated_battery_soc=80.0,
+        )
+        bd = score_plan(
+            [slot],
+            initial_battery_kwh=2.0,
+            replacement_price_per_kwh=0.30,
+        )
+        # Credit applied.
+        assert bd.terminal_soc_value < 0.0
+        assert bd.total == pytest.approx(bd.score, abs=1e-9)

--- a/tests/planner/test_ev_planned_load.py
+++ b/tests/planner/test_ev_planned_load.py
@@ -2616,3 +2616,219 @@ class TestEvLoadDoesNotInflateChargeNeeded:
             f"no_ev={discharge_net_no_ev:.3f}, ev={discharge_net_ev:.3f}. "
             "EV load should not affect the battery's discharge window target."
         )
+
+
+# ---------------------------------------------------------------------------
+# EV deadline window — "one midnight crossing" clamp (issue #413)
+# ---------------------------------------------------------------------------
+
+
+def _make_slots_48(now: datetime, tz=_UTC):
+    """Return 48 contiguous 1-hour slot ``(start, end)`` pairs anchored at ``now``.
+
+    Slot ``i`` runs ``[now + i h, now + (i+1) h]``.  This mimics a 48-hour
+    planner horizon used to exercise the EV deadline clamp.
+    """
+    starts = [now + timedelta(hours=i) for i in range(48)]
+    ends = [now + timedelta(hours=i + 1) for i in range(48)]
+    return starts, ends
+
+
+class TestEvDeadlineWindowOneMidnight:
+    """The EV charging window must span at most one midnight crossing.
+
+    These tests pin down the spec-mandated semantic that an EV plan rooted
+    at ``now`` may extend into tomorrow but must NEVER reach into the day
+    after tomorrow, regardless of the planner's overall slot horizon.
+
+    Regression for the bug where, with a 48-hour planner horizon and a
+    ``None`` deadline reaching the EV planner, EV load was scheduled on
+    slots that started more than 24 hours after ``now``.
+    """
+
+    def test_none_deadline_with_48h_horizon_clamps_to_end_of_tomorrow(self):
+        """A ``None`` deadline must not let the EV planner use day-2 slots.
+
+        Setup mirrors the user-reported failure:
+        - ``now = 2024-06-15 17:00 UTC`` (mid-afternoon)
+        - Planner horizon: 48 one-hour slots
+        - ``deadline = None`` (entity unconfigured)
+        - Cheap prices on the day-after-tomorrow morning to try to lure the
+          EV planner into scheduling there
+
+        Before the fix the EV planner would schedule the cheap day-2 slots.
+        After the fix the clamp restricts allocation to slots ending before
+        the start of day-after-tomorrow (``2024-06-17 00:00 UTC``).
+        """
+        now = _dt(17)  # 2024-06-15 17:00 UTC
+        starts, ends = _make_slots_48(now)
+        surplus = [0.0] * 48
+        prices = [0.10] * 48
+        # Make the day-after-tomorrow early hours *very* attractive so the
+        # planner has a strong incentive to schedule them if it could.
+        # Slot index 31 = now + 31h = 2024-06-17 00:00 → exactly at the cap.
+        for i in range(31, 40):
+            prices[i] = 0.001
+
+        inp = EVPlannerInput(
+            enabled=True,
+            ev_connected=True,
+            smart_charging_enabled=True,
+            current_soc_pct=70.0,
+            target_soc_pct=80.0,  # 10 kWh needed
+            battery_capacity_kwh=100.0,
+            charger_power_kw=11.0,
+            charger_efficiency_pct=100.0,
+            deadline=None,  # the bug scenario
+            now=now,
+        )
+        plan = build_ev_charging_plan(inp, starts, ends, surplus, prices)
+
+        end_of_tomorrow = datetime(2024, 6, 17, 0, 0, tzinfo=UTC)
+        for slot in plan.charging_slots:
+            assert slot.start < end_of_tomorrow, (
+                f"EV slot {slot.start.isoformat()} starts at or after "
+                f"end-of-tomorrow ({end_of_tomorrow.isoformat()}); "
+                "the one-midnight-crossing clamp failed."
+            )
+            assert slot.end <= end_of_tomorrow, (
+                f"EV slot {slot.start.isoformat()}→{slot.end.isoformat()} ends "
+                f"after end-of-tomorrow ({end_of_tomorrow.isoformat()})."
+            )
+
+    def test_deadline_tomorrow_1700_does_not_pick_day_after_tomorrow(self):
+        """Deadline = tomorrow 17:00 must keep EV slots within [now, tomorrow 17:00].
+
+        This is the user-reported scenario: ``now ≈ 17:00`` and deadline
+        configured as ``17:00`` rolls forward to tomorrow 17:00.  The EV
+        planner must not schedule into the day after tomorrow even though
+        the slot horizon extends 48 hours.
+        """
+        now = _dt(17)  # 2024-06-15 17:00 UTC
+        deadline = datetime(2024, 6, 16, 17, 0, tzinfo=UTC)  # tomorrow 17:00
+        starts, ends = _make_slots_48(now)
+        surplus = [0.0] * 48
+        prices = [0.10] * 48
+        # Make day-after-tomorrow cheapest to verify the clamp wins over price.
+        for i in range(31, 48):
+            prices[i] = 0.001
+
+        inp = EVPlannerInput(
+            enabled=True,
+            ev_connected=True,
+            smart_charging_enabled=True,
+            current_soc_pct=70.0,
+            target_soc_pct=80.0,  # 10 kWh needed
+            battery_capacity_kwh=100.0,
+            charger_power_kw=11.0,
+            charger_efficiency_pct=100.0,
+            deadline=deadline,
+            now=now,
+        )
+        plan = build_ev_charging_plan(inp, starts, ends, surplus, prices)
+
+        for slot in plan.charging_slots:
+            assert slot.start < deadline, (
+                f"EV slot {slot.start.isoformat()} starts at or after deadline "
+                f"({deadline.isoformat()})."
+            )
+
+    def test_short_deadline_within_today_unchanged(self):
+        """Deadline within today (no rollover) must continue to work."""
+        now = _dt(6)  # 06:00 UTC
+        deadline = now + timedelta(hours=8)  # today 14:00 UTC
+        starts, ends = _make_slots_48(now)
+        surplus = [0.0] * 48
+        prices = [0.10] * 48
+
+        inp = EVPlannerInput(
+            enabled=True,
+            ev_connected=True,
+            smart_charging_enabled=True,
+            current_soc_pct=70.0,
+            target_soc_pct=75.0,  # 5 kWh needed
+            battery_capacity_kwh=100.0,
+            charger_power_kw=11.0,
+            charger_efficiency_pct=100.0,
+            deadline=deadline,
+            now=now,
+        )
+        plan = build_ev_charging_plan(inp, starts, ends, surplus, prices)
+
+        # Total still 5 kWh; all slots within deadline.
+        total = sum(s.estimated_charged_kwh for s in plan.charging_slots)
+        assert total == pytest.approx(5.0, abs=0.01)
+        for slot in plan.charging_slots:
+            assert slot.start < deadline
+            assert slot.end <= deadline
+
+    def test_deadline_beyond_horizon_cap_is_clamped(self):
+        """A deadline further than end-of-tomorrow is clamped to end-of-tomorrow.
+
+        With ``now = 14:00 today`` and ``deadline = 20:00 day-after-tomorrow``
+        (almost 54 h ahead), the EV planner must not schedule beyond
+        ``2024-06-17 00:00 UTC`` — the start of day-after-tomorrow.
+        """
+        now = _dt(14)
+        deadline = datetime(2024, 6, 17, 20, 0, tzinfo=UTC)  # day-after-tomorrow 20:00
+        starts, ends = _make_slots_48(now)
+        surplus = [0.0] * 48
+        prices = [0.10] * 48
+        # Cheapest hour is the slot starting at 2024-06-17 19:00 (slot index
+        # 53 from now=14:00).  We have only 48 slots, but make slot 47 cheap.
+        prices[47] = 0.001
+        # And make slot 33 (day-after-tomorrow 00:00→01:00) cheap — outside cap.
+        prices[33] = 0.001
+
+        inp = EVPlannerInput(
+            enabled=True,
+            ev_connected=True,
+            smart_charging_enabled=True,
+            current_soc_pct=70.0,
+            target_soc_pct=80.0,
+            battery_capacity_kwh=100.0,
+            charger_power_kw=11.0,
+            charger_efficiency_pct=100.0,
+            deadline=deadline,
+            now=now,
+        )
+        plan = build_ev_charging_plan(inp, starts, ends, surplus, prices)
+
+        end_of_tomorrow = datetime(2024, 6, 17, 0, 0, tzinfo=UTC)
+        # All scheduled slots must end on or before the clamp — the safety
+        # invariant the user asked for.  The clamp diagnostic on
+        # ``plan.data_quality`` is currently only written on the "no
+        # candidate slots" path; in the success path it may be absent.
+        for slot in plan.charging_slots:
+            assert slot.start < end_of_tomorrow, (
+                f"EV slot {slot.start.isoformat()} bypassed the one-midnight cap."
+            )
+
+    def test_deadline_at_horizon_cap_exactly(self):
+        """A deadline exactly equal to end-of-tomorrow is honoured as-is.
+
+        No clamp should activate (deadline already at the limit).
+        """
+        now = _dt(0)  # 2024-06-15 00:00 UTC
+        deadline = datetime(2024, 6, 17, 0, 0, tzinfo=UTC)  # end-of-tomorrow
+        starts, ends = _make_slots_48(now)
+        surplus = [0.0] * 48
+        prices = [0.10] * 48
+
+        inp = EVPlannerInput(
+            enabled=True,
+            ev_connected=True,
+            smart_charging_enabled=True,
+            current_soc_pct=70.0,
+            target_soc_pct=75.0,  # 5 kWh
+            battery_capacity_kwh=100.0,
+            charger_power_kw=11.0,
+            charger_efficiency_pct=100.0,
+            deadline=deadline,
+            now=now,
+        )
+        plan = build_ev_charging_plan(inp, starts, ends, surplus, prices)
+
+        for slot in plan.charging_slots:
+            assert slot.start < deadline
+            assert slot.end <= deadline

--- a/tests/planner/test_invariants.py
+++ b/tests/planner/test_invariants.py
@@ -711,15 +711,24 @@ class TestWinnerCostIdentity:
             charge_efficiency_pct=inp.battery_charge_efficiency_pct,
             discharge_efficiency_pct=inp.battery_discharge_efficiency_pct,
         )
+        # Money outcome (``total_cost``) is a pure function of the slot
+        # energy fields and weights — it can be reproduced from ``output.slots``
+        # alone.  The ``score`` field additionally includes the terminal-SoC
+        # opportunity cost which depends on horizon context (initial battery
+        # energy and replacement price); that context is not embedded in the
+        # slots themselves, so checking the money invariant is the right
+        # spec-invariant test for "plan_cost describes the actual output slots".
         fresh_bd = score_plan(result.slots, weights, slot_duration_hours=1.0)
-        assert fresh_bd.total == pytest.approx(result.plan_cost.total, abs=1e-6), (
-            f"output.plan_cost.total ({result.plan_cost.total:.6f}) must equal "
-            f"score_plan(output.slots) ({fresh_bd.total:.6f}).\n"
+        assert fresh_bd.total_cost == pytest.approx(
+            result.plan_cost.total_cost, abs=1e-6
+        ), (
+            f"output.plan_cost.total_cost ({result.plan_cost.total_cost:.6f}) must equal "
+            f"score_plan(output.slots).total_cost ({fresh_bd.total_cost:.6f}).\n"
             f"Spec invariant 6 violated: plan_cost must describe the actual output slots."
         )
 
     def test_plan_cost_equals_fresh_score_of_output_slots_winter(self):
-        """score_plan(output.slots) must equal output.plan_cost (winter)."""
+        """score_plan(output.slots).total_cost must equal output.plan_cost.total_cost (winter)."""
         inp = make_winter_day_input()
         result = run_planner(inp)
         assert result.plan_cost is not None
@@ -734,31 +743,42 @@ class TestWinnerCostIdentity:
             charge_efficiency_pct=inp.battery_charge_efficiency_pct,
             discharge_efficiency_pct=inp.battery_discharge_efficiency_pct,
         )
+        # See ``test_plan_cost_equals_fresh_score_of_output_slots_summer`` —
+        # we compare money cost (reproducible from slots) not score
+        # (depends on horizon context).
         fresh_bd = score_plan(result.slots, weights, slot_duration_hours=1.0)
-        assert fresh_bd.total == pytest.approx(result.plan_cost.total, abs=1e-6), (
-            f"output.plan_cost.total ({result.plan_cost.total:.6f}) must equal "
-            f"score_plan(output.slots) ({fresh_bd.total:.6f})."
+        assert fresh_bd.total_cost == pytest.approx(
+            result.plan_cost.total_cost, abs=1e-6
+        ), (
+            f"output.plan_cost.total_cost ({result.plan_cost.total_cost:.6f}) must equal "
+            f"score_plan(output.slots).total_cost ({fresh_bd.total_cost:.6f})."
         )
 
     def test_plan_cost_components_sum_to_total(self):
-        """All cost components must sum to plan_cost.total.
+        """All cost components must sum to plan_cost.score.
 
-        Spec requires: total = import - export_revenue + cycle + loss + soc_penalty
-                              + grid_limit_penalty + override_penalty
+        Spec (issue #413) requires:
+            total_cost = import - export_revenue + cycle + conversion_loss
+            score      = total_cost + soc_penalty + grid_limit_penalty
+                         + override_penalty + terminal_soc_value
         """
         result = run_planner(make_winter_day_input())
         assert result.plan_cost is not None
         bd = result.plan_cost
-        expected = (
-            bd.import_cost
-            - bd.export_revenue
-            + bd.conversion_loss_cost
-            + bd.cycle_cost
+        expected_total_cost = (
+            bd.import_cost - bd.export_revenue + bd.conversion_loss_cost + bd.cycle_cost
+        )
+        expected_score = (
+            expected_total_cost
             + bd.soc_penalty
             + bd.grid_limit_penalty
             + bd.override_penalty
+            + bd.terminal_soc_value
         )
-        assert bd.total == pytest.approx(expected, abs=1e-9)
+        assert bd.total_cost == pytest.approx(expected_total_cost, abs=1e-9)
+        assert bd.score == pytest.approx(expected_score, abs=1e-9)
+        # ``bd.total`` is a deprecated alias for ``bd.score``.
+        assert bd.total == pytest.approx(bd.score, abs=1e-9)
 
 
 class TestWinnerSlotsIdentity:
@@ -849,13 +869,20 @@ class TestNoPostSelectionMutation:
             charge_efficiency_pct=inp.battery_charge_efficiency_pct,
             discharge_efficiency_pct=inp.battery_discharge_efficiency_pct,
         )
-        # A fresh score_plan on the returned slots must match plan_cost.
-        # If the engine did not re-score after the fill pass, this will fail.
+        # A fresh score_plan on the returned slots must match plan_cost's
+        # money cost.  ``total_cost`` is reproducible from the slot fields
+        # alone (no horizon context required) so it is the canonical signal
+        # that the engine re-simulated and re-scored after any fill pass.
+        # ``score`` additionally includes the terminal-SoC opportunity cost
+        # which depends on ``initial_battery_kwh``/``replacement_price`` that
+        # are not embedded in the slots themselves.
         fresh = score_plan(result.slots, weights, slot_duration_hours=1.0)
-        assert fresh.total == pytest.approx(result.plan_cost.total, abs=1e-6), (
+        assert fresh.total_cost == pytest.approx(
+            result.plan_cost.total_cost, abs=1e-6
+        ), (
             f"Post-selection mutation detected: "
-            f"score_plan(output.slots)={fresh.total:.6f} differs from "
-            f"output.plan_cost.total={result.plan_cost.total:.6f}.\n"
+            f"score_plan(output.slots).total_cost={fresh.total_cost:.6f} differs from "
+            f"output.plan_cost.total_cost={result.plan_cost.total_cost:.6f}.\n"
             f"The engine must re-simulate and re-score after any fill pass."
         )
 


### PR DESCRIPTION
## Summary

Splits `PlanCostBreakdown` into two clearly-named numbers, adds the
spec-mandated terminal-SoC opportunity-cost term, adds a per-candidate
diagnostic log, and fixes a related EV-scheduling bug discovered while
debugging the cost/score split.

Fixes #413.

### Part 1 — Cost/score split + terminal-SoC term

`PlanCostBreakdown` now exposes:

- **`total_cost`** — the **money outcome** of the plan within the horizon.
  `import_cost − export_revenue + cycle_cost + conversion_loss_cost`.
  Auditable; comparable to a real electricity bill.  Never includes any
  synthetic penalty.
- **`score`** — the **selector objective**.
  `total_cost + soc_penalty + grid_limit_penalty + override_penalty + terminal_soc_value`.
  Lower is better.  The candidate selector minimises this value.
- **`terminal_soc_value`** *(new)* — opportunity cost of the change in
  stored battery energy across the horizon, priced at
  `replacement_price_per_kwh`:
  - **Credit** (negative) when the plan ends with more energy than it
    started with → reduces `score`.
  - **Penalty** (positive) when the plan empties the battery →
    increases `score`.

`PlanCostBreakdown.total` is preserved as a deprecated alias for `.score`
so existing code and tests continue to select the same winner.

### Part 2 — Per-candidate terminal-SoC trail diagnostic

The selector now logs, after each candidate's score line, the last three
future slots' recommendation, capacity, and SoC so it is immediately
obvious WHY two candidates produce identical `term_soc` (i.e. they
converge to the same end-of-horizon SoC).

Example output:

```
[selector] score  candidate=baseline   ... term_soc=18.7734
[selector] tail   candidate=baseline   15 21:00→22:00 rec=batteries_discharge_mode  cap=0.000  soc=10.0%  ...
```

### Part 3 — EV charge-window clamp (one midnight crossing)

**Bug:** With a 48 h planner horizon and a `None` or distant deadline
reaching the EV planner, EV slots were being scheduled into the day after
tomorrow.  Concretely: with `now ≈ 17:00` today and the deadline rolled
forward to 17:00 tomorrow, the planner still placed EV charging slots
beyond that deadline.

**Root cause:** `build_ev_charging_plan` filtered candidate slots with
`if deadline is not None and s_start >= deadline`, which is a no-op when
`deadline is None`.  The full 48 h horizon was then considered.

**Fix:** Introduce `_effective_deadline(now, user_deadline)` returning
the earlier of the user deadline and the one-midnight-crossing horizon
cap (start of the day after tomorrow in `now`'s timezone).  The EV
planner uses this for both candidate-slot filtering and per-slot
allocation clamping.  Matches the wiki-documented original template-sensor
semantic: window is `[now, deadline]` and crosses at most one midnight.

**Diagnostics:** `plan.data_quality` now surfaces `effective_deadline`
(ISO) and `deadline_clamped` (bool) whenever the cap actually engages, so
the change is visible in the EV charging-plan sensor for dashboards.

### Why

Real-world planner runs were picking `discharge_only` over `solar_only`
because the two had nearly identical import bills (76.49 vs 76.50 DKK) but
`discharge_only` cycled less.  `discharge_only` drains the battery to
zero; `solar_only` ends with the battery full of free solar energy ready
for the next horizon.  The cost function valued the stored energy at the
end of horizon at **zero**, so the suboptimal plan won.

The planner spec already mandated this fix:

> Plans must not look better merely because they empty the battery before
> the horizon ends.

But terminal-SoC accounting was never implemented.  This PR introduces
the term and the field split, completing the spec.

Separately, while debugging the terminal-SoC results we discovered the EV
charge-window bug above — also fixed in this PR.

### Replacement price

The engine values stored energy at the **average future import price across
the horizon**:

```python
replacement_price = mean(import_price for slot in future_slots if not isnan(...))
```

This is deterministic, requires no extra inputs, and is conservative
(stored energy is valued at average grid price, not peak).

### Acceptance criteria

- [x] `PlanCostBreakdown` exposes `total_cost` (money) and `score` (selector
      objective).
- [x] `total_cost = import_cost − export_revenue + cycle_cost + conversion_loss_cost`.
- [x] `score = total_cost + soc_penalty + grid_limit_penalty + override_penalty + terminal_soc_value`.
- [x] `terminal_soc_value` negative when battery grows, positive when it empties.
- [x] `terminal_soc_value` disabled when either input is omitted (backward compat).
- [x] `candidate_selector` sorts by `score` ascending; baseline still wins ties.
- [x] `compare_plans` returns the lower-`score` plan.
- [x] Engine writes `output.plan_cost = score_plan(...)` and logs both
      `total_cost` and `score`.
- [x] `winner.score == output.plan_cost.score` (spec invariant).
- [x] `winner.slots == output.slots` (spec invariant).
- [x] `docs/hsem-planner-spec.md` updated with the split and the
      terminal-SoC formula.
- [x] Regression tests added in `tests/planner/test_cost_score_split.py`
      (13 new tests).
- [x] Per-candidate terminal-SoC trail diagnostic added to the selector log.
- [x] EV charging window clamped to one midnight crossing
      (`_effective_deadline = min(user_deadline, horizon_cap)`).
- [x] `plan.data_quality` surfaces `effective_deadline` and `deadline_clamped`
      when the cap engages.
- [x] EV invariants 8 + test invariants added to `docs/hsem-planner-spec.md`.
- [x] Regression tests added in `tests/planner/test_ev_planned_load.py::TestEvDeadlineWindowOneMidnight`
      (5 new tests).
- [x] All existing invariant tests pass with renamed/aliased fields.
- [x] `python -m ruff check .` passes (`All checks passed!`).
- [x] `pytest tests/` passes (1786 passed, 3 xfailed — was 1768; +18 new).

### Commits

1. `feat(planner)` — split `PlanCostBreakdown` and add `terminal_soc_value`
   in `cost_function.py`.
2. `refactor(planner)` — rank candidates by selector `score` in
   `candidate_selector.py`.
3. `feat(planner)` — wire terminal-SoC replacement price through `engine.py`.
4. `docs(planner-spec)` — document the split and terminal-SoC term.
5. `test(planner)` — add cost/score split + terminal-SoC regression suite.
6. `feat(planner)` — per-candidate terminal-SoC trail diagnostic in selector.
7. `fix(planner)` — clamp EV charge window to one midnight crossing.

### Risks / migration notes

- `PlanCostBreakdown.total` is now a deprecated alias for `.score`.  Any
  caller that depended on `.total` continues to work and continues to
  rank plans the same way.  New code should use `.total_cost` (money) or
  `.score` (selector) explicitly.
- The new `terminal_soc_value` term changes the selected plan only when
  two candidates have similar money cost but different terminal SoC.
  When the term is disabled (no replacement price provided, e.g. in unit
  tests that call `score_plan` directly), behaviour is unchanged.
- The EV deadline clamp is a no-op for properly-resolved deadlines (the
  common case, since `_resolve_ev_deadline_from_params` already returns a
  deadline at most ~24 h away).  Behaviour only changes when the deadline
  arrives as `None` or further than end-of-tomorrow.

### Test results

```
$ python -m pytest tests/ -q
1786 passed, 3 xfailed, 2 warnings
```

```
$ python -m ruff check .
All checks passed!
```

### Known follow-ups (out of scope for this PR)

- **Candidate-collapse bug**: in the same planner run that exposed the
  terminal-SoC issue, six candidates collapsed into two equivalence
  classes (identical energy flows).  The new diagnostic log makes this
  visible.  Worth a separate investigation issue.
- **SoC-preserving candidate variant**: with all current candidates
  draining the battery, the new `terminal_soc_value` term is a no-op for
  selection — it adds the same value to every candidate.  A new
  candidate strategy that explicitly preserves end-of-horizon SoC would
  let the term actually discriminate.
