### PR TITLE
refactor(candidates): add passive candidate, exclude no_action from winner, fix terminal-SoC replacement price and multi-day scoping

### DIFF
--- a/custom_components/hsem/planner/candidate_generator.py
+++ b/custom_components/hsem/planner/candidate_generator.py
@@ -21,15 +21,18 @@ Candidates produced
 -------------------
 1. ``baseline``       — current HSEM scheduling output (slots already processed).
 2. ``no_action``      — all recommendations cleared; battery is completely idle.
-3. ``grid_charge``    — grid-charge slots are kept; solar charging is removed.
-4. ``solar_only``     — only solar-charge slots are kept; grid charging cleared.
-5. ``discharge_only`` — discharge slots are kept; all charge slots cleared.
-6. ``aggressive``     — cheapest N slots forced to grid-charge regardless of
+                        Diagnostic floor only — never eligible to win selection.
+3. ``passive``        — solar charging where PV surplus exists; no grid charge or
+                        forced discharge. Models the inverter default behaviour.
+4. ``grid_charge``    — grid-charge slots are kept; solar charging is removed.
+5. ``solar_only``     — only solar-charge slots are kept; grid charging cleared.
+6. ``discharge_only`` — discharge slots are kept; all charge slots cleared.
+7. ``aggressive``     — cheapest N slots forced to grid-charge regardless of
                         schedule; most expensive M slots forced to discharge.
                         N is derived dynamically from battery headroom and
                         max charge per slot so it scales with the horizon and
                         battery size (fix for issue #416 Bug 2).
-7. ``milp``           — globally-optimal LP solution (when scipy is available);
+8. ``milp``           — globally-optimal LP solution (when scipy is available);
                         falls back gracefully if the solver fails.
 """
 
@@ -57,6 +60,7 @@ from custom_components.hsem.utils.recommendations import Recommendations
 
 CANDIDATE_BASELINE = "baseline"
 CANDIDATE_NO_ACTION = "no_action"
+CANDIDATE_PASSIVE = "passive"
 CANDIDATE_GRID_CHARGE = "grid_charge"
 CANDIDATE_SOLAR_ONLY = "solar_only"
 CANDIDATE_DISCHARGE_ONLY = "discharge_only"
@@ -66,6 +70,7 @@ CANDIDATE_AGGRESSIVE = "aggressive"
 __all__ = [
     "CANDIDATE_BASELINE",
     "CANDIDATE_NO_ACTION",
+    "CANDIDATE_PASSIVE",
     "CANDIDATE_GRID_CHARGE",
     "CANDIDATE_SOLAR_ONLY",
     "CANDIDATE_DISCHARGE_ONLY",
@@ -190,29 +195,36 @@ def generate_candidates(
         )
     )
 
-    # 2. No-action — battery completely idle
+    # 2. No-action — battery completely idle (diagnostic floor only, never
+    #    eligible to win selection).
     no_action = _copy_slots(baseline_slots)
     _clear_all_charge_discharge(no_action)
     candidates.append(CandidatePlan(name=CANDIDATE_NO_ACTION, slots=no_action))
 
-    # 3. Grid-charge only — keep discharge windows; drop solar-only charge slots
+    # 3. Passive — solar charging only where PV surplus exists; no grid charge,
+    #    no forced discharge. Models the inverter default behaviour.
+    passive = _copy_slots(baseline_slots)
+    _apply_passive_solar(passive, now)
+    candidates.append(CandidatePlan(name=CANDIDATE_PASSIVE, slots=passive))
+
+    # 4. Grid-charge only — keep discharge windows; drop solar-only charge slots
     grid_charge = _copy_slots(baseline_slots)
     _remove_solar_charge(grid_charge)
     candidates.append(CandidatePlan(name=CANDIDATE_GRID_CHARGE, slots=grid_charge))
 
-    # 4. Solar-only — keep solar charge + discharge windows; drop grid-charge slots
+    # 5. Solar-only — keep solar charge + discharge windows; drop grid-charge slots
     solar_only = _copy_slots(baseline_slots)
     _remove_grid_charge(solar_only)
     candidates.append(CandidatePlan(name=CANDIDATE_SOLAR_ONLY, slots=solar_only))
 
-    # 5. Discharge-only — keep discharge slots; drop ALL charge slots
+    # 6. Discharge-only — keep discharge slots; drop ALL charge slots
     discharge_only = _copy_slots(baseline_slots)
     _remove_all_charge(discharge_only)
     candidates.append(
         CandidatePlan(name=CANDIDATE_DISCHARGE_ONLY, slots=discharge_only)
     )
 
-    # 6. Aggressive — force-charge during N cheapest future slots,
+    # 7. Aggressive — force-charge during N cheapest future slots,
     #    force-discharge during M most-expensive future slots.
     #    N is derived from remaining battery headroom (Bug 2 fix, issue #416).
     aggressive = _copy_slots(baseline_slots)
@@ -225,7 +237,7 @@ def generate_candidates(
     )
     candidates.append(CandidatePlan(name=CANDIDATE_AGGRESSIVE, slots=aggressive))
 
-    # 7. MILP — globally-optimal LP solution (requires scipy, falls back gracefully)
+    # 8. MILP — globally-optimal LP solution (requires scipy, falls back gracefully)
     if is_scipy_available():
         milp_slots = solve_milp(
             baseline_slots,
@@ -322,6 +334,33 @@ def _clear_all_charge_discharge(slots: list[PlannedSlot]) -> None:
         if slot.recommendation in _CHARGE_RECS | _DISCHARGE_RECS:
             slot.recommendation = None
             slot.batteries_charged = 0.0
+
+
+def _apply_passive_solar(slots: list[PlannedSlot], now: datetime) -> None:
+    """Allow solar charging wherever estimated_net_consumption < 0 (PV surplus).
+
+    This models the inverter default behaviour: no grid charging, no forced
+    discharge, but passive absorption of PV surplus into the battery.
+    estimated_net_consumption is negative when PV production exceeds house
+    load (including EV).  The surplus magnitude is used directly as
+    batteries_charged.  The SoC simulation caps it against actual battery
+    limits afterwards.
+    """
+    for slot in slots:
+        # Clear all active scheduling first
+        if slot.recommendation in _CHARGE_RECS | _DISCHARGE_RECS:
+            slot.recommendation = None
+            slot.batteries_charged = 0.0
+
+        # Passively absorb surplus into battery for future slots only
+        # NaN < 0.0 is False in Python so no explicit NaN guard is needed
+        if (
+            as_tz(slot.end, now.tzinfo) > now
+            and slot.estimated_net_consumption is not None
+            and slot.estimated_net_consumption < 0.0
+        ):
+            slot.recommendation = Recommendations.BatteriesChargeSolar.value
+            slot.batteries_charged = round(-slot.estimated_net_consumption, 3)
 
 
 def _remove_solar_charge(slots: list[PlannedSlot]) -> None:

--- a/custom_components/hsem/planner/candidate_selector.py
+++ b/custom_components/hsem/planner/candidate_selector.py
@@ -36,6 +36,7 @@ from datetime import datetime
 from custom_components.hsem.models.planner_outputs import RejectedPlan
 from custom_components.hsem.planner.candidate_generator import (
     CANDIDATE_BASELINE,
+    CANDIDATE_NO_ACTION,
     CandidatePlan,
 )
 from custom_components.hsem.planner.cost_function import CostWeights, score_plan
@@ -150,17 +151,21 @@ def select_best_candidate(
         len(candidates),
     )
 
-    # --- Step 4: pick winner (lowest cost) among valid candidates --------
-    if not valid:
+    # --- Step 4: pick winner (lowest cost) among eligible candidates ------
+    # Exclude no_action from winner selection — it is a diagnostic floor
+    # only and must never win.
+    eligible = [c for c in valid if c.name != CANDIDATE_NO_ACTION]
+
+    if not eligible:
         # Degenerate case — fall back to baseline regardless of validity
         winner = _find_by_name(candidates, CANDIDATE_BASELINE) or candidates[0]
         winner.is_valid = True
         winner.rejection_reason = ""
         log_planner(
-            "warning", "[selector] No valid candidates — falling back to baseline"
+            "warning", "[selector] No eligible candidates — falling back to baseline"
         )
     else:
-        # Score all valid candidates
+        # Score all valid candidates (including no_action for diagnostics)
         for candidate in valid:
             candidate._cost = score_plan(  # type: ignore[attr-defined]
                 candidate.slots,
@@ -209,8 +214,8 @@ def select_best_candidate(
                 )
 
         # Sort by selector score ascending; baseline wins ties (it comes first)
-        valid_sorted = sorted(
-            valid,
+        eligible_sorted = sorted(
+            eligible,
             key=lambda c: (
                 c._cost.score,  # type: ignore[attr-defined]
                 # Stable tie-break: baseline index is 0, so it wins ties
@@ -220,7 +225,7 @@ def select_best_candidate(
                 ),
             ),
         )
-        winner = valid_sorted[0]
+        winner = eligible_sorted[0]
         log_planner(
             "info",
             "[selector] SELECTED candidate=%-20s  score=%.4f  total_cost=%.4f",
@@ -238,6 +243,12 @@ def select_best_candidate(
 
         if not candidate.is_valid:
             reason = candidate.rejection_reason
+        elif candidate.name == CANDIDATE_NO_ACTION:
+            reason = (
+                "Diagnostic floor only — excluded from winner selection. "
+                "The no_action candidate models a fully idle battery and "
+                "is never a realistic operating choice."
+            )
         else:
             winner_score = getattr(
                 getattr(winner, "_cost", None), "score", float("inf")

--- a/custom_components/hsem/planner/candidate_selector.py
+++ b/custom_components/hsem/planner/candidate_selector.py
@@ -31,8 +31,10 @@ Design constraints
 
 from __future__ import annotations
 
+import math
 from datetime import datetime
 
+from custom_components.hsem.datetime_utils import as_tz
 from custom_components.hsem.models.planner_outputs import RejectedPlan
 from custom_components.hsem.planner.candidate_generator import (
     CANDIDATE_BASELINE,
@@ -42,6 +44,7 @@ from custom_components.hsem.planner.candidate_generator import (
 from custom_components.hsem.planner.cost_function import CostWeights, score_plan
 from custom_components.hsem.planner.planner_logger import log_planner
 from custom_components.hsem.planner.soc_simulation import simulate_soc
+from custom_components.hsem.utils.recommendations import Recommendations
 
 # SoC floor tolerance — plans are accepted even if they dip this many
 # percentage points below end_of_discharge_soc_pct (rounding / simulation
@@ -324,3 +327,48 @@ def _validate_candidate(
 def _find_by_name(candidates: list[CandidatePlan], name: str) -> CandidatePlan | None:
     """Return the first candidate with the given name, or ``None``."""
     return next((c for c in candidates if c.name == name), None)
+
+
+def replacement_price_from_next_discharge(
+    slots: list,
+    now: datetime,
+    top_n: int = 4,
+) -> float | None:
+    """Derive the terminal-SoC replacement price from the next discharge window.
+
+    The energy stored at end-of-horizon is worth what it would cost to
+    re-purchase that energy from the grid during the first active discharge
+    schedule window.  Within that window the battery discharges in priority
+    order from the most expensive slots, so we use the average of the
+    *top_n* most expensive import prices among future discharge slots.
+
+    Args:
+        slots:
+            Any candidate's populated slot list (must have
+            ``recommendation``, ``price.import_price``, ``start`` set).
+        now:
+            Timezone-aware current datetime.  Past slots are excluded.
+        top_n:
+            Number of most expensive discharge slots to average over.
+            Default 4 corresponds to ~1 hour at 15-min resolution.
+
+    Returns:
+        Replacement price in currency/kWh, or ``None`` when no future
+        discharge slot exists.
+    """
+    discharge_prices = sorted(
+        [
+            slot.price.import_price
+            for slot in slots
+            if (
+                slot.recommendation == Recommendations.BatteriesDischargeMode.value
+                and as_tz(slot.start, now.tzinfo) > now
+                and not math.isnan(slot.price.import_price)
+            )
+        ],
+        reverse=True,
+    )
+    if not discharge_prices:
+        return None
+    top = discharge_prices[:top_n]
+    return sum(top) / len(top)

--- a/custom_components/hsem/planner/candidate_selector.py
+++ b/custom_components/hsem/planner/candidate_selector.py
@@ -32,7 +32,7 @@ Design constraints
 from __future__ import annotations
 
 import math
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from custom_components.hsem.datetime_utils import as_tz
 from custom_components.hsem.models.planner_outputs import RejectedPlan
@@ -337,10 +337,17 @@ def replacement_price_from_next_discharge(
     """Derive the terminal-SoC replacement price from the next discharge window.
 
     The energy stored at end-of-horizon is worth what it would cost to
