### PR TITLE
refactor(planner): extract clamp_efficiency() helper to eliminate repeated pattern

### DIFF
--- a/custom_components/hsem/planner/candidate_generator.py
+++ b/custom_components/hsem/planner/candidate_generator.py
@@ -52,6 +52,7 @@ from custom_components.hsem.planner.milp_optimizer import (
 )
 from custom_components.hsem.utils.datetime_utils import as_tz
 from custom_components.hsem.utils.logger import log_planner
+from custom_components.hsem.utils.misc import clamp_efficiency
 from custom_components.hsem.utils.recommendations import CHARGE_RECS as _CHARGE_RECS
 from custom_components.hsem.utils.recommendations import (
     DISCHARGE_RECS as _DISCHARGE_RECS,
@@ -639,8 +640,8 @@ def _apply_soc_plan(
     )
 
     # Account for charge and discharge efficiency.
-    charge_eff = max(min(charge_efficiency_pct, 100.0), 1.0) / 100.0
-    discharge_eff = max(min(discharge_efficiency_pct, 100.0), 1.0) / 100.0
+    charge_eff = clamp_efficiency(charge_efficiency_pct)
+    discharge_eff = clamp_efficiency(discharge_efficiency_pct)
     battery_energy_needed = total_needed_kwh / discharge_eff
 
     # Subtract what's already in the battery

--- a/custom_components/hsem/planner/charge_scheduler.py
+++ b/custom_components/hsem/planner/charge_scheduler.py
@@ -20,7 +20,7 @@ from custom_components.hsem.models.planner_inputs import BatteryScheduleInput
 from custom_components.hsem.models.planner_outputs import PlannedSlot
 from custom_components.hsem.utils.datetime_utils import as_tz
 from custom_components.hsem.utils.logger import log_planner
-from custom_components.hsem.utils.misc import next_window_start_dt
+from custom_components.hsem.utils.misc import clamp_efficiency, next_window_start_dt
 from custom_components.hsem.utils.recommendations import CHARGE_RECS as _CHARGE_RECS
 from custom_components.hsem.utils.recommendations import (
     DISCHARGE_RECS as _DISCHARGE_RECS,
@@ -911,7 +911,7 @@ def concentrate_discharge_on_expensive_slots(
             ``None`` means unlimited (inverter default).
         discharge_efficiency_pct: Discharge-side efficiency (0-100 %).
     """
-    discharge_eff = max(min(discharge_efficiency_pct, 100.0), 1.0) / 100.0
+    discharge_eff = clamp_efficiency(discharge_efficiency_pct)
 
     # Collect all future discharge slots (both BatteriesDischargeMode and
     # ForceBatteriesDischarge — issue #425 Bug I fix).

--- a/custom_components/hsem/planner/cost_function.py
+++ b/custom_components/hsem/planner/cost_function.py
@@ -74,6 +74,7 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from custom_components.hsem.models.planner_outputs import PlannedSlot
+from custom_components.hsem.utils.misc import clamp_efficiency
 from custom_components.hsem.utils.recommendations import Recommendations
 
 # ---------------------------------------------------------------------------
@@ -508,8 +509,8 @@ def score_plan(
     # we compute the roundtrip loss from them:
     #   roundtrip_loss = 1 - (charge_eff × discharge_eff)
     # Compute roundtrip loss from charge/discharge efficiencies.
-    charge_eff = max(min(weights.charge_efficiency_pct, 100.0), 1.0) / 100.0
-    discharge_eff = max(min(weights.discharge_efficiency_pct, 100.0), 1.0) / 100.0
+    charge_eff = clamp_efficiency(weights.charge_efficiency_pct)
+    discharge_eff = clamp_efficiency(weights.discharge_efficiency_pct)
 
     import_cost = 0.0
     export_revenue = 0.0

--- a/custom_components/hsem/planner/milp_optimizer.py
+++ b/custom_components/hsem/planner/milp_optimizer.py
@@ -100,6 +100,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from custom_components.hsem.utils.datetime_utils import as_tz
+from custom_components.hsem.utils.misc import clamp_efficiency
 from custom_components.hsem.utils.recommendations import Recommendations
 
 if TYPE_CHECKING:
@@ -269,8 +270,8 @@ def solve_milp(
     # The MILP must account for real-world conversion losses so its solution
     # matches the cost function's total_cost (which includes conversion loss
     # via the conversion_loss_cost term).
-    charge_eff = max(min(charge_efficiency_pct, 100.0), 1.0) / 100.0
-    discharge_eff = max(min(discharge_efficiency_pct, 100.0), 1.0) / 100.0
+    charge_eff = clamp_efficiency(charge_efficiency_pct)
+    discharge_eff = clamp_efficiency(discharge_efficiency_pct)
     charge_loss = 1.0 - charge_eff
     discharge_loss = 1.0 - discharge_eff
 

--- a/custom_components/hsem/planner/soc_simulation.py
+++ b/custom_components/hsem/planner/soc_simulation.py
@@ -34,6 +34,7 @@ from datetime import datetime
 from custom_components.hsem.models.planner_outputs import PlannedSlot
 from custom_components.hsem.utils.datetime_utils import as_tz
 from custom_components.hsem.utils.logger import log_planner
+from custom_components.hsem.utils.misc import clamp_efficiency
 from custom_components.hsem.utils.recommendations import Recommendations
 
 
@@ -110,8 +111,8 @@ def simulate_soc(
             Defaults to 100 % (no discharge-side loss) for backward compatibility.
     """
     # Clamp efficiencies to a valid range to avoid division by zero or nonsense.
-    charge_eff = max(min(charge_efficiency_pct, 100.0), 1.0) / 100.0
-    discharge_eff = max(min(discharge_efficiency_pct, 100.0), 1.0) / 100.0
+    charge_eff = clamp_efficiency(charge_efficiency_pct)
+    discharge_eff = clamp_efficiency(discharge_efficiency_pct)
     cap = current_kwh  # working state — kWh above discharge floor
 
     log_planner(

--- a/custom_components/hsem/utils/misc.py
+++ b/custom_components/hsem/utils/misc.py
@@ -269,6 +269,21 @@ def convert_to_boolean(state) -> bool:
     return False
 
 
+def clamp_efficiency(pct: float) -> float:
+    """Convert an efficiency percentage (0-100) to a fraction (0.01-1.0).
+
+    Clamps input to [1.0, 100.0] before dividing by 100 so downstream
+    code never divides by zero or exceeds 100% efficiency.
+
+    Args:
+        pct: Efficiency as a percentage, e.g. 97.0 for 97%.
+
+    Returns:
+        Efficiency as a fraction in [0.01, 1.0].
+    """
+    return max(min(pct, 100.0), 1.0) / 100.0
+
+
 async def async_resolve_entity_id_from_unique_id(
     self, unique_entity_id, domain="sensor"
 ) -> str | None:

--- a/tests/test_convert_to_float_none.py
+++ b/tests/test_convert_to_float_none.py
@@ -529,3 +529,50 @@ class TestFlowExpectedCyclesNullSafety:
         )
         # (48000 * 0.30) / (2 * 6000 * 10) = 14400 / 120000 = 0.12
         assert result == pytest.approx(0.12, abs=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# clamp_efficiency — validates the shared helper
+# ---------------------------------------------------------------------------
+
+
+class TestClampEfficiency:
+    """Verify that clamp_efficiency correctly clamps and converts percentages."""
+
+    @staticmethod
+    def _clamp(pct: float) -> float:
+        from custom_components.hsem.utils.misc import clamp_efficiency
+
+        return clamp_efficiency(pct)
+
+    def test_normal_efficiency(self) -> None:
+        """97 % → 0.97."""
+        assert self._clamp(97.0) == pytest.approx(0.97)
+
+    def test_zero_input_floor(self) -> None:
+        """0 % is below the 1.0 floor → 0.01."""
+        assert self._clamp(0.0) == pytest.approx(0.01)
+
+    def test_below_one_floor(self) -> None:
+        """0.5 % is below the 1.0 floor → 0.01."""
+        assert self._clamp(0.5) == pytest.approx(0.01)
+
+    def test_above_one_hundred_cap(self) -> None:
+        """101 % is above the 100.0 cap → 1.0."""
+        assert self._clamp(101.0) == pytest.approx(1.0)
+
+    def test_negative_input(self) -> None:
+        """-5 % is below the 1.0 floor → 0.01."""
+        assert self._clamp(-5.0) == pytest.approx(0.01)
+
+    def test_exactly_one(self) -> None:
+        """1.0 % → 0.01."""
+        assert self._clamp(1.0) == pytest.approx(0.01)
+
+    def test_exactly_one_hundred(self) -> None:
+        """100.0 % → 1.0."""
+        assert self._clamp(100.0) == pytest.approx(1.0)
+
+    def test_fifty_percent(self) -> None:
+        """50.0 % → 0.5."""
+        assert self._clamp(50.0) == pytest.approx(0.5)


### PR DESCRIPTION
Extracts a reusable clamp_efficiency() helper function in utils/misc.py and replaces all 9 occurrences of the inline max(min(...), 1.0) / 100.0 pattern across 5 planner files.

## Changes

### New helper
- **custom_components/hsem/utils/misc.py** � Added clamp_efficiency(pct: float) -> float that clamps input to [1.0, 100.0] and divides by 100.

### Updated consumers
- **custom_components/hsem/planner/candidate_generator.py** � Replaced 2 occurrences (charge_eff, discharge_eff)
- **custom_components/hsem/planner/charge_scheduler.py** � Replaced 1 occurrence (discharge_eff)
- **custom_components/hsem/planner/cost_function.py** � Replaced 2 occurrences (charge_eff, discharge_eff via weights)
- **custom_components/hsem/planner/milp_optimizer.py** � Replaced 2 occurrences (charge_eff, discharge_eff)
- **custom_components/hsem/planner/soc_simulation.py** � Replaced 2 occurrences (charge_eff, discharge_eff)

### Tests
- **	ests/test_convert_to_float_none.py** � Added TestClampEfficiency with 8 test cases covering:
  - Normal input (97% ? 0.97)
  - Floor clamping (0%, 0.5%, -5% ? 0.01)
  - Cap clamping (101% ? 1.0)
  - Boundary values (1%, 100%, 50%)

## Acceptance Criteria
- [x] clamp_efficiency(pct) defined in utils/misc.py with full docstring
- [x] All consumer files use clamp_efficiency() instead of inline expression
- [x] No inline max(min(..., 100.0), 1.0) / 100.0 patterns remain for efficiency conversion
- [x] Unit test added covering edge cases
- [x] All existing tests pass
- [x] tox -e lint passes

Fixes #440
