### PR TITLE
refactor(utils): move DISCHARGE_RECS and CHARGE_RECS to utils/recommendations

### DIFF
--- a/custom_components/hsem/planner/candidate_generator.py
+++ b/custom_components/hsem/planner/candidate_generator.py
@@ -52,6 +52,10 @@ from custom_components.hsem.planner.milp_optimizer import (
 )
 from custom_components.hsem.utils.datetime_utils import as_tz
 from custom_components.hsem.utils.logger import log_planner
+from custom_components.hsem.utils.recommendations import CHARGE_RECS as _CHARGE_RECS
+from custom_components.hsem.utils.recommendations import (
+    DISCHARGE_RECS as _DISCHARGE_RECS,
+)
 from custom_components.hsem.utils.recommendations import Recommendations
 
 # ---------------------------------------------------------------------------
@@ -110,22 +114,6 @@ __all__ = [
     "CandidatePlan",
     "generate_candidates",
 ]
-
-# Recommendations that represent charging (any source)
-_CHARGE_RECS: frozenset[str] = frozenset(
-    {
-        Recommendations.BatteriesChargeGrid.value,
-        Recommendations.BatteriesChargeSolar.value,
-    }
-)
-
-# Recommendations that represent discharging (any form)
-_DISCHARGE_RECS: frozenset[str] = frozenset(
-    {
-        Recommendations.BatteriesDischargeMode.value,
-        Recommendations.ForceBatteriesDischarge.value,
-    }
-)
 
 # The charge and discharge slot counts are derived dynamically from battery
 # capacity (see _apply_aggressive_strategy).

--- a/custom_components/hsem/planner/candidate_selector.py
+++ b/custom_components/hsem/planner/candidate_selector.py
@@ -37,7 +37,6 @@ from datetime import datetime, timedelta
 
 from custom_components.hsem.models.planner_outputs import RejectedPlan
 from custom_components.hsem.planner.candidate_generator import (
-    _DISCHARGE_RECS,
     CANDIDATE_BASELINE,
     CANDIDATE_NO_ACTION,
     CandidatePlan,
@@ -46,6 +45,9 @@ from custom_components.hsem.planner.cost_function import CostWeights, score_plan
 from custom_components.hsem.planner.soc_simulation import simulate_soc
 from custom_components.hsem.utils.datetime_utils import as_tz
 from custom_components.hsem.utils.logger import log_planner
+from custom_components.hsem.utils.recommendations import (
+    DISCHARGE_RECS as _DISCHARGE_RECS,
+)
 
 # SoC floor tolerance — plans are accepted even if they dip this many
 # percentage points below end_of_discharge_soc_pct (rounding / simulation

--- a/custom_components/hsem/planner/charge_scheduler.py
+++ b/custom_components/hsem/planner/charge_scheduler.py
@@ -21,17 +21,11 @@ from custom_components.hsem.models.planner_outputs import PlannedSlot
 from custom_components.hsem.utils.datetime_utils import as_tz
 from custom_components.hsem.utils.logger import log_planner
 from custom_components.hsem.utils.misc import next_window_start_dt
-from custom_components.hsem.utils.recommendations import Recommendations
-
-# Recommendations that represent discharging (any form) — local copy to
-# avoid circular imports from candidate_generator.
-_DISCHARGE_RECS: frozenset[str] = frozenset(
-    {
-        Recommendations.BatteriesDischargeMode.value,
-        Recommendations.ForceBatteriesDischarge.value,
-        Recommendations.ForceExport.value,
-    }
+from custom_components.hsem.utils.recommendations import CHARGE_RECS as _CHARGE_RECS
+from custom_components.hsem.utils.recommendations import (
+    DISCHARGE_RECS as _DISCHARGE_RECS,
 )
+from custom_components.hsem.utils.recommendations import Recommendations
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -976,16 +970,6 @@ def concentrate_discharge_on_expensive_slots(
 # ---------------------------------------------------------------------------
 # Window-level hysteresis — prevent rapid charge↔discharge toggles
 # ---------------------------------------------------------------------------
-
-
-# Recommendations that represent "charging" the battery (any form).
-_CHARGE_RECS: frozenset[str] = frozenset(
-    {
-        Recommendations.BatteriesChargeGrid.value,
-        Recommendations.BatteriesChargeSolar.value,
-        Recommendations.EVSmartCharging.value,
-    }
-)
 
 
 def apply_window_hysteresis(

--- a/custom_components/hsem/utils/recommendations.py
+++ b/custom_components/hsem/utils/recommendations.py
@@ -19,3 +19,24 @@ class Recommendations(Enum):
     ForceBatteriesDischarge = "force_batteries_discharge"
     ForceExport = "force_export"
     MissingInputEntities = "missing_input_entities"
+
+
+# Canonical set of all discharge-type recommendations.
+# Import these instead of re-defining locally.
+DISCHARGE_RECS: frozenset[str] = frozenset(
+    {
+        Recommendations.BatteriesDischargeMode.value,
+        Recommendations.ForceBatteriesDischarge.value,
+        Recommendations.ForceExport.value,
+    }
+)
+
+# Canonical set of all charge-type recommendations.
+# Import these instead of re-defining locally.
+CHARGE_RECS: frozenset[str] = frozenset(
+    {
+        Recommendations.BatteriesChargeGrid.value,
+        Recommendations.BatteriesChargeSolar.value,
+        Recommendations.EVSmartCharging.value,
+    }
+)


### PR DESCRIPTION
## Problem

_DISCHARGE_RECS and _CHARGE_RECS were defined independently in 3 files, creating a maintenance risk.

## Solution

Moved the canonical definitions to utils/recommendations.py as public constants, then imported them in each consumer file.

## Changes

- **utils/recommendations.py** � Added public DISCHARGE_RECS (3 items: includes ForceExport) and CHARGE_RECS (3 items: includes EVSmartCharging)
- **planner/candidate_generator.py** � Removed local definitions, imports from utils
- **planner/charge_scheduler.py** � Removed local definitions, imports from utils
- **planner/candidate_selector.py** � Replaced private import from candidate_generator with import from utils/recommendations

## Test Results

All 1984 tests pass, 10 xfailed, 0 failures.

## Acceptance Criteria

- [x] DISCHARGE_RECS and CHARGE_RECS are defined exactly once in utils/recommendations.py as public names
- [x] All consumer files import from utils/recommendations.py
- [x] candidate_selector.py no longer imports private _DISCHARGE_RECS from candidate_generator
- [x] No local re-definitions remain anywhere in the codebase
- [x] All existing tests pass

Fixes #439
