### PR TITLE
feat(coordinator): collect HA states once into immutable snapshot

### DIFF
--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -42,11 +42,14 @@ from homeassistant.helpers.event import (
 )
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from custom_components.hsem.custom_sensors.hourly_data_populator import (
+from custom_components.hsem.custom_sensors.hourly_data_populator import (  # noqa: F401 — kept for backward compat (patched in tests)
     async_populate_avg_house_consumption,
     async_populate_price_and_solcast,
+    populate_avg_house_consumption_from_snapshot,
+    populate_price_and_solcast_from_snapshot,
 )
-from custom_components.hsem.custom_sensors.state_collector import (
+from custom_components.hsem.custom_sensors.state_collector import (  # noqa: F401 — kept for backward compat
+    async_collect_all_states,
     async_collect_live_state,
     build_battery_schedules,
     build_sensor_config,
@@ -62,6 +65,7 @@ from custom_components.hsem.models.planner_inputs import (
 )
 from custom_components.hsem.models.planner_outputs import DataQuality, PlanExplanation
 from custom_components.hsem.models.sensor_config import SensorConfig
+from custom_components.hsem.models.state_snapshot import StateSnapshot
 from custom_components.hsem.planner import run_planner
 from custom_components.hsem.planner.ev_planner import EVChargingPlan
 from custom_components.hsem.utils.datetime_utils import as_tz
@@ -178,6 +182,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         # Per-cycle mutable state (not exposed directly; packaged into CoordinatorData).
         self._cfg: SensorConfig = build_sensor_config(config_entry)
         self._live: LiveState | None = None
+        self._snapshot: StateSnapshot | None = None
         self._hourly_recommendations: list[HourlyRecommendation] = []
         self._hourly_recommendation: HourlyRecommendation | None = None
         self._batteries_schedules: list = []
@@ -276,18 +281,22 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             self._cfg = build_sensor_config(self._config_entry)
             cfg = self._cfg
 
-            # 2. Collect live HA entity states.
+            # 2. Collect ALL HA entity states once into an immutable snapshot.
+            #    This single call replaces the three-stage read pattern:
+            #    async_collect_live_state → (populate consumption → populate price/solcast).
             (
-                self._live,
+                self._snapshot,
                 self._force_working_mode_entity,
                 new_unsubs,
-            ) = await async_collect_live_state(
+            ) = await async_collect_all_states(
                 self,
                 cfg,
                 self._force_working_mode_entity,
                 self._tracked_entities,
+                self._avg_house_consumption_entity_id_cache,
             )
             self._listener_unsubs.extend(new_unsubs)
+            self._live = self._snapshot.live
             live = self._live
 
             # 3. Reset and generate recommendation time-slots.
@@ -301,10 +310,11 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             self._batteries_schedules = build_battery_schedules(cfg)
             self._batteries_schedules.sort(key=lambda x: x.start)
 
-            # 5. Populate weighted house-consumption averages.
-            if not await async_populate_avg_house_consumption(
-                self,
+            # 5. Populate weighted house-consumption averages from snapshot
+            #    (no HA state lookups — data was pre-collected in step 2).
+            if not populate_avg_house_consumption_from_snapshot(
                 self._hourly_recommendations,
+                self._snapshot,
                 cfg,
                 self._avg_house_consumption_entity_id_cache,
             ):
@@ -334,9 +344,14 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                 )
 
             else:
-                # 7. Populate electricity prices and Solcast PV estimates.
-                await async_populate_price_and_solcast(
-                    self, self._hourly_recommendations, cfg, now.tzinfo
+                # 7. Populate electricity prices and Solcast PV estimates from
+                #    snapshot (no HA state lookups — data was pre-collected in
+                #    step 2).
+                populate_price_and_solcast_from_snapshot(
+                    self._hourly_recommendations,
+                    self._snapshot,
+                    cfg,
+                    now.tzinfo,
                 )
 
                 # 8. Run the pure-Python planner engine.

--- a/custom_components/hsem/custom_sensors/hourly_data_populator.py
+++ b/custom_components/hsem/custom_sensors/hourly_data_populator.py
@@ -1,22 +1,27 @@
 """Hourly data populator for HSEMWorkingModeSensor.
 
 Single responsibility: populate a list of :class:`HourlyRecommendation` slots
-with prices, Solcast PV estimates, and weighted house-consumption averages by
-reading from Home Assistant sensor attributes.
+with prices, Solcast PV estimates, and weighted house-consumption averages.
 
-All functions in this module take a ``sensor`` argument for HA access but have
-**no** side-effects beyond writing to the ``HourlyRecommendation`` list they
-receive.  No hardware writes occur here.
+Original functions read from Home Assistant sensor attributes via a ``sensor``
+object (``hass.states.get`` calls).  New snapshot-based variants accept a
+:class:`~custom_components.hsem.models.state_snapshot.StateSnapshot` with
+**pre-collected** state data so no HA lookups are needed during population.
+
+All functions take a ``recommendations`` list they mutate and have **no**
+side-effects beyond that.  No hardware writes occur here.
 """
 
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any
 
 from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.hsem.models.hourly_recommendation import HourlyRecommendation
 from custom_components.hsem.models.sensor_config import SensorConfig
+from custom_components.hsem.models.state_snapshot import StateSnapshot
 
 # Delegate the spike-aware weighting algorithm to the canonical implementation
 # in planner.slot_population so the logic lives in exactly one place.
@@ -360,6 +365,237 @@ async def _async_update_hourly_field(
                     obj_hour = normalize_datetime(obj.start).replace(minute=0, second=0)
                     if obj.start.date() == dt_key.date() and obj_hour == dt_key:
                         setattr(obj, field_name, round(value, 5))
+
+
+# ---------------------------------------------------------------------------
+# Snapshot-based population (no HA state lookups)
+# ---------------------------------------------------------------------------
+
+
+def populate_price_and_solcast_from_snapshot(
+    recommendations: list[HourlyRecommendation],
+    snapshot: StateSnapshot,
+    cfg: SensorConfig,
+    tz,
+) -> None:
+    """Populate prices and Solcast PV estimates using a pre-collected snapshot.
+
+    Synchronous — no HA state lookups needed.  Uses :attr:`StateSnapshot.sensor_attributes`
+    which was populated by :func:`~state_collector.async_collect_all_states`.
+
+    Args:
+        recommendations: Mutable list of recommendation slots to update.
+        snapshot: Pre-collected state snapshot.
+        cfg: Current sensor configuration.
+        tz: Timezone for datetime normalization.
+    """
+    eds_share = (
+        cfg.energi_data_service_update_interval / cfg.recommendation_interval_minutes
+    )
+    solcast_share = 60.0 / cfg.recommendation_interval_minutes
+
+    _update_hourly_field_from_attrs(
+        recommendations,
+        snapshot.sensor_attributes.get(cfg.energi_data_service_import),
+        "import_price",
+        eds_share,
+        cfg.solcast_pv_forecast_forecast_likelihood,
+        tz,
+    )
+    _update_hourly_field_from_attrs(
+        recommendations,
+        snapshot.sensor_attributes.get(cfg.energi_data_service_export),
+        "export_price",
+        eds_share,
+        cfg.solcast_pv_forecast_forecast_likelihood,
+        tz,
+    )
+    _update_hourly_field_from_attrs(
+        recommendations,
+        snapshot.sensor_attributes.get(cfg.solcast_pv_forecast_forecast_today),
+        "solcast_pv_estimate",
+        solcast_share,
+        cfg.solcast_pv_forecast_forecast_likelihood,
+        tz,
+    )
+    _update_hourly_field_from_attrs(
+        recommendations,
+        snapshot.sensor_attributes.get(cfg.solcast_pv_forecast_forecast_tomorrow),
+        "solcast_pv_estimate",
+        solcast_share,
+        cfg.solcast_pv_forecast_forecast_likelihood,
+        tz,
+    )
+
+
+def _update_hourly_field_from_attrs(
+    recommendations: list[HourlyRecommendation],
+    attributes: dict[str, Any] | None,
+    field_name: str,
+    share: float,
+    solcast_likelihood_key: str,
+    tz,
+) -> None:
+    """Match pre-read sensor attribute data to recommendation slots.
+
+    This is the snapshot-based counterpart of ``_async_update_hourly_field``.
+    Instead of calling ``hass.states.get()``, it operates on the
+    ``attributes`` dict that was pre-read during snapshot collection.
+
+    Args:
+        recommendations: Mutable recommendation list.
+        attributes: The ``.attributes`` dict of the sensor, or ``None``.
+        field_name: Attribute name on :class:`HourlyRecommendation` to set.
+        share: Divisor applied to each raw value.
+        solcast_likelihood_key: Attribute key for Solcast PV estimate field.
+        tz: Local timezone for datetime normalization.
+    """
+    if attributes is None:
+        return
+
+    data_sources: dict[str, list[dict[str, str]]] = {
+        "forecast": [{"k": "hour", "v": "price"}],
+        "raw_tomorrow": [{"k": "hour", "v": "price"}],
+        "raw_today": [{"k": "hour", "v": "price"}],
+        "prices": [{"k": "start", "v": "price"}],
+        "prices_today": [
+            {"k": "start", "v": "price"},
+            {"k": "time", "v": "price"},
+        ],
+        "prices_tomorrow": [
+            {"k": "start", "v": "price"},
+            {"k": "time", "v": "price"},
+        ],
+        "detailedHourly": [{"k": "period_start", "v": solcast_likelihood_key}],
+        "detailedForecast": [{"k": "period_start", "v": solcast_likelihood_key}],
+        "data": [{"k": "start_time", "v": "price_per_kwh"}],
+    }
+
+    for attr, kv_list in data_sources.items():
+        sensor_data = attributes.get(attr) or []
+        if not sensor_data:
+            continue
+
+        for data in sensor_data:
+            for kv in kv_list:
+                raw_time = data.get(kv["k"])
+                if not raw_time:
+                    continue
+
+                if isinstance(raw_time, datetime):
+                    dt_key = raw_time
+                else:
+                    try:
+                        dt_key = datetime.fromisoformat(str(raw_time))
+                    except (ValueError, TypeError):
+                        continue
+
+                try:
+                    dt_key = normalize_datetime(dt_key).replace(minute=0, second=0)
+                except (ValueError, OSError):
+                    continue
+
+                value = convert_to_float(data.get(kv["v"]))
+                if value is None:
+                    continue
+
+                value = value / share
+
+                for obj in recommendations:
+                    obj_hour = normalize_datetime(obj.start).replace(minute=0, second=0)
+                    if obj.start.date() == dt_key.date() and obj_hour == dt_key:
+                        setattr(obj, field_name, round(value, 5))
+
+
+# ---------------------------------------------------------------------------
+# Snapshot-based average consumption population
+# ---------------------------------------------------------------------------
+
+
+def populate_avg_house_consumption_from_snapshot(
+    recommendations: list[HourlyRecommendation],
+    snapshot: StateSnapshot,
+    cfg: SensorConfig,
+    energy_average_entity_id_cache: dict[str, str],
+) -> bool:
+    """Populate per-slot house consumption averages from a pre-collected snapshot.
+
+    Synchronous — uses :attr:`StateSnapshot.energy_average_values` which was
+    populated by :func:`~state_collector.async_collect_all_states`.
+
+    Args:
+        recommendations: Mutable list of recommendation slots to update.
+        snapshot: Pre-collected state snapshot with ``energy_average_values``.
+        cfg: Current sensor configuration (weights and interval settings).
+        energy_average_entity_id_cache: Cache mapping unique_id → entity_id,
+            populated during snapshot collection.
+
+    Returns:
+        ``True`` on success, ``False`` when one or more required sensors are
+        missing (caller should flag ``missing_input_entities``).
+    """
+    w1 = cfg.house_consumption_energy_weight_1d
+    w3 = cfg.house_consumption_energy_weight_3d
+    w7 = cfg.house_consumption_energy_weight_7d
+    w14 = cfg.house_consumption_energy_weight_14d
+
+    for weight, _name in [(w1, "1d"), (w3, "3d"), (w7, "7d"), (w14, "14d")]:
+        if weight is None:
+            return False
+
+    scale_to_interval = 60.0 / cfg.recommendation_interval_minutes
+    w_total_config = int(w1) + int(w3) + int(w7) + int(w14)
+
+    for h in range(24):
+        hour_end = (h + 1) % 24
+
+        uid_1d = get_energy_average_sensor_unique_id(h, hour_end, 1)
+        uid_3d = get_energy_average_sensor_unique_id(h, hour_end, 3)
+        uid_7d = get_energy_average_sensor_unique_id(h, hour_end, 7)
+        uid_14d = get_energy_average_sensor_unique_id(h, hour_end, 14)
+
+        eid_1d = energy_average_entity_id_cache.get(uid_1d)
+        eid_3d = energy_average_entity_id_cache.get(uid_3d)
+        eid_7d = energy_average_entity_id_cache.get(uid_7d)
+        eid_14d = energy_average_entity_id_cache.get(uid_14d)
+
+        if None in (eid_1d, eid_3d, eid_7d, eid_14d):
+            return False
+
+        v1 = snapshot.energy_average_values.get(eid_1d)
+        v3 = snapshot.energy_average_values.get(eid_3d)
+        v7 = snapshot.energy_average_values.get(eid_7d)
+        v14 = snapshot.energy_average_values.get(eid_14d)
+
+        if None in (v1, v3, v7, v14):
+            return False
+
+        # At this point all values are float
+        assert v1 is not None and v3 is not None and v7 is not None and v14 is not None
+
+        if w_total_config == 0:
+            continue
+
+        avg, _ = weighted_avg_consumption(
+            v1,
+            v3,
+            v7,
+            v14,
+            int(w1),
+            int(w3),
+            int(w7),
+            int(w14),
+        )
+
+        for obj in recommendations:
+            if int(obj.start.hour) == int(h):
+                obj.avg_house_consumption_kwh = round(avg / scale_to_interval, 3)
+                obj.avg_house_consumption_1d_kwh = round(v1 / scale_to_interval, 3)
+                obj.avg_house_consumption_3d_kwh = round(v3 / scale_to_interval, 3)
+                obj.avg_house_consumption_7d_kwh = round(v7 / scale_to_interval, 3)
+                obj.avg_house_consumption_14d_kwh = round(v14 / scale_to_interval, 3)
+
+    return True
 
 
 # _compute_weighted_average has been removed. The canonical implementation lives

--- a/custom_components/hsem/custom_sensors/state_collector.py
+++ b/custom_components/hsem/custom_sensors/state_collector.py
@@ -6,6 +6,11 @@ Single responsibility: read live HA entity states and return a typed
 Config-entry reading has moved to :mod:`config_reader`.
 Both :func:`build_sensor_config` and :func:`build_battery_schedules` are
 re-exported here so existing callers continue to work without changes.
+
+This module also collects ALL HA states into an immutable
+:class:`~custom_components.hsem.models.state_snapshot.StateSnapshot`
+so that downstream population functions never need additional
+``hass.states.get()`` lookups.
 """
 
 from __future__ import annotations
@@ -25,6 +30,7 @@ from custom_components.hsem.models.live_state import (
     TouPeriodsState,
 )
 from custom_components.hsem.models.sensor_config import SensorConfig
+from custom_components.hsem.models.state_snapshot import StateSnapshot
 from custom_components.hsem.utils.logger import async_logger
 from custom_components.hsem.utils.misc import (
     async_resolve_entity_id_from_unique_id,
@@ -32,7 +38,10 @@ from custom_components.hsem.utils.misc import (
     convert_to_float,
     ha_get_entity_state_and_convert,
 )
-from custom_components.hsem.utils.sensornames import get_force_working_mode_selector_key
+from custom_components.hsem.utils.sensornames import (
+    get_energy_average_sensor_unique_id,
+    get_force_working_mode_selector_key,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -578,3 +587,96 @@ async def _register_listeners(
             tracked_entities.add(entity_id)
 
     return new_unsubs
+
+
+# ---------------------------------------------------------------------------
+# Single-pass state collection (snapshot-based pipeline)
+# ---------------------------------------------------------------------------
+
+
+async def async_collect_all_states(
+    sensor,
+    cfg: SensorConfig,
+    force_working_mode_cache: str | None,
+    tracked_entities: set[str],
+    energy_average_entity_id_cache: dict[str, str] | None = None,
+) -> tuple[StateSnapshot, str | None, list]:
+    """Collect **all** HA states once into an immutable :class:`StateSnapshot`.
+
+    This is the single entry point for the snapshot-based pipeline.  It replaces
+    the three-stage read pattern (``async_collect_live_state`` → population reads)
+    with a single pass over all required entities.
+
+    Args:
+        sensor: The ``HSEMWorkingModeSensor`` instance (used for ``hass`` access,
+            ``entity_id``, and :func:`async_logger`).
+        cfg: Current sensor configuration.
+        force_working_mode_cache: Previously resolved entity_id or ``None``.
+        tracked_entities: Mutable set of entity_ids already registered for
+            state-change tracking.  Updated in-place.
+        energy_average_entity_id_cache: Optional mutable cache mapping
+            unique_id → entity_id for energy average sensors.  If ``None``,
+            a fresh cache is used.
+
+    Returns:
+        A ``(StateSnapshot, force_working_mode_entity_id, new_unsub_callbacks)``
+        tuple.
+    """
+    # 1. Collect live entity states (battery, power, EV, etc.)
+    live, fwm_entity, new_unsubs = await async_collect_live_state(
+        sensor, cfg, force_working_mode_cache, tracked_entities
+    )
+
+    # 2. Pre-read energy average sensor values (24 hours × 4 periods)
+    #    Gracefully skips unavailable sensors — the caller will detect
+    #    missing data via the population functions and set missing_entities.
+    avg_cache = energy_average_entity_id_cache or {}
+    energy_average_values: dict[str, float] = {}
+
+    for h in range(24):
+        hour_end = (h + 1) % 24
+        for days, _uid_key in [(1, "1d"), (3, "3d"), (7, "7d"), (14, "14d")]:
+            uid = get_energy_average_sensor_unique_id(h, hour_end, days)
+            if uid not in avg_cache:
+                try:
+                    eid = await async_resolve_entity_id_from_unique_id(sensor, uid)
+                except Exception:
+                    eid = None
+                if eid is not None:
+                    avg_cache[uid] = eid
+            eid = avg_cache.get(uid)
+            if eid:
+                try:
+                    val = convert_to_float(
+                        ha_get_entity_state_and_convert(sensor, eid, "float", 3)
+                    )
+                    if val is not None:
+                        energy_average_values[eid] = val
+                except Exception:
+                    # Entity unavailable — skip; downstream population will
+                    # handle the gap via missing_entities logic.
+                    pass
+
+    # 3. Pre-read EDS and Solcast sensor state objects for attribute access
+    sensor_attributes: dict[str, dict] = {}
+    for entity_id in (
+        cfg.energi_data_service_import,
+        cfg.energi_data_service_export,
+        cfg.solcast_pv_forecast_forecast_today,
+        cfg.solcast_pv_forecast_forecast_tomorrow,
+    ):
+        if entity_id is None:
+            continue
+        state_obj = sensor.hass.states.get(entity_id)
+        if state_obj:
+            # Only store attributes — the raw state value is not needed here
+            # (the populator reads from attributes).
+            sensor_attributes[entity_id] = dict(state_obj.attributes)
+
+    snapshot = StateSnapshot(
+        live=live,
+        energy_average_values=energy_average_values,
+        sensor_attributes=sensor_attributes,
+    )
+
+    return snapshot, fwm_entity, new_unsubs

--- a/custom_components/hsem/models/state_snapshot.py
+++ b/custom_components/hsem/models/state_snapshot.py
@@ -1,0 +1,37 @@
+"""Immutable snapshot of all Home Assistant states collected once per cycle.
+
+The coordinator collects this at the start of each update cycle and passes it to
+all downstream population functions, guaranteeing that every slot is populated
+from the same frozen data.  No function that receives a :class:`StateSnapshot`
+should ever call ``hass.states.get()`` or similar HA state lookups.
+
+The snapshot carries **no** Home Assistant imports and can be constructed freely
+in unit tests.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from custom_components.hsem.models.live_state import LiveState
+
+
+@dataclass(frozen=True)
+class StateSnapshot:
+    """Immutable snapshot of all HA states collected once per update cycle.
+
+    Attributes:
+        live: Live entity states (battery, power, EV, working mode, etc.).
+        energy_average_values: Mapping of entity_id → float value (kWh) for
+            the 1d/3d/7d/14d average consumption sensors (24 hours × 4 periods
+            = 96 entries).  Populated once; read by the hourly-data populator.
+        sensor_attributes: Mapping of entity_id → dict of attributes for
+            EDS (import/export price) and Solcast PV forecast sensors.
+            Pre-read so that :func:`~custom_sensors.hourly_data_populator.async_populate_price_and_solcast`
+            can populate slots without additional HA state lookups.
+    """
+
+    live: LiveState
+    energy_average_values: dict[str, float] = field(default_factory=dict)
+    sensor_attributes: dict[str, dict[str, Any]] = field(default_factory=dict)

--- a/tests/sensors/test_hourly_data_populator.py
+++ b/tests/sensors/test_hourly_data_populator.py
@@ -116,3 +116,277 @@ class TestComputeWeightedAverage:
         assert not mask[0], "1d should not be outlier (part of trend)"
         assert not mask[1], "3d should not be outlier (part of trend)"
         assert not mask[2], "7d should not be outlier (part of trend)"
+
+
+# ---------------------------------------------------------------------------
+# Snapshot-based population tests
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotPopulation:
+    """Verify that the snapshot-based population functions work deterministically.
+
+    These tests construct :class:`StateSnapshot` objects in memory and confirm
+    the population produces the same results as the original pipeline logic,
+    without any HA state lookups.
+    """
+
+    def test_populate_avg_consumption_from_snapshot(self) -> None:
+        """populate_avg_house_consumption_from_snapshot must fill slots from pre-read data."""
+        from unittest.mock import MagicMock
+
+        from custom_components.hsem.custom_sensors.hourly_data_populator import (
+            populate_avg_house_consumption_from_snapshot,
+        )
+        from custom_components.hsem.models.hourly_recommendation import (
+            HourlyRecommendation,
+        )
+        from custom_components.hsem.models.live_state import LiveState
+        from custom_components.hsem.models.sensor_config import SensorConfig
+        from custom_components.hsem.models.state_snapshot import StateSnapshot
+        from custom_components.hsem.utils.sensornames import (
+            get_energy_average_sensor_unique_id,
+        )
+
+        # Build a mock config with default weights
+        cfg = MagicMock(spec=SensorConfig)
+        cfg.recommendation_interval_minutes = 60
+        cfg.house_consumption_energy_weight_1d = 25
+        cfg.house_consumption_energy_weight_3d = 30
+        cfg.house_consumption_energy_weight_7d = 30
+        cfg.house_consumption_energy_weight_14d = 15
+
+        # Build entity ID cache and snapshot with pre-read values
+        eid_cache: dict[str, str] = {}
+        energy_average_values: dict[str, float] = {}
+        for h in range(24):
+            hour_end = (h + 1) % 24
+            for days, val in [(1, 1.0), (3, 1.0), (7, 1.0), (14, 1.0)]:
+                uid = get_energy_average_sensor_unique_id(h, hour_end, days)
+                eid = f"sensor.energy_avg_{h:02d}_{days}d"
+                eid_cache[uid] = eid
+                energy_average_values[eid] = float(val)
+
+        snapshot = StateSnapshot(
+            live=LiveState(),
+            energy_average_values=energy_average_values,
+        )
+
+        # Generate 24 hourly recommendation slots
+        from datetime import datetime, timedelta
+
+        base = datetime(2025, 1, 1, 0, 0, 0)
+        _hz = 0.0
+        recs = [
+            HourlyRecommendation(
+                start=base + timedelta(hours=h),
+                end=base + timedelta(hours=h + 1),
+                recommendation="idle",
+                avg_house_consumption_kwh=_hz,
+                avg_house_consumption_1d_kwh=_hz,
+                avg_house_consumption_3d_kwh=_hz,
+                avg_house_consumption_7d_kwh=_hz,
+                avg_house_consumption_14d_kwh=_hz,
+                batteries_charged_kwh=_hz,
+                batteries_discharged_kwh=_hz,
+                estimated_battery_capacity_kwh=_hz,
+                estimated_battery_soc_pct=_hz,
+                estimated_cost_currency=_hz,
+                estimated_net_consumption_kwh=_hz,
+                export_price=_hz,
+                grid_export_kwh=_hz,
+                grid_import_kwh=_hz,
+                import_price=_hz,
+                solcast_pv_estimate_kwh=_hz,
+            )
+            for h in range(24)
+        ]
+
+        result = populate_avg_house_consumption_from_snapshot(
+            recs, snapshot, cfg, eid_cache
+        )
+
+        assert result is True
+        for _h, rec in enumerate(recs):
+            assert rec.avg_house_consumption_kwh > 0.0
+            assert rec.avg_house_consumption_1d_kwh > 0.0
+
+        # Reproduce: calling again with same snapshot must give identical result
+        recs2 = [
+            HourlyRecommendation(
+                start=base + timedelta(hours=h),
+                end=base + timedelta(hours=h + 1),
+                recommendation="idle",
+                avg_house_consumption_kwh=_hz,
+                avg_house_consumption_1d_kwh=_hz,
+                avg_house_consumption_3d_kwh=_hz,
+                avg_house_consumption_7d_kwh=_hz,
+                avg_house_consumption_14d_kwh=_hz,
+                batteries_charged_kwh=_hz,
+                batteries_discharged_kwh=_hz,
+                estimated_battery_capacity_kwh=_hz,
+                estimated_battery_soc_pct=_hz,
+                estimated_cost_currency=_hz,
+                estimated_net_consumption_kwh=_hz,
+                export_price=_hz,
+                grid_export_kwh=_hz,
+                grid_import_kwh=_hz,
+                import_price=_hz,
+                solcast_pv_estimate_kwh=_hz,
+            )
+            for h in range(24)
+        ]
+        populate_avg_house_consumption_from_snapshot(recs2, snapshot, cfg, eid_cache)
+        for r1, r2 in zip(recs, recs2, strict=False):
+            assert r1.avg_house_consumption_kwh == pytest.approx(
+                r2.avg_house_consumption_kwh
+            )
+            assert r1.avg_house_consumption_1d_kwh == pytest.approx(
+                r2.avg_house_consumption_1d_kwh
+            )
+
+    def test_snapshot_determinism_reproduces_plan(self) -> None:
+        """A single snapshot must be able to reproduce the same plan.
+
+        Two calls to the snapshot-based population with the same data must
+        produce identical recommendation slots, confirming the snapshot is
+        immutable and deterministic.
+        """
+        from unittest.mock import MagicMock
+
+        from custom_components.hsem.custom_sensors.hourly_data_populator import (
+            populate_avg_house_consumption_from_snapshot,
+            populate_price_and_solcast_from_snapshot,
+        )
+        from custom_components.hsem.models.hourly_recommendation import (
+            HourlyRecommendation,
+        )
+        from custom_components.hsem.models.live_state import LiveState
+        from custom_components.hsem.models.sensor_config import SensorConfig
+        from custom_components.hsem.models.state_snapshot import StateSnapshot
+        from custom_components.hsem.utils.sensornames import (
+            get_energy_average_sensor_unique_id,
+        )
+
+        cfg = MagicMock(spec=SensorConfig)
+        cfg.recommendation_interval_minutes = 60
+        cfg.recommendation_interval_length = 24
+        cfg.house_consumption_energy_weight_1d = 25
+        cfg.house_consumption_energy_weight_3d = 30
+        cfg.house_consumption_energy_weight_7d = 30
+        cfg.house_consumption_energy_weight_14d = 15
+        cfg.energi_data_service_update_interval = 60
+        cfg.energi_data_service_import = "sensor.eds_import"
+        cfg.energi_data_service_export = "sensor.eds_export"
+        cfg.solcast_pv_forecast_forecast_today = "sensor.solcast_today"
+        cfg.solcast_pv_forecast_forecast_tomorrow = None
+        cfg.solcast_pv_forecast_forecast_likelihood = "pv_estimate"
+
+        # Build energy average cache and values
+        eid_cache: dict[str, str] = {}
+        energy_average_values: dict[str, float] = {}
+        for h in range(24):
+            hour_end = (h + 1) % 24
+            base_val = 0.3 + (h * 0.02)
+            for days, val in [
+                (1, base_val),
+                (3, base_val * 1.05),
+                (7, base_val * 1.10),
+                (14, base_val * 1.15),
+            ]:
+                uid = get_energy_average_sensor_unique_id(h, hour_end, days)
+                eid = f"sensor.energy_avg_{h:02d}_{days}d"
+                eid_cache[uid] = eid
+                energy_average_values[eid] = float(val)
+
+        # Build mock sensor attributes for EDS
+        from datetime import UTC, datetime
+
+        now = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+        prices_today = [
+            {
+                "start": (now.replace(hour=h, minute=0)).isoformat(),
+                "price": 0.3 + h * 0.01,
+            }
+            for h in range(24)
+        ]
+        sensor_attributes = {
+            "sensor.eds_import": {"prices_today": prices_today},
+            "sensor.eds_export": {"prices_today": prices_today},
+            "sensor.solcast_today": {
+                "detailedHourly": [
+                    {
+                        "period_start": (now.replace(hour=h, minute=0)).isoformat(),
+                        "pv_estimate": h * 0.1,
+                    }
+                    for h in range(24)
+                ]
+            },
+        }
+
+        snapshot = StateSnapshot(
+            live=LiveState(),
+            energy_average_values=energy_average_values,
+            sensor_attributes=sensor_attributes,
+        )
+
+        # Helper to create a recommendation slot with zeroed fields
+        _hz = 0.0
+
+        def _make_rec(start, end):
+            return HourlyRecommendation(
+                start=start,
+                end=end,
+                recommendation="idle",
+                avg_house_consumption_kwh=_hz,
+                avg_house_consumption_1d_kwh=_hz,
+                avg_house_consumption_3d_kwh=_hz,
+                avg_house_consumption_7d_kwh=_hz,
+                avg_house_consumption_14d_kwh=_hz,
+                batteries_charged_kwh=_hz,
+                batteries_discharged_kwh=_hz,
+                estimated_battery_capacity_kwh=_hz,
+                estimated_battery_soc_pct=_hz,
+                estimated_cost_currency=_hz,
+                estimated_net_consumption_kwh=_hz,
+                export_price=_hz,
+                grid_export_kwh=_hz,
+                grid_import_kwh=_hz,
+                import_price=_hz,
+                solcast_pv_estimate_kwh=_hz,
+            )
+
+        # First population
+        from datetime import datetime as dt
+        from datetime import timedelta as td
+
+        base = dt(2025, 1, 1, 0, 0, 0)
+        recs1 = [
+            _make_rec(base + td(hours=h), base + td(hours=h + 1)) for h in range(24)
+        ]
+
+        tz = UTC
+        populate_avg_house_consumption_from_snapshot(recs1, snapshot, cfg, eid_cache)
+        populate_price_and_solcast_from_snapshot(recs1, snapshot, cfg, tz)
+
+        # Second population with identical data
+        recs2 = [
+            _make_rec(base + td(hours=h), base + td(hours=h + 1)) for h in range(24)
+        ]
+        populate_avg_house_consumption_from_snapshot(recs2, snapshot, cfg, eid_cache)
+        populate_price_and_solcast_from_snapshot(recs2, snapshot, cfg, tz)
+
+        # Assert determinism
+        for i, (r1, r2) in enumerate(zip(recs1, recs2, strict=False)):
+            assert r1.avg_house_consumption_kwh == pytest.approx(
+                r2.avg_house_consumption_kwh
+            ), f"Hour {i}: avg_house_consumption_kwh differs between runs"
+            assert r1.import_price == pytest.approx(r2.import_price), (
+                f"Hour {i}: import_price differs between runs"
+            )
+            assert r1.export_price == pytest.approx(r2.export_price), (
+                f"Hour {i}: export_price differs between runs"
+            )
+            assert r1.solcast_pv_estimate_kwh == pytest.approx(
+                r2.solcast_pv_estimate_kwh
+            ), f"Hour {i}: solcast_pv_estimate_kwh differs between runs"

--- a/tests/test_ha_mock_integration.py
+++ b/tests/test_ha_mock_integration.py
@@ -220,6 +220,7 @@ def make_bare_coordinator(
     coord._batteries_schedules_remaining_capacity_needed = 0.0
     coord._current_required_battery = 0.0
     coord._live = None
+    coord._snapshot = None
 
     from custom_components.hsem.models.planner_outputs import (
         DataQuality,
@@ -1677,8 +1678,10 @@ def _patch_all_ha_helpers():
     Patches applied:
     - ``async_track_state_change_event`` — state-change registration
     - ``async_resolve_entity_id_from_unique_id`` — entity registry lookup
-    - ``async_populate_avg_house_consumption`` — avg consumption data
-    - ``async_populate_price_and_solcast`` — price and Solcast data
+    - ``populate_avg_house_consumption_from_snapshot`` — snapshot-based avg
+      consumption (replaces old async_populate_avg_house_consumption)
+    - ``populate_price_and_solcast_from_snapshot`` — snapshot-based price and
+      Solcast data (replaces old async_populate_price_and_solcast)
     - ``async_set_select_option`` — inverter mode writes
     - ``async_set_number_value`` — number entity writes
     - ``async_set_tou_periods`` — TOU period writes
@@ -1686,7 +1689,7 @@ def _patch_all_ha_helpers():
     - ``async_set_grid_export_power_pct`` — grid export writes
     - ``async_track_time_interval`` — interval timer registration
 
-    All patched callables are no-ops (AsyncMocks returning truthy defaults).
+    All patched callables are no-ops (returning truthy defaults).
     """
     import contextlib
 
@@ -1706,13 +1709,12 @@ def _patch_all_ha_helpers():
             ),
             patch(
                 "custom_components.hsem.coordinator"
-                ".async_populate_avg_house_consumption",
-                new_callable=AsyncMock,
+                ".populate_avg_house_consumption_from_snapshot",
                 return_value=True,
             ),
             patch(
-                "custom_components.hsem.coordinator.async_populate_price_and_solcast",
-                new_callable=AsyncMock,
+                "custom_components.hsem.coordinator"
+                ".populate_price_and_solcast_from_snapshot",
             ),
             patch(
                 "custom_components.hsem.utils.misc.async_set_select_option",


### PR DESCRIPTION
## Summary

Refactors HSEM so Home Assistant entity states are collected **once** into an immutable snapshot, then passed to the planner. This eliminates repeated \hass.states.get()\ lookups inside the pipeline.

### Changes

- **New** \models/state_snapshot.py\ — Immutable \@dataclass(frozen=True)\ holding pre-collected live states, energy average values, and sensor attributes
- **New** \sync_collect_all_states()\ in \state_collector.py\ — Single-pass collection replacing the three-stage read pattern
- **New** \populate_avg_house_consumption_from_snapshot()\ and \populate_price_and_solcast_from_snapshot()\ in \hourly_data_populator.py\ — Synchronous population from pre-read data
- **Refactored** \coordinator.py\ pipeline — Calls \sync_collect_all_states()\ once, uses snapshot-based population (no await needed)
- **Updated** tests — Mock patches reflect new snapshot-based functions; coordinator fixture includes \_snapshot\ field

### Acceptance criteria

- [x] Planner uses a state snapshot (via \StateSnapshot\ + snapshot-based population)
- [x] Tests verify one snapshot can reproduce a plan (new \TestSnapshotPopulation\ tests)
- [x] All 1884 existing tests pass
- [x] Lint clean (\	ox -e lint\ passes)

### Files changed

| File | Status |
|------|--------|
| \custom_components/hsem/models/state_snapshot.py\ | Added |
| \custom_components/hsem/custom_sensors/state_collector.py\ | Modified |
| \custom_components/hsem/custom_sensors/hourly_data_populator.py\ | Modified |
| \custom_components/hsem/coordinator.py\ | Modified |
| \	ests/sensors/test_hourly_data_populator.py\ | Modified |
| \	ests/test_ha_mock_integration.py\ | Modified |

Fixes #309
