### PR TITLE
chore(logging): set safe logging levels

### DIFF
--- a/custom_components/hsem/__init__.py
+++ b/custom_components/hsem/__init__.py
@@ -103,7 +103,7 @@ async def async_setup(hass: HomeAssistant, _config: dict) -> bool:
         )
         return False
 
-    _LOGGER.info("HSEM integration successfully initialized.")
+    _LOGGER.debug("HSEM integration successfully initialized.")
     hass.data.setdefault(DOMAIN, {})
 
     return True
@@ -129,13 +129,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Add update listener for options
     entry.async_on_unload(entry.add_update_listener(async_update_options))
 
-    _LOGGER.info("HSEM integration successfully set up.")
+    _LOGGER.debug("HSEM integration successfully set up.")
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    _LOGGER.info(f"Unloading HSEM integration for {entry.entry_id}")
+    _LOGGER.debug("Unloading HSEM integration for %s", entry.entry_id)
 
     # Tear down the coordinator's timers before unloading platforms.
     domain_data = hass.data.get(DOMAIN, {}).get(entry.entry_id, {})

--- a/custom_components/hsem/planner/candidate_selector.py
+++ b/custom_components/hsem/planner/candidate_selector.py
@@ -228,7 +228,7 @@ def select_best_candidate(
         )
         winner = eligible_sorted[0]
         log_planner(
-            "info",
+            "debug",
             "[selector] SELECTED candidate=%-20s  score=%.4f  total_cost=%.4f",
             winner.name,
             winner._cost.score,

--- a/custom_components/hsem/planner/engine.py
+++ b/custom_components/hsem/planner/engine.py
@@ -123,7 +123,7 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
     now = _parse_now(inp.now_iso)
 
     log_planner(
-        "info",
+        "debug",
         "==== HSEM PLANNER RUN START ==== now=%s interval=%dmin horizon=%dh",
         inp.now_iso,
         inp.interval_minutes,
@@ -900,11 +900,11 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
             slot.recommendation = Recommendations.EVSmartCharging.value
 
     # Log final per-slot decisions with full energy-flow detail
-    log_planner("info", "[engine] ---- Final slot decisions (post-simulation) ----")
+    log_planner("debug", "[engine] ---- Final slot decisions (post-simulation) ----")
     for slot in slots:
         is_current = as_tz(slot.start, now.tzinfo) <= now < as_tz(slot.end, now.tzinfo)
         log_planner(
-            "info",
+            "debug",
             "[final] %s%s→%s  rec=%-30s  soc=%5.1f%%  "
             "charged=%.3f  discharged=%.3f  "
             "pv=%.3f  cons=%.3f  net=%.3f  "


### PR DESCRIPTION
## Summary

Cleaned up HSEM logging levels per issue #312 to reduce noise in normal operation.

### Changes

**`custom_components/hsem/__init__.py`**
- `info` level setup/teardown logs changed to `debug`
- Fixed f-string logging style on unload message

**`custom_components/hsem/planner/engine.py`**
- Planner run start banner: `info` -> `debug`
- Final slot decisions header: `info` -> `debug`
- Per-slot final decision lines: `info` -> `debug`

**`custom_components/hsem/planner/candidate_selector.py`**
- Selected candidate line: `info` -> `debug`

### What was kept at appropriate levels

- **Degraded mode** blocks -> already `warning` in `applier.py`
- **Failed hardware writes** -> already `error` in `inverter_verify.py`
- **User-initiated service calls** -> kept at `info` in `services.py`
- **Entity read failures** -> already `warning` in `state_collector.py`
- **Planner verbose logging** -> already gated behind verbose flag

### Verification

- Lint: `tox -e lint` - passed
- Quality: `tox -e quality` - passed (0 pyright errors)
- Tests: 1926 passed, 3 xfailed (pre-existing)

Fixes #312