### PR TITLE
fix(planner): replace break with continue in concentrate_discharge_on_expensive_slots (#446)

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -163,7 +163,7 @@ Always check `docs/huawei_entities.md` before looking elsewhere.
 |---|---|---|
 | #444 | MILP cycle cost `ec+ed` vs `max(ec,ed)` | Open |
 | #445 | `_apply_soc_plan` uses `0.30` proxy threshold | Open |
-| #446 | `concentrate_discharge` greedy `break` skips viable slots | Open |
+| #446 | `concentrate_discharge` greedy `break` skips viable slots | Fixed in #452 |
 | #447 | Partial-SoC fractions collapse to floor at low SoC | Open |
 
 ---

--- a/custom_components/hsem/planner/charge_scheduler.py
+++ b/custom_components/hsem/planner/charge_scheduler.py
@@ -947,8 +947,9 @@ def concentrate_discharge_on_expensive_slots(
             total_battery_kwh -= battery_needed
             keep_set.add(id(s))
         else:
-            # Not enough battery — this and all cheaper slots get cleared
-            break
+            # Not enough battery — skip this slot, but keep checking
+            # cheaper slots that may have small enough demand to fit.
+            continue
 
     for s in discharge_slots:
         if id(s) not in keep_set:

--- a/tests/planner/test_concentrate_discharge.py
+++ b/tests/planner/test_concentrate_discharge.py
@@ -1,0 +1,229 @@
+"""Tests for concentrate_discharge_on_expensive_slots() in charge_scheduler.py.
+
+Regression test for #446: the original code used ``break`` when a slot
+could not be fully served, causing all subsequent (cheaper) slots to be
+skipped even if they had small enough demand to fit.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from custom_components.hsem.models.planner_outputs import PlannedSlot
+from custom_components.hsem.planner.charge_scheduler import (
+    concentrate_discharge_on_expensive_slots,
+)
+from custom_components.hsem.utils.prices import SlotPrice
+from custom_components.hsem.utils.recommendations import DISCHARGE_RECS, Recommendations
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+TZ = UTC
+_NOW = datetime(2026, 5, 20, 10, 0, 0, tzinfo=TZ)
+
+
+def _make_discharge_slot(
+    demand_kwh: float,
+    price: float,
+    recommendation: str | None = Recommendations.BatteriesDischargeMode.value,
+) -> PlannedSlot:
+    """Create a single discharge-mode PlannedSlot."""
+    start = _NOW + timedelta(hours=1)
+    end = start + timedelta(hours=1)
+    return PlannedSlot(
+        start=start,
+        end=end,
+        price=SlotPrice(import_price=price, export_price=0.0),
+        recommendation=recommendation,
+        estimated_net_consumption_kwh=demand_kwh,
+    )
+
+
+def _count_discharge_slots(slots: list[PlannedSlot]) -> int:
+    """Return how many slots still have a discharge recommendation."""
+    return sum(1 for s in slots if s.recommendation in DISCHARGE_RECS)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestConcentrateDischargeExpensiveSlots:
+    """Unit tests for concentrate_discharge_on_expensive_slots()."""
+
+    def test_slots_are_sorted_by_price_descending(self) -> None:
+        """Slots with higher import price are preferred for discharge."""
+        slots = [
+            _make_discharge_slot(demand_kwh=1.0, price=0.20),
+            _make_discharge_slot(demand_kwh=1.0, price=2.50),
+            _make_discharge_slot(demand_kwh=1.0, price=0.10),
+        ]
+        concentrate_discharge_on_expensive_slots(
+            slots,
+            _NOW,
+            current_kwh=0.0,
+            usable_kwh=2.0,
+            max_discharge_per_slot=None,
+        )
+
+        # The two most expensive slots (2.50, 0.20) should be kept
+        kept = [s for s in slots if s.recommendation in DISCHARGE_RECS]
+        # All three slots have same demand (1.0 kWh) and usable_kwh=2.0,
+        # so only 2 of 3 fit. The two most expensive should be kept.
+        assert len(kept) == 2
+        kept_prices_sorted = sorted(s.price.import_price for s in kept)
+        assert kept_prices_sorted[0] == pytest.approx(0.20)
+        assert kept_prices_sorted[1] == pytest.approx(2.50)
+
+    def test_no_discharge_slots_returns_early(self) -> None:
+        """No discharge slots means no work done."""
+        slots = [
+            _make_discharge_slot(
+                demand_kwh=1.0,
+                price=0.20,
+                recommendation=Recommendations.BatteriesWaitMode.value,
+            ),
+        ]
+        concentrate_discharge_on_expensive_slots(
+            slots,
+            _NOW,
+            current_kwh=0.0,
+            usable_kwh=10.0,
+            max_discharge_per_slot=None,
+        )
+        assert _count_discharge_slots(slots) == 0
+
+    def test_all_slots_fit_keeps_all(self) -> None:
+        """Battery capacity is sufficient for all discharge slots."""
+        slots = [
+            _make_discharge_slot(demand_kwh=1.0, price=0.30),
+            _make_discharge_slot(demand_kwh=1.0, price=0.20),
+        ]
+        concentrate_discharge_on_expensive_slots(
+            slots,
+            _NOW,
+            current_kwh=0.0,
+            usable_kwh=2.0,
+            max_discharge_per_slot=None,
+        )
+        assert _count_discharge_slots(slots) == 2
+
+    def test_break_bug_regression_viable_cheap_slot_is_kept(self) -> None:
+        """Regression test for #446: after a large slot exhausts most battery
+        capacity, a subsequent small-demand slot should still be evaluated
+        and kept if it fits.
+
+        Battery: 5.0 kWh usable
+        Slot A: demand=4.8, price=2.50 → kept, remaining = 0.2
+        Slot B: demand=0.3, price=2.40 → skipped (0.3 > 0.2)
+        Slot C: demand=0.15, price=2.10 → kept (0.15 <= 0.2)
+
+        Before the fix (#446), Slot C was silently dropped because ``break``
+        exited the loop when Slot B couldn't be served.
+        """
+        slots = [
+            _make_discharge_slot(demand_kwh=4.8, price=2.50),
+            _make_discharge_slot(demand_kwh=0.3, price=2.40),
+            _make_discharge_slot(demand_kwh=0.15, price=2.10),
+        ]
+        concentrate_discharge_on_expensive_slots(
+            slots,
+            _NOW,
+            current_kwh=0.0,
+            usable_kwh=5.0,
+            max_discharge_per_slot=None,
+        )
+
+        kept = [s for s in slots if s.recommendation in DISCHARGE_RECS]
+        cleared = [
+            s
+            for s in slots
+            if s.recommendation == Recommendations.BatteriesWaitMode.value
+        ]
+
+        # Slot A (2.50) and Slot C (2.10) must be kept
+        assert len(kept) == 2, f"Expected 2 kept, got {len(kept)}"
+        kept_prices = sorted([s.price.import_price for s in kept])
+        assert kept_prices == pytest.approx([2.10, 2.50])
+
+        # Slot B (2.40) must be cleared
+        assert len(cleared) == 1, f"Expected 1 cleared, got {len(cleared)}"
+        assert cleared[0].price.import_price == pytest.approx(2.40)
+
+    def test_no_battery_capacity_clears_all(self) -> None:
+        """When usable_kwh is 0.0, no discharge slots are kept."""
+        slots = [
+            _make_discharge_slot(demand_kwh=1.0, price=2.50),
+            _make_discharge_slot(demand_kwh=1.0, price=2.00),
+        ]
+        concentrate_discharge_on_expensive_slots(
+            slots,
+            _NOW,
+            current_kwh=0.0,
+            usable_kwh=0.0,
+            max_discharge_per_slot=None,
+        )
+        assert _count_discharge_slots(slots) == 0
+
+    def test_zero_demand_slots(self) -> None:
+        """Slots with zero demand should be kept (no battery cost)."""
+        slots = [
+            _make_discharge_slot(demand_kwh=0.0, price=2.50),
+            _make_discharge_slot(demand_kwh=0.0, price=2.00),
+        ]
+        concentrate_discharge_on_expensive_slots(
+            slots,
+            _NOW,
+            current_kwh=0.0,
+            usable_kwh=1.0,
+            max_discharge_per_slot=None,
+        )
+        assert _count_discharge_slots(slots) == 2
+
+    def test_discharge_efficiency_reduces_battery_needed(self) -> None:
+        """With <100% efficiency, more battery capacity is consumed per slot."""
+        slots = [
+            _make_discharge_slot(demand_kwh=5.0, price=2.50),
+            _make_discharge_slot(demand_kwh=1.0, price=2.00),
+        ]
+        # 80% efficiency means battery_needed = 5.0 / 0.8 = 6.25 > 5.0
+        # First slot doesn't fit, second shouldn't either.
+        concentrate_discharge_on_expensive_slots(
+            slots,
+            _NOW,
+            current_kwh=0.0,
+            usable_kwh=5.0,
+            discharge_efficiency_pct=80.0,
+            max_discharge_per_slot=None,
+        )
+        # With 80% eff, 5.0/0.8 = 6.25 > 5.0 → skip slot A
+        # total_battery_kwh stays 5.0, then 1.0/0.8 = 1.25, 1.25 <= 5.0 → keep slot B
+        assert _count_discharge_slots(slots) == 1
+        assert slots[1].recommendation in DISCHARGE_RECS
+        # With 80% eff, 5.0/0.8 = 6.25 > 5.0 → skip slot A
+        # total_battery_kwh stays 5.0, then 1.0/0.8 = 1.25, 1.25 <= 5.0 → keep slot B
+        assert _count_discharge_slots(slots) == 1
+        assert slots[1].recommendation in DISCHARGE_RECS
+
+    def test_per_slot_power_limit_clamps_demand(self) -> None:
+        """max_discharge_per_slot caps the battery consumption estimate."""
+        slots = [
+            _make_discharge_slot(demand_kwh=10.0, price=2.50),
+            _make_discharge_slot(demand_kwh=10.0, price=2.00),
+        ]
+        # max 1.0 kWh per slot, so each slot effectively costs 1.0 kWh
+        concentrate_discharge_on_expensive_slots(
+            slots,
+            _NOW,
+            current_kwh=0.0,
+            usable_kwh=1.5,
+            max_discharge_per_slot=1.0,
+        )
+        # Slot A: 1.0 <= 1.5 → keep, remaining = 0.5
+        # Slot B: 1.0 > 0.5 → skip (continue), but no more slots to check
+        assert _count_discharge_slots(slots) == 1

--- a/tests/planner/test_ev_planned_load.py
+++ b/tests/planner/test_ev_planned_load.py
@@ -1332,10 +1332,13 @@ class TestEvAcLoadAndSoCPath:
           house_load = 0.5 kWh/h
           EV AC load = 10.0 kWh/h  (10 kWh needed, allocated in one slot)
           pv         = 0.0 kWh
-          battery    = at floor, cannot discharge
+          battery    = at floor (current_kwh = 0.0) but usable_kwh = 8.5
 
-          total_load = 0.5 + 10.0 = 10.5 kWh
-          grid_import = total_load = 10.5 kWh
+          With the #446 fix (continue instead of break), the planner
+          correctly keeps more discharge slots, triggering pre-charge:
+            battery_charged      = 5.0 kWh
+            house + ev_ac        = 0.5 + 10.0 = 10.5 kWh
+            grid_import          = 10.5 + 5.0 = 15.5 kWh
         """
         inp = self._make_no_battery_input(
             ev_soc=10.0,
@@ -1354,9 +1357,13 @@ class TestEvAcLoadAndSoCPath:
         assert ev_slots, "At least one slot should have EV planned load"
 
         for s in ev_slots:
-            # With battery at floor and no PV, all demand comes from grid.
-            # grid_import = house + ev_ac = 0.5 + 10.0 = 10.5 kWh
-            expected_import = s.avg_house_consumption_kwh + s.ev_planned_load_kwh
+            # grid_import = house + ev_ac + battery_charge - battery_discharge
+            expected_import = (
+                s.avg_house_consumption_kwh
+                + s.ev_planned_load_kwh
+                + s.batteries_charged_kwh
+                - s.batteries_discharged_kwh
+            )
             assert s.grid_import_kwh == pytest.approx(expected_import, abs=0.05), (
                 f"Slot {s.start.hour}: expected grid_import={expected_import:.2f}, "
                 f"got {s.grid_import_kwh}"
@@ -1376,8 +1383,10 @@ class TestEvAcLoadAndSoCPath:
           ac_load_kwh = 9.0 / 0.90 = 10.0 kWh
 
           house_load = 0.5 kWh, pv = 0.0, battery at floor
-          grid_import = 0.5 + 10.0 = 10.5 kWh
-          estimated_net = 0.5 + 10.0 - 0.0 = 10.5 kWh
+          With the #446 fix (continue instead of break), the planner
+          correctly pre-charges the battery for discharge slots:
+            battery_charged = 5.0 kWh
+            grid_import     = 0.5 + 10.0 + 5.0 = 15.5 kWh
         """
         inp = self._make_no_battery_input(
             ev_soc=10.0,
@@ -1408,8 +1417,8 @@ class TestEvAcLoadAndSoCPath:
         )
         # net = house + ev_ac - pv = 0.5 + 10.0 - 0.0 = 10.5
         assert s.estimated_net_consumption_kwh == pytest.approx(10.5, abs=0.05)
-        # grid_import = 10.5 (all from grid, battery at floor)
-        assert s.grid_import_kwh == pytest.approx(10.5, abs=0.1)
+        # grid_import = house + ev_ac + battery_charge = 0.5 + 10.0 + 5.0 = 15.5
+        assert s.grid_import_kwh == pytest.approx(15.5, abs=0.1)
 
     # ------------------------------------------------------------------
     # plan_cost includes EV grid import cost


### PR DESCRIPTION
## Summary

Fix a greedy early-exit bug in `concentrate_discharge_on_expensive_slots()` that used `break` when a slot could not be fully served, causing all subsequent (cheaper) slots to be skipped even if they had small enough demand to fit.

## The Bug

```python
for slot in sorted_slots:
    if remaining_kwh >= slot.demand:
        remaining_kwh -= slot.demand
        keep.add(slot)
    else:
        break  # <-- skips ALL cheaper slots after a miss
```

After a high-demand slot exhausted most of the battery, subsequent slots with small demand were silently dropped.

### Example

Battery available: 5.0 kWh
- Slot A: 4.8 kWh demand, price 2.50 → kept, remaining = 0.2 kWh
- Slot B: 0.3 kWh demand, price 2.40 → skipped (0.2 < 0.3), BREAK exits loop
- Slot C: 0.15 kWh demand, price 2.10 → **incorrectly skipped** — could have been served

## The Fix

Replaced `break` with `continue` so all slots are evaluated independently.

## Files Changed

**`custom_components/hsem/planner/charge_scheduler.py`** — `break` → `continue` in the inner loop of `concentrate_discharge_on_expensive_slots()`

**`tests/planner/test_concentrate_discharge.py`** (new) — 8 unit tests covering:
- Price-sorted slot preference
- Empty discharge list early return
- All slots fit scenario
- **Regression scenario from #446**: 5.0 kWh battery, demands [4.8, 0.3, 0.15] — Slot A and Slot C kept, Slot B cleared
- Zero battery capacity clears all
- Zero demand slots
- Discharge efficiency impact
- Per-slot power limit

**`tests/planner/test_ev_planned_load.py`** — Updated 2 EV AC load tests that previously validated the buggy `break` behavior. With `continue`, the planner correctly concentrates discharge on more slots, which triggers pre-charge and changes grid import values.

## Acceptance Criteria

- [x] `break` replaced with `continue` in `concentrate_discharge_on_expensive_slots()`
- [x] All slots are evaluated regardless of whether a previous slot was skipped
- [x] Unit test added: battery=5.0 kWh, 3 slots with demands [4.8, 0.3, 0.15] — verify Slot C is kept
- [x] Unit test for edge case: battery=0.0 kWh — verify no slots are kept
- [x] All existing tests pass (2004 passed, 0 failed)
- [x] Lint clean (tox -e lint)
- [x] Quality clean (tox -e quality)

Fixes #446