### PR TITLE
chore(planner): add log_planner tracing to all planner modules

### DIFF
--- a/custom_components/hsem/planner/charge_scheduler.py
+++ b/custom_components/hsem/planner/charge_scheduler.py
@@ -71,6 +71,10 @@ def apply_charge_schedules(
             ``_apply_grid_charge`` to guard profitability.
     """
     if max_charge_per_interval <= 0:
+        log_planner(
+            "debug",
+            "[chg] apply_charge_schedules  skipped — max_charge_per_interval <= 0",
+        )
         return
 
     # Cross-occurrence capacity cap: only enforce when usable_kwh is
@@ -78,6 +82,16 @@ def apply_charge_schedules(
     # (backward-compatible default), no cap is applied.
     remaining_capacity = (
         max(usable_kwh - current_kwh, 0.0) if usable_kwh > 0 else float("inf")
+    )
+    log_planner(
+        "debug",
+        "[chg] apply_charge_schedules  schedules=%d  remaining_cap=%.3f  "
+        "max_charge/slot=%.3f  current=%.3f  usable=%.3f",
+        len(battery_schedules),
+        remaining_capacity,
+        max_charge_per_interval,
+        current_kwh,
+        usable_kwh,
     )
     total_charged = 0.0
 
@@ -323,6 +337,15 @@ def apply_opportunistic_charge(
             ``max(depreciation_threshold - cycle_cost_per_kwh, 0)`` are eligible.
             Defaults to 0.0 (backwards compatible).
     """
+    log_planner(
+        "debug",
+        "[chg] apply_opportunistic_charge  current=%.3f  usable=%.3f  "
+        "depr_threshold=%.4f  cycle_cost=%.4f",
+        current_capacity,
+        usable_capacity,
+        depreciation_threshold,
+        cycle_cost_per_kwh,
+    )
     if max_charge_per_interval <= 0:
         return
 
@@ -446,6 +469,17 @@ def apply_arbitrage_grid_charge(
             schedule has supplied a non-zero ``min_price_difference``.
             Defaults to 0.0.
     """
+    log_planner(
+        "debug",
+        "[chg] apply_arbitrage_grid_charge  current=%.3f  usable=%.3f  "
+        "max_charge/slot=%.3f  conv_loss_pct=%.2f  cycle_cost=%.4f  threshold=%.4f",
+        current_capacity,
+        usable_capacity,
+        max_charge_per_interval,
+        conversion_loss_pct,
+        cycle_cost_per_kwh,
+        recommended_threshold,
+    )
     if max_charge_per_interval <= 0:
         _LOGGER.debug("arbitrage: max_charge_per_interval <= 0, skipping")
         return

--- a/custom_components/hsem/planner/cost_function.py
+++ b/custom_components/hsem/planner/cost_function.py
@@ -74,6 +74,7 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from custom_components.hsem.models.planner_outputs import PlannedSlot
+from custom_components.hsem.utils.logger import log_planner
 from custom_components.hsem.utils.misc import clamp_efficiency
 from custom_components.hsem.utils.recommendations import Recommendations
 
@@ -323,7 +324,13 @@ def _resolve_cycle_cost(weights: CostWeights) -> float:
         Depreciation cost in local currency per kWh.
     """
     if weights.cycle_cost_per_kwh is not None:
-        return weights.cycle_cost_per_kwh
+        result = weights.cycle_cost_per_kwh
+        log_planner(
+            "debug",
+            "[cost] _resolve_cycle_cost  explicit=%.6f",
+            result,
+        )
+        return result
 
     if (
         weights.battery_purchase_price > 1e-9
@@ -334,10 +341,21 @@ def _resolve_cycle_cost(weights: CostWeights) -> float:
         usable_kwh = weights.battery_rated_capacity_kwh * dod_fraction
         if usable_kwh < 1e-9:
             usable_kwh = weights.battery_rated_capacity_kwh  # fallback: full rated
-        return weights.battery_purchase_price / (
+        result = weights.battery_purchase_price / (
             2 * usable_kwh * weights.battery_expected_cycles
         )
+        log_planner(
+            "debug",
+            "[cost] _resolve_cycle_cost  purchase=%.2f  usable=%.3f  cycles=%d  "
+            "cycle_cost=%.6f",
+            weights.battery_purchase_price,
+            usable_kwh,
+            weights.battery_expected_cycles,
+            result,
+        )
+        return result
 
+    log_planner("debug", "[cost] _resolve_cycle_cost  return 0 (insufficient data)")
     return 0.0
 
 
@@ -377,7 +395,15 @@ def _final_battery_kwh(
                 continue
         elif slot.recommendation == _time_passed_value:
             continue
-        return slot.estimated_battery_capacity_kwh
+        result = slot.estimated_battery_capacity_kwh
+        log_planner(
+            "debug",
+            "[cost] _final_battery_kwh  result=%.3f  slot=%s",
+            result,
+            slot.start.isoformat(),
+        )
+        return result
+    log_planner("debug", "[cost] _final_battery_kwh  return 0.0 (no future slot)")
     return 0.0
 
 
@@ -496,6 +522,18 @@ def score_plan(
     """
     if weights is None:
         weights = CostWeights()
+
+    log_planner(
+        "debug",
+        "[cost] score_plan  slots=%d  initial_battery=%s  repl_price=%s",
+        len(slots),
+        f"{initial_battery_kwh:.3f}" if initial_battery_kwh is not None else "None",
+        (
+            f"{replacement_price_per_kwh:.6f}"
+            if replacement_price_per_kwh is not None
+            else "None"
+        ),
+    )
 
     # Resolve grid limit (keyword arg takes precedence)
     effective_grid_limit_kw: float | None = (
@@ -679,7 +717,7 @@ def score_plan(
 
     score_rounded = round(score, 6)
 
-    return PlanCostBreakdown(
+    result = PlanCostBreakdown(
         import_cost=round(import_cost, 6),
         export_revenue=round(export_revenue, 6),
         conversion_loss_cost=round(conversion_loss_cost, 6),
@@ -693,6 +731,25 @@ def score_plan(
         # ``total`` is a deprecated alias for ``score`` (issue #413).
         total=score_rounded,
     )
+
+    log_planner(
+        "debug",
+        "[cost] score_plan DONE  total_cost=%.6f  score=%.6f  "
+        "import=%.6f  export_rev=%.6f  conv_loss=%.6f  "
+        "cycle=%.6f  soc_pen=%.6f  grid=%.6f  override=%.6f  term_soc=%.6f",
+        result.total_cost,
+        result.score,
+        result.import_cost,
+        result.export_revenue,
+        result.conversion_loss_cost,
+        result.cycle_cost,
+        result.soc_penalty,
+        result.grid_limit_penalty,
+        result.override_penalty,
+        result.terminal_soc_value,
+    )
+
+    return result
 
 
 def compare_plans(
@@ -757,5 +814,14 @@ def compare_plans(
         winner = "plan_a"
     else:
         winner = "plan_b"
+
+    log_planner(
+        "debug",
+        "[cost] compare_plans  a_score=%.6f  b_score=%.6f  diff=%.6f  winner=%s",
+        bd_a.score,
+        bd_b.score,
+        diff,
+        winner,
+    )
 
     return bd_a, bd_b, winner

--- a/custom_components/hsem/planner/discharge_scheduler.py
+++ b/custom_components/hsem/planner/discharge_scheduler.py
@@ -16,6 +16,7 @@ from custom_components.hsem.const import NEAR_ZERO_CONSUMPTION_THRESHOLD_KWH
 from custom_components.hsem.models.planner_inputs import BatteryScheduleInput
 from custom_components.hsem.models.planner_outputs import PlannedSlot
 from custom_components.hsem.utils.datetime_utils import as_tz
+from custom_components.hsem.utils.logger import log_planner
 from custom_components.hsem.utils.misc import clamp_efficiency, next_window_start_dt
 from custom_components.hsem.utils.recommendations import (
     DISCHARGE_RECS as _DISCHARGE_RECS,
@@ -45,6 +46,12 @@ def apply_discharge_schedules(
         battery_schedules: Schedule configurations to evaluate.
         now: Timezone-aware current datetime.
     """
+    log_planner(
+        "debug",
+        "[disch] apply_discharge_schedules  schedules=%d  now=%s",
+        len(battery_schedules),
+        now.isoformat(),
+    )
     for sched in battery_schedules:
         if not sched.enabled:
             continue
@@ -177,7 +184,15 @@ def calculate_required_battery_until_solar(
             required += slot.estimated_net_consumption_kwh
 
     buffer_kwh = usable_capacity * (discharge_buffer_pct / 100)
-    return round(required + buffer_kwh, 3)
+    result = round(required + buffer_kwh, 3)
+    log_planner(
+        "debug",
+        "[disch] calculate_required_battery_until_solar  required=%.3f  buffer=%.3f  result=%.3f",
+        required,
+        buffer_kwh,
+        result,
+    )
+    return result
 
 
 def apply_excess_export(
@@ -209,7 +224,20 @@ def apply_excess_export(
     # in estimated_net_consumption.  Only positive net consumption (house load > solar)
     # draws down the battery, so we drain the budget by max(net, 0) per slot.
     battery_discharge_budget_kwh = current_capacity - required_capacity
+    log_planner(
+        "debug",
+        "[disch] apply_excess_export  budget=%.3f  current=%.3f  required=%.3f  "
+        "price_threshold=%.4f",
+        battery_discharge_budget_kwh,
+        current_capacity,
+        required_capacity,
+        export_price_threshold,
+    )
     if battery_discharge_budget_kwh <= 0:
+        log_planner(
+            "debug",
+            "[disch] apply_excess_export  skipped — budget <= 0",
+        )
         return
 
     # D16 fix: track actual solar vs grid fractions rather than a coarse flag.
@@ -308,6 +336,14 @@ def concentrate_discharge_on_expensive_slots(
             ``None`` means unlimited (inverter default).
         discharge_efficiency_pct: Discharge-side efficiency (0-100 %).
     """
+    log_planner(
+        "debug",
+        "[disch] concentrate_discharge_on_expensive_slots  usable=%.3f  current=%.3f  "
+        "max_discharge=%s",
+        usable_kwh,
+        current_kwh,
+        f"{max_discharge_per_slot:.3f}" if max_discharge_per_slot is not None else "∞",
+    )
     discharge_eff = clamp_efficiency(discharge_efficiency_pct)
 
     # Collect all future discharge slots (both BatteriesDischargeMode and
@@ -404,6 +440,15 @@ def apply_optimization_strategy(
             threshold are not marked for export even if export > import.
             Defaults to ``0.0`` (any positive export price qualifies).
     """
+    log_planner(
+        "debug",
+        "[disch] apply_optimization_strategy  current=%.3f  usable=%.3f  "
+        "required=%.3f  export_min_price=%.4f",
+        current_capacity,
+        usable_capacity,
+        required_capacity,
+        export_min_price,
+    )
     current_month = now.month
     months_summer = [m for m in range(1, 13) if m not in months_winter]
 

--- a/custom_components/hsem/planner/engine_core.py
+++ b/custom_components/hsem/planner/engine_core.py
@@ -71,6 +71,13 @@ def _populate_slots(
     slots: list, inp: PlannerInput, tsi, warnings: list[str], missing_inputs: list[str]
 ) -> tuple[DataQuality, list[str], list[str]]:
     """Populate price/PV/consumption data, data-quality diagnostics, confidence decay."""
+    log_planner(
+        "debug",
+        "[core] _populate_slots  slots=%d  interval=%dmin  horizon=%dh",
+        len(slots),
+        inp.interval_minutes,
+        inp.interval_length_hours,
+    )
     populate_prices(slots, inp.price_points, tsi)
     populate_solcast(slots, inp.solcast_slots, inp.interval_minutes, tsi)
     populate_consumption(
@@ -146,6 +153,16 @@ def _populate_slots(
             warnings.append(
                 f"Multi-day horizon ({horizon_days} day(s)): confidence decay applied to PV estimates."
             )
+    log_planner(
+        "debug",
+        "[core] _populate_slots DONE  warnings=%d  missing=%d  horizon_days=%d  "
+        "has_tomorrow=%s",
+        len(warnings),
+        len(missing_inputs),
+        horizon_days,
+        horizon_has_tomorrow,
+    )
+
     return dq, warnings, missing_inputs
 
 
@@ -161,6 +178,11 @@ def _schedule_slots(
     """All charge/discharge scheduling passes."""
     mark_time_passed(slots, now)
     apply_discharge_schedules(slots, inp.battery_schedules, now)
+    log_planner(
+        "debug",
+        "[core] _schedule_slots  pass=discharge_schedules  slots=%d",
+        len(slots),
+    )
     cd = inp.battery_charge_efficiency_pct / 100.0
     dd = inp.battery_discharge_efficiency_pct / 100.0
     rlp = (1.0 - cd * dd) * 100.0
@@ -204,9 +226,22 @@ def _schedule_slots(
     rc = calculate_required_battery_until_solar(
         slots, now, usable_kwh, inp.excess_export_discharge_buffer_pct
     )
+    log_planner(
+        "debug",
+        "[core] _schedule_slots  pass=after_scheduling  mcps=%.3f  mdps=%s  "
+        "max_soc=%.3f  rc=%.3f",
+        mcps,
+        f"{mdps:.3f}" if mdps is not None else "∞",
+        max_soc_kwh,
+        rc,
+    )
     if inp.excess_export_enabled:
         apply_excess_export(
             slots, now, current_kwh, rc, inp.excess_export_price_threshold, warnings
+        )
+        log_planner(
+            "debug",
+            "[core] _schedule_slots  pass=excess_export  enabled=True",
         )
     apply_optimization_strategy(
         slots,
@@ -217,6 +252,16 @@ def _schedule_slots(
         inp.months_winter,
         warnings,
         export_min_price=inp.export_min_price,
+    )
+    log_planner(
+        "debug",
+        "[core] _schedule_slots DONE  mcps=%.3f  mdps=%s  max_soc=%.3f  rc=%.3f  "
+        "warnings=%d",
+        mcps,
+        f"{mdps:.3f}" if mdps is not None else "∞",
+        max_soc_kwh,
+        rc,
+        len(warnings),
     )
     return mcps, mdps, max_soc_kwh, rc, warnings
 
@@ -246,6 +291,19 @@ def _build_and_inject_for_ev(
     """Build an EV charging plan and accumulate its loads."""
     if not enabled:
         return None
+    log_planner(
+        "debug",
+        "[core] _build_and_inject_for_ev  label=%s  connected=%s  smart=%s  "
+        "soc=%.1f%%  target=%.1f%%  cap=%.2f  pwr=%.2f  eff=%.1f%%",
+        label,
+        connected,
+        smart,
+        soc,
+        target,
+        cap_kwh,
+        pwr_kw,
+        eff,
+    )
     ev_inp = EVPlannerInput(
         enabled=enabled,
         ev_connected=connected,
@@ -288,6 +346,15 @@ def _build_and_inject_for_ev(
         warnings.append(
             f"EV planned load ({label}): state={plan.state}, total_kwh_needed={plan.total_kwh_needed:.2f}, charging_slots={len(plan.charging_slots)}, base_load_includes_ev={base_includes}."
         )
+    log_planner(
+        "debug",
+        "[core] _build_and_inject_for_ev DONE  label=%s  state=%s  slots=%d  "
+        "total_kwh=%.3f",
+        label,
+        plan.state,
+        len(plan.charging_slots),
+        plan.total_kwh_needed,
+    )
     return plan
 
 
@@ -336,6 +403,14 @@ def _select_candidate(
         previous_winner_name=inp.previous_winner_name,
         previous_winner_score=inp.previous_winner_score,
     )
+    log_planner(
+        "debug",
+        "[core] _select_candidate DONE  candidates=%d  winner=%s  rejected=%d  hyst=%s",
+        len(candidates),
+        winner.name,
+        len(rejected),
+        f"applied={hyst.applied}" if hyst.applied else "inactive",
+    )
     return candidates, winner, rejected, hyst
 
 
@@ -371,6 +446,10 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
     tsi = build_time_series_index(inp, now)
     slots = build_slots(inp, now)
     if not slots:
+        log_planner(
+            "warning",
+            "[core] run_planner ABORTED — no slots generated",
+        )
         warnings.append(
             "No slots generated; check interval_minutes and interval_length_hours."
         )
@@ -378,6 +457,16 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
     # Step 1 — populate time-series data
     data_quality, warnings, missing_inputs = _populate_slots(
         slots, inp, tsi, warnings, missing_inputs
+    )
+    log_planner(
+        "debug",
+        "[core] run_planner  step=1_populate_slots COMPLETE  "
+        "data_quality=horizon_has_tomorrow=%s,horizon_days=%d  "
+        "warnings=%d  missing=%d",
+        data_quality.horizon_has_tomorrow,
+        data_quality.horizon_days,
+        len(warnings),
+        len(missing_inputs),
     )
     # Step 2 — EV planned load injection
     ev_cp: EVChargingPlan | None = None
@@ -446,8 +535,20 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
             f"Recommended price threshold: {rt:.4f} (depreciation + conversion loss)."
         )
     # Step 3 — charge/discharge scheduling
+    log_planner(
+        "debug",
+        "[core] run_planner  step=3_schedule_slots START  "
+        "current=%.3f  usable=%.3f  rt=%.4f",
+        current_kwh,
+        usable_kwh,
+        rt,
+    )
     mcps, mdps, max_soc_kwh, rc, warnings = _schedule_slots(
         slots, inp, now, current_kwh, usable_kwh, rt, warnings
+    )
+    log_planner(
+        "debug",
+        "[core] run_planner  step=3_schedule_slots COMPLETE",
     )
     # Step 4 — candidate plan generation and selection
     cw = CostWeights(
@@ -468,6 +569,12 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
         top_n = math.ceil(usable_kwh / mdps)
     rppk = replacement_price_from_next_discharge(
         slots, now, top_n=top_n, interval_minutes=inp.interval_minutes
+    )
+    log_planner(
+        "debug",
+        "[core] run_planner  step=4_candidate_selection START  top_n=%d  rppk=%s",
+        top_n,
+        f"{rppk:.6f}" if rppk is not None else "None",
     )
     concentrate_discharge_on_expensive_slots(
         slots,
@@ -539,6 +646,23 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
     )
     for rp in candidate_rejected:
         expl.rejected_plans.append(rp)
+
+    log_planner(
+        "debug",
+        "[core] run_planner DONE  winner=%s  cost=%.4f  score=%.4f  "
+        "cur_rec=%s  bsoc_end=%.1f%%  rc=%.3f  warnings=%d  missing=%d  "
+        "cw=%d  dw=%d",
+        winner.name,
+        pc.total_cost,
+        pc.score,
+        cur_rec if cur_rec is not None else "(none)",
+        bsoc_end,
+        rc,
+        len(warnings),
+        len(missing_inputs),
+        len(cw_out),
+        len(dw_out),
+    )
     return PlannerOutput(
         slots=slots,
         charge_windows=cw_out,

--- a/custom_components/hsem/planner/engine_explanation.py
+++ b/custom_components/hsem/planner/engine_explanation.py
@@ -20,6 +20,7 @@ from custom_components.hsem.models.planner_outputs import (
     RejectedPlan,
 )
 from custom_components.hsem.utils.datetime_utils import as_tz
+from custom_components.hsem.utils.logger import log_planner
 from custom_components.hsem.utils.misc import calculate_recommended_threshold
 from custom_components.hsem.utils.recommendations import Recommendations
 
@@ -50,6 +51,11 @@ def _derive_windows(
     Returns:
         Tuple of ``(charge_windows, discharge_windows)``.
     """
+    log_planner(
+        "debug",
+        "[expl] _derive_windows  slots=%d",
+        len(slots),
+    )
     charge_windows: list[ChargeWindow] = []
     discharge_windows: list[DischargeWindow] = []
 
@@ -111,6 +117,13 @@ def _derive_windows(
     if current_discharge_group:
         _flush_discharge(current_discharge_group)
 
+    log_planner(
+        "debug",
+        "[expl] _derive_windows DONE  charge=%d  discharge=%d",
+        len(charge_windows),
+        len(discharge_windows),
+    )
+
     return charge_windows, discharge_windows
 
 
@@ -135,6 +148,13 @@ def _build_explanation(
     Returns:
         A populated :class:`PlanExplanation` instance.
     """
+    log_planner(
+        "debug",
+        "[expl] _build_explanation  slots=%d  soc_end=%.1f%%  now=%s",
+        len(slots),
+        battery_soc_at_end,
+        now.isoformat(),
+    )
     future_slots = [s for s in slots if as_tz(s.end, now.tzinfo) > now]
 
     # --- Price metrics ---------------------------------------------------

--- a/custom_components/hsem/planner/milp_optimizer.py
+++ b/custom_components/hsem/planner/milp_optimizer.py
@@ -102,6 +102,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from custom_components.hsem.utils.datetime_utils import as_tz
+from custom_components.hsem.utils.logger import log_planner
 from custom_components.hsem.utils.misc import clamp_efficiency
 from custom_components.hsem.utils.recommendations import Recommendations
 
@@ -193,6 +194,27 @@ def solve_milp(
         or ``None`` if the solver fails or the problem is infeasible.
     """
     import copy
+
+    log_planner(
+        "debug",
+        "[milp] solve_milp  slots=%d  current=%.3f  usable=%.3f  "
+        "max_chg=%.3f  max_dis=%s  cycle_cost=%.6f  "
+        "chg_eff=%.2f  dis_eff=%.2f  discount=%.4f  repl_price=%s",
+        len(slots),
+        current_kwh,
+        usable_kwh,
+        max_charge_per_slot,
+        f"{max_discharge_per_slot:.3f}" if max_discharge_per_slot is not None else "∞",
+        cycle_cost_per_kwh,
+        charge_efficiency_pct,
+        discharge_efficiency_pct,
+        time_discount_rate,
+        (
+            f"{replacement_price_per_kwh:.6f}"
+            if replacement_price_per_kwh is not None
+            else "None"
+        ),
+    )
 
     try:
         import numpy as np

--- a/custom_components/hsem/planner/slot_population.py
+++ b/custom_components/hsem/planner/slot_population.py
@@ -37,6 +37,7 @@ from custom_components.hsem.models.planner_inputs import (
 from custom_components.hsem.models.planner_outputs import PlannedSlot
 from custom_components.hsem.models.time_series import TimeSeriesIndex
 from custom_components.hsem.utils.datetime_utils import as_tz
+from custom_components.hsem.utils.logger import log_planner
 from custom_components.hsem.utils.prices import SlotPrice
 from custom_components.hsem.utils.recommendations import Recommendations
 
@@ -59,6 +60,13 @@ def build_time_series_index(inp: PlannerInput, now: datetime) -> TimeSeriesIndex
     Returns:
         A fully constructed :class:`TimeSeriesIndex`.
     """
+    log_planner(
+        "debug",
+        "[pop] build_time_series_index  now=%s  interval=%dmin  horizon=%dh",
+        now.isoformat(),
+        inp.interval_minutes,
+        inp.interval_length_hours,
+    )
     return TimeSeriesIndex.from_now(
         now,
         interval_minutes=inp.interval_minutes,
@@ -80,7 +88,15 @@ def build_slots(inp: PlannerInput, now: datetime) -> list[PlannedSlot]:
         List of empty :class:`PlannedSlot` objects.
     """
     tsi = build_time_series_index(inp, now)
-    return [PlannedSlot(start=meta.start, end=meta.end) for meta in tsi]
+    slots = [PlannedSlot(start=meta.start, end=meta.end) for meta in tsi]
+    log_planner(
+        "debug",
+        "[pop] build_slots  count=%d  horizon_start=%s  horizon_end=%s",
+        len(slots),
+        slots[0].start.isoformat() if slots else "N/A",
+        slots[-1].end.isoformat() if slots else "N/A",
+    )
+    return slots
 
 
 def index_by_hour(items: list, hour_attr: str = "hour") -> dict[int, Any]:
@@ -112,6 +128,12 @@ def populate_prices(
             delegated to :meth:`TimeSeriesIndex.align_hourly_prices` so that
             missing slots are tracked centrally.
     """
+    log_planner(
+        "debug",
+        "[pop] populate_prices  price_points=%d  tsi_provided=%s",
+        len(price_points),
+        tsi is not None,
+    )
     if tsi is not None:
         # Use (day_offset, hour) keys when any entry carries a non-zero
         # day_offset so that tomorrow's prices are not overwritten by today's.
@@ -164,6 +186,13 @@ def populate_solcast(
         interval_minutes: Slot width in minutes.
         tsi: Optional shared time-series index.
     """
+    log_planner(
+        "debug",
+        "[pop] populate_solcast  solcast_slots=%d  interval=%dmin  tsi_provided=%s",
+        len(solcast_slots),
+        interval_minutes,
+        tsi is not None,
+    )
     if tsi is not None:
         # Use (day_offset, hour) keys when any entry carries a non-zero
         # day_offset so that tomorrow's PV forecast is not shadowed by today's.
@@ -209,6 +238,18 @@ def populate_consumption(
         interval_minutes: Slot width in minutes.
         tsi: Optional shared time-series index.
     """
+    log_planner(
+        "debug",
+        "[pop] populate_consumption  averages=%d  weights=%d/%d/%d/%d  "
+        "interval=%dmin  tsi_provided=%s",
+        len(averages),
+        w1,
+        w3,
+        w7,
+        w14,
+        interval_minutes,
+        tsi is not None,
+    )
     if tsi is not None:
         # Use (day_offset, hour) keys when any entry carries a non-zero
         # day_offset so that tomorrow's consumption forecast is not overwritten
@@ -293,6 +334,11 @@ def populate_net_consumption(slots: list[PlannedSlot]) -> None:
     Args:
         slots: Mutable list of planned slots to update.
     """
+    log_planner(
+        "debug",
+        "[pop] populate_net_consumption  slots=%d",
+        len(slots),
+    )
     for slot in slots:
         slot.estimated_net_consumption_kwh = round(
             slot.avg_house_consumption_kwh
@@ -308,6 +354,11 @@ def populate_estimated_cost(slots: list[PlannedSlot]) -> None:
     Args:
         slots: Mutable list of planned slots to update.
     """
+    log_planner(
+        "debug",
+        "[pop] populate_estimated_cost  slots=%d",
+        len(slots),
+    )
     for slot in slots:
         net = slot.estimated_net_consumption_kwh
         if net >= 0:
@@ -323,9 +374,18 @@ def mark_time_passed(slots: list[PlannedSlot], now: datetime) -> None:
         slots: Mutable list of planned slots to update.
         now: Timezone-aware current datetime.
     """
+    past_count = 0
     for slot in slots:
         if as_tz(slot.end, now.tzinfo) < now:
             slot.recommendation = Recommendations.TimePassed.value
+            past_count += 1
+    log_planner(
+        "debug",
+        "[pop] mark_time_passed  total=%d  past=%d  now=%s",
+        len(slots),
+        past_count,
+        now.isoformat(),
+    )
 
 
 def populate_battery_capacity(
@@ -342,6 +402,13 @@ def populate_battery_capacity(
         current_capacity: Currently available battery energy in kWh.
         usable_capacity: Maximum usable battery energy in kWh.
     """
+    log_planner(
+        "debug",
+        "[pop] populate_battery_capacity  current=%.3f kWh  usable=%.3f kWh  slots=%d",
+        current_capacity,
+        usable_capacity,
+        len(slots),
+    )
     previous_capacity = 0.0
 
     for slot in slots:
@@ -402,7 +469,16 @@ def usable_capacity(
     effective_max_soc = min(max(max_soc_pct, end_of_discharge_soc_pct), 100.0)
     usable = rated_kwh * (effective_max_soc - end_of_discharge_soc_pct) / 100
     current = rated_kwh * (soc_pct / 100) - rated_kwh * end_of_discharge_soc_pct / 100
-    return max(usable, 0.0), min(max(current, 0.0), max(usable, 0.0))
+    result = max(usable, 0.0), min(max(current, 0.0), max(usable, 0.0))
+    log_planner(
+        "debug",
+        "[pop] usable_capacity  rated=%.2f  soc=%.1f%%  usable=%.3f  current=%.3f",
+        rated_kwh,
+        soc_pct,
+        result[0],
+        result[1],
+    )
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -501,6 +577,18 @@ def weighted_avg_consumption(
         final weighted average in kWh/hour and *outlier_mask* is a list of 4
         booleans ``[is_1d_outlier, is_3d_outlier, is_7d_outlier, is_14d_outlier]``.
     """
+    log_planner(
+        "debug",
+        "[pop] weighted_avg_consumption  vals=%.3f/%.3f/%.3f/%.3f  weights=%d/%d/%d/%d",
+        value_1d,
+        value_3d,
+        value_7d,
+        value_14d,
+        w1,
+        w3,
+        w7,
+        w14,
+    )
     w_total_config = w1 + w3 + w7 + w14
     if w_total_config == 0:
         return 0.0, [False, False, False, False]


### PR DESCRIPTION
## Summary

Add comprehensive log_planner tracing to every public function across all planner modules for end-to-end traceability of the planning pipeline.

## Changes

### 7 files modified, 406 insertions, 7 deletions

| File | What changed |
|---|---|
| **planner/engine_core.py** | Step markers in un_planner, entry/DONE logs on _populate_slots, _schedule_slots, _build_and_inject_for_ev, _select_candidate, plus early-abort logging |
| **planner/engine_explanation.py** | Added log_planner import + entry logs to _derive_windows and _build_explanation |
| **planner/slot_population.py** | Added log_planner import + entry/logs to all 9 public functions |
| **planner/cost_function.py** | Entry/DONE logs on score_plan with full breakdown, _resolve_cycle_cost, _final_battery_kwh, compare_plans |
| **planner/charge_scheduler.py** | Entry logs on pply_charge_schedules, pply_opportunistic_charge, pply_arbitrage_grid_charge |
| **planner/discharge_scheduler.py** | Added log_planner import + entry/DONE logs to all 5 public functions |
| **planner/milp_optimizer.py** | Entry log on solve_milp with full LP parameters |

### Logging conventions
- All logs use the [module_prefix] pattern: [core], [pop], [cost], [chg], [disch], [milp], [expl]
- %-style formatting for deferred string interpolation
- Gated by the existing _PLANNER_VERBOSE flag (controlled via set_planner_verbose())
- All non-planner files were also auto-formatted by isort/lack/uff via 	ox -e lint

## Verification
- ? 	ox -e lint � passes (isort, black, ruff format, ruff check)
- ? 	ox -e quality � passes (pyright 0 errors, vulture)
- ? pytest tests/planner/ � **612 passed, 10 xfailed** (all planner tests green)
