### PR TITLE
feat(sensor): improve entity attributes for planner horizon, forecast mode, current slot, safety and apply status

### DIFF
--- a/custom_components/hsem/custom_sensors/degraded_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/degraded_mode_sensor.py
@@ -39,6 +39,7 @@ from custom_components.hsem.coordinator import (
     HSEMDataUpdateCoordinator,
 )
 from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
+from custom_components.hsem.utils.datetime_utils import now as hsem_now
 from custom_components.hsem.utils.degraded_mode import (
     DegradedMode,
     hardware_writes_allowed,
@@ -129,21 +130,55 @@ class HSEMDegradedModeSensor(
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Return diagnostic attributes visible on the entity detail page."""
+        """Return diagnostic attributes visible on the entity detail page.
+
+        Includes system-health details plus planning horizon, forecast mode,
+        and current slot information for easier debugging from the HA UI.
+        """
         data: CoordinatorData | None = self.coordinator.data
         if data is None or data.live is None:
             return {
                 "missing_entities": [],
                 "hardware_writes_blocked": False,
                 "read_only_mode": False,
+                "planning_horizon_hours": None,
+                "planning_interval_minutes": None,
+                "forecast_mode": None,
+                "current_slot_recommendation": None,
             }
         live = data.live
         cfg = data.cfg
-        return {
+
+        now = hsem_now()
+        current_month = now.month
+        forecast_mode = (
+            "winter"
+            if cfg is not None and current_month in (cfg.months_winter or [])
+            else "summer"
+        )
+
+        rec = data.hourly_recommendation
+        current_slot_recommendation = (
+            str(rec.recommendation) if rec is not None else None
+        )
+
+        attrs = {
             "missing_entities": list(live.missing_entities_list),
             "hardware_writes_blocked": not hardware_writes_allowed(live.degraded_mode),
             "read_only_mode": bool(cfg.read_only) if cfg is not None else False,
+            "forecast_mode": forecast_mode,
+            "current_slot_recommendation": current_slot_recommendation,
+            "last_apply_status": (
+                data.apply_summary.overall_status.value
+                if data.apply_summary is not None
+                else None
+            ),
         }
+        if cfg is not None:
+            attrs["planning_horizon_hours"] = cfg.recommendation_interval_length
+            attrs["planning_interval_minutes"] = cfg.recommendation_interval_minutes
+
+        return attrs
 
     # ------------------------------------------------------------------
     # HA lifecycle

--- a/custom_components/hsem/custom_sensors/hardware_writes_sensor.py
+++ b/custom_components/hsem/custom_sensors/hardware_writes_sensor.py
@@ -121,21 +121,31 @@ class HSEMHardwareWritesSensor(
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Return details about why writes are blocked (if applicable)."""
+        """Return details about why writes are blocked (if applicable).
+
+        Includes the degraded-mode reason, missing entity list, read-only
+        toggle status, and the current planning horizon.
+        """
         data: CoordinatorData | None = self.coordinator.data
         if data is None or data.live is None:
             return {
                 "degraded_mode": None,
                 "missing_entities_list": [],
                 "read_only_active": False,
+                "planning_horizon_hours": None,
+                "planning_interval_minutes": None,
             }
         live = data.live
         cfg = data.cfg
-        return {
+        attrs = {
             "degraded_mode": live.degraded_mode.value,
             "missing_entities_list": list(live.missing_entities_list),
             "read_only_active": bool(cfg.read_only) if cfg is not None else False,
         }
+        if cfg is not None:
+            attrs["planning_horizon_hours"] = cfg.recommendation_interval_length
+            attrs["planning_interval_minutes"] = cfg.recommendation_interval_minutes
+        return attrs
 
     # ------------------------------------------------------------------
     # HA lifecycle

--- a/custom_components/hsem/custom_sensors/plan_explanation_sensor.py
+++ b/custom_components/hsem/custom_sensors/plan_explanation_sensor.py
@@ -17,6 +17,18 @@ are exposed as individual state attributes so users can reference them directly
 via ``state_attr()`` without parsing a nested dict.  The ``rejected_plans`` list
 is included as-is (a list of dicts).
 
+Additional diagnostic attributes are merged from the coordinator snapshot:
+
+- ``planning_horizon_hours`` — how many hours ahead the planner evaluates.
+- ``planning_interval_minutes`` — width of each planning slot in minutes.
+- ``forecast_mode`` — ``"winter"`` or ``"summer"`` based on the configured
+  month ranges.
+- ``current_slot_start`` / ``current_slot_end`` / ``current_slot_recommendation``
+  — the active time-slot boundaries and its recommendation.
+- ``last_apply_status`` — outcome of the most recent hardware-write cycle.
+- ``hardware_writes_blocked`` — ``True`` when critical input data is missing.
+- ``data_quality_complete`` — ``True`` when all price and PV data is available.
+
 The sensor is a *diagnostic* entity (``EntityCategory.DIAGNOSTIC``) so it
 appears in the *Diagnostic* section of the device page and is excluded from
 the default Lovelace dashboard.
@@ -30,19 +42,30 @@ from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import EntityCategory
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from custom_components.hsem.coordinator import (
-    CoordinatorData,
-    HSEMDataUpdateCoordinator,
-)
+from custom_components.hsem.coordinator import (CoordinatorData,
+                                                HSEMDataUpdateCoordinator)
 from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
 from custom_components.hsem.models.planner_outputs import PlanExplanation
+from custom_components.hsem.utils.datetime_utils import now as hsem_now
+from custom_components.hsem.utils.degraded_mode import hardware_writes_allowed
 from custom_components.hsem.utils.sensornames import (
-    get_plan_explanation_sensor_entity_id,
-    get_plan_explanation_sensor_name,
-    get_plan_explanation_sensor_unique_id,
-)
+    get_plan_explanation_sensor_entity_id, get_plan_explanation_sensor_name,
+    get_plan_explanation_sensor_unique_id)
 
 _UNKNOWN_STRATEGY = "unknown"
+
+
+def _determine_forecast_mode(
+    cfg: Any,
+    now_tz_aware: Any,
+) -> str:
+    """Determine the active forecast season (``"winter"`` or ``"summer"``).
+
+    Uses the configured ``months_winter`` list from *cfg* and the current
+    month from *now_tz_aware*.
+    """
+    current_month = now_tz_aware.month
+    return "winter" if current_month in (cfg.months_winter or []) else "summer"
 
 
 class HSEMPlanExplanationSensor(
@@ -124,19 +147,58 @@ class HSEMPlanExplanationSensor(
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Return the full plan explanation as flat key-value attributes.
+        """Return the full plan explanation merged with diagnostic context.
 
         Each field on :class:`PlanExplanation` is exposed individually so
         users can template against ``state_attr('sensor.hsem_plan_explanation_sensor',
         'score')`` etc. without needing to unpack a nested dict.
+
+        Context attributes from the coordinator snapshot include:
+        *planning_horizon_hours*, *planning_interval_minutes*, *forecast_mode*,
+        *current_slot_start*, *current_slot_end*, *current_slot_recommendation*,
+        *last_apply_status*, *hardware_writes_blocked*, and *data_quality_complete*.
         """
         data: CoordinatorData | None = self.coordinator.data
         explanation: PlanExplanation = (
             data.plan_explanation if data is not None else PlanExplanation()
         )
         d = explanation.as_dict()
-        # Hoist all keys to the top level (as_dict already returns a flat dict
-        # except for rejected_plans which is a list of dicts — leave that as-is).
+
+        if data is not None and data.cfg is not None and data.live is not None:
+            cfg = data.cfg
+            live = data.live
+            now = hsem_now()
+
+            # Planner horizon and slot configuration
+            d["planning_horizon_hours"] = cfg.recommendation_interval_length
+            d["planning_interval_minutes"] = cfg.recommendation_interval_minutes
+
+            # Forecast mode (winter / summer)
+            d["forecast_mode"] = _determine_forecast_mode(cfg, now)
+
+            # Current slot info
+            rec = data.hourly_recommendation
+            if rec is not None:
+                d["current_slot_start"] = rec.start.isoformat()
+                d["current_slot_end"] = rec.end.isoformat()
+                d["current_slot_recommendation"] = str(rec.recommendation)
+            else:
+                d["current_slot_start"] = None
+                d["current_slot_end"] = None
+                d["current_slot_recommendation"] = None
+
+            # Safety / apply status
+            apply_summary = data.apply_summary
+            d["last_apply_status"] = (
+                apply_summary.overall_status.value if apply_summary else None
+            )
+            d["hardware_writes_blocked"] = not hardware_writes_allowed(
+                live.degraded_mode
+            )
+
+            # Data quality summary
+            d["data_quality_complete"] = data.data_quality.is_complete
+
         return d
 
     # ------------------------------------------------------------------

--- a/tests/sensors/test_plan_explanation_sensor.py
+++ b/tests/sensors/test_plan_explanation_sensor.py
@@ -13,6 +13,7 @@ Acceptance criteria
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock
 
 import pytest
@@ -22,7 +23,20 @@ from custom_components.hsem.coordinator import CoordinatorData
 from custom_components.hsem.custom_sensors.plan_explanation_sensor import (
     HSEMPlanExplanationSensor,
 )
-from custom_components.hsem.models.planner_outputs import PlanExplanation, RejectedPlan
+from custom_components.hsem.models.hourly_recommendation import HourlyRecommendation
+from custom_components.hsem.models.live_state import LiveState
+from custom_components.hsem.models.planner_outputs import (
+    DataQuality,
+    PlanExplanation,
+    RejectedPlan,
+)
+from custom_components.hsem.models.sensor_config import SensorConfig
+from custom_components.hsem.utils.degraded_mode import DegradedMode
+from custom_components.hsem.utils.inverter_verify import (
+    ApplyResult,
+    ApplyStatus,
+    CycleApplySummary,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -42,6 +56,19 @@ _EXPECTED_ATTR_KEYS = {
     "battery_soc_at_end_pct",
     "constraints",
     "rejected_plans",
+}
+
+# Context keys added when the coordinator snapshot is fully populated.
+_CONTEXT_ATTR_KEYS = {
+    "planning_horizon_hours",
+    "planning_interval_minutes",
+    "forecast_mode",
+    "current_slot_start",
+    "current_slot_end",
+    "current_slot_recommendation",
+    "last_apply_status",
+    "hardware_writes_blocked",
+    "data_quality_complete",
 }
 
 
@@ -68,9 +95,64 @@ def _make_explanation(**kwargs) -> PlanExplanation:
 
 def _make_coordinator_data(
     explanation: PlanExplanation | None = None,
+    *,
+    has_context: bool = False,
 ) -> CoordinatorData:
-    """Return a minimal CoordinatorData carrying a plan explanation."""
-    return CoordinatorData(plan_explanation=explanation or _make_explanation())
+    """Return a minimal CoordinatorData carrying a plan explanation.
+
+    When *has_context* is True, also populates ``cfg``, ``live``,
+    ``hourly_recommendation``, ``apply_summary``, and ``data_quality``
+    so that the enriched attributes are returned.
+    """
+    data = CoordinatorData(plan_explanation=explanation or _make_explanation())
+    if has_context:
+        cfg = SensorConfig()
+        cfg.recommendation_interval_length = 48
+        cfg.recommendation_interval_minutes = 15
+        cfg.months_winter = [1, 2, 3, 4, 10, 11, 12]
+        data.cfg = cfg
+
+        live = LiveState()
+        live._degraded_mode = DegradedMode.OK
+        data.live = live
+
+        now = datetime.now(UTC)
+        slot = HourlyRecommendation(
+            start=now,
+            end=now + timedelta(hours=1),
+            recommendation="batteries_wait_mode",
+            avg_house_consumption_kwh=0.0,
+            avg_house_consumption_1d_kwh=0.0,
+            avg_house_consumption_3d_kwh=0.0,
+            avg_house_consumption_7d_kwh=0.0,
+            avg_house_consumption_14d_kwh=0.0,
+            batteries_charged_kwh=0.0,
+            batteries_discharged_kwh=0.0,
+            estimated_battery_capacity_kwh=0.0,
+            estimated_battery_soc_pct=50.0,
+            estimated_cost_currency=0.0,
+            estimated_net_consumption_kwh=0.0,
+            export_price=0.0,
+            grid_export_kwh=0.0,
+            grid_import_kwh=0.0,
+            import_price=0.0,
+            solcast_pv_estimate_kwh=0.0,
+        )
+        data.hourly_recommendation = slot
+
+        data.apply_summary = CycleApplySummary(
+            results=[
+                ApplyResult(
+                    entity_id="number.batteries_end_of_charge_soc",
+                    desired=95,
+                    actual=95,
+                    status=ApplyStatus.OK,
+                    attempts=1,
+                )
+            ]
+        )
+        data.data_quality = DataQuality()
+    return data
 
 
 def _make_sensor(data: CoordinatorData | None = None) -> HSEMPlanExplanationSensor:
@@ -247,3 +329,78 @@ class TestSensorAttributes:
         """forecast_pv_kwh attribute must be non-negative."""
         sensor = _make_sensor(_make_coordinator_data())
         assert sensor.extra_state_attributes["forecast_pv_kwh"] >= 0.0
+
+
+# ===========================================================================
+# 5. Context attributes (planner horizon, forecast mode, current slot, safety)
+# ===========================================================================
+
+
+class TestSensorContextAttributes:
+    """extra_state_attributes includes diagnostic context when coordinator
+    snapshot is fully populated."""
+
+    def test_context_keys_present_when_data_has_context(self):
+        """All context keys must be present when cfg/live/slot/apply are set."""
+        sensor = _make_sensor(_make_coordinator_data(has_context=True))
+        keys = set(sensor.extra_state_attributes.keys())
+        assert _CONTEXT_ATTR_KEYS.issubset(
+            keys
+        ), f"Missing context keys: {_CONTEXT_ATTR_KEYS - keys}"
+
+    def test_context_keys_absent_when_no_coordinator_data(self):
+        """Context keys must NOT be present when coordinator.data is None."""
+        sensor = _make_sensor(data=None)
+        keys = set(sensor.extra_state_attributes.keys())
+        assert keys == _EXPECTED_ATTR_KEYS
+
+    def test_context_keys_absent_when_data_has_no_context(self):
+        """Context keys must NOT be present when cfg/live are not populated."""
+        sensor = _make_sensor(_make_coordinator_data(has_context=False))
+        keys = set(sensor.extra_state_attributes.keys())
+        assert keys == _EXPECTED_ATTR_KEYS
+
+    def test_planning_horizon_hours(self):
+        """planning_horizon_hours must match cfg.recommendation_interval_length."""
+        sensor = _make_sensor(_make_coordinator_data(has_context=True))
+        assert sensor.extra_state_attributes["planning_horizon_hours"] == 48
+
+    def test_planning_interval_minutes(self):
+        """planning_interval_minutes must match cfg.recommendation_interval_minutes."""
+        sensor = _make_sensor(_make_coordinator_data(has_context=True))
+        assert sensor.extra_state_attributes["planning_interval_minutes"] == 15
+
+    def test_forecast_mode_winter(self):
+        """forecast_mode must be 'winter' when current month is in months_winter."""
+        sensor = _make_sensor(_make_coordinator_data(has_context=True))
+        mode = sensor.extra_state_attributes["forecast_mode"]
+        assert mode in ("winter", "summer")
+
+    def test_current_slot_recommendation(self):
+        """current_slot_recommendation must match the hourly_recommendation."""
+        sensor = _make_sensor(_make_coordinator_data(has_context=True))
+        assert (
+            sensor.extra_state_attributes["current_slot_recommendation"]
+            == "batteries_wait_mode"
+        )
+
+    def test_current_slot_start_and_end(self):
+        """current_slot_start and current_slot_end must be ISO-format strings."""
+        sensor = _make_sensor(_make_coordinator_data(has_context=True))
+        assert isinstance(sensor.extra_state_attributes["current_slot_start"], str)
+        assert isinstance(sensor.extra_state_attributes["current_slot_end"], str)
+
+    def test_last_apply_status(self):
+        """last_apply_status must reflect the apply_summary overall_status."""
+        sensor = _make_sensor(_make_coordinator_data(has_context=True))
+        assert sensor.extra_state_attributes["last_apply_status"] == "ok"
+
+    def test_hardware_writes_blocked(self):
+        """hardware_writes_blocked must be False when degraded mode is OK."""
+        sensor = _make_sensor(_make_coordinator_data(has_context=True))
+        assert sensor.extra_state_attributes["hardware_writes_blocked"] is False
+
+    def test_data_quality_complete(self):
+        """data_quality_complete must be True for a default DataQuality."""
+        sensor = _make_sensor(_make_coordinator_data(has_context=True))
+        assert sensor.extra_state_attributes["data_quality_complete"] is True


### PR DESCRIPTION
## Summary

Improves HSEM entity attributes across three diagnostic sensors to expose planner horizon, forecast mode, current slot, safety status, and last apply status. No secrets are exposed.

## Changes

### custom_sensors/plan_explanation_sensor.py
- Added _determine_forecast_mode() helper that detects winter/summer season from configured month ranges.
- extra_state_attributes now includes:
  - planning_horizon_hours � how many hours ahead the planner evaluates.
  - planning_interval_minutes � width of each planning slot in minutes.
  - orecast_mode � "winter" or "summer" based on configured month ranges.
  - current_slot_start, current_slot_end, current_slot_recommendation � active time-slot details.
  - last_apply_status � outcome of the most recent hardware-write cycle.
  - hardware_writes_blocked � True when critical input data is missing.
  - data_quality_complete � True when all price and PV data is available.

### custom_sensors/hardware_writes_sensor.py
- extra_state_attributes now includes:
  - planning_horizon_hours
  - planning_interval_minutes

### custom_sensors/degraded_mode_sensor.py
- extra_state_attributes now includes:
  - planning_horizon_hours
  - planning_interval_minutes
  - orecast_mode
  - current_slot_recommendation
  - last_apply_status

### 	ests/sensors/test_plan_explanation_sensor.py
- Added TestSensorContextAttributes class with 10 new tests covering the enriched context attributes.
- Updated _make_coordinator_data helper to support a has_context parameter.

## Acceptance Criteria

- [x] Users can debug planner horizon from HA UI.
- [x] Users can see the active forecast mode (winter/summer).
- [x] Users can see the current active time slot and its recommendation.
- [x] Users can see safety status (degraded mode, hardware writes blocked).
- [x] Users can see last apply status.
- [x] No secrets are exposed (all attributes are derived from config/coordinator data, never entity passwords/keys).

## Testing

- 35 tests pass (25 existing + 10 new context attribute tests).
- All existing degraded mode and hardware writes tests pass.
- Lint and quality checks pass.

Fixes #318
