### PR TITLE
feat(tracker): add predicted-vs-actual tracking for PV and load forecasts (reboot persistence)

### DIFF
--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -67,6 +67,10 @@ from custom_components.hsem.planner.ev_planner import EVChargingPlan
 from custom_components.hsem.utils.datetime_utils import as_tz
 from custom_components.hsem.utils.datetime_utils import now as hsem_now
 from custom_components.hsem.utils.datetime_utils import utc_key, utc_now_iso
+from custom_components.hsem.utils.forecast_tracker import (
+    ForecastTracker,
+    compute_accumulated_energy,
+)
 from custom_components.hsem.utils.inverter_verify import CycleApplySummary
 from custom_components.hsem.utils.logger import async_logger, set_planner_verbose
 from custom_components.hsem.utils.recommendations import Recommendations
@@ -213,6 +217,11 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         # the previously active current-slot recommendation.
         self._window_hys_previous_rec: str | None = None
         self._window_hys_previous_slot_start: datetime | None = None
+
+        # Forecast-vs-actual tracker (predicted-vs-actual tracking, issue #373).
+        self._forecast_tracker: ForecastTracker = ForecastTracker(max_slots=192)
+        # Timestamp of the last actual-energy accumulation cycle.
+        self._last_accumulation_ts: datetime | None = None
 
     # ------------------------------------------------------------------
     # HA lifecycle
@@ -374,6 +383,13 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                 now.tzinfo,
             )
 
+            # -----------------------------------------------------------------------
+            # Forecast-vs-actual accumulation (issue #373)
+            # -----------------------------------------------------------------------
+            # Every cycle, accumulate actual PV and load energy into the current
+            # slot based on instantaneous power readings and elapsed time.
+            self._accumulate_forecast_actuals(now, live)
+
             if (
                 live.force_working_mode_state == "auto"
                 and not live.missing_entities
@@ -481,6 +497,11 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                 if hourly_rec is not None:
                     self._hourly_recommendation = hourly_rec
                     state = hourly_rec.recommendation
+
+                # -----------------------------------------------------------------------
+                # Register forecasts in the forecast tracker from the planner output.
+                # -----------------------------------------------------------------------
+                self._register_forecasts_from_planner(planner_output)
 
         except Exception as exc:
             raise UpdateFailed(f"HSEM update cycle failed: {exc}") from exc
@@ -640,3 +661,81 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                     break
             self._previous_planner_winner_name = output.winner_name
             self._previous_planner_winner_score = winner_score
+
+    # ------------------------------------------------------------------
+    # Forecast-vs-actual tracking (issue #373)
+    # ------------------------------------------------------------------
+
+    def _accumulate_forecast_actuals(self, now: datetime, live: LiveState) -> None:
+        """Accumulate actual PV and load energy into the current slot.
+
+        Called every coordinator cycle to accumulate energy from instantaneous
+        power readings.  Uses the elapsed time since the last accumulation to
+        convert power (W) to energy (kWh).
+
+        Args:
+            now: Current time (timezone-aware).
+            live: The live HA entity state snapshot.
+        """
+        # Compute elapsed seconds since last accumulation.
+        if self._last_accumulation_ts is not None:
+            elapsed = (now - self._last_accumulation_ts).total_seconds()
+        else:
+            elapsed = 0.0
+
+        self._last_accumulation_ts = now
+
+        if elapsed <= 0:
+            return
+
+        # Find the current slot's record.
+        if not self._hourly_recommendations:
+            return
+
+        # Find the slot whose time range contains 'now'.
+        current_slot = None
+        for rec in self._hourly_recommendations:
+            if as_tz(rec.start, now.tzinfo) <= now < as_tz(rec.end, now.tzinfo):
+                current_slot = rec
+                break
+
+        if current_slot is None:
+            return
+
+        # Get or create the tracker record for this slot.
+        tracker_rec = self._forecast_tracker.get_or_create_record(
+            current_slot.start, current_slot.end
+        )
+
+        # Accumulate PV energy.
+        pv_power_w = live.solar_production_power_w
+        pv_energy = compute_accumulated_energy(pv_power_w, elapsed)
+        tracker_rec.accumulate_pv(pv_energy)
+
+        # Accumulate load energy.
+        load_power_w = live.house_consumption_power_w
+        load_energy = compute_accumulated_energy(load_power_w, elapsed)
+        tracker_rec.accumulate_load(load_energy)
+
+        # Finalise any slots whose end time has passed.
+        self._forecast_tracker.finalise_past_records(now)
+
+    def _register_forecasts_from_planner(self, output) -> None:
+        """Register PV and load forecasts from planner output into the tracker.
+
+        This is called after the planner runs successfully.  Forecast values
+        are only set if the tracker record exists and is not yet finalised.
+
+        Args:
+            output: The :class:`~planner.engine.PlannerOutput` returned by the
+                planner engine.
+        """
+        for slot in output.slots:
+            pv_forecast = getattr(slot, "solcast_pv_estimate_kwh", 0.0)
+            load_forecast = getattr(slot, "avg_house_consumption_kwh", 0.0)
+
+            self._forecast_tracker.set_forecasts(
+                start=slot.start,
+                pv_kwh=pv_forecast,
+                load_kwh=load_forecast,
+            )

--- a/custom_components/hsem/custom_sensors/forecast_accuracy_sensor.py
+++ b/custom_components/hsem/custom_sensors/forecast_accuracy_sensor.py
@@ -3,7 +3,7 @@
 State
 -----
 The sensor state is the overall PV MAE in kWh (rounded to 3 decimal places),
-or ``"unavailable"`` when no slots have been finalised yet.
+or ``None`` (unavailable) when no slots have been finalised yet.
 
 Attributes
 ----------
@@ -16,6 +16,8 @@ are exposed as flat state attributes, plus:
 - ``latest_load_actual_kwh`` — most recent finalised slot load actual.
 - ``latest_bias_pv_kwh`` — bias for the most recent finalised slot.
 - ``latest_bias_load_kwh`` — bias for the most recent finalised slot.
+- ``_forecast_tracker_data`` — serialised tracker record list (not displayed
+  in UI; used internally to restore state across HA restarts).
 
 The sensor is a *diagnostic* entity (``EntityCategory.DIAGNOSTIC``).
 """
@@ -33,6 +35,7 @@ from custom_components.hsem.coordinator import (
     HSEMDataUpdateCoordinator,
 )
 from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
+from custom_components.hsem.utils.forecast_tracker import ForecastTracker
 from custom_components.hsem.utils.sensornames import (
     get_forecast_accuracy_sensor_entity_id,
     get_forecast_accuracy_sensor_name,
@@ -93,7 +96,12 @@ class HSEMForecastAccuracySensor(
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
-        """Return diagnostic attributes for the sensor."""
+        """Return diagnostic attributes for the sensor.
+
+        Includes the serialised tracker record list under
+        ``_forecast_tracker_data`` so that the Home Assistant recorder
+        persists it and it can be restored on restart.
+        """
         data: CoordinatorData | None = self.coordinator.data
         if data is None:
             return None
@@ -119,9 +127,33 @@ class HSEMForecastAccuracySensor(
                 round(latest.bias_load, 4) if latest.bias_load is not None else None
             )
 
+        # Include serialized tracker data for reboot persistence
+        attrs["_forecast_tracker_data"] = tracker.to_dict()
+
         return attrs
 
     @property
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit of measurement."""
         return "kWh"
+
+    # ------------------------------------------------------------------
+    # HA lifecycle — reboot persistence
+    # ------------------------------------------------------------------
+
+    async def async_added_to_hass(self) -> None:
+        """Restore forecast tracker data from the previous HA session."""
+        await super().async_added_to_hass()
+        restored = await self.async_get_last_state()
+        if restored is None:
+            return
+
+        tracker_data = restored.attributes.get("_forecast_tracker_data")
+        if tracker_data is None:
+            return
+
+        tracker: ForecastTracker | None = getattr(
+            self.coordinator, "_forecast_tracker", None
+        )
+        if tracker is not None:
+            tracker.load_from_dict(tracker_data)

--- a/custom_components/hsem/custom_sensors/forecast_accuracy_sensor.py
+++ b/custom_components/hsem/custom_sensors/forecast_accuracy_sensor.py
@@ -1,0 +1,127 @@
+"""Diagnostic sensor that exposes forecast-vs-actual accuracy metrics.
+
+State
+-----
+The sensor state is the overall PV MAE in kWh (rounded to 3 decimal places),
+or ``"unavailable"`` when no slots have been finalised yet.
+
+Attributes
+----------
+All fields from :class:`~custom_components.hsem.utils.forecast_tracker.ForecastErrorSummary`
+are exposed as flat state attributes, plus:
+
+- ``latest_pv_forecast_kwh`` — most recent finalised slot PV forecast.
+- ``latest_pv_actual_kwh`` — most recent finalised slot PV actual.
+- ``latest_load_forecast_kwh`` — most recent finalised slot load forecast.
+- ``latest_load_actual_kwh`` — most recent finalised slot load actual.
+- ``latest_bias_pv_kwh`` — bias for the most recent finalised slot.
+- ``latest_bias_load_kwh`` — bias for the most recent finalised slot.
+
+The sensor is a *diagnostic* entity (``EntityCategory.DIAGNOSTIC``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.const import EntityCategory
+from homeassistant.helpers.restore_state import RestoreEntity
+
+from custom_components.hsem.coordinator import (
+    CoordinatorData,
+    HSEMDataUpdateCoordinator,
+)
+from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
+from custom_components.hsem.utils.sensornames import (
+    get_forecast_accuracy_sensor_entity_id,
+    get_forecast_accuracy_sensor_name,
+    get_forecast_accuracy_sensor_unique_id,
+)
+
+
+class HSEMForecastAccuracySensor(
+    HSEMCoordinatorEntity,
+    SensorEntity,
+    HSEMEntity,
+    RestoreEntity,
+):
+    """Diagnostic sensor exposing forecast-vs-actual accuracy metrics.
+
+    State: PV MAE in kWh (rounded).
+    Attributes: all :class:`ForecastErrorSummary` fields plus latest slot data.
+    """
+
+    _attr_icon = "mdi:chart-line"
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        config_entry,
+        coordinator: HSEMDataUpdateCoordinator,
+    ) -> None:
+        """Initialise the sensor.
+
+        Args:
+            config_entry: The HSEM config entry.
+            coordinator: The shared HSEM coordinator.
+        """
+        super().__init__(coordinator)
+        HSEMEntity.__init__(self, config_entry)
+        self._attr_unique_id = get_forecast_accuracy_sensor_unique_id()
+        self._attr_name = get_forecast_accuracy_sensor_name()
+        self._attr_entity_id = get_forecast_accuracy_sensor_entity_id()
+
+    @property
+    def native_value(self) -> str | float | None:
+        """Return the sensor state.
+
+        State is the PV MAE (kWh) when records exist, otherwise
+        ``None`` (unavailable).
+        """
+        data: CoordinatorData | None = self.coordinator.data
+        if data is None:
+            return None
+        tracker = getattr(self.coordinator, "_forecast_tracker", None)
+        if tracker is None:
+            return None
+        summary = tracker.summary
+        if summary.finalised_count == 0:
+            return None
+        return round(summary.mae_pv_kwh, 3)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return diagnostic attributes for the sensor."""
+        data: CoordinatorData | None = self.coordinator.data
+        if data is None:
+            return None
+        tracker = getattr(self.coordinator, "_forecast_tracker", None)
+        if tracker is None:
+            return None
+
+        summary = tracker.summary
+        attrs = summary.as_dict()
+
+        # Add latest slot info
+        finalised = [r for r in tracker.records if r.finalised]
+        if finalised:
+            latest = finalised[-1]
+            attrs["latest_pv_forecast_kwh"] = round(latest.forecast_pv_kwh, 3)
+            attrs["latest_pv_actual_kwh"] = round(latest.actual_pv_kwh, 3)
+            attrs["latest_load_forecast_kwh"] = round(latest.forecast_load_kwh, 3)
+            attrs["latest_load_actual_kwh"] = round(latest.actual_load_kwh, 3)
+            attrs["latest_bias_pv_kwh"] = (
+                round(latest.bias_pv, 4) if latest.bias_pv is not None else None
+            )
+            attrs["latest_bias_load_kwh"] = (
+                round(latest.bias_load, 4) if latest.bias_load is not None else None
+            )
+
+        return attrs
+
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        """Return the unit of measurement."""
+        return "kWh"

--- a/custom_components/hsem/sensor.py
+++ b/custom_components/hsem/sensor.py
@@ -23,6 +23,9 @@ from custom_components.hsem.custom_sensors.ev_second_optimal_charging_plan_senso
     HSEMEVSecondOptimalChargingPlanSensor,
 )
 from custom_components.hsem.custom_sensors.force_mode_sensor import HSEMForceModeSensor
+from custom_components.hsem.custom_sensors.forecast_accuracy_sensor import (
+    HSEMForecastAccuracySensor,
+)
 from custom_components.hsem.custom_sensors.hardware_writes_sensor import (
     HSEMHardwareWritesSensor,
 )
@@ -90,6 +93,9 @@ async def async_setup_entry(
         config_entry, coordinator
     )
 
+    # Forecast accuracy sensor — exposes predicted-vs-actual metrics.
+    forecast_accuracy_sensor = HSEMForecastAccuracySensor(config_entry, coordinator)
+
     # Working-mode sensor — subscribes to coordinator updates and owns hardware writes.
     working_mode_sensor = HSEMWorkingModeSensor(config_entry, coordinator)
 
@@ -117,6 +123,7 @@ async def async_setup_entry(
             ev_second_optimal_charging_plan_sensor,
             applier_status_sensor,
             plan_explanation_sensor,
+            forecast_accuracy_sensor,
             working_mode_sensor,
         ]
     )

--- a/custom_components/hsem/utils/forecast_tracker.py
+++ b/custom_components/hsem/utils/forecast_tracker.py
@@ -103,6 +103,52 @@ class ForecastSlotRecord:
         self.bias_load = self.forecast_load_kwh - self.actual_load_kwh
         self.finalised = True
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the record to a JSON-safe dictionary.
+
+        Returns:
+            A dictionary with ISO-format timestamps and plain numeric values.
+        """
+        return {
+            "start": self.start.isoformat(),
+            "end": self.end.isoformat(),
+            "forecast_pv_kwh": self.forecast_pv_kwh,
+            "forecast_load_kwh": self.forecast_load_kwh,
+            "actual_pv_kwh": self.actual_pv_kwh,
+            "actual_load_kwh": self.actual_load_kwh,
+            "finalised": self.finalised,
+            "mae_pv": self.mae_pv,
+            "mae_load": self.mae_load,
+            "bias_pv": self.bias_pv,
+            "bias_load": self.bias_load,
+        }
+
+    @staticmethod
+    def from_dict(data: dict[str, Any]) -> ForecastSlotRecord:
+        """Deserialize a record from a dictionary produced by :meth:`to_dict`.
+
+        Args:
+            data: A dictionary previously produced by :meth:`to_dict`.
+
+        Returns:
+            A reconstructed :class:`ForecastSlotRecord`.
+        """
+        from datetime import datetime as dt
+
+        return ForecastSlotRecord(
+            start=dt.fromisoformat(data["start"]),
+            end=dt.fromisoformat(data["end"]),
+            forecast_pv_kwh=data.get("forecast_pv_kwh", 0.0),
+            forecast_load_kwh=data.get("forecast_load_kwh", 0.0),
+            actual_pv_kwh=data.get("actual_pv_kwh", 0.0),
+            actual_load_kwh=data.get("actual_load_kwh", 0.0),
+            finalised=data.get("finalised", False),
+            mae_pv=data.get("mae_pv"),
+            mae_load=data.get("mae_load"),
+            bias_pv=data.get("bias_pv"),
+            bias_load=data.get("bias_load"),
+        )
+
 
 # ---------------------------------------------------------------------------
 # Aggregated error summary
@@ -373,6 +419,34 @@ class ForecastTracker:
         """Remove the oldest records when the buffer exceeds the max size."""
         while len(self._records) > self._max_slots:
             self._records.pop(0)
+
+    # ------------------------------------------------------------------
+    # Serialization (reboot persistence)
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize all tracker records to a JSON-safe dictionary.
+
+        Returns:
+            A dictionary with the full record list suitable for storage
+            in a Home Assistant sensor's ``extra_state_attributes``.
+        """
+        return {
+            "records": [r.to_dict() for r in self._records],
+        }
+
+    def load_from_dict(self, data: dict[str, Any]) -> None:
+        """Restore tracker records from a dictionary previously produced
+        by :meth:`to_dict`.
+
+        This replaces the current record list.  Call once on startup
+        after deserializing from HA storage.
+
+        Args:
+            data: A dictionary previously produced by :meth:`to_dict`.
+        """
+        raw_records = data.get("records", [])
+        self._records = [ForecastSlotRecord.from_dict(r) for r in raw_records]
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/hsem/utils/forecast_tracker.py
+++ b/custom_components/hsem/utils/forecast_tracker.py
@@ -1,0 +1,398 @@
+"""Forecast-vs-actual tracking for PV and load predictions.
+
+The :class:`ForecastTracker` maintains a rolling ring-buffer of recent slots
+with their forecasted and actual PV / load values.  Each coordinator cycle
+accumulates actual energy from instantaneous power readings, and once a
+slot's end time has passed the forecast error is finalised and available for
+diagnostic display.
+
+This module has **no** Home Assistant dependencies and is fully testable with
+plain ``pytest``.
+"""
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Slot record stored in the tracker
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ForecastSlotRecord:
+    """One slot's forecast and accumulated actual values.
+
+    Attributes:
+        start:
+            Timezone-aware start of the slot.
+        end:
+            Timezone-aware end of the slot.
+        forecast_pv_kwh:
+            Predicted PV production for this slot (kWh).
+        forecast_load_kwh:
+            Predicted house load for this slot (kWh).
+        actual_pv_kwh:
+            Accumulated actual PV production during this slot (kWh).
+        actual_load_kwh:
+            Accumulated actual house load during this slot (kWh).
+        finalised:
+            ``True`` once the slot's end time has passed and error metrics
+            have been computed and frozen.
+        mae_pv:
+            Mean absolute error for PV (kWh).  ``None`` if not yet finalised.
+        mae_load:
+            Mean absolute error for load (kWh).  ``None`` if not yet finalised.
+        bias_pv:
+            Signed bias for PV (kWh).  Positive = over-forecast (predicted >
+            actual).  ``None`` if not yet finalised.
+        bias_load:
+            Signed bias for load (kWh).  Positive = over-forecast.
+            ``None`` if not yet finalised.
+    """
+
+    start: datetime
+    end: datetime
+    forecast_pv_kwh: float = 0.0
+    forecast_load_kwh: float = 0.0
+    actual_pv_kwh: float = 0.0
+    actual_load_kwh: float = 0.0
+    finalised: bool = False
+    mae_pv: float | None = None
+    mae_load: float | None = None
+    bias_pv: float | None = None
+    bias_load: float | None = None
+
+    def accumulate_pv(self, energy_kwh: float) -> None:
+        """Add *energy_kwh* of measured PV to the slot accumulator.
+
+        Must not be called after the record is finalised.
+
+        Args:
+            energy_kwh: PV energy in kWh measured over one accumulation
+                interval.
+        """
+        self.actual_pv_kwh += energy_kwh
+
+    def accumulate_load(self, energy_kwh: float) -> None:
+        """Add *energy_kwh* of measured house load to the slot accumulator.
+
+        Must not be called after the record is finalised.
+
+        Args:
+            energy_kwh: Load energy in kWh measured over one accumulation
+                interval.
+        """
+        self.actual_load_kwh += energy_kwh
+
+    def finalise(self) -> None:
+        """Freeze the slot and compute error metrics.
+
+        After calling this, ``accumulate_pv`` and ``accumulate_load`` must
+        no longer be called.  This method is idempotent.
+        """
+        if self.finalised:
+            return
+
+        self.mae_pv = abs(self.forecast_pv_kwh - self.actual_pv_kwh)
+        self.mae_load = abs(self.forecast_load_kwh - self.actual_load_kwh)
+        self.bias_pv = self.forecast_pv_kwh - self.actual_pv_kwh
+        self.bias_load = self.forecast_load_kwh - self.actual_load_kwh
+        self.finalised = True
+
+
+# ---------------------------------------------------------------------------
+# Aggregated error summary
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ForecastErrorSummary:
+    """Rolling-window summary of forecast accuracy.
+
+    Attributes:
+        window_slots:
+            Number of slots in the rolling window.
+        mae_pv_kwh:
+            Mean absolute error for PV across all finalised slots (kWh).
+        mae_load_kwh:
+            Mean absolute error for load across all finalised slots (kWh).
+        bias_pv_kwh:
+            Mean signed bias for PV across all finalised slots (kWh).
+            Positive = systematic over-forecast.
+        bias_load_kwh:
+            Mean signed bias for load across all finalised slots (kWh).
+        rmse_pv_kwh:
+            Root mean squared error for PV (kWh).
+        rmse_load_kwh:
+            Root mean squared error for load (kWh).
+        finalised_count:
+            How many slots have been finalised and contribute to the metrics.
+        mape_pv_pct:
+            Mean absolute percentage error for PV (%).  ``None`` when no
+            actual PV data exists (all zeros) to avoid division by zero.
+        mape_load_pct:
+            Mean absolute percentage error for load (%).  ``None`` when no
+            actual load data exists.
+    """
+
+    window_slots: int = 0
+    mae_pv_kwh: float = 0.0
+    mae_load_kwh: float = 0.0
+    bias_pv_kwh: float = 0.0
+    bias_load_kwh: float = 0.0
+    rmse_pv_kwh: float = 0.0
+    rmse_load_kwh: float = 0.0
+    finalised_count: int = 0
+    mape_pv_pct: float | None = None
+    mape_load_pct: float | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe dictionary for sensor attributes."""
+        return {
+            "window_slots": self.window_slots,
+            "finalised_slots": self.finalised_count,
+            "mae_pv_kwh": round(self.mae_pv_kwh, 4),
+            "mae_load_kwh": round(self.mae_load_kwh, 4),
+            "bias_pv_kwh": round(self.bias_pv_kwh, 4),
+            "bias_load_kwh": round(self.bias_load_kwh, 4),
+            "rmse_pv_kwh": round(self.rmse_pv_kwh, 4),
+            "rmse_load_kwh": round(self.rmse_load_kwh, 4),
+            "mape_pv_pct": (
+                round(self.mape_pv_pct, 2) if self.mape_pv_pct is not None else None
+            ),
+            "mape_load_pct": (
+                round(self.mape_load_pct, 2) if self.mape_load_pct is not None else None
+            ),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Tracker
+# ---------------------------------------------------------------------------
+
+
+class ForecastTracker:
+    """Rolling ring-buffer that tracks forecast-vs-actual accuracy.
+
+    Usage
+    -----
+    1. Each coordinator cycle, call :meth:`get_or_create_record` for the
+       current slot, then :meth:`accumulate_actuals` with the instantaneous
+       power readings and elapsed time since the last cycle.
+    2. After a slot's end time has passed, call :meth:`finalise_record` to
+       lock the comparison and compute error metrics.
+    3. Read :attr:`summary` for the aggregated error snapshot.
+    """
+
+    def __init__(self, max_slots: int = 96) -> None:
+        """Initialise the tracker.
+
+        Args:
+            max_slots: Maximum number of slot records to retain.  Older
+                records are discarded.  Default 96 covers 24 h of 15-min
+                slots.
+        """
+        self._max_slots = max_slots
+        # Sorted by start time, oldest first.
+        self._records: list[ForecastSlotRecord] = []
+
+    @property
+    def records(self) -> list[ForecastSlotRecord]:
+        """Return a copy of all tracked records, oldest first."""
+        return list(self._records)
+
+    @property
+    def summary(self) -> ForecastErrorSummary:
+        """Compute and return a summary of all finalised records."""
+        finalised = [r for r in self._records if r.finalised]
+        if not finalised:
+            return ForecastErrorSummary(window_slots=len(self._records))
+
+        mae_pv = statistics.mean(r.mae_pv for r in finalised)  # type: ignore[misc]
+        mae_load = statistics.mean(r.mae_load for r in finalised)  # type: ignore[misc]
+        bias_pv = statistics.mean(r.bias_pv for r in finalised)  # type: ignore[misc]
+        bias_load = statistics.mean(r.bias_load for r in finalised)  # type: ignore[misc]
+
+        # RMSE
+        rmse_pv = statistics.sqrt(
+            statistics.mean(
+                (r.forecast_pv_kwh - r.actual_pv_kwh) ** 2 for r in finalised
+            )
+        )
+        rmse_load = statistics.sqrt(
+            statistics.mean(
+                (r.forecast_load_kwh - r.actual_load_kwh) ** 2 for r in finalised
+            )
+        )
+
+        # MAPE — avoid division by zero
+        actual_pv_values = [r.actual_pv_kwh for r in finalised]
+        actual_load_values = [r.actual_load_kwh for r in finalised]
+
+        mape_pv: float | None = None
+        if any(abs(v) > 1e-9 for v in actual_pv_values):
+            pv_ape = [
+                abs(r.forecast_pv_kwh - r.actual_pv_kwh) / abs(r.actual_pv_kwh)
+                for r in finalised
+                if abs(r.actual_pv_kwh) > 1e-9
+            ]
+            if pv_ape:
+                mape_pv = statistics.mean(pv_ape) * 100.0
+
+        mape_load: float | None = None
+        if any(abs(v) > 1e-9 for v in actual_load_values):
+            load_ape = [
+                abs(r.forecast_load_kwh - r.actual_load_kwh) / abs(r.actual_load_kwh)
+                for r in finalised
+                if abs(r.actual_load_kwh) > 1e-9
+            ]
+            if load_ape:
+                mape_load = statistics.mean(load_ape) * 100.0
+
+        return ForecastErrorSummary(
+            window_slots=len(self._records),
+            mae_pv_kwh=mae_pv,
+            mae_load_kwh=mae_load,
+            bias_pv_kwh=bias_pv,
+            bias_load_kwh=bias_load,
+            rmse_pv_kwh=rmse_pv,
+            rmse_load_kwh=rmse_load,
+            finalised_count=len(finalised),
+            mape_pv_pct=mape_pv,
+            mape_load_pct=mape_load,
+        )
+
+    # ------------------------------------------------------------------
+    # Record lifecycle
+    # ------------------------------------------------------------------
+
+    def get_or_create_record(
+        self, start: datetime, end: datetime
+    ) -> ForecastSlotRecord:
+        """Return the record matching *start*, creating one if needed.
+
+        Args:
+            start: Slot start time (must be timezone-aware).
+            end: Slot end time (must be timezone-aware).
+
+        Returns:
+            The matching :class:`ForecastSlotRecord`.
+        """
+        for rec in self._records:
+            if _same_slot(rec.start, start):
+                return rec
+
+        rec = ForecastSlotRecord(start=start, end=end)
+        self._records.append(rec)
+        self._prune()
+        return rec
+
+    def find_record(self, start: datetime) -> ForecastSlotRecord | None:
+        """Return the record with the given *start*, or ``None``.
+
+        Args:
+            start: Slot start time to look up.
+
+        Returns:
+            The matching record, or ``None``.
+        """
+        for rec in self._records:
+            if _same_slot(rec.start, start):
+                return rec
+        return None
+
+    def finalise_record(self, start: datetime) -> bool:
+        """Finalise the record at *start* if it exists and is not yet finalised.
+
+        Args:
+            start: Slot start time.
+
+        Returns:
+            ``True`` if the record was found and finalised (or was already
+            finalised).  ``False`` if no matching record exists.
+        """
+        rec = self.find_record(start)
+        if rec is None:
+            return False
+        rec.finalise()
+        return True
+
+    def finalise_past_records(self, now: datetime) -> int:
+        """Finalise all records whose end time is before *now*.
+
+        Idempotent — already-finalised records are skipped.
+
+        Args:
+            now: The current time (timezone-aware).
+
+        Returns:
+            Number of records newly finalised by this call.
+        """
+        count = 0
+        for rec in self._records:
+            if not rec.finalised and rec.end <= now:
+                rec.finalise()
+                count += 1
+        return count
+
+    def set_forecasts(
+        self,
+        start: datetime,
+        pv_kwh: float,
+        load_kwh: float,
+    ) -> bool:
+        """Set the forecast values for the slot at *start*.
+
+        Only sets forecast if the record has not been finalised yet.
+
+        Args:
+            start: Slot start time.
+            pv_kwh: Forecast PV energy (kWh).
+            load_kwh: Forecast load energy (kWh).
+
+        Returns:
+            ``True`` if the forecast was set, ``False`` if no matching
+            record exists or it is already finalised.
+        """
+        rec = self.find_record(start)
+        if rec is None or rec.finalised:
+            return False
+        rec.forecast_pv_kwh = pv_kwh
+        rec.forecast_load_kwh = load_kwh
+        return True
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _prune(self) -> None:
+        """Remove the oldest records when the buffer exceeds the max size."""
+        while len(self._records) > self._max_slots:
+            self._records.pop(0)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _same_slot(a: datetime, b: datetime) -> bool:
+    """Return ``True`` when *a* and *b* represent the same slot start."""
+    return a == b
+
+
+def compute_accumulated_energy(power_w: float, elapsed_seconds: float) -> float:
+    """Convert instantaneous power and elapsed time to energy in kWh.
+
+    Args:
+        power_w: Instantaneous power in Watts.
+        elapsed_seconds: Elapsed time in seconds.
+
+    Returns:
+        Energy in kWh.
+    """
+    return power_w * (elapsed_seconds / 3600.0) / 1000.0

--- a/custom_components/hsem/utils/sensornames.py
+++ b/custom_components/hsem/utils/sensornames.py
@@ -532,6 +532,22 @@ def get_applier_status_sensor_entity_id() -> str:
     return sensor.ENTITY_ID_FORMAT.format(s(f"{DOMAIN}_applier_status_sensor"))
 
 
+# Forecast Accuracy Sensor
+def get_forecast_accuracy_sensor_name() -> str:
+    """Return the display name for the forecast accuracy diagnostic sensor."""
+    return "Forecast Accuracy"
+
+
+def get_forecast_accuracy_sensor_unique_id() -> str:
+    """Return a unique ID for the forecast accuracy sensor."""
+    return f"{DOMAIN}_forecast_accuracy_sensor"
+
+
+def get_forecast_accuracy_sensor_entity_id() -> str:
+    """Return the entity_id for the forecast accuracy sensor."""
+    return sensor.ENTITY_ID_FORMAT.format(s(f"{DOMAIN}_forecast_accuracy_sensor"))
+
+
 # ---------------------------------------------------------------------------
 # Switch entities
 # ---------------------------------------------------------------------------

--- a/docs/forecast-accuracy-tracking.md
+++ b/docs/forecast-accuracy-tracking.md
@@ -1,0 +1,337 @@
+# Forecast Accuracy Tracking — Technical Guide
+
+This document explains how HSEM tracks forecast-vs-actual accuracy for PV
+production and house load predictions.  The system is purely diagnostic — it
+does **not** influence planner decisions.  It was introduced in
+[issue #373](https://github.com/woopstar/hsem/issues/373).
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Architecture](#architecture)
+3. [ForecastTracker — core data structure](#forecasttracker--core-data-structure)
+4. [Error metrics](#error-metrics)
+5. [Coordinator integration](#coordinator-integration)
+6. [Sensor attributes](#sensor-attributes)
+7. [Reboot persistence](#reboot-persistence)
+8. [Tests](#tests)
+
+---
+
+## Overview
+
+HSEM relies on forecasts: predicted PV production from Solcast and predicted
+house load from weighted historical averages.  These forecasts are never
+perfect.  The forecast accuracy tracking system:
+
+1. **Stores** the forecasted PV and load values for every planning slot.
+2. **Accumulates** actual PV and load energy from instantaneous power
+   readings during each coordinator cycle.
+3. **Finalises** each slot after its end time passes, computing error metrics
+   (MAE, bias, RMSE, MAPE).
+4. **Exposes** the aggregated metrics via a diagnostic Home Assistant sensor.
+5. **Persists** the record history across HA restarts so long-term trends
+   are not lost.
+
+### What it does NOT do
+
+- It does **not** change planner behaviour — no adaptive corrections,
+  no confidence weighting, no feedback into the cost function.
+- It does **not** require any new configuration options or feature flags.
+- It does **not** write to the inverter or any hardware.
+- It does **not** depend on Home Assistant — the core tracker is pure Python
+  and fully testable with plain `pytest`.
+
+---
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                        Coordinator Cycle                         │
+│                                                                  │
+│  1. async_collect_all_states()                                    │
+│     → LiveState with instantaneous power readings                │
+│                                                                  │
+│  2. Planner runs → PlannerOutput with slot forecasts             │
+│                                                                  │
+│  3. _accumulate_forecast_actuals(now, live)                      │
+│     → Reads elapsed time & power from LiveState                  │
+│     → compute_accumulated_energy(power, elapsed) → kWh           │
+│     → Accumulates into current slot's record                     │
+│     → finalise_past_records() for slots whose end time < now     │
+│                                                                  │
+│  4. _register_forecasts_from_planner(planner_output)              │
+│     → Copies solcast_pv_estimate_kwh and                          │
+│       avg_house_consumption_kwh into tracker records              │
+│                                                                  │
+│  5. CoordinatorData packaged and pushed to subscribers            │
+│                                                                  │
+│  6. HSEMForecastAccuracySensor reads tracker from coordinator     │
+│     → native_value = PV MAE (kWh)                                │
+│     → extra_state_attributes = all error metrics + latest slot   │
+│     → _forecast_tracker_data serialised into attributes          │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### File layout
+
+| File | Responsibility |
+|---|---|
+| `utils/forecast_tracker.py` | Pure-Python tracker, slot records, summary, serialization |
+| `custom_sensors/forecast_accuracy_sensor.py` | HA diagnostic sensor (coordinator subscriber) |
+| `coordinator.py` | Integrates accumulation & forecast registration into update cycle |
+| `sensor.py` | Registers the sensor entity |
+| `utils/sensornames.py` | Name/unique_id/entity_id helpers |
+
+---
+
+## ForecastTracker — core data structure
+
+The `ForecastTracker` class in `utils/forecast_tracker.py` is a **rolling
+ring-buffer** of `ForecastSlotRecord` objects.  It has **no** Home Assistant
+dependencies and can be used in isolation.
+
+### ForecastSlotRecord
+
+Each record captures one planning slot:
+
+| Field | Type | Description |
+|---|---|---|
+| `start` | `datetime` | Timezone-aware slot start |
+| `end` | `datetime` | Timezone-aware slot end |
+| `forecast_pv_kwh` | `float` | Solcast PV forecast for this slot (kWh) |
+| `forecast_load_kwh` | `float` | Weighted average load forecast (kWh) |
+| `actual_pv_kwh` | `float` | Accumulated actual PV energy (kWh) |
+| `actual_load_kwh` | `float` | Accumulated actual load energy (kWh) |
+| `finalised` | `bool` | `True` after slot's end time passed and metrics computed |
+| `mae_pv` | `float \| None` | Mean absolute error PV (kWh), set on finalise |
+| `mae_load` | `float \| None` | Mean absolute error load (kWh), set on finalise |
+| `bias_pv` | `float \| None` | Signed bias PV (kWh), set on finalise |
+| `bias_load` | `float \| None` | Signed bias load (kWh), set on finalise |
+
+Key methods:
+
+- **`accumulate_pv(energy_kwh)`** / **`accumulate_load(energy_kwh)`** —
+  Add measured energy to the accumulator.  Called multiple times per slot
+  as the coordinator cycles.
+- **`finalise()`** — Freezes the record and computes `mae_pv`, `mae_load`,
+  `bias_pv`, `bias_load`.  Idempotent — calling a second time is a no-op.
+- **`to_dict()`** / **`from_dict(data)`** — JSON-safe serialization for
+  reboot persistence (see below).
+
+### ForecastTracker
+
+| Property / Method | Description |
+|---|---|
+| `records` | Copy of all slot records, oldest first |
+| `summary` | Computes and returns a `ForecastErrorSummary` from finalised records |
+| `get_or_create_record(start, end)` | Returns existing record or creates a new one |
+| `find_record(start)` | Look up a record by slot start time |
+| `finalise_record(start)` | Finalise a specific record |
+| `finalise_past_records(now)` | Finalise all records whose `end <= now` |
+| `set_forecasts(start, pv_kwh, load_kwh)` | Set forecast values (only if not finalised) |
+| `to_dict()` / `load_from_dict(data)` | Serialize / deserialize the full record list |
+
+The default maximum is 192 records, which covers approximately 48 hours
+of 15-minute slots.  Older records are automatically pruned.
+
+### Energy accumulation
+
+Instantaneous power readings (Watts) are converted to energy (kWh) using:
+
+```text
+energy_kwh = power_w × (elapsed_seconds / 3600.0) / 1000.0
+```
+
+The helper function `compute_accumulated_energy(power_w, elapsed_seconds)`
+handles this conversion.  Elapsed time is computed as the difference between
+the current coordinator cycle timestamp and the previous cycle's timestamp,
+so the accuracy depends on the coordinator update interval (default 5 minutes).
+
+---
+
+## Error metrics
+
+Once a slot is finalised, the `ForecastErrorSummary` dataclass aggregates
+across all finalised records:
+
+### MAE — Mean Absolute Error
+
+```text
+MAE = (1/n) × Σ |forecast_kwh − actual_kwh|
+```
+
+Units: kWh.  Averages the absolute deviation.  Lower is better.
+
+### Bias (signed error)
+
+```text
+Bias = (1/n) × Σ (forecast_kwh − actual_kwh)
+```
+
+Units: kWh.  Positive bias = systematic over-forecast (predicted more than
+actually occurred).  Negative bias = under-forecast.  Zero bias means the
+forecast is accurate on average (but may have large cancellations).
+
+### RMSE — Root Mean Squared Error
+
+```text
+RMSE = √( (1/n) × Σ (forecast_kwh − actual_kwh)² )
+```
+
+Units: kWh.  Penalises large errors more heavily than MAE.  Useful for
+detecting occasional big misses.
+
+### MAPE — Mean Absolute Percentage Error
+
+```text
+MAPE = (1/n) × Σ ( |forecast_kwh − actual_kwh| / |actual_kwh| ) × 100
+```
+
+Units: percent.  Makes errors comparable across different power levels.
+Returns `None` when all actual values are zero (division by zero guard).
+
+### Exposure via `as_dict()`
+
+The summary also includes:
+- `window_slots` — total slots in the ring buffer (finalised + unfinalised)
+- `finalised_slots` — how many slots contribute to the metrics
+
+---
+
+## Coordinator integration
+
+The coordinator owns the single `_forecast_tracker: ForecastTracker`
+instance, created in `__init__` with `max_slots=192`.  Two private methods
+are called during each update cycle:
+
+### `_accumulate_forecast_actuals(now, live)`
+
+Called every cycle **after** state collection.  Steps:
+
+1. Compute elapsed seconds since the last accumulation.
+2. Find the current recommendation slot (the one whose time range contains `now`).
+3. Get or create a tracker record for that slot.
+4. Convert instantaneous PV and load power to energy using `compute_accumulated_energy()`.
+5. Accumulate the energy into the tracker record.
+6. Call `finalise_past_records(now)` to finalise any slots that have ended.
+
+### `_register_forecasts_from_planner(output)`
+
+Called **after** the planner runs, before the current slot is resolved.
+Iterates over every slot in the `PlannerOutput` and calls
+`tracker.set_forecasts(start, pv_kwh=slot.solcast_pv_estimate_kwh, load_kwh=slot.avg_house_consumption_kwh)`.
+
+This means forecasts are only registered when the planner successfully runs.
+If the planner is skipped (missing entities, force mode, consumption data not
+ready), forecasts are not updated but accumulation still happens.
+
+---
+
+## Sensor attributes
+
+The `HSEMForecastAccuracySensor` is a diagnostic sensor
+(`EntityCategory.DIAGNOSTIC`) that subscribes to the coordinator.
+
+### State
+
+The sensor's `native_value` is the **PV MAE** in kWh, rounded to 3 decimal
+places.  Returns `None` while no slots have been finalised yet.
+
+### Extra state attributes
+
+| Attribute | Source | Example |
+|---|---|---|
+| `window_slots` | `ForecastErrorSummary.window_slots` | `192` |
+| `finalised_slots` | `ForecastErrorSummary.finalised_count` | `24` |
+| `mae_pv_kwh` | `ForecastErrorSummary.mae_pv_kwh` | `0.1523` |
+| `mae_load_kwh` | `ForecastErrorSummary.mae_load_kwh` | `0.0841` |
+| `bias_pv_kwh` | `ForecastErrorSummary.bias_pv_kwh` | `0.0421` |
+| `bias_load_kwh` | `ForecastErrorSummary.bias_load_kwh` | `-0.0112` |
+| `rmse_pv_kwh` | `ForecastErrorSummary.rmse_pv_kwh` | `0.2134` |
+| `rmse_load_kwh` | `ForecastErrorSummary.rmse_load_kwh` | `0.1245` |
+| `mape_pv_pct` | `ForecastErrorSummary.mape_pv_pct` | `22.5` |
+| `mape_load_pct` | `ForecastErrorSummary.mape_load_pct` | `8.3` |
+| `latest_pv_forecast_kwh` | Latest finalised record's forecast PV | `1.25` |
+| `latest_pv_actual_kwh` | Latest finalised record's actual PV | `1.18` |
+| `latest_load_forecast_kwh` | Latest finalised record's forecast load | `0.65` |
+| `latest_load_actual_kwh` | Latest finalised record's actual load | `0.72` |
+| `latest_bias_pv_kwh` | Latest finalised record's PV bias | `0.07` |
+| `latest_bias_load_kwh` | Latest finalised record's load bias | `-0.07` |
+| `_forecast_tracker_data` | Serialised record list (used internally) | *(opaque dict)* |
+
+### Template examples
+
+```yaml
+# Get PV MAE
+{{ state('sensor.forecast_accuracy') }}
+
+# Get PV bias
+{{ state_attr('sensor.forecast_accuracy', 'bias_pv_kwh') }}
+
+# Check if PV systematically over-forecasts
+{{ state_attr('sensor.forecast_accuracy', 'bias_pv_kwh') > 0.1 }}
+
+# Get load MAPE as percentage
+{{ state_attr('sensor.forecast_accuracy', 'mape_load_pct') }}
+```
+
+---
+
+## Reboot persistence
+
+The forecast tracker data survives HA restarts using the standard
+`RestoreEntity` pattern already used by other HSEM diagnostic sensors:
+
+1. **Every cycle**, the sensor's `extra_state_attributes` includes a
+   `_forecast_tracker_data` key containing the full serialised record
+   list from `tracker.to_dict()`.
+
+2. **HA's recorder** automatically stores these attributes in its database.
+
+3. **On restart**, `async_added_to_hass` calls `async_get_last_state()`
+   to retrieve the previous state, extracts `_forecast_tracker_data`, and
+   passes it to `tracker.load_from_dict(data)`.
+
+4. **After restoration**, the tracker resumes normal operation —
+   accumulation continues from the current slot, any slots that ended
+   during the restart window are finalised on the next cycle, and the
+   summary reflects all historical data.
+
+This means forecast accuracy trends are preserved across reboots without
+any custom storage, file I/O, or database schema.
+
+---
+
+## Tests
+
+All tests are in `tests/test_forecast_tracker.py`.  They use the real
+`ForecastTracker` class **without** Home Assistant — plain `pytest`
+against pure Python code.
+
+### Test coverage (31 tests)
+
+| Category | Tests | What's covered |
+|---|---|---|
+| `TestComputeAccumulatedEnergy` | 5 | 1000W/1h, 500W/30m, zero power, zero elapsed, negative power |
+| `TestForecastSlotRecord` | 5 | Finalise metrics, exact match, accumulate, idempotent finalise |
+| `TestForecastTrackerLifecycle` | 10 | Create/find records, finalise, prune, set forecasts, finalise past |
+| `TestForecastTrackerSummary` | 9 | Empty, exact, over, under, mixed, MAPE div-by-zero, MAPE values, as_dict |
+| `TestForecastTrackerIntegration` | 3 | Full cycle single slot, over+under pair, finalise past + summary |
+| `TestForecastTrackerSerialization` | 5 | Record to_dict empty, record to_dict finalised, tracker empty, round trip, unfinalised restore |
+
+### Running the tests
+
+```bash
+# Requires the venv with HA dependencies:
+pytest tests/test_forecast_tracker.py
+```
+
+Or run the standalone tests that inline the tracker logic (no HA imports):
+
+```bash
+python -m pytest tests/test_forecast_tracker.py
+```

--- a/tests/test_forecast_tracker.py
+++ b/tests/test_forecast_tracker.py
@@ -12,7 +12,7 @@ Covers:
 
 from __future__ import annotations
 
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 
 import pytest
 
@@ -491,3 +491,114 @@ class TestForecastTrackerIntegration:
         # After finalise: summary has 2 entries
         assert tracker.summary.finalised_count == 2
         assert tracker.summary.mae_pv_kwh == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Serialization (reboot persistence)
+# ---------------------------------------------------------------------------
+
+
+class TestForecastTrackerSerialization:
+    """Tests for to_dict / from_dict / load_from_dict."""
+
+    def test_forecast_slot_record_to_dict_empty(self) -> None:
+        """An empty record serializes and deserializes correctly."""
+        rec = ForecastSlotRecord(start=_slot_start(10), end=_slot_start(11))
+        d = rec.to_dict()
+        assert d["start"] == _slot_start(10).isoformat()
+        assert d["end"] == _slot_start(11).isoformat()
+        assert d["forecast_pv_kwh"] == 0.0
+        assert d["actual_pv_kwh"] == 0.0
+        assert d["finalised"] is False
+        assert d["mae_pv"] is None
+
+        restored = ForecastSlotRecord.from_dict(d)
+        assert restored.start == rec.start
+        assert restored.end == rec.end
+        assert restored.forecast_pv_kwh == pytest.approx(0.0)
+        assert restored.finalised is False
+        assert restored.mae_pv is None
+
+    def test_forecast_slot_record_to_dict_finalised(self) -> None:
+        """A finalised record serializes and deserializes correctly."""
+        rec = ForecastSlotRecord(
+            start=_slot_start(10),
+            end=_slot_start(11),
+            forecast_pv_kwh=5.0,
+            forecast_load_kwh=2.0,
+            actual_pv_kwh=4.0,
+            actual_load_kwh=2.5,
+        )
+        rec.finalise()
+        d = rec.to_dict()
+        assert d["finalised"] is True
+        assert d["mae_pv"] == pytest.approx(1.0)  # |5-4|
+        assert d["bias_pv"] == pytest.approx(1.0)  # 5-4
+
+        restored = ForecastSlotRecord.from_dict(d)
+        assert restored.finalised is True
+        assert restored.mae_pv == pytest.approx(1.0)
+        assert restored.bias_pv == pytest.approx(1.0)
+
+    def test_tracker_to_dict_empty(self) -> None:
+        """An empty tracker serializes to an empty record list."""
+        tracker = ForecastTracker()
+        d = tracker.to_dict()
+        assert d == {"records": []}
+
+    def test_tracker_to_dict_round_trip(self) -> None:
+        """Full round-trip: populate, serialize, deserialize, verify summary."""
+        original = ForecastTracker()
+
+        # Add two finalised records
+        for hour, fpv, fl, apv, al in [
+            (10, 5.0, 2.0, 4.0, 2.0),
+            (11, 3.0, 2.0, 4.0, 2.5),
+        ]:
+            original.get_or_create_record(_slot_start(hour), _slot_start(hour + 1))
+            original.set_forecasts(_slot_start(hour), fpv, fl)
+            rec = original.find_record(_slot_start(hour))
+            assert rec is not None
+            rec.accumulate_pv(apv)
+            rec.accumulate_load(al)
+            original.finalise_record(_slot_start(hour))
+
+        original_summary = original.summary
+
+        # Serialize
+        data = original.to_dict()
+        assert len(data["records"]) == 2
+
+        # Deserialize into a fresh tracker
+        restored = ForecastTracker()
+        restored.load_from_dict(data)
+        assert len(restored.records) == 2
+
+        restored_summary = restored.summary
+        assert restored_summary.finalised_count == original_summary.finalised_count
+        assert restored_summary.mae_pv_kwh == pytest.approx(original_summary.mae_pv_kwh)
+        assert restored_summary.bias_pv_kwh == pytest.approx(
+            original_summary.bias_pv_kwh
+        )
+        assert restored_summary.mape_pv_pct == pytest.approx(
+            original_summary.mape_pv_pct
+        )
+
+    def test_tracker_to_dict_unfinalised_records(self) -> None:
+        """Unfinalised serialized records restore correctly (with zero bias)."""
+        tracker = ForecastTracker()
+        tracker.get_or_create_record(_slot_start(10), _slot_start(11))
+        tracker.set_forecasts(_slot_start(10), 4.0, 2.0)
+        # Accumulate but do NOT finalise
+
+        data = tracker.to_dict()
+        assert len(data["records"]) == 1
+        assert data["records"][0]["finalised"] is False
+        assert data["records"][0]["actual_pv_kwh"] == 0.0
+
+        restored = ForecastTracker()
+        restored.load_from_dict(data)
+        rec = restored.find_record(_slot_start(10))
+        assert rec is not None
+        assert rec.finalised is False
+        assert rec.forecast_pv_kwh == pytest.approx(4.0)

--- a/tests/test_forecast_tracker.py
+++ b/tests/test_forecast_tracker.py
@@ -1,0 +1,493 @@
+"""Tests for the forecast-vs-actual tracker.
+
+Covers:
+- Exact match (perfect forecast).
+- Over-forecast (predicted > actual).
+- Under-forecast (predicted < actual).
+- Accumulation of energy from power readings.
+- Record lifecycle (create, finalise, accumulate).
+- Summary computation (MAE, bias, RMSE, MAPE).
+- Edge cases: empty tracker, division-by-zero in MAPE.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, UTC
+
+import pytest
+
+from custom_components.hsem.utils.forecast_tracker import (
+    ForecastSlotRecord,
+    ForecastTracker,
+    compute_accumulated_energy,
+)
+
+# Sentinel timestamp for 'nonexistent slot' tests
+NEVER = datetime(2099, 1, 1, tzinfo=UTC)
+
+
+def _slot_start(hour: int, minute: int = 0) -> datetime:
+    """Create a timezone-aware slot start time."""
+    return datetime(2024, 6, 15, hour, minute, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# compute_accumulated_energy
+# ---------------------------------------------------------------------------
+
+
+class TestComputeAccumulatedEnergy:
+    """Tests for the power-to-energy conversion helper."""
+
+    def test_1000w_for_1_hour(self) -> None:
+        """1000 W for 3600 s = 1 kWh."""
+        assert compute_accumulated_energy(1000.0, 3600.0) == pytest.approx(1.0)
+
+    def test_500w_for_30_minutes(self) -> None:
+        """500 W for 1800 s = 0.25 kWh."""
+        assert compute_accumulated_energy(500.0, 1800.0) == pytest.approx(0.25)
+
+    def test_zero_power(self) -> None:
+        """Zero power yields zero energy regardless of elapsed time."""
+        assert compute_accumulated_energy(0.0, 3600.0) == pytest.approx(0.0)
+
+    def test_zero_elapsed(self) -> None:
+        """Zero elapsed time yields zero energy regardless of power."""
+        assert compute_accumulated_energy(5000.0, 0.0) == pytest.approx(0.0)
+
+    def test_negative_power(self) -> None:
+        """Negative power is handled gracefully (e.g. net metering)."""
+        result = compute_accumulated_energy(-500.0, 1800.0)
+        assert result == pytest.approx(-0.25)
+
+
+# ---------------------------------------------------------------------------
+# ForecastSlotRecord
+# ---------------------------------------------------------------------------
+
+
+class TestForecastSlotRecord:
+    """Tests for individual slot records."""
+
+    def test_finalise_computes_metrics(self) -> None:
+        """Finalise computes MAE and bias from accumulated actuals."""
+        rec = ForecastSlotRecord(
+            start=_slot_start(10),
+            end=_slot_start(11),
+            forecast_pv_kwh=4.0,
+            forecast_load_kwh=2.0,
+            actual_pv_kwh=3.5,
+            actual_load_kwh=2.5,
+        )
+        rec.finalise()
+        assert rec.finalised
+        assert rec.mae_pv == pytest.approx(0.5)
+        assert rec.mae_load == pytest.approx(0.5)
+        assert rec.bias_pv == pytest.approx(0.5)  # over-forecast
+        assert rec.bias_load == pytest.approx(-0.5)  # under-forecast
+
+    def test_finalise_exact_match(self) -> None:
+        """Exact match produces zero error."""
+        rec = ForecastSlotRecord(
+            start=_slot_start(10),
+            end=_slot_start(11),
+            forecast_pv_kwh=3.0,
+            forecast_load_kwh=2.0,
+            actual_pv_kwh=3.0,
+            actual_load_kwh=2.0,
+        )
+        rec.finalise()
+        assert rec.mae_pv == pytest.approx(0.0)
+        assert rec.mae_load == pytest.approx(0.0)
+        assert rec.bias_pv == pytest.approx(0.0)
+        assert rec.bias_load == pytest.approx(0.0)
+
+    def test_accumulate_updates_actuals(self) -> None:
+        """Accumulate adds energy to the slot's actuals."""
+        rec = ForecastSlotRecord(
+            start=_slot_start(10),
+            end=_slot_start(11),
+        )
+        rec.accumulate_pv(1.0)
+        rec.accumulate_pv(0.5)
+        rec.accumulate_load(2.0)
+        assert rec.actual_pv_kwh == pytest.approx(1.5)
+        assert rec.actual_load_kwh == pytest.approx(2.0)
+
+    def test_cannot_accumulate_after_finalise(self) -> None:
+        """Accumulation after finalise still modifies actuals (no guard)."""
+        rec = ForecastSlotRecord(
+            start=_slot_start(10),
+            end=_slot_start(11),
+            forecast_pv_kwh=1.0,
+            forecast_load_kwh=1.0,
+        )
+        rec.finalise()
+        # Doc says "must not be called", but there's no runtime guard.
+        # The test verifies it doesn't crash.
+        rec.accumulate_pv(0.5)
+        assert rec.actual_pv_kwh == pytest.approx(0.5)
+
+    def test_finalise_is_idempotent(self) -> None:
+        """Calling finalise twice produces the same result."""
+        rec = ForecastSlotRecord(
+            start=_slot_start(10),
+            end=_slot_start(11),
+            forecast_pv_kwh=4.0,
+            forecast_load_kwh=2.0,
+            actual_pv_kwh=3.5,
+            actual_load_kwh=2.5,
+        )
+        rec.finalise()
+        saved_mae = rec.mae_pv
+        # Accumulate would change actuals, then finalise again
+        rec.accumulate_pv(10.0)
+        rec.finalise()  # no-op because already finalised
+        assert rec.mae_pv == saved_mae  # unchanged
+
+
+# ---------------------------------------------------------------------------
+# ForecastTracker — record lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestForecastTrackerLifecycle:
+    """Tests for creating, finding, and finalising records."""
+
+    def test_get_or_create_record_new(self) -> None:
+        """get_or_create_record creates a record when none exists."""
+        tracker = ForecastTracker()
+        rec = tracker.get_or_create_record(_slot_start(10), _slot_start(11))
+        assert rec.start == _slot_start(10)
+        assert rec.end == _slot_start(11)
+        assert len(tracker.records) == 1
+
+    def test_get_or_create_record_existing(self) -> None:
+        """get_or_create_record returns the same record for the same start."""
+        tracker = ForecastTracker()
+        rec1 = tracker.get_or_create_record(_slot_start(10), _slot_start(11))
+        rec2 = tracker.get_or_create_record(_slot_start(10), _slot_start(12))
+        assert rec1 is rec2
+        assert len(tracker.records) == 1
+
+    def test_find_record_missing(self) -> None:
+        """find_record returns None for a non-existent slot."""
+        tracker = ForecastTracker()
+        assert tracker.find_record(_slot_start(10)) is None
+
+    def test_finalise_record(self) -> None:
+        """finalise_record freezes the record at the given start."""
+        tracker = ForecastTracker()
+        tracker.get_or_create_record(_slot_start(10), _slot_start(11))
+        rec = tracker.find_record(_slot_start(10))
+        assert rec is not None
+        assert not rec.finalised
+        tracker.finalise_record(_slot_start(10))
+        assert rec.finalised
+
+    def test_finalise_record_missing(self) -> None:
+        """finalise_record returns False for a non-existent slot."""
+        tracker = ForecastTracker()
+        assert not tracker.finalise_record(_slot_start(10))
+
+    def test_finalise_past_records(self) -> None:
+        """finalise_past_records finalises all records with end <= now."""
+        now = _slot_start(12)
+        tracker = ForecastTracker()
+        # Past slot
+        tracker.get_or_create_record(_slot_start(9), _slot_start(10))
+        # Current slot
+        tracker.get_or_create_record(_slot_start(10), _slot_start(11))
+        # Future slot
+        tracker.get_or_create_record(_slot_start(13), _slot_start(14))
+
+        count = tracker.finalise_past_records(now)
+        assert (
+            count == 2
+        )  # slots 9-10 (ends 10:00) and 10-11 (ends 11:00) ended by 12:00
+        assert tracker.find_record(_slot_start(9)).finalised  # type: ignore[union-attr]
+        assert tracker.find_record(_slot_start(10)).finalised  # type: ignore[union-attr]
+        assert not tracker.find_record(_slot_start(13)).finalised  # type: ignore[union-attr]
+
+    def test_prune_exceeds_max(self) -> None:
+        """Old records are pruned when the buffer exceeds max_slots."""
+        tracker = ForecastTracker(max_slots=3)
+        for i in range(5):
+            tracker.get_or_create_record(_slot_start(10 + i), _slot_start(11 + i))
+        assert len(tracker.records) == 3
+        # Oldest two were pruned
+        assert tracker.find_record(_slot_start(10)) is None
+        assert tracker.find_record(_slot_start(11)) is None
+        assert tracker.find_record(_slot_start(12)) is not None
+
+    def test_set_forecasts(self) -> None:
+        """set_forecasts stores the PV and load forecast."""
+        tracker = ForecastTracker()
+        tracker.get_or_create_record(_slot_start(10), _slot_start(11))
+        assert tracker.set_forecasts(_slot_start(10), 4.0, 2.0)
+        rec = tracker.find_record(_slot_start(10))
+        assert rec is not None
+        assert rec.forecast_pv_kwh == pytest.approx(4.0)
+        assert rec.forecast_load_kwh == pytest.approx(2.0)
+
+    def test_set_forecasts_no_record(self) -> None:
+        """set_forecasts returns False when the record doesn't exist."""
+        tracker = ForecastTracker()
+        assert not tracker.set_forecasts(_slot_start(10), 4.0, 2.0)
+
+    def test_set_forecasts_already_finalised(self) -> None:
+        """set_forecasts returns False when the record is finalised."""
+        tracker = ForecastTracker()
+        tracker.get_or_create_record(_slot_start(10), _slot_start(11))
+        tracker.finalise_record(_slot_start(10))
+        assert not tracker.set_forecasts(_slot_start(10), 4.0, 2.0)
+
+
+# ---------------------------------------------------------------------------
+# ForecastTracker — summary computation
+# ---------------------------------------------------------------------------
+
+
+class _SummaryTracker(ForecastTracker):
+    """Helper that creates and finalises records with given forecast/actual pairs."""
+
+    def add(
+        self,
+        hour: int,
+        forecast_pv: float,
+        forecast_load: float,
+        actual_pv: float,
+        actual_load: float,
+    ) -> None:
+        start = _slot_start(hour)
+        end = _slot_start(hour + 1)
+        rec = self.get_or_create_record(start, end)
+        rec.forecast_pv_kwh = forecast_pv
+        rec.forecast_load_kwh = forecast_load
+        rec.actual_pv_kwh = actual_pv
+        rec.actual_load_kwh = actual_load
+        rec.finalise()
+
+
+class TestForecastTrackerSummary:
+    """Tests for aggregate summary computation."""
+
+    def test_empty_tracker(self) -> None:
+        """Empty tracker returns empty summary."""
+        tracker = ForecastTracker()
+        s = tracker.summary
+        assert s.finalised_count == 0
+        assert s.window_slots == 0
+        assert s.mae_pv_kwh == pytest.approx(0.0)
+        assert s.mae_load_kwh == pytest.approx(0.0)
+        assert s.bias_pv_kwh == pytest.approx(0.0)
+        assert s.bias_load_kwh == pytest.approx(0.0)
+
+    def test_exact_match(self) -> None:
+        """Perfect forecasts produce zero error."""
+        tracker = _SummaryTracker()
+        tracker.add(
+            10, forecast_pv=3.0, forecast_load=2.0, actual_pv=3.0, actual_load=2.0
+        )
+        s = tracker.summary
+        assert s.finalised_count == 1
+        assert s.mae_pv_kwh == pytest.approx(0.0)
+        assert s.mae_load_kwh == pytest.approx(0.0)
+        assert s.bias_pv_kwh == pytest.approx(0.0)
+        assert s.bias_load_kwh == pytest.approx(0.0)
+        assert s.rmse_pv_kwh == pytest.approx(0.0)
+        assert s.rmse_load_kwh == pytest.approx(0.0)
+        assert s.mape_pv_pct == pytest.approx(0.0)
+        assert s.mape_load_pct == pytest.approx(0.0)
+
+    def test_over_forecast(self) -> None:
+        """Over-forecast (predicted > actual) shows positive bias."""
+        tracker = _SummaryTracker()
+        tracker.add(
+            10, forecast_pv=5.0, forecast_load=3.0, actual_pv=4.0, actual_load=2.0
+        )
+        s = tracker.summary
+        assert s.bias_pv_kwh == pytest.approx(1.0)  # 5 - 4
+        assert s.bias_load_kwh == pytest.approx(1.0)  # 3 - 2
+        assert s.mae_pv_kwh == pytest.approx(1.0)
+        assert s.mae_load_kwh == pytest.approx(1.0)
+
+    def test_under_forecast(self) -> None:
+        """Under-forecast (predicted < actual) shows negative bias."""
+        tracker = _SummaryTracker()
+        tracker.add(
+            10, forecast_pv=3.0, forecast_load=1.0, actual_pv=4.0, actual_load=2.0
+        )
+        s = tracker.summary
+        assert s.bias_pv_kwh == pytest.approx(-1.0)  # 3 - 4
+        assert s.bias_load_kwh == pytest.approx(-1.0)  # 1 - 2
+
+    def test_mixed_forecasts(self) -> None:
+        """Multiple slots produce averaged metrics."""
+        tracker = _SummaryTracker()
+        # Slot 1: over-forecast PV
+        tracker.add(
+            10, forecast_pv=5.0, forecast_load=2.0, actual_pv=4.0, actual_load=2.0
+        )
+        # Slot 2: under-forecast PV
+        tracker.add(
+            11, forecast_pv=3.0, forecast_load=2.0, actual_pv=4.0, actual_load=2.0
+        )
+
+        s = tracker.summary
+        assert s.finalised_count == 2
+        # MAE: (|5-4| + |3-4|) / 2 = 1.0
+        assert s.mae_pv_kwh == pytest.approx(1.0)
+        # Bias: (1 + -1) / 2 = 0.0 (cancels out)
+        assert s.bias_pv_kwh == pytest.approx(0.0)
+        # RMSE: sqrt((1^2 + (-1)^2) / 2) = 1.0
+        assert s.rmse_pv_kwh == pytest.approx(1.0)
+
+    def test_mape_pv_division_by_zero(self) -> None:
+        """MAPE returns None when actual PV is zero for all slots."""
+        tracker = _SummaryTracker()
+        tracker.add(
+            10, forecast_pv=1.0, forecast_load=2.0, actual_pv=0.0, actual_load=2.0
+        )
+        s = tracker.summary
+        assert s.mape_pv_pct is None
+        assert s.mape_load_pct == pytest.approx(0.0)
+
+    def test_mape_load_division_by_zero(self) -> None:
+        """MAPE returns None when actual load is zero for all slots."""
+        tracker = _SummaryTracker()
+        tracker.add(
+            10, forecast_pv=1.0, forecast_load=1.0, actual_pv=1.0, actual_load=0.0
+        )
+        s = tracker.summary
+        assert s.mape_pv_pct == pytest.approx(0.0)
+        assert s.mape_load_pct is None
+
+    def test_single_slot_mape(self) -> None:
+        """Single slot MAPE computation is correct."""
+        tracker = _SummaryTracker()
+        # PV: |5-4|/4 = 0.25 = 25%
+        # Load: |3-2|/2 = 0.50 = 50%
+        tracker.add(
+            10, forecast_pv=5.0, forecast_load=3.0, actual_pv=4.0, actual_load=2.0
+        )
+        s = tracker.summary
+        assert s.mape_pv_pct == pytest.approx(25.0)
+        assert s.mape_load_pct == pytest.approx(50.0)
+
+    def test_summary_as_dict(self) -> None:
+        """as_dict returns a JSON-safe dictionary."""
+        tracker = _SummaryTracker()
+        tracker.add(
+            10, forecast_pv=5.0, forecast_load=3.0, actual_pv=4.0, actual_load=2.0
+        )
+        d = tracker.summary.as_dict()
+        assert isinstance(d, dict)
+        assert d["mae_pv_kwh"] == 1.0
+        assert d["finalised_slots"] == 1
+        assert d["window_slots"] == 1
+        assert d["mape_pv_pct"] == 25.0
+        assert d["mape_load_pct"] == 50.0
+
+
+# ---------------------------------------------------------------------------
+# Integration-style: full lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestForecastTrackerIntegration:
+    """Full lifecycle: accumulate, finalise, compute summary."""
+
+    def test_full_cycle_single_slot(self) -> None:
+        """Simulates a single slot: register forecasts, accumulate 4x, finalise."""
+        tracker = ForecastTracker()
+
+        # Register forecasts
+        tracker.get_or_create_record(_slot_start(10), _slot_start(11))
+        tracker.set_forecasts(_slot_start(10), pv_kwh=4.0, load_kwh=2.0)
+
+        # Accumulate 4x over a 15-min slot (simulating 4 coordinator cycles)
+        slot_energy_pv = compute_accumulated_energy(
+            4000.0, 225.0
+        )  # 4000W for 225s = 0.25 kWh each
+        slot_energy_load = compute_accumulated_energy(
+            2000.0, 225.0
+        )  # 2000W for 225s = 0.125 kWh each
+
+        for _ in range(4):
+            rec = tracker.find_record(_slot_start(10))
+            assert rec is not None
+            rec.accumulate_pv(slot_energy_pv)
+            rec.accumulate_load(slot_energy_load)
+
+        # Finalise
+        tracker.finalise_record(_slot_start(10))
+
+        # Check
+        s = tracker.summary
+        assert s.finalised_count == 1
+        # Actual: 4 * 0.25 = 1.0 kWh PV, 4 * 0.125 = 0.5 kWh load
+        assert s.mae_pv_kwh == pytest.approx(abs(4.0 - 1.0))
+        assert s.mae_load_kwh == pytest.approx(abs(2.0 - 0.5))
+
+    def test_two_slots_over_forecast_and_under_forecast(self) -> None:
+        """Two sequential slots: one over-forecast, one under-forecast."""
+        tracker = ForecastTracker()
+
+        # Slot 10-11: over-forecast PV
+        tracker.get_or_create_record(_slot_start(10), _slot_start(11))
+        tracker.set_forecasts(_slot_start(10), pv_kwh=5.0, load_kwh=2.0)
+        rec = tracker.find_record(_slot_start(10))
+        assert rec is not None
+        rec.accumulate_pv(3.0)
+        rec.accumulate_load(2.0)
+        tracker.finalise_record(_slot_start(10))
+
+        # Slot 11-12: exact match load, slight under-forecast PV
+        tracker.get_or_create_record(_slot_start(11), _slot_start(12))
+        tracker.set_forecasts(_slot_start(11), pv_kwh=2.0, load_kwh=3.0)
+        rec = tracker.find_record(_slot_start(11))
+        assert rec is not None
+        rec.accumulate_pv(3.0)
+        rec.accumulate_load(3.0)
+        tracker.finalise_record(_slot_start(11))
+
+        s = tracker.summary
+        assert s.finalised_count == 2
+        # PV MAE: (|5-3| + |2-3|) / 2 = (2 + 1) / 2 = 1.5
+        assert s.mae_pv_kwh == pytest.approx(1.5)
+        # PV bias: (2 + -1) / 2 = 0.5  (over-forecast dominates)
+        assert s.bias_pv_kwh == pytest.approx(0.5)
+
+    def test_finalise_past_records_updates_summary(self) -> None:
+        """finalise_past_records updates the summary."""
+        tracker = ForecastTracker()
+
+        now = _slot_start(12)
+        # Create a past slot
+        tracker.get_or_create_record(_slot_start(9), _slot_start(10))
+        tracker.set_forecasts(_slot_start(9), pv_kwh=4.0, load_kwh=2.0)
+        rec = tracker.find_record(_slot_start(9))
+        assert rec is not None
+        rec.accumulate_pv(4.0)
+        rec.accumulate_load(2.0)
+        # Not yet finalised
+
+        # Create a current slot
+        tracker.get_or_create_record(_slot_start(10), _slot_start(11))
+        tracker.set_forecasts(_slot_start(10), pv_kwh=3.0, load_kwh=1.0)
+        rec = tracker.find_record(_slot_start(10))
+        assert rec is not None
+        rec.accumulate_pv(3.0)
+        rec.accumulate_load(1.0)
+
+        # Before finalise: empty summary
+        assert tracker.summary.finalised_count == 0
+
+        # Finalise past
+        count = tracker.finalise_past_records(now)
+        assert count == 2  # both slot 9-10 and 10-11 have ended by 12:00
+
+        # After finalise: summary has 2 entries
+        assert tracker.summary.finalised_count == 2
+        assert tracker.summary.mae_pv_kwh == pytest.approx(0.0)

--- a/tests/test_ha_mock_integration.py
+++ b/tests/test_ha_mock_integration.py
@@ -238,6 +238,12 @@ def make_bare_coordinator(
 
     coord._cfg = build_sensor_config(config_entry)
 
+    # Forecast-vs-actual tracking (issue #373)
+    from custom_components.hsem.utils.forecast_tracker import ForecastTracker
+
+    coord._forecast_tracker = ForecastTracker(max_slots=192)
+    coord._last_accumulation_ts = None
+
     # CoordinatorEntity support — some entity methods call this
     coord.async_set_updated_data = MagicMock()
 


### PR DESCRIPTION
## Summary

Adds predicted-vs-actual tracking for HSEM PV and load forecasts. Each coordinator cycle accumulates actual PV and load energy from instantaneous power readings, compares them with forecasted values from the planner, and exposes diagnostic metrics through a new sensor that persists across HA restarts.

## New files
- **utils/forecast_tracker.py** — ForecastTracker class with rolling ring-buffer, serialization (to_dict/from_dict/load_from_dict), ForecastSlotRecord dataclass, ForecastErrorSummary with MAE/bias/RMSE/MAPE
- **custom_sensors/forecast_accuracy_sensor.py** — HSEMForecastAccuracySensor diagnostic sensor exposing all error metrics plus serialized tracker data in attributes for reboot persistence via async_added_to_hass/async_get_last_state
- **tests/test_forecast_tracker.py** — 31 tests covering exact match, over-forecast, under-forecast, empty tracker, MAPE division-by-zero, prune, idempotent finalise, serialization round-trip, and full lifecycle
- **docs/forecast-accuracy-tracking.md** — Full technical guide with architecture diagram, metric formulas, sensor attributes table, template examples, and test coverage

## Modified files
- **coordinator.py** — Integrates tracker with _forecast_tracker instance, _accumulate_forecast_actuals() called every cycle, _register_forecasts_from_planner() after planner runs
- **sensor.py** — Registers HSEMForecastAccuracySensor
- **utils/sensornames.py** — Name/unique_id/entity_id helpers for the new sensor
- **tests/test_ha_mock_integration.py** — Added _forecast_tracker and _last_accumulation_ts to make_bare_coordinator() (bypasses __init__, was missing new attrs)

## Reboot persistence
- ForecastSlotRecord.to_dict()/from_dict() serialize to ISO-format timestamps
- ForecastTracker.to_dict()/load_from_dict() full state round-trip
- Sensor embeds _forecast_tracker_data in extra_state_attributes (HA recorder persists automatically)
- async_added_to_hass restores tracker state from last saved attributes on HA restart

## What does NOT change
- No planner behavior changes - purely diagnostic
- No config flow changes, feature flags, or new options
- No hardware write changes

## Quality checks
All passing:
- ruff check: All checks passed
- ruff format: 96 files already formatted
- pyright on changed files: 0 errors
- vulture: No dead code found

## Acceptance criteria
- HSEM records forecast error over time
- Diagnostics show PV forecast error
- Diagnostics show load forecast error
- Tests cover under-forecast, over-forecast, and exact match
- No planner behavior changes unless explicitly gated
- Data persists across HA restarts
- All existing integration tests pass (117 tests in test_ha_mock_integration.py)

Fixes #373