### PR TITLE
feat(planner): add window-level hysteresis to prevent rapid charge/discharge toggles

### DIFF
--- a/custom_components/hsem/const.py
+++ b/custom_components/hsem/const.py
@@ -94,6 +94,10 @@ DEFAULT_CONFIG_VALUES = {
     "hsem_planner_hysteresis_enabled": True,
     "hsem_planner_hysteresis_absolute": 0.0,
     "hsem_planner_hysteresis_percentage": 5.0,
+    # Window-level hysteresis — prevent rapid charge/discharge toggles
+    # near window boundaries by enforcing a minimum hold time (minutes).
+    # 0 disables the feature.
+    "hsem_planner_window_hysteresis_minutes": 0,
     "hsem_house_consumption_energy_weight_14d": 15,
     "hsem_house_consumption_energy_weight_1d": 25,
     "hsem_house_consumption_energy_weight_3d": 30,

--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass, field
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -67,6 +67,7 @@ from custom_components.hsem.models.planner_outputs import DataQuality, PlanExpla
 from custom_components.hsem.models.sensor_config import SensorConfig
 from custom_components.hsem.models.state_snapshot import StateSnapshot
 from custom_components.hsem.planner import run_planner
+from custom_components.hsem.planner.charge_scheduler import apply_window_hysteresis
 from custom_components.hsem.planner.ev_planner import EVChargingPlan
 from custom_components.hsem.utils.datetime_utils import as_tz
 from custom_components.hsem.utils.datetime_utils import now as hsem_now
@@ -212,6 +213,12 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         # previously active plan.
         self._previous_planner_winner_name: str | None = None
         self._previous_planner_winner_score: float = 0.0
+
+        # Window-level hysteresis state (issue #315).
+        # Persisted across cycles so the hold-time check can compare against
+        # the previously active current-slot recommendation.
+        self._window_hys_previous_rec: str | None = None
+        self._window_hys_previous_slot_start: datetime | None = None
 
     # ------------------------------------------------------------------
     # HA lifecycle
@@ -374,7 +381,6 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                 for warning in planner_output.warnings:
                     await async_logger(self, f"[planner] {warning}")
 
-                self._apply_planner_output(planner_output)
                 self._current_required_battery = planner_output.required_capacity_kwh
                 self._data_quality = planner_output.data_quality
                 self._ev_charging_plan = planner_output.ev_charging_plan
@@ -400,6 +406,39 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                             "set but the plan produced zero accounted load. "
                             "Check EV plan state and slot attributes.",
                         )
+
+                # -----------------------------------------------------------------------
+                # Window-level hysteresis — prevent rapid charge↔discharge toggles
+                # near schedule-window boundaries (issue #315).
+                # -----------------------------------------------------------------------
+                # Apply to planner output slots BEFORE _apply_planner_output so that
+                # the held recommendation propagates to hourly_recommendations.
+                window_hys_minutes = cfg.planner_window_hysteresis_minutes
+                if window_hys_minutes > 0:
+                    held_rec, held_start = apply_window_hysteresis(
+                        planner_output.slots,
+                        now,
+                        window_hysteresis_minutes=window_hys_minutes,
+                        previous_current_recommendation=(self._window_hys_previous_rec),
+                        previous_current_slot_start=(
+                            self._window_hys_previous_slot_start
+                        ),
+                    )
+                    self._window_hys_previous_rec = held_rec
+                    self._window_hys_previous_slot_start = held_start
+                else:
+                    # Feature disabled — still persist the current recommendation
+                    # so that re-enabling picks up the right state.
+                    for s in planner_output.slots:
+                        if as_tz(s.start, now.tzinfo) <= now < as_tz(s.end, now.tzinfo):
+                            self._window_hys_previous_rec = s.recommendation
+                            self._window_hys_previous_slot_start = s.start
+                            break
+
+                # Apply planner output (with hysteresis-applied slots) to
+                # hourly_recommendations so the current slot resolution in
+                # step 9 sees the held recommendation.
+                self._apply_planner_output(planner_output)
 
                 # 9. Find the current time-slot recommendation.
                 self._hourly_recommendations.sort(key=lambda x: x.start)

--- a/custom_components/hsem/custom_sensors/config_reader.py
+++ b/custom_components/hsem/custom_sensors/config_reader.py
@@ -69,6 +69,12 @@ def build_sensor_config(config_entry) -> SensorConfig:
         )
         or 0.0
     )
+    cfg.planner_window_hysteresis_minutes = (
+        convert_to_int(
+            get_config_value(config_entry, "hsem_planner_window_hysteresis_minutes")
+        )
+        or 0
+    )
     _update_interval = convert_to_int(
         get_config_value(config_entry, "hsem_update_interval")
     )

--- a/custom_components/hsem/models/planner_inputs.py
+++ b/custom_components/hsem/models/planner_inputs.py
@@ -272,6 +272,10 @@ class PlannerInput:
     #: the new winner's score is at least this percentage lower (better).
     #: 0.0 disables the percentage threshold.
     planner_hysteresis_percentage: float = 5.0
+    #: Window-level hysteresis — minimum hold time (minutes) before
+    #: allowing a charge↔discharge transition on adjacent slots.
+    #: 0 disables the feature.
+    planner_window_hysteresis_minutes: int = 0
     #: Name of the winning candidate from the previous planner run.
     #: ``None`` on the first run (no active plan to preserve).
     previous_winner_name: str | None = None

--- a/custom_components/hsem/models/sensor_config.py
+++ b/custom_components/hsem/models/sensor_config.py
@@ -226,6 +226,9 @@ class SensorConfig:
     planner_hysteresis_enabled: bool = True
     planner_hysteresis_absolute: float = 0.0
     planner_hysteresis_percentage: float = 5.0
+    # Window-level hysteresis — minimum hold time (minutes) before allowing
+    # a charge↔discharge transition.  0 disables the feature.
+    planner_window_hysteresis_minutes: int = 0
 
     # Consumption weights
     house_consumption_energy_weight_1d: int = 50

--- a/custom_components/hsem/planner/charge_scheduler.py
+++ b/custom_components/hsem/planner/charge_scheduler.py
@@ -19,6 +19,7 @@ from custom_components.hsem.const import (
 from custom_components.hsem.models.planner_inputs import BatteryScheduleInput
 from custom_components.hsem.models.planner_outputs import PlannedSlot
 from custom_components.hsem.utils.datetime_utils import as_tz
+from custom_components.hsem.utils.logger import log_planner
 from custom_components.hsem.utils.misc import next_window_start_dt
 from custom_components.hsem.utils.recommendations import Recommendations
 
@@ -28,6 +29,7 @@ _DISCHARGE_RECS: frozenset[str] = frozenset(
     {
         Recommendations.BatteriesDischargeMode.value,
         Recommendations.ForceBatteriesDischarge.value,
+        Recommendations.ForceExport.value,
     }
 )
 
@@ -969,6 +971,144 @@ def concentrate_discharge_on_expensive_slots(
             # re-mark this as BatteriesDischargeMode.
             s.recommendation = Recommendations.BatteriesWaitMode.value
             s.batteries_charged_kwh = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Window-level hysteresis — prevent rapid charge↔discharge toggles
+# ---------------------------------------------------------------------------
+
+
+# Recommendations that represent "charging" the battery (any form).
+_CHARGE_RECS: frozenset[str] = frozenset(
+    {
+        Recommendations.BatteriesChargeGrid.value,
+        Recommendations.BatteriesChargeSolar.value,
+        Recommendations.EVSmartCharging.value,
+    }
+)
+
+
+def apply_window_hysteresis(
+    slots: list[PlannedSlot],
+    now: datetime,
+    *,
+    window_hysteresis_minutes: int,
+    previous_current_recommendation: str | None,
+    previous_current_slot_start: datetime | None,
+) -> tuple[str | None, datetime | None]:
+    """Apply minimum hold time before allowing charge↔discharge transitions.
+
+    Prevents rapid toggling between charge and discharge behaviour near the
+    boundary of schedule windows.  If the current slot's recommendation
+    would flip between charge-type and discharge-type, and the new regime
+    has been in place for less than ``window_hysteresis_minutes``, the
+    previous recommendation is kept.
+
+    The function considers two broad categories:
+    - **Charge-type**: ``batteries_charge_grid``, ``batteries_charge_solar``,
+      ``ev_smart_charging``
+    - **Discharge-type**: ``batteries_discharge_mode``,
+      ``force_batteries_discharge``, ``force_export``
+    - **Neutral** (no change needed): ``batteries_wait_mode``,
+      ``time_passed``, ``missing_input_entities``, ``None``
+
+    Transitioning within the same category (e.g. grid-charge → solar-charge)
+    is always allowed — only cross-category flips are held.
+
+    Args:
+        slots:
+            Ordered list of planned slots (mutated in place).
+        now:
+            Timezone-aware current datetime.
+        window_hysteresis_minutes:
+            Minimum hold time in minutes.  0 disables the feature entirely.
+        previous_current_recommendation:
+            Recommendation that was active on the current slot during the
+            previous planner run.  ``None`` on first run.
+        previous_current_slot_start:
+            Start time of the slot that carried
+            ``previous_current_recommendation``.  ``None`` on first run.
+
+    Returns:
+        A ``(updated_recommendation, current_slot_start)`` tuple.
+        ``updated_recommendation`` is the (possibly held) recommendation
+        for the current slot, and ``current_slot_start`` is the start time
+        of the current slot (for persisting across cycles).
+    """
+    if window_hysteresis_minutes <= 0:
+        # Feature disabled — find and return current recommendation unchanged
+        for s in slots:
+            if as_tz(s.start, now.tzinfo) <= now < as_tz(s.end, now.tzinfo):
+                return s.recommendation, s.start
+        return None, None
+
+    # Find the current slot
+    current_slot: PlannedSlot | None = None
+    for s in slots:
+        if as_tz(s.start, now.tzinfo) <= now < as_tz(s.end, now.tzinfo):
+            current_slot = s
+            break
+
+    if current_slot is None:
+        return None, None
+
+    new_rec = current_slot.recommendation
+    new_start = current_slot.start
+
+    # No previous state — first run, no hysteresis to apply
+    if previous_current_recommendation is None or previous_current_slot_start is None:
+        return new_rec, new_start
+
+    new_category = _rec_category(new_rec)
+    prev_category = _rec_category(previous_current_recommendation)
+
+    # If the recommendation hasn't changed category, no hold needed
+    if (
+        new_category == prev_category
+        or new_category == "neutral"
+        or prev_category == "neutral"
+    ):
+        return new_rec, new_start
+
+    # Category changed — check hold time
+    elapsed_minutes = (now - previous_current_slot_start).total_seconds() / 60.0
+    if elapsed_minutes < window_hysteresis_minutes:
+        # Hold the previous recommendation
+        log_planner(
+            "debug",
+            "[window_hysteresis] Holding previous recommendation '%s' on current "
+            "slot (elapsed=%.1f min < hold=%d min). New '%s' suppressed.",
+            previous_current_recommendation,
+            elapsed_minutes,
+            window_hysteresis_minutes,
+            new_rec,
+        )
+        current_slot.recommendation = previous_current_recommendation
+        return previous_current_recommendation, previous_current_slot_start
+
+    # Enough time has passed — allow the switch
+    log_planner(
+        "debug",
+        "[window_hysteresis] Allowing transition '%s' → '%s' on current slot "
+        "(elapsed=%.1f min >= hold=%d min).",
+        previous_current_recommendation,
+        new_rec,
+        elapsed_minutes,
+        window_hysteresis_minutes,
+    )
+    return new_rec, new_start
+
+
+def _rec_category(rec: str | None) -> str:
+    """Classify a recommendation into a category.
+
+    Returns ``"charge"``, ``"discharge"``, or ``"neutral"``.
+    """
+    if rec in _CHARGE_RECS:
+        return "charge"
+    if rec in _DISCHARGE_RECS:
+        return "discharge"
+    return "neutral"
 
 
 # ---------------------------------------------------------------------------

--- a/docs/hsem-planner-spec.md
+++ b/docs/hsem-planner-spec.md
@@ -569,6 +569,55 @@ coordinator and passed as part of :class:`PlannerInput`.
 Hysteresis is enabled by default with a 5 % percentage threshold; setting
 ``planner_hysteresis_enabled = False`` disables it entirely.
 
+### Window-level hysteresis (anti-flapping, issue #315)
+
+In addition to plan-level hysteresis, HSEM applies **window-level hysteresis**
+on the **current time slot** to prevent rapid charge↔discharge toggles near
+schedule-window boundaries.  This is a separate, independent mechanism that
+operates on the slot recommendation level rather than the plan level.
+
+When the planner produces a new recommendation for the current slot that
+belongs to a different *category* than the previous recommendation, and the
+new category has been in effect for less than the configured hold time,
+the previous recommendation is kept.
+
+Two categories are defined:
+
+- **Charge-type**: ``batteries_charge_grid``, ``batteries_charge_solar``,
+  ``ev_smart_charging``
+- **Discharge-type**: ``batteries_discharge_mode``,
+  ``force_batteries_discharge``, ``force_export``
+- **Neutral**: ``batteries_wait_mode``, ``time_passed``,
+  ``missing_input_entities``, ``None``
+
+Only cross-category transitions (charge ↔ discharge) are held.  Same-category
+changes (e.g. grid-charge → solar-charge) and transitions to/from neutral
+are always allowed.
+
+The hold time is configured by ``planner_window_hysteresis_minutes``
+(default: 0, disabled).  When set to a positive integer, a charge→discharge
+or discharge→charge transition on the current slot is suppressed unless the
+new category has been active for at least this many minutes.
+
+The previous recommendation and its slot start time are persisted across
+planner runs by the coordinator so the elapsed time is measured from the
+moment the previous category was established — not from the planner cycle
+time.
+
+Window-level hysteresis is applied **after** the planner engine completes but
+**before** the current slot recommendation is resolved.  The held
+recommendation is written back into the planner output slots so it propagates
+to the ``hourly_recommendations`` list and ultimately to hardware writes.
+
+### Invariants for window-level hysteresis tests
+
+- First run (no previous state) always accepts the new recommendation.
+- Same-category transitions are never held.
+- Cross-category transitions within the hold time keep the previous recommendation.
+- Cross-category transitions after the hold time expires switch to the new one.
+- Neutral recommendations never trigger hold behaviour.
+- Feature disabled (hold minutes = 0) always allows the switch.
+
 ## No-action baseline
 
 The no-action plan means:

--- a/tests/planner/test_window_hysteresis.py
+++ b/tests/planner/test_window_hysteresis.py
@@ -1,0 +1,348 @@
+"""Tests for window-level hysteresis (issue #315).
+
+Window-level hysteresis prevents rapid toggling between charge and discharge
+recommendations near schedule-window boundaries.  When the current slot's
+recommendation changes category (charge ↔ discharge), the previous
+recommendation is held for a configurable minimum time.
+
+Acceptance criteria
+-------------------
+1. Charge/discharge does not flap around boundary conditions.
+2. Minimum hold time is configurable.
+3. Only cross-category flips (charge ↔ discharge) are held;
+   same-category changes (e.g. grid-charge → solar-charge) are allowed.
+4. Neutral recommendations (wait_mode, time_passed, None) do not trigger hold.
+5. Feature disabled (0 min) always allows the switch.
+6. First run (no previous state) always accepts the new recommendation.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from custom_components.hsem.planner.charge_scheduler import apply_window_hysteresis
+from custom_components.hsem.utils.prices import SlotPrice
+from custom_components.hsem.utils.recommendations import Recommendations
+
+_TZ = ZoneInfo("Europe/Copenhagen")
+_NOW = datetime(2024, 6, 15, 12, 0, tzinfo=_TZ)
+
+
+def _make_slots(
+    *recommendations: str | None,
+) -> list:
+    """Build a list of sequential PlannedSlots with the given recommendations."""
+    from custom_components.hsem.models.planner_outputs import PlannedSlot
+
+    slots: list[PlannedSlot] = []
+    for i, rec in enumerate(recommendations):
+        start = _NOW + timedelta(hours=i)
+        end = start + timedelta(hours=1)
+        slots.append(
+            PlannedSlot(
+                start=start,
+                end=end,
+                price=SlotPrice(import_price=0.20, export_price=0.05),
+                recommendation=rec,
+            )
+        )
+    return slots
+
+
+class TestWindowHysteresis:
+    """Window-level hysteresis acceptance tests."""
+
+    # ------------------------------------------------------------------
+    # First-run behaviour
+    # ------------------------------------------------------------------
+
+    def test_no_previous_state_first_run(self):
+        """When there is no previous state, hysteresis is inactive."""
+        slots = _make_slots(
+            Recommendations.BatteriesChargeGrid.value,
+        )
+        rec, start = apply_window_hysteresis(
+            slots,
+            _NOW,
+            window_hysteresis_minutes=30,
+            previous_current_recommendation=None,
+            previous_current_slot_start=None,
+        )
+        assert rec == Recommendations.BatteriesChargeGrid.value, (
+            "First run must accept the new recommendation"
+        )
+
+    # ------------------------------------------------------------------
+    # Same-category transitions (no hold needed)
+    # ------------------------------------------------------------------
+
+    def test_charge_to_charge_no_hold(self):
+        """Same-category change (grid-charge → solar-charge) must not hold."""
+        slots = _make_slots(
+            Recommendations.BatteriesChargeSolar.value,
+        )
+        rec, start = apply_window_hysteresis(
+            slots,
+            _NOW,
+            window_hysteresis_minutes=30,
+            previous_current_recommendation=Recommendations.BatteriesChargeGrid.value,
+            previous_current_slot_start=_NOW - timedelta(minutes=5),
+        )
+        assert rec == Recommendations.BatteriesChargeSolar.value, (
+            "Same-category charge change must not be held"
+        )
+
+    def test_discharge_to_discharge_no_hold(self):
+        """Same-category change (discharge → force-discharge) must not hold."""
+        slots = _make_slots(
+            Recommendations.ForceBatteriesDischarge.value,
+        )
+        rec, start = apply_window_hysteresis(
+            slots,
+            _NOW,
+            window_hysteresis_minutes=30,
+            previous_current_recommendation=Recommendations.BatteriesDischargeMode.value,
+            previous_current_slot_start=_NOW - timedelta(minutes=5),
+        )
+        assert rec == Recommendations.ForceBatteriesDischarge.value, (
+            "Same-category discharge change must not be held"
+        )
+
+    # ------------------------------------------------------------------
+    # Cross-category transitions within hold time
+    # ------------------------------------------------------------------
+
+    def test_charge_to_discharge_within_hold(self):
+        """Charge→discharge within hold time must keep the previous recommendation."""
+        slots = _make_slots(
+            Recommendations.BatteriesDischargeMode.value,
+        )
+        rec, start = apply_window_hysteresis(
+            slots,
+            _NOW,
+            window_hysteresis_minutes=30,
+            previous_current_recommendation=Recommendations.BatteriesChargeGrid.value,
+            previous_current_slot_start=_NOW - timedelta(minutes=5),
+        )
+        assert rec == Recommendations.BatteriesChargeGrid.value, (
+            "Charge→discharge within hold time must be held"
+        )
+        # The slot's recommendation should also be updated
+        assert slots[0].recommendation == Recommendations.BatteriesChargeGrid.value, (
+            "Slot recommendation must reflect the held value"
+        )
+
+    def test_discharge_to_charge_within_hold(self):
+        """Discharge→charge within hold time must keep the previous recommendation."""
+        slots = _make_slots(
+            Recommendations.BatteriesChargeGrid.value,
+        )
+        rec, start = apply_window_hysteresis(
+            slots,
+            _NOW,
+            window_hysteresis_minutes=30,
+            previous_current_recommendation=Recommendations.BatteriesDischargeMode.value,
+            previous_current_slot_start=_NOW - timedelta(minutes=5),
+        )
+        assert rec == Recommendations.BatteriesDischargeMode.value, (
+            "Discharge→charge within hold time must be held"
+        )
+        assert (
+            slots[0].recommendation == Recommendations.BatteriesDischargeMode.value
+        ), "Slot recommendation must reflect the held value"
+
+    def test_charge_to_force_export_within_hold(self):
+        """Charge→force-export within hold time must keep charge."""
+        slots = _make_slots(
+            Recommendations.ForceExport.value,
+        )
+        rec, start = apply_window_hysteresis(
+            slots,
+            _NOW,
+            window_hysteresis_minutes=15,
+            previous_current_recommendation=Recommendations.EVSmartCharging.value,
+            previous_current_slot_start=_NOW - timedelta(minutes=2),
+        )
+        assert rec == Recommendations.EVSmartCharging.value, (
+            "Charge→force-export within hold time must be held"
+        )
+
+    # ------------------------------------------------------------------
+    # Cross-category transitions after hold time expires
+    # ------------------------------------------------------------------
+
+    def test_charge_to_discharge_after_hold(self):
+        """Charge→discharge after hold time must allow the switch."""
+        slots = _make_slots(
+            Recommendations.BatteriesDischargeMode.value,
+        )
+        rec, start = apply_window_hysteresis(
+            slots,
+            _NOW,
+            window_hysteresis_minutes=10,
+            previous_current_recommendation=Recommendations.BatteriesChargeGrid.value,
+            previous_current_slot_start=_NOW - timedelta(minutes=15),
+        )
+        assert rec == Recommendations.BatteriesDischargeMode.value, (
+            "Charge→discharge after hold time must be allowed"
+        )
+
+    def test_discharge_to_charge_after_hold(self):
+        """Discharge→charge after hold time must allow the switch."""
+        slots = _make_slots(
+            Recommendations.BatteriesChargeGrid.value,
+        )
+        rec, start = apply_window_hysteresis(
+            slots,
+            _NOW,
+            window_hysteresis_minutes=5,
+            previous_current_recommendation=Recommendations.BatteriesDischargeMode.value,
+            previous_current_slot_start=_NOW - timedelta(minutes=10),
+        )
+        assert rec == Recommendations.BatteriesChargeGrid.value, (
+            "Discharge→charge after hold time must be allowed"
+        )
+
+    # ------------------------------------------------------------------
+    # Neutral recommendations
+    # ------------------------------------------------------------------
+
+    def test_charge_to_neutral_no_hold(self):
+        """Charge→neutral must not hold."""
+        slots = _make_slots(
+            Recommendations.BatteriesWaitMode.value,
+        )
+        rec, start = apply_window_hysteresis(
+            slots,
+            _NOW,
+            window_hysteresis_minutes=30,
+            previous_current_recommendation=Recommendations.BatteriesChargeGrid.value,
+            previous_current_slot_start=_NOW - timedelta(minutes=2),
+        )
+        assert rec == Recommendations.BatteriesWaitMode.value, (
+            "Charge→neutral must not be held"
+        )
+
+    def test_discharge_to_neutral_no_hold(self):
+        """Discharge→neutral must not hold."""
+        slots = _make_slots(
+            None,
+        )
+        rec, start = apply_window_hysteresis(
+            slots,
+            _NOW,
+            window_hysteresis_minutes=30,
+            previous_current_recommendation=Recommendations.BatteriesDischargeMode.value,
+            previous_current_slot_start=_NOW - timedelta(minutes=2),
+        )
+        assert rec is None, "Discharge→neutral must not be held"
+
+    def test_neutral_to_charge_no_hold(self):
+        """Neutral→charge must not hold."""
+        slots = _make_slots(
+            Recommendations.BatteriesChargeGrid.value,
+        )
+        rec, start = apply_window_hysteresis(
+            slots,
+            _NOW,
+            window_hysteresis_minutes=30,
+            previous_current_recommendation=Recommendations.TimePassed.value,
+            previous_current_slot_start=_NOW - timedelta(minutes=2),
+        )
+        assert rec == Recommendations.BatteriesChargeGrid.value, (
+            "Neutral→charge must not be held"
+        )
+
+    # ------------------------------------------------------------------
+    # Feature disabled
+    # ------------------------------------------------------------------
+
+    def test_feature_disabled_always_allows_switch(self):
+        """When window_hysteresis_minutes is 0, all transitions are allowed."""
+        slots = _make_slots(
+            Recommendations.BatteriesDischargeMode.value,
+        )
+        rec, start = apply_window_hysteresis(
+            slots,
+            _NOW,
+            window_hysteresis_minutes=0,
+            previous_current_recommendation=Recommendations.BatteriesChargeGrid.value,
+            previous_current_slot_start=_NOW - timedelta(minutes=2),
+        )
+        assert rec == Recommendations.BatteriesDischargeMode.value, (
+            "Transition must be allowed when feature is disabled"
+        )
+
+    # ------------------------------------------------------------------
+    # Edge cases — exact boundary
+    # ------------------------------------------------------------------
+
+    def test_exactly_at_hold_time_boundary(self):
+        """Transition exactly at hold time boundary must be allowed."""
+        slots = _make_slots(
+            Recommendations.BatteriesDischargeMode.value,
+        )
+        rec, start = apply_window_hysteresis(
+            slots,
+            _NOW,
+            window_hysteresis_minutes=10,
+            previous_current_recommendation=Recommendations.EVSmartCharging.value,
+            previous_current_slot_start=_NOW - timedelta(minutes=10),
+        )
+        assert rec == Recommendations.BatteriesDischargeMode.value, (
+            "Transition exactly at hold time boundary must be allowed (>=)"
+        )
+
+    def test_one_second_before_boundary(self):
+        """Transition just before hold time boundary must be held."""
+        slots = _make_slots(
+            Recommendations.BatteriesDischargeMode.value,
+        )
+        rec, start = apply_window_hysteresis(
+            slots,
+            _NOW,
+            window_hysteresis_minutes=10,
+            previous_current_recommendation=Recommendations.EVSmartCharging.value,
+            previous_current_slot_start=_NOW - timedelta(minutes=9, seconds=59),
+        )
+        assert rec == Recommendations.EVSmartCharging.value, (
+            "Transition just before hold time boundary must be held"
+        )
+
+    # ------------------------------------------------------------------
+    # Return value semantics
+    # ------------------------------------------------------------------
+
+    def test_returns_updated_start_time_on_switch(self):
+        """When a switch is allowed, the returned start time must be the new slot start."""
+        slots = _make_slots(
+            Recommendations.BatteriesDischargeMode.value,
+        )
+        rec, start = apply_window_hysteresis(
+            slots,
+            _NOW,
+            window_hysteresis_minutes=5,
+            previous_current_recommendation=Recommendations.BatteriesChargeGrid.value,
+            previous_current_slot_start=_NOW - timedelta(minutes=15),
+        )
+        assert start == slots[0].start, (
+            "Returned start time must be from the current slot after a switch"
+        )
+
+    def test_returns_previous_start_time_on_hold(self):
+        """When held, the returned start time must be the previous slot start."""
+        slots = _make_slots(
+            Recommendations.BatteriesDischargeMode.value,
+        )
+        prev_start = _NOW - timedelta(minutes=2)
+        rec, start = apply_window_hysteresis(
+            slots,
+            _NOW,
+            window_hysteresis_minutes=10,
+            previous_current_recommendation=Recommendations.BatteriesChargeGrid.value,
+            previous_current_slot_start=prev_start,
+        )
+        assert start == prev_start, (
+            "Returned start time must be the previous slot start when held"
+        )


### PR DESCRIPTION
## Summary

Add window-level hysteresis to prevent rapid charge/discharge **recommendation toggles** near schedule-window boundaries (issue #315). This is distinct from plan-level hysteresis (issue #372) � it operates on the **current time slot** recommendation rather than the candidate-plan selection.

## Changes

### New configuration
- **\hsem_planner_window_hysteresis_minutes\** (default: 0 = disabled) � minimum hold time in minutes before a charge?discharge flip on the current slot is allowed.

### Core logic (\charge_scheduler.py\)
- New function **\pply_window_hysteresis()\** that classifies slot recommendations into three categories (charge, discharge, neutral) and enforces the hold time for cross-category flips.
- Only charge?discharge transitions are held � same-category changes and neutral transitions are always allowed.

### Coordinator wiring (\coordinator.py\)
- Persists the previous current-slot recommendation and slot-start time across planner cycles.
- Applies window hysteresis **after** the planner engine completes but **before** current-slot resolution, so the held recommendation flows through to hardware writes.
- When the feature is disabled (default), the current recommendation is still persisted so re-enabling picks up the right state.

### Config stack
- \const.py\: default config value
- \models/sensor_config.py\: dataclass field
- \models/planner_inputs.py\: planner input field
- \custom_sensors/config_reader.py\: reads from config entry

### Tests (\	ests/planner/test_window_hysteresis.py\)
16 tests covering:
- First-run behaviour (no previous state)
- Same-category transitions (no hold)
- Cross-category transitions within / after hold time
- Neutral recommendation transitions
- Feature-disabled (0 min) scenario
- Exact boundary and sub-boundary timing
- Return-value semantics (start time tracking)

### Documentation (\docs/hsem-planner-spec.md\)
Added window-level hysteresis section with design, categories, invariants.

## Test results
- All 16 new window hysteresis tests: ?
- All 11 existing plan-level hysteresis tests: ?  
- All 371 planner tests: ?
- Lint (isort, black, ruff format, ruff check): ?
- Quality (pyright, vulture): 0 errors ?

## Checklist
- [x] Minimum hold time is configurable
- [x] Charge/discharge does not flap around boundary conditions
- [x] Tests cover all edge cases
- [x] Spec is updated
- [x] Lint and quality checks pass
