### PR TITLE
fix(config): align batteries_conversion_loss default with config_reader (0.04)

### DIFF
--- a/custom_components/hsem/models/sensor_config.py
+++ b/custom_components/hsem/models/sensor_config.py
@@ -171,7 +171,7 @@ class SensorConfig:
     #: the min-price-difference guard so cycling only happens when the price
     #: spread covers both losses AND wear.  0.0 means no extra guard.
     batteries_cycle_cost: float = 0.0
-    batteries_conversion_loss: float = 0.004
+    batteries_conversion_loss: float = 0.04
 
     # Battery discharge schedules
     batteries_schedule_1: BatteryScheduleConfig = field(


### PR DESCRIPTION
Align the default value of atteries_conversion_loss in SensorConfig from  .004 to  .04 to match the override in config_reader.py (line 50).

**Problem:** The dataclass default (0.004 = 0.4 %) diverged from what config_reader.py actually writes (0.04 = 4 %). Any code path that constructs SensorConfig directly without going through config_reader.py would get the wrong value.

**Change:** models/sensor_config.py � default changed from  .004 ?  .04.

**Tests:** Existing tests pass � config_reader.py already overrides this field, so all runtime paths are unaffected.