-    re-purchase that energy from the grid during the first active discharge
-    schedule window.  Within that window the battery discharges in priority
-    order from the most expensive slots, so we use the average of the
-    *top_n* most expensive import prices among future discharge slots.
+    re-purchase that energy from the grid during the **first** upcoming
+    discharge schedule window.  Within that window the battery discharges
+    in priority order from the most expensive slots, so we use the average
+    of the *top_n* most expensive import prices within that window.
+
+    In a 48h or 72h horizon the planner marks ``BatteriesDischargeMode``
+    across all days, but the replacement price must reflect only the
+    closest discharge window — not windows 2+ days away.  We identify the
+    first window by collecting all future discharge slots, sorting them by
+    start time, and taking the first contiguous block of slots belonging
+    to the same schedule occurrence.
 
     Args:
         slots:
@@ -356,9 +363,10 @@ def replacement_price_from_next_discharge(
         Replacement price in currency/kWh, or ``None`` when no future
         discharge slot exists.
     """
-    discharge_prices = sorted(
+    # Collect all future discharge slots sorted by start time
+    future_discharge = sorted(
         [
-            slot.price.import_price
+            slot
             for slot in slots
             if (
                 slot.recommendation == Recommendations.BatteriesDischargeMode.value
@@ -366,9 +374,27 @@ def replacement_price_from_next_discharge(
                 and not math.isnan(slot.price.import_price)
             )
         ],
-        reverse=True,
+        key=lambda s: as_tz(s.start, now.tzinfo),
     )
-    if not discharge_prices:
+
+    if not future_discharge:
         return None
-    top = discharge_prices[:top_n]
-    return sum(top) / len(top)
+
+    # Find the first contiguous block of discharge slots.  A 15-min gap
+    # between consecutive discharge slots signals a new schedule occurrence
+    # (the gap between discharge windows).  We take only the first block.
+    GAP_THRESHOLD = timedelta(minutes=20)
+    first_block: list = [future_discharge[0]]
+    tz = now.tzinfo
+    for slot in future_discharge[1:]:
+        prev_end = as_tz(first_block[-1].end, tz)
+        this_start = as_tz(slot.start, tz)
+        if this_start - prev_end <= GAP_THRESHOLD:
+            first_block.append(slot)
+        else:
+            break  # reached the next schedule occurrence
+
+    # Average the top_n most expensive import prices within the first block
+    first_block.sort(key=lambda s: s.price.import_price, reverse=True)
+    top = [s.price.import_price for s in first_block[:top_n]]
+    return sum(top) / len(top) if top else None

--- a/custom_components/hsem/planner/engine.py
+++ b/custom_components/hsem/planner/engine.py
@@ -25,7 +25,6 @@ Design notes
 
 from __future__ import annotations
 
-import math
 from datetime import datetime
 
 from custom_components.hsem.datetime_utils import as_tz
@@ -40,7 +39,10 @@ from custom_components.hsem.models.planner_outputs import (
     RejectedPlan,
 )
 from custom_components.hsem.planner.candidate_generator import generate_candidates
-from custom_components.hsem.planner.candidate_selector import select_best_candidate
+from custom_components.hsem.planner.candidate_selector import (
+    replacement_price_from_next_discharge,
+    select_best_candidate,
+)
 from custom_components.hsem.planner.charge_scheduler import (
     apply_arbitrage_grid_charge,
     apply_charge_schedules,
@@ -718,31 +720,20 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
     slot_duration_hours = inp.interval_minutes / 60.0
 
     # Replacement price for the terminal-SoC opportunity cost term (issue #413).
-    # We use the *minimum future import price* across the horizon (Bug 3 fix,
-    # issue #416).  The marginal cost of one stored kWh at end-of-horizon is
-    # the cheapest price at which that energy could be re-purchased — not the
-    # average.  Using the average over all future slots (including expensive
-    # peak prices) systematically over-values stored energy during high-price
-    # periods and biases the selector against discharging.
-    # Past slots (recommendation == TimePassed) are excluded so the value
-    # reflects the actual decision window.
-    _future_import_prices = [
-        s.price.import_price
-        for s in slots
-        if as_tz(s.end, now.tzinfo) > now and not math.isnan(s.price.import_price)
-    ]
-    replacement_price_per_kwh: float | None = (
-        min(_future_import_prices) if _future_import_prices else None
+    # We use the most expensive import prices from the next active discharge
+    # schedule window.  The energy stored at end-of-horizon avoids importing at
+    # those peak prices, so those are the appropriate replacement cost.
+    replacement_price_per_kwh: float | None = replacement_price_from_next_discharge(
+        slots, now
     )
     log_planner(
         "debug",
-        "[engine] terminal-SoC replacement price: %s  (min of %d future slots)",
+        "[engine] terminal-SoC replacement price: %s  (from next discharge window)",
         (
             f"{replacement_price_per_kwh:.4f}"
             if replacement_price_per_kwh is not None
-            else "(none — no future slots)"
+            else "(none — no future discharge slots)"
         ),
-        len(_future_import_prices),
     )
 
     candidates = generate_candidates(

--- a/custom_components/hsem/planner/milp_optimizer.py
+++ b/custom_components/hsem/planner/milp_optimizer.py
@@ -353,10 +353,24 @@ def solve_milp(
 
 
 def is_scipy_available() -> bool:
-    """Return ``True`` if scipy is importable in the current environment."""
+    """Return ``True`` if scipy is importable in the current environment.
+
+    The import result is cached at module level so that the blocking
+    ``import scipy.optimize`` happens exactly once at import time rather
+    than on every planner run inside the Home Assistant event loop.
+    """
+    return _SCIPY_AVAILABLE
+
+
+# --- Module-level cache: computed once at import time --------------------
+def _check_scipy() -> bool:
+    """Check whether scipy is importable.  Called once at module load."""
     try:
         import scipy.optimize  # noqa: F401
 
         return True
     except ImportError:
         return False
+
+
+_SCIPY_AVAILABLE: bool = _check_scipy()

--- a/tests/planner/test_candidate_generation.py
+++ b/tests/planner/test_candidate_generation.py
@@ -31,8 +31,10 @@ from custom_components.hsem.planner.candidate_generator import (
     CANDIDATE_DISCHARGE_ONLY,
     CANDIDATE_GRID_CHARGE,
     CANDIDATE_NO_ACTION,
+    CANDIDATE_PASSIVE,
     CANDIDATE_SOLAR_ONLY,
     CandidatePlan,
+    _apply_passive_solar,
     _clear_all_charge_discharge,
     _copy_slots,
     _remove_all_charge,
@@ -259,7 +261,7 @@ class TestGenerateCandidates:
         return make_summer_day_input()
 
     def test_all_candidate_names_present(self):
-        """generate_candidates must return all six named candidates."""
+        """generate_candidates must return all seven named candidates."""
         inp = self._inp()
         now = datetime.fromisoformat(inp.now_iso)
         slots = self._make_baseline()
@@ -267,6 +269,7 @@ class TestGenerateCandidates:
         names = {c.name for c in candidates}
         assert CANDIDATE_BASELINE in names
         assert CANDIDATE_NO_ACTION in names
+        assert CANDIDATE_PASSIVE in names
         assert CANDIDATE_GRID_CHARGE in names
         assert CANDIDATE_SOLAR_ONLY in names
         assert CANDIDATE_DISCHARGE_ONLY in names
@@ -489,8 +492,8 @@ class TestSelectBestCandidate:
             )
             assert winner_cost <= candidate_cost + 1e-9
 
-    def test_no_action_wins_when_all_others_invalid(self):
-        """When only no_action is valid, it must be selected as the winner."""
+    def test_no_action_never_wins_when_only_valid(self):
+        """When only no_action is valid, it must NOT win — baseline must win."""
         inp = make_summer_day_input()
         now = datetime.fromisoformat(inp.now_iso)
         slots = _populated_slots_for_input(inp)
@@ -500,9 +503,7 @@ class TestSelectBestCandidate:
             if candidate.name != CANDIDATE_NO_ACTION:
                 candidate.is_valid = False
                 candidate.rejection_reason = "forced invalid for test"
-        # Run select (skip SoC simulation — candidates already have is_valid set)
-        # We need to call simulate_soc on each to populate grid flows, then
-        # manually re-set invalidity.
+        # Run select
         for candidate in candidates:
             from custom_components.hsem.planner.soc_simulation import simulate_soc
 
@@ -517,18 +518,42 @@ class TestSelectBestCandidate:
                 rated_kwh=10.0,
                 end_of_discharge_soc_pct=10.0,
             )
-        # Re-force invalidity (simulate_soc resets nothing, just populates fields)
+        # Re-force invalidity
         for candidate in candidates:
             if candidate.name != CANDIDATE_NO_ACTION:
                 candidate.is_valid = False
                 candidate.rejection_reason = "forced invalid for test"
 
-        # Now call select, but pre-set is_valid to bypass the internal validate step.
-        # We test the fallback path by checking that when valid list == [no_action]
-        # the winner is no_action.
-        valid_candidates = [c for c in candidates if c.is_valid]
-        assert len(valid_candidates) == 1
-        assert valid_candidates[0].name == CANDIDATE_NO_ACTION
+        cost_weights = CostWeights(
+            min_soc_pct=10.0,
+            max_soc_pct=100.0,
+            battery_purchase_price=10_000.0,
+            battery_rated_capacity_kwh=10.0,
+            battery_expected_cycles=6000,
+            conversion_loss_pct=10.0,
+        )
+        winner, rejected = select_best_candidate(
+            candidates,
+            now=now,
+            current_kwh=4.5,
+            usable_kwh=9.0,
+            max_soc_capacity_kwh=9.0,
+            max_charge_per_slot=1.25,
+            max_discharge_per_slot=None,
+            rated_kwh=10.0,
+            end_of_discharge_soc_pct=10.0,
+            cost_weights=cost_weights,
+            slot_duration_hours=1.0,
+        )
+        # With only no_action valid (and excluded), the fallback is baseline
+        assert winner.name == CANDIDATE_BASELINE, (
+            f"Expected baseline to win (fallback), got {winner.name}"
+        )
+        # Verify no_action is in rejected with an exclusion reason
+        no_action_rejected = next(
+            (r for r in rejected if r.name == CANDIDATE_NO_ACTION), None
+        )
+        assert no_action_rejected is not None, "no_action must appear in rejected plans"
 
 
 # ===========================================================================
@@ -550,11 +575,11 @@ class TestPlannerOutputCandidates:
         names = [c.name for c in output.candidates]
         assert CANDIDATE_BASELINE in names
 
-    def test_all_six_candidates_present(self):
-        """The six core named candidates must appear in a standard summer run.
+    def test_all_seven_candidates_present(self):
+        """The seven core named candidates must appear in a standard summer run.
 
-        When scipy is available a 7th ``milp`` candidate is also added.  This
-        test only asserts the six mandatory candidates are present; the MILP
+        When scipy is available an 8th ``milp`` candidate is also added.  This
+        test only asserts the seven mandatory candidates are present; the MILP
         candidate is validated separately in test_milp_optimizer.py.
         """
         output = run_planner(make_summer_day_input())
@@ -562,6 +587,7 @@ class TestPlannerOutputCandidates:
         expected_core = {
             CANDIDATE_BASELINE,
             CANDIDATE_NO_ACTION,
+            CANDIDATE_PASSIVE,
             CANDIDATE_GRID_CHARGE,
             CANDIDATE_SOLAR_ONLY,
             CANDIDATE_DISCHARGE_ONLY,
@@ -624,3 +650,113 @@ class TestPlannerOutputCandidates:
         assert len(winner_candidates) == 1, (
             "Exactly one candidate should share its slots list with output.slots"
         )
+
+
+# ===========================================================================
+# 7. Passive candidate tests (issue #420)
+# ===========================================================================
+
+
+class TestPassiveCandidate:
+    """Tests for the passive candidate and _apply_passive_solar helper."""
+
+    def test_passive_candidate_present(self):
+        """CANDIDATE_PASSIVE must be present after a standard summer day run."""
+        output = run_planner(make_summer_day_input())
+        names = {c.name for c in output.candidates}
+        assert CANDIDATE_PASSIVE in names, (
+            f"Expected CANDIDATE_PASSIVE in candidates, got {names}"
+        )
+
+    def test_passive_charges_on_pv_surplus(self):
+        """Slots with negative estimated_net_consumption get solar charge."""
+        tz = ZoneInfo("Europe/Copenhagen")
+        now = datetime(2024, 6, 15, 12, 0, tzinfo=tz)
+        slots = [
+            _make_simple_slot(
+                hour=8,  # start=08:00, end=09:00 — past
+                recommendation=Recommendations.BatteriesChargeGrid.value,
+                batteries_charged=3.0,
+            ),
+            _make_simple_slot(
+                hour=13,  # start=13:00, end=14:00 — future
+                recommendation=Recommendations.BatteriesDischargeMode.value,
+                batteries_charged=0.0,
+            ),
+            _make_simple_slot(
+                hour=14,  # start=14:00, end=15:00 — future
+                recommendation=None,
+                batteries_charged=0.0,
+            ),
+            _make_simple_slot(
+                hour=15,  # start=15:00, end=16:00 — future
+                recommendation=None,
+                batteries_charged=0.0,
+            ),
+        ]
+        # Set up: slot 0 (past, surplus), slot 1 (future, surplus),
+        # slot 2 (future, net positive), slot 3 (future, surplus)
+        slots[0].estimated_net_consumption = -2.0  # past surplus — ignored
+        slots[1].estimated_net_consumption = -2.0  # future surplus
+        slots[2].estimated_net_consumption = 1.5  # positive — ignored
+        slots[3].estimated_net_consumption = -0.5  # future surplus
+
+        _apply_passive_solar(slots, now)
+
+        # Past slot with surplus: recommendation cleared, not re-assigned
+        assert slots[0].recommendation is None
+        assert abs(slots[0].batteries_charged) < 1e-9
+
+        # Future slot with surplus (-2.0): gets BatteriesChargeSolar, charged=2.0
+        assert slots[1].recommendation == Recommendations.BatteriesChargeSolar.value
+        assert slots[1].batteries_charged == pytest.approx(2.0)
+
+        # Future slot with positive net consumption: remains None
+        assert slots[2].recommendation is None
+        assert abs(slots[2].batteries_charged) < 1e-9
+
+        # Future slot with surplus (-0.5): gets BatteriesChargeSolar, charged=0.5
+        assert slots[3].recommendation == Recommendations.BatteriesChargeSolar.value
+        assert slots[3].batteries_charged == pytest.approx(0.5)
+
+    def test_no_action_never_wins(self):
+        """run_planner on a summer day must never select no_action as winner."""
+        output = run_planner(make_summer_day_input())
+        # The winning candidate is the one whose slots list IS output.slots
+        winner_candidates = [
+            c
+            for c in output.candidates
+            if len(c.slots) == len(output.slots)
+            and all(a is b for a, b in zip(c.slots, output.slots))
+        ]
+        assert len(winner_candidates) == 1
+        winner = winner_candidates[0]
+        assert winner.name != CANDIDATE_NO_ACTION, (
+            "no_action must never be the winning candidate"
+        )
+
+    def test_passive_never_grid_charges(self):
+        """_apply_passive_solar must never assign BatteriesChargeGrid."""
+        tz = ZoneInfo("Europe/Copenhagen")
+        now = datetime(2024, 6, 15, 0, 0, tzinfo=tz)
+        slots = [
+            _make_simple_slot(
+                hour=h,
+                recommendation=(
+                    Recommendations.BatteriesChargeGrid.value
+                    if h % 2 == 0
+                    else Recommendations.BatteriesDischargeMode.value
+                ),
+            )
+            for h in range(24)
+        ]
+        for s in slots:
+            s.estimated_net_consumption = -1.0  # all surplus
+
+        _apply_passive_solar(slots, now)
+
+        for slot in slots:
+            assert slot.recommendation != Recommendations.BatteriesChargeGrid.value, (
+                f"_apply_passive_solar must never assign BatteriesChargeGrid "
+                f"(found at slot starting {slot.start})"
+            )


### PR DESCRIPTION
## Summary

Replaces `no_action`'s behavioural role with a new `passive` candidate that models what the inverter actually does when given no scheduling instructions: absorb PV surplus into the battery when `estimated_net_consumption < 0`.

Also fixes three bugs:
1. **Blocking `import scipy.optimize`** inside the HA event loop — cached at module level
2. **`terminal_soc_value = 0.0` for all candidates** — `replacement_price_per_kwh` was computed as the *minimum* future import price, undervaluing stored energy. Now uses top-N most expensive import prices from the next discharge schedule window.
3. **Multi-day horizon scoping** — `replacement_price_from_next_discharge` now isolates only the **first** contiguous block of discharge slots (using a >20 min gap detector), preventing prices from windows 2-3 days away from inflating the replacement value.

## What changed

### `candidate_generator.py`
- Added `CANDIDATE_PASSIVE = "passive"` constant and exported in `__all__`
- Added `_apply_passive_solar()` helper that clears all active scheduling, then assigns `BatteriesChargeSolar` to future slots where `estimated_net_consumption < 0`
- Inserted `passive` candidate (№3) after `no_action` in `generate_candidates()`
- Renumbered all remaining candidate comments (3→4 through 7→8)
- Updated module docstring to list all 8 candidates

### `candidate_selector.py`
- Imported `CANDIDATE_NO_ACTION` from `candidate_generator`
- Created `eligible` list filtering out `no_action` from the winner pool
- Winner selection now operates on `eligible` instead of `valid`
- `no_action` still scored for diagnostics and appears in `output.candidates`
- Special rejection reason for `no_action`: "Diagnostic floor only — excluded from winner selection"
- Added `replacement_price_from_next_discharge()` helper:
  - Collects all future `BatteriesDischargeMode` slots, sorts by start time
  - Detects first contiguous block using a 20-min gap threshold (the gap between schedule occurrences)
  - Averages the top-N most expensive import prices within that first block only
  - Correctly scopes to only the next discharge window regardless of horizon length

### `milp_optimizer.py`
- Cached `_SCIPY_AVAILABLE` at module level via `_check_scipy()` called once at import time
- `is_scipy_available()` now returns the cached boolean — no blocking import inside the event loop

### `engine.py`
- Replaced `min(future import prices)` with `replacement_price_from_next_discharge(slots, now)` for computing `replacement_price_per_kwh`
- Removed now-unused `import math`

### `tests/planner/test_candidate_generation.py`
- Updated imports to include `CANDIDATE_PASSIVE` and `_apply_passive_solar`
- Updated `test_all_candidate_names_present` → checks 7 candidates
- Updated `test_no_action_wins_when_all_others_invalid` → renamed to `test_no_action_never_wins_when_only_valid`, asserts baseline wins (fallback)
- Updated `test_all_six_candidates_present` → `test_all_seven_candidates_present`
- Added `TestPassiveCandidate` class with 4 new tests

## Test results
- 525 planner tests passed, 0 failed
- `tox -e lint` clean (0 issues)

Fixes #420
