### PR TITLE
feat(services): add Home Assistant services for manual actions

### DIFF
--- a/custom_components/hsem/__init__.py
+++ b/custom_components/hsem/__init__.py
@@ -4,6 +4,7 @@ import inspect
 import logging
 from importlib.metadata import PackageNotFoundError, version
 
+import homeassistant.helpers.config_validation as cv
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -21,6 +22,8 @@ from custom_components.hsem.utils.logger import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 PLATFORMS = [Platform.SENSOR, Platform.SWITCH, Platform.TIME, Platform.SELECT]
 

--- a/custom_components/hsem/__init__.py
+++ b/custom_components/hsem/__init__.py
@@ -11,6 +11,10 @@ from packaging.version import InvalidVersion, Version
 
 from custom_components.hsem.const import DOMAIN, MIN_HUAWEI_SOLAR_VERSION
 from custom_components.hsem.coordinator import HSEMDataUpdateCoordinator
+from custom_components.hsem.services import (
+    async_register_services,
+    async_unregister_services,
+)
 from custom_components.hsem.utils.logger import (
     async_close_hsem_logger,
     async_init_hsem_logger,
@@ -116,6 +120,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    # Register HSEM services (force_recalculation, set_temporary_override, etc.)
+    await async_register_services(hass)
+
     # Add update listener for options
     entry.async_on_unload(entry.add_update_listener(async_update_options))
 
@@ -137,6 +144,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id, None)
+
+    # Unregister HSEM services when the last entry is removed.
+    remaining = hass.data.get(DOMAIN, {})
+    if not remaining:
+        await async_unregister_services(hass)
 
     # Close the HSEM dedicated log file handler.
     await async_close_hsem_logger()

--- a/custom_components/hsem/services.py
+++ b/custom_components/hsem/services.py
@@ -1,0 +1,335 @@
+"""Service handlers for the HSEM integration.
+
+This module implements the four HSEM services:
+
+- ``force_recalculation`` — Re-run the full planning pipeline immediately.
+- ``set_temporary_override`` — Force a specific working mode on the select entity.
+- ``clear_override`` — Reset the force-mode select to ``"auto"``.
+- ``export_diagnostics`` — Return a structured diagnostics dump as service response.
+
+All services expect the caller to provide the config-entry device ID (or the
+coordinator is looked up from the only configured HSEM entry).  Service schemas
+are defined in ``services.yaml``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.hsem.const import DOMAIN
+from custom_components.hsem.coordinator import HSEMDataUpdateCoordinator
+from custom_components.hsem.utils.diagnostics import build_diagnostics_dump
+from custom_components.hsem.utils.sensornames import (
+    get_force_working_mode_selector_entity_id,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Supported override modes
+# ---------------------------------------------------------------------------
+
+SUPPORTED_OVERRIDE_MODES: list[str] = [
+    "batteries_charge_grid",
+    "batteries_charge_solar",
+    "batteries_discharge_mode",
+    "batteries_wait_mode",
+    "ev_smart_charging",
+    "force_batteries_discharge",
+    "force_export",
+]
+
+# ---------------------------------------------------------------------------
+# Service name constants
+# ---------------------------------------------------------------------------
+
+SERVICE_FORCE_RECALCULATION = "force_recalculation"
+SERVICE_SET_TEMPORARY_OVERRIDE = "set_temporary_override"
+SERVICE_CLEAR_OVERRIDE = "clear_override"
+SERVICE_EXPORT_DIAGNOSTICS = "export_diagnostics"
+
+# ---------------------------------------------------------------------------
+# Voluptuous schemas for input validation
+# ---------------------------------------------------------------------------
+
+SCHEMA_FORCE_RECALCULATION = vol.Schema({})
+
+SCHEMA_SET_TEMPORARY_OVERRIDE = vol.Schema(
+    {
+        vol.Required("working_mode"): vol.In(SUPPORTED_OVERRIDE_MODES),
+    }
+)
+
+SCHEMA_CLEAR_OVERRIDE = vol.Schema({})
+
+SCHEMA_EXPORT_DIAGNOSTICS = vol.Schema({})
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_coordinator(hass: HomeAssistant) -> HSEMDataUpdateCoordinator | None:
+    """Return the first available HSEM coordinator.
+
+    HSEM only supports a single config entry, but looking up by the first
+    entry is safer than assuming a fixed entry ID.
+
+    Args:
+        hass: The Home Assistant instance.
+
+    Returns:
+        The HSEM coordinator, or ``None`` if no entry is configured.
+    """
+    domain_data = hass.data.get(DOMAIN, {})
+    for entry_data in domain_data.values():
+        if isinstance(entry_data, dict):
+            coordinator = entry_data.get("coordinator")
+            if isinstance(coordinator, HSEMDataUpdateCoordinator):
+                return coordinator
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Service handler implementations
+# ---------------------------------------------------------------------------
+
+
+async def async_handle_force_recalculation(
+    hass: HomeAssistant,
+    call: ServiceCall,  # noqa: ARG001
+) -> None:
+    """Trigger an immediate full planner recalculation.
+
+    Args:
+        hass: The Home Assistant instance.
+        call: The service call (unused, schema is empty).
+    """
+    coordinator = _get_coordinator(hass)
+    if coordinator is None:
+        raise HomeAssistantError(
+            "HSEM coordinator not found — integration may not be configured."
+        )
+    _LOGGER.info("HSEM service: force_recalculation called — triggering update cycle.")
+    await coordinator._async_handle_update(None)  # noqa: SLF001
+    _LOGGER.info("HSEM service: force_recalculation completed.")
+
+
+async def async_handle_set_temporary_override(
+    hass: HomeAssistant,
+    call: ServiceCall,
+) -> None:
+    """Force a specific working mode via the force-mode select entity.
+
+    The service writes ``call.data["working_mode"]`` to the
+    ``select.hsem_force_working_mode`` entity, which the coordinator reads
+    on the next cycle to bypass the planner and send the chosen mode
+    directly to the inverter.
+
+    Args:
+        hass: The Home Assistant instance.
+        call: The service call with ``working_mode`` key in ``data``.
+
+    Raises:
+        HomeAssistantError: When the select entity cannot be found or the
+            service call fails.
+    """
+    working_mode: str = call.data["working_mode"]
+    entity_id = get_force_working_mode_selector_entity_id()
+
+    # Verify the entity exists before making the service call.
+    if hass.states.get(entity_id) is None:
+        raise HomeAssistantError(
+            f"HSEM force working mode entity '{entity_id}' not found. "
+            "Ensure the HSEM integration is fully configured."
+        )
+
+    _LOGGER.info(
+        "HSEM service: set_temporary_override called — setting '%s' to '%s'.",
+        entity_id,
+        working_mode,
+    )
+
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": entity_id, "option": working_mode},
+        blocking=True,
+    )
+
+    # Trigger a recalculation so the override takes effect immediately.
+    coordinator = _get_coordinator(hass)
+    if coordinator is not None:
+        await coordinator._async_handle_update(None)  # noqa: SLF001
+
+    _LOGGER.info(
+        "HSEM service: set_temporary_override completed — mode='%s'.", working_mode
+    )
+
+
+async def async_handle_clear_override(
+    hass: HomeAssistant,
+    call: ServiceCall,  # noqa: ARG001
+) -> None:
+    """Clear any active working-mode override by setting the select to ``"auto"``.
+
+    Args:
+        hass: The Home Assistant instance.
+        call: The service call (unused, schema is empty).
+
+    Raises:
+        HomeAssistantError: When the select entity cannot be found.
+    """
+    entity_id = get_force_working_mode_selector_entity_id()
+
+    if hass.states.get(entity_id) is None:
+        raise HomeAssistantError(
+            f"HSEM force working mode entity '{entity_id}' not found. "
+            "Ensure the HSEM integration is fully configured."
+        )
+
+    _LOGGER.info(
+        "HSEM service: clear_override called — resetting '%s' to 'auto'.",
+        entity_id,
+    )
+
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": entity_id, "option": "auto"},
+        blocking=True,
+    )
+
+    # Trigger a recalculation so the planner takes over again immediately.
+    coordinator = _get_coordinator(hass)
+    if coordinator is not None:
+        await coordinator._async_handle_update(None)  # noqa: SLF001
+
+    _LOGGER.info("HSEM service: clear_override completed.")
+
+
+async def async_handle_export_diagnostics(
+    hass: HomeAssistant,
+    call: ServiceCall,  # noqa: ARG001
+) -> dict[str, Any]:
+    """Export a structured diagnostics dump for the HSEM integration.
+
+    The returned dictionary contains the most recent planner input, planner
+    output, hardware-write summary, and integration version — with all
+    entity-level identifiers redacted.  Suitable for debugging or attaching
+    to GitHub issues.
+
+    Args:
+        hass: The Home Assistant instance.
+        call: The service call (unused, schema is empty).
+
+    Returns:
+        A JSON-serialisable diagnostics dump dictionary.
+
+    Raises:
+        HomeAssistantError: When no planner cycle has completed yet or the
+            coordinator is not found.
+    """
+    coordinator = _get_coordinator(hass)
+    if coordinator is None:
+        raise HomeAssistantError(
+            "HSEM coordinator not found — integration may not be configured."
+        )
+
+    planner_input = getattr(coordinator, "_last_planner_input", None)
+    planner_output = getattr(coordinator, "_last_planner_output", None)
+    apply_summary = coordinator.data.apply_summary if coordinator.data else None
+
+    if planner_input is None or planner_output is None:
+        raise HomeAssistantError(
+            "HSEM diagnostics: no planner cycle has completed yet. "
+            "Wait for the first update cycle to finish."
+        )
+
+    try:
+        from importlib.metadata import version as pkg_version
+
+        integration_version = pkg_version("hsem")
+    except Exception:  # noqa: BLE001
+        integration_version = "unknown"
+
+    dump = build_diagnostics_dump(
+        planner_input,
+        planner_output,
+        apply_summary,
+        integration_version=str(integration_version),
+    )
+
+    _LOGGER.info("HSEM service: export_diagnostics completed.")
+    return dump
+
+
+# ---------------------------------------------------------------------------
+# Service registration
+# ---------------------------------------------------------------------------
+
+SERVICE_HANDLER_MAP: dict[str, tuple[vol.Schema, Any, SupportsResponse]] = {
+    SERVICE_FORCE_RECALCULATION: (
+        SCHEMA_FORCE_RECALCULATION,
+        async_handle_force_recalculation,
+        SupportsResponse.NONE,
+    ),
+    SERVICE_SET_TEMPORARY_OVERRIDE: (
+        SCHEMA_SET_TEMPORARY_OVERRIDE,
+        async_handle_set_temporary_override,
+        SupportsResponse.NONE,
+    ),
+    SERVICE_CLEAR_OVERRIDE: (
+        SCHEMA_CLEAR_OVERRIDE,
+        async_handle_clear_override,
+        SupportsResponse.NONE,
+    ),
+    SERVICE_EXPORT_DIAGNOSTICS: (
+        SCHEMA_EXPORT_DIAGNOSTICS,
+        async_handle_export_diagnostics,
+        SupportsResponse.ONLY,
+    ),
+}
+
+
+async def async_register_services(hass: HomeAssistant) -> None:
+    """Register all HSEM services with Home Assistant.
+
+    Called during :func:`~custom_components.hsem.__init__.async_setup_entry`.
+    Services are unregistered automatically when the config entry is unloaded
+    because they are tied to the integration domain.
+
+    Args:
+        hass: The Home Assistant instance.
+    """
+    for service_name, (
+        schema,
+        handler,
+        supports_response,
+    ) in SERVICE_HANDLER_MAP.items():
+        if not hass.services.has_service(DOMAIN, service_name):
+            hass.services.async_register(
+                domain=DOMAIN,
+                service=service_name,
+                service_func=handler,
+                schema=schema,
+                supports_response=supports_response,
+            )
+
+
+async def async_unregister_services(hass: HomeAssistant) -> None:
+    """Remove all HSEM services from Home Assistant.
+
+    Called during :func:`~custom_components.hsem.__init__.async_unload_entry`.
+
+    Args:
+        hass: The Home Assistant instance.
+    """
+    for service_name in SERVICE_HANDLER_MAP:
+        if hass.services.has_service(DOMAIN, service_name):
+            hass.services.async_remove(DOMAIN, service_name)

--- a/custom_components/hsem/services.yaml
+++ b/custom_components/hsem/services.yaml
@@ -1,0 +1,52 @@
+# HSEM Service definitions
+# Schema validation for all service calls.
+
+force_recalculation:
+  name: Force recalculation
+  description: >-
+    Force the HSEM coordinator to run a full recalculation cycle immediately.
+    All entity states are re-read and the planner is re-run. Useful for
+    testing or when you need the most up-to-date recommendation without
+    waiting for the next scheduled update.
+  fields: {}
+
+set_temporary_override:
+  name: Set temporary override
+  description: >-
+    Temporarily override the automatic planner by forcing a specific working
+    mode. While the override is active the planner output is bypassed and the
+    chosen mode is sent directly to the inverter. Set the working mode to
+    "auto" via the clear_override service to resume normal planner control.
+  fields:
+    working_mode:
+      required: true
+      selector:
+        select:
+          options:
+            - "batteries_charge_grid"
+            - "batteries_charge_solar"
+            - "batteries_discharge_mode"
+            - "batteries_wait_mode"
+            - "ev_smart_charging"
+            - "force_batteries_discharge"
+            - "force_export"
+      description: "The working mode to force. Must be one of the supported override modes."
+
+clear_override:
+  name: Clear override
+  description: >-
+    Clear any active temporary working-mode override and return to automatic
+    planner control. Has no effect when no override is currently active.
+  fields: {}
+
+export_diagnostics:
+  name: Export diagnostics
+  description: >-
+    Export a structured diagnostics dump for the HSEM integration. The
+    response contains the most recent planner input, planner output, hardware
+    write status, and integration version — with all entity IDs redacted for
+    safe sharing. Useful for debugging and issue reports.
+  response:
+    content:
+      media_type: "application/json"
+  fields: {}

--- a/custom_components/hsem/services.yaml
+++ b/custom_components/hsem/services.yaml
@@ -8,6 +8,8 @@ force_recalculation:
     All entity states are re-read and the planner is re-run. Useful for
     testing or when you need the most up-to-date recommendation without
     waiting for the next scheduled update.
+  target:
+    entity: {}
   fields: {}
 
 set_temporary_override:
@@ -17,6 +19,8 @@ set_temporary_override:
     mode. While the override is active the planner output is bypassed and the
     chosen mode is sent directly to the inverter. Set the working mode to
     "auto" via the clear_override service to resume normal planner control.
+  target:
+    entity: {}
   fields:
     working_mode:
       required: true
@@ -37,6 +41,8 @@ clear_override:
   description: >-
     Clear any active temporary working-mode override and return to automatic
     planner control. Has no effect when no override is currently active.
+  target:
+    entity: {}
   fields: {}
 
 export_diagnostics:
@@ -46,7 +52,7 @@ export_diagnostics:
     response contains the most recent planner input, planner output, hardware
     write status, and integration version — with all entity IDs redacted for
     safe sharing. Useful for debugging and issue reports.
-  response:
-    content:
-      media_type: "application/json"
+  target:
+    entity:
+      integration: hsem
   fields: {}

--- a/custom_components/hsem/translations/en.json
+++ b/custom_components/hsem/translations/en.json
@@ -723,5 +723,29 @@
         "60": "60 minutes"
       }
     }
+  },
+  "services": {
+    "force_recalculation": {
+      "name": "Force recalculation",
+      "description": "Force the HSEM coordinator to run a full recalculation cycle immediately."
+    },
+    "set_temporary_override": {
+      "name": "Set temporary override",
+      "description": "Temporarily override the automatic planner by forcing a specific working mode.",
+      "fields": {
+        "working_mode": {
+          "name": "Working mode",
+          "description": "The working mode to force. Must be one of the supported override modes."
+        }
+      }
+    },
+    "clear_override": {
+      "name": "Clear override",
+      "description": "Clear any active temporary working-mode override and return to automatic planner control."
+    },
+    "export_diagnostics": {
+      "name": "Export diagnostics",
+      "description": "Export a structured diagnostics dump for the HSEM integration with all entity IDs redacted."
+    }
   }
 }

--- a/tests/test_import_integrity.py
+++ b/tests/test_import_integrity.py
@@ -56,6 +56,8 @@ TOP_LEVEL_MODULES = [
     "custom_components.hsem.config_flow",
     "custom_components.hsem.options_flow",
     "custom_components.hsem.const",
+    "custom_components.hsem.services",
+    "custom_components.hsem.diagnostics",
 ]
 
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,451 @@
+"""Tests for the HSEM service handlers (issue #319).
+
+Acceptance criteria
+-------------------
+1. ``force_recalculation`` triggers a coordinator update cycle.
+2. ``set_temporary_override`` sets the force-mode select and triggers an update.
+3. ``clear_override`` resets the force-mode select to ``"auto"`` and triggers
+   an update.
+4. ``export_diagnostics`` returns a structured diagnostics dump.
+5. All services validate input (voluptuous schemas).
+6. Services raise ``HomeAssistantError`` when the coordinator is unavailable.
+7. The force-mode select entity existence check traps missing entities.
+8. The schema for ``set_temporary_override`` rejects invalid working modes.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import voluptuous as vol
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.hsem.const import DOMAIN
+from custom_components.hsem.coordinator import HSEMDataUpdateCoordinator
+from custom_components.hsem.services import (
+    SCHEMA_CLEAR_OVERRIDE,
+    SCHEMA_EXPORT_DIAGNOSTICS,
+    SCHEMA_FORCE_RECALCULATION,
+    SCHEMA_SET_TEMPORARY_OVERRIDE,
+    SERVICE_CLEAR_OVERRIDE,
+    SERVICE_EXPORT_DIAGNOSTICS,
+    SERVICE_FORCE_RECALCULATION,
+    SERVICE_SET_TEMPORARY_OVERRIDE,
+    SUPPORTED_OVERRIDE_MODES,
+    async_handle_clear_override,
+    async_handle_export_diagnostics,
+    async_handle_force_recalculation,
+    async_handle_set_temporary_override,
+    async_register_services,
+    async_unregister_services,
+)
+from custom_components.hsem.utils.sensornames import (
+    get_force_working_mode_selector_entity_id,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_hass(coordinator: MagicMock | None = None) -> MagicMock:
+    """Return a minimal mocked ``hass`` with an HSEM coordinator in domain data."""
+    hass = MagicMock()
+    hass.data = {DOMAIN: {}}
+    if coordinator is not None:
+        hass.data[DOMAIN]["test_entry"] = {"coordinator": coordinator}
+    # Add a simple state machine that returns None by default.
+    state_mock = MagicMock()
+    state_mock.state = "auto"
+    hass.states.get.return_value = state_mock
+    hass.services.async_call = AsyncMock()
+    hass.services.has_service.side_effect = lambda domain, _: domain == DOMAIN
+    hass.services.async_remove = MagicMock()
+    hass.config_entries.async_entries.return_value = []
+    return hass
+
+
+def _make_coordinator(hass: MagicMock | None = None) -> MagicMock:
+    """Return a mocked HSEMDataUpdateCoordinator."""
+    coordinator = MagicMock(spec=HSEMDataUpdateCoordinator)
+    coordinator._async_handle_update = AsyncMock()  # noqa: SLF001
+    coordinator._last_planner_input = MagicMock()
+    coordinator._last_planner_output = MagicMock()
+    coordinator.data = MagicMock()
+    coordinator.data.apply_summary = MagicMock()
+    if hass is not None:
+        coordinator.hass = hass
+    return coordinator
+
+
+# ---------------------------------------------------------------------------
+# Schema validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaForceRecalculation:
+    """Voluptuous schema for force_recalculation accepts only empty data."""
+
+    def test_empty_data_accepted(self):
+        """Schema must accept an empty dict."""
+        assert SCHEMA_FORCE_RECALCULATION({}) == {}
+
+    def test_extra_fields_rejected(self):
+        """Schema must reject unexpected keys."""
+        with pytest.raises(vol.Invalid):
+            SCHEMA_FORCE_RECALCULATION({"unknown": "value"})
+
+
+class TestSchemaSetTemporaryOverride:
+    """Voluptuous schema for set_temporary_override input validation."""
+
+    def test_valid_mode_accepted(self):
+        """Schema must accept a valid working mode."""
+        for mode in SUPPORTED_OVERRIDE_MODES:
+            result = SCHEMA_SET_TEMPORARY_OVERRIDE({"working_mode": mode})
+            assert result == {"working_mode": mode}
+
+    def test_invalid_mode_rejected(self):
+        """Schema must reject an invalid working mode."""
+        with pytest.raises(vol.Invalid):
+            SCHEMA_SET_TEMPORARY_OVERRIDE({"working_mode": "invalid_mode"})
+
+    def test_missing_working_mode_rejected(self):
+        """Schema must reject when working_mode is missing."""
+        with pytest.raises(vol.Invalid):
+            SCHEMA_SET_TEMPORARY_OVERRIDE({})
+
+    def test_empty_string_rejected(self):
+        """Schema must reject an empty string working mode."""
+        with pytest.raises(vol.Invalid):
+            SCHEMA_SET_TEMPORARY_OVERRIDE({"working_mode": ""})
+
+
+class TestSchemaClearOverride:
+    """Voluptuous schema for clear_override accepts only empty data."""
+
+    def test_empty_data_accepted(self):
+        """Schema must accept an empty dict."""
+        assert SCHEMA_CLEAR_OVERRIDE({}) == {}
+
+    def test_extra_fields_rejected(self):
+        """Schema must reject unexpected keys."""
+        with pytest.raises(vol.Invalid):
+            SCHEMA_CLEAR_OVERRIDE({"working_mode": "auto"})
+
+
+class TestSchemaExportDiagnostics:
+    """Voluptuous schema for export_diagnostics accepts only empty data."""
+
+    def test_empty_data_accepted(self):
+        """Schema must accept an empty dict."""
+        assert SCHEMA_EXPORT_DIAGNOSTICS({}) == {}
+
+    def test_extra_fields_rejected(self):
+        """Schema must reject unexpected keys."""
+        with pytest.raises(vol.Invalid):
+            SCHEMA_EXPORT_DIAGNOSTICS({"format": "json"})
+
+
+# ---------------------------------------------------------------------------
+# Service registration / unregistration
+# ---------------------------------------------------------------------------
+
+
+class TestServiceRegistration:
+    """Service registration and unregistration logic."""
+
+    @pytest.mark.asyncio
+    async def test_register_services(self):
+        """Must register all four HSEM services."""
+        hass = _make_hass()
+        # Clear the side_effect so return_value takes effect.
+        hass.services.has_service.side_effect = None
+        hass.services.has_service.return_value = False
+
+        await async_register_services(hass)
+
+        expected_calls = {
+            SERVICE_FORCE_RECALCULATION,
+            SERVICE_SET_TEMPORARY_OVERRIDE,
+            SERVICE_CLEAR_OVERRIDE,
+            SERVICE_EXPORT_DIAGNOSTICS,
+        }
+        actual_calls = {
+            call.kwargs["service"]
+            for call in hass.services.async_register.call_args_list
+        }
+        assert actual_calls == expected_calls
+
+    @pytest.mark.asyncio
+    async def test_register_services_skips_existing(self):
+        """Must not re-register services that already exist."""
+        hass = _make_hass()
+        hass.services.has_service.return_value = True
+
+        await async_register_services(hass)
+
+        hass.services.async_register.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unregister_services(self):
+        """Must remove all four HSEM services."""
+        hass = _make_hass()
+        hass.services.has_service.return_value = True
+
+        await async_unregister_services(hass)
+
+        assert hass.services.async_remove.call_count == 4
+
+    @pytest.mark.asyncio
+    async def test_unregister_services_skips_missing(self):
+        """Must not try to remove services that don't exist."""
+        hass = _make_hass()
+        # Override side_effect so has_service returns False for all services.
+        hass.services.has_service.side_effect = None
+        hass.services.has_service.return_value = False
+
+        await async_unregister_services(hass)
+
+        hass.services.async_remove.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Service handler tests
+# ---------------------------------------------------------------------------
+
+
+class TestForceRecalculation:
+    """Tests for async_handle_force_recalculation."""
+
+    @pytest.mark.asyncio
+    async def test_triggers_update_cycle(self):
+        """Must call _async_handle_update on the coordinator."""
+        coordinator = _make_coordinator()
+        hass = _make_hass(coordinator)
+
+        await async_handle_force_recalculation(hass, MagicMock())
+
+        coordinator._async_handle_update.assert_awaited_once_with(None)
+
+    @pytest.mark.asyncio
+    async def test_raises_when_no_coordinator(self):
+        """Must raise HomeAssistantError when no coordinator is found."""
+        hass = _make_hass()  # No coordinator added
+
+        with pytest.raises(HomeAssistantError, match="HSEM coordinator not found"):
+            await async_handle_force_recalculation(hass, MagicMock())
+
+
+class TestSetTemporaryOverride:
+    """Tests for async_handle_set_temporary_override."""
+
+    @pytest.mark.asyncio
+    async def test_sets_override_and_triggers_update(self):
+        """Must set the select entity and trigger an update cycle."""
+        coordinator = _make_coordinator()
+        hass = _make_hass(coordinator)
+
+        call = MagicMock()
+        call.data = {"working_mode": "batteries_charge_grid"}
+
+        await async_handle_set_temporary_override(hass, call)
+
+        selector_entity_id = get_force_working_mode_selector_entity_id()
+        hass.services.async_call.assert_awaited_with(
+            "select",
+            "select_option",
+            {"entity_id": selector_entity_id, "option": "batteries_charge_grid"},
+            blocking=True,
+        )
+        coordinator._async_handle_update.assert_awaited_once_with(None)
+
+    @pytest.mark.asyncio
+    async def test_raises_when_entity_not_found(self):
+        """Must raise HomeAssistantError when select entity is missing."""
+        coordinator = _make_coordinator()
+        hass = _make_hass(coordinator)
+        # Simulate missing entity by returning None from states.get.
+        hass.states.get.return_value = None
+
+        call = MagicMock()
+        call.data = {"working_mode": "batteries_charge_grid"}
+
+        with pytest.raises(HomeAssistantError, match="force working mode entity"):
+            await async_handle_set_temporary_override(hass, call)
+
+        # The service call should NOT have been made.
+        hass.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_raises_when_no_coordinator_still_calls_select(self):
+        """Must still set the select entity even when coordinator is absent."""
+        hass = _make_hass()  # No coordinator
+
+        call = MagicMock()
+        call.data = {"working_mode": "force_export"}
+
+        await async_handle_set_temporary_override(hass, call)
+
+        # The select call should have been made regardless.
+        hass.services.async_call.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_all_modes_accepted(self):
+        """Must accept every supported override mode."""
+        coordinator = _make_coordinator()
+        hass = _make_hass(coordinator)
+
+        for mode in SUPPORTED_OVERRIDE_MODES:
+            call = MagicMock()
+            call.data = {"working_mode": mode}
+            await async_handle_set_temporary_override(hass, call)
+            assert True  # No exception raised
+
+    @pytest.mark.asyncio
+    async def test_handles_select_service_error(self):
+        """Must propagate errors from the select service call."""
+        coordinator = _make_coordinator()
+        hass = _make_hass(coordinator)
+        hass.services.async_call.side_effect = HomeAssistantError("select failed")
+
+        call = MagicMock()
+        call.data = {"working_mode": "batteries_charge_grid"}
+
+        with pytest.raises(HomeAssistantError, match="select failed"):
+            await async_handle_set_temporary_override(hass, call)
+
+
+class TestClearOverride:
+    """Tests for async_handle_clear_override."""
+
+    @pytest.mark.asyncio
+    async def test_resets_to_auto_and_triggers_update(self):
+        """Must set the select to 'auto' and trigger an update cycle."""
+        coordinator = _make_coordinator()
+        hass = _make_hass(coordinator)
+
+        await async_handle_clear_override(hass, MagicMock())
+
+        selector_entity_id = get_force_working_mode_selector_entity_id()
+        hass.services.async_call.assert_awaited_with(
+            "select",
+            "select_option",
+            {"entity_id": selector_entity_id, "option": "auto"},
+            blocking=True,
+        )
+        coordinator._async_handle_update.assert_awaited_once_with(None)
+
+    @pytest.mark.asyncio
+    async def test_raises_when_entity_not_found(self):
+        """Must raise HomeAssistantError when select entity is missing."""
+        hass = _make_hass()
+        hass.states.get.return_value = None
+
+        with pytest.raises(HomeAssistantError, match="force working mode entity"):
+            await async_handle_clear_override(hass, MagicMock())
+
+        hass.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_noop_when_already_auto(self):
+        """Must set 'auto' even when already 'auto' (idempotent)."""
+        coordinator = _make_coordinator()
+        hass = _make_hass(coordinator)
+
+        await async_handle_clear_override(hass, MagicMock())
+
+        # Should attempt to set 'auto' regardless.
+        hass.services.async_call.assert_awaited_once()
+
+
+class TestExportDiagnostics:
+    """Tests for async_handle_export_diagnostics."""
+
+    @pytest.mark.asyncio
+    async def test_returns_diagnostics_dump(self):
+        """Must return a structured diagnostics dictionary."""
+        coordinator = _make_coordinator()
+        hass = _make_hass(coordinator)
+
+        with patch(
+            "custom_components.hsem.services.build_diagnostics_dump",
+            return_value={"key": "value"},
+        ):
+            result = await async_handle_export_diagnostics(hass, MagicMock())
+
+        assert isinstance(result, dict)
+        assert result["key"] == "value"
+
+    @pytest.mark.asyncio
+    async def test_raises_when_no_coordinator(self):
+        """Must raise HomeAssistantError when no coordinator is found."""
+        hass = _make_hass()  # No coordinator
+
+        with pytest.raises(HomeAssistantError, match="HSEM coordinator not found"):
+            await async_handle_export_diagnostics(hass, MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_raises_when_no_planner_cycle(self):
+        """Must raise HomeAssistantError when no planner cycle has completed."""
+        coordinator = _make_coordinator()
+        coordinator._last_planner_input = None  # Simulate no cycle
+        hass = _make_hass(coordinator)
+
+        with pytest.raises(HomeAssistantError, match="no planner cycle has completed"):
+            await async_handle_export_diagnostics(hass, MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_includes_integration_version(self):
+        """Must include the integration version in the dump."""
+        coordinator = _make_coordinator()
+        hass = _make_hass(coordinator)
+
+        with patch(
+            "custom_components.hsem.services.build_diagnostics_dump",
+            return_value={
+                "integration_version": "5.1.0",
+                "timestamp": "2025-01-01T00:00:00",
+            },
+        ):
+            result = await async_handle_export_diagnostics(hass, MagicMock())
+
+        assert "integration_version" in result
+        assert result["integration_version"] == "5.1.0"
+
+
+class TestSupportedOverrideModes:
+    """Verifies SUPPORTED_OVERRIDE_MODES matches the available recommendations."""
+
+    def test_includes_all_expected_modes(self):
+        """Must include all modes from the recommendations enum that are not 'auto'."""
+        assert "batteries_charge_grid" in SUPPORTED_OVERRIDE_MODES
+        assert "batteries_charge_solar" in SUPPORTED_OVERRIDE_MODES
+        assert "batteries_discharge_mode" in SUPPORTED_OVERRIDE_MODES
+        assert "batteries_wait_mode" in SUPPORTED_OVERRIDE_MODES
+        assert "ev_smart_charging" in SUPPORTED_OVERRIDE_MODES
+        assert "force_batteries_discharge" in SUPPORTED_OVERRIDE_MODES
+        assert "force_export" in SUPPORTED_OVERRIDE_MODES
+
+    def test_does_not_include_override_sentinel(self):
+        """Must not include 'auto' or 'missing_input_entities' in the list."""
+        assert "auto" not in SUPPORTED_OVERRIDE_MODES
+        assert "missing_input_entities" not in SUPPORTED_OVERRIDE_MODES
+        assert "time_passed" not in SUPPORTED_OVERRIDE_MODES
+
+
+# ---------------------------------------------------------------------------
+# Service name constants
+# ---------------------------------------------------------------------------
+
+
+class TestServiceNameConstants:
+    """Verifies service name constants match the yaml definitions."""
+
+    def test_service_names_match_yaml(self):
+        """Service name constants must match the services.yaml definitions."""
+        assert SERVICE_FORCE_RECALCULATION == "force_recalculation"
+        assert SERVICE_SET_TEMPORARY_OVERRIDE == "set_temporary_override"
+        assert SERVICE_CLEAR_OVERRIDE == "clear_override"
+        assert SERVICE_EXPORT_DIAGNOSTICS == "export_diagnostics"


### PR DESCRIPTION
## Summary

Add four Home Assistant services to HSEM for manual actions, with voluptuous schema validation.

## Services Added

1. **force_recalculation** � Triggers an immediate full planner re-run.
2. **set_temporary_override** � Sets the force-mode select entity to a specific working mode, then triggers recalculation.
3. **clear_override** � Resets the force-mode select to "auto" and triggers recalculation.
4. **export_diagnostics** � Returns a structured diagnostics dump (planner input, output, hardware-write summary, version � all entity IDs redacted).

## Files Changed

| File | Action |
|---|---|
| \custom_components/hsem/services.py\ | **NEW** � Service handlers, schemas, registration |
| \custom_components/hsem/services.yaml\ | **NEW** � Service definitions for HA frontend |
| \custom_components/hsem/__init__.py\ | **MODIFIED** � Added service register/unregister + CONFIG_SCHEMA |
| \custom_components/hsem/translations/en.json\ | **MODIFIED** � Added service translations |
| \	ests/test_services.py\ | **NEW** � 31 tests covering schema validation, handlers, registration |
| \	ests/test_import_integrity.py\ | **MODIFIED** � Added services and diagnostics to import check |

## Checklist

- [x] Services are documented (\services.yaml\)
- [x] Services validate input (voluptuous schemas)
- [x] Tests cover service calls (31 tests)
- [x] Tests pass
- [x] Lint passes (\	ox -e lint\)
- [x] Quality passes (\	ox -e quality\)
- [x] Translations added (\en.json\)
- [x] Hassfest validation passes (CONFIG_SCHEMA + services.yaml target/response)

Fixes #319
