### PR TITLE
fix: implement async_set_grid_export_power_watt with 100W floor instead of 0%

### DIFF
--- a/custom_components/hsem/const.py
+++ b/custom_components/hsem/const.py
@@ -195,6 +195,15 @@ RELIABILITY_EPS = 0.05  # kWh; prevents division by zero and over-sensitivity
 RELIABILITY_SCALE_STRENGTH = 1.00  # 1.0 = full effect; lower to soften
 
 # ---------------------------------------------------------------------------
+# Grid export power limit (watts)
+# ---------------------------------------------------------------------------
+
+# Grid export limit in watts when export should be blocked (instead of 0%).
+# Setting 0% export via the percentage-based service is not well handled by
+# the inverter; a 100 W floor is used instead.
+GRID_EXPORT_LIMIT_WATT = 100
+
+# ---------------------------------------------------------------------------
 # Planner power thresholds (kWh per slot)
 # ---------------------------------------------------------------------------
 

--- a/custom_components/hsem/custom_sensors/applier.py
+++ b/custom_components/hsem/custom_sensors/applier.py
@@ -37,6 +37,7 @@ from custom_components.hsem.const import (
     DEFAULT_HSEM_BATTERIES_WAIT_MODE,
     DEFAULT_HSEM_EV_CHARGER_TOU_MODES,
     DEFAULT_HSEM_TOU_MODES_FORCE_CHARGE,
+    GRID_EXPORT_LIMIT_WATT,
 )
 from custom_components.hsem.models.hourly_recommendation import HourlyRecommendation
 from custom_components.hsem.models.live_state import LiveState
@@ -45,6 +46,7 @@ from custom_components.hsem.utils.degraded_mode import hardware_writes_allowed
 from custom_components.hsem.utils.huawei import (
     async_set_forcible_discharge,
     async_set_grid_export_power_pct,
+    async_set_grid_export_power_watt,
     async_set_tou_periods,
 )
 from custom_components.hsem.utils.inverter_verify import (
@@ -165,15 +167,44 @@ async def async_apply_inverter_power_control(
     )
 
     current_pct = _parse_power_control_pct(live.huawei_inverter_active_power_control)
-    if current_pct is not None and current_pct != export_pct:
-        for inv_id in [
-            cfg.huawei_solar_device_id_inverter_1,
-            cfg.huawei_solar_device_id_inverter_2,
-        ]:
-            if inv_id is None:
-                continue
+    current_is_watt = _is_watt_limit(live.huawei_inverter_active_power_control)
 
-            inv_entity = cfg.huawei_solar_inverter_active_power_control
+    for inv_id in [
+        cfg.huawei_solar_device_id_inverter_1,
+        cfg.huawei_solar_device_id_inverter_2,
+    ]:
+        if inv_id is None:
+            continue
+
+        inv_entity = cfg.huawei_solar_inverter_active_power_control
+        reader_fn = lambda: _parse_power_control_pct(
+            sensor.hass.states.get(inv_entity).state
+            if inv_entity and sensor.hass.states.get(inv_entity) is not None
+            else None
+        )
+
+        if export_pct == 0:
+            # Block export → set a soft floor at GRID_EXPORT_LIMIT_WATT.
+            desired = GRID_EXPORT_LIMIT_WATT
+            if current_pct is not None and current_is_watt and current_pct == desired:
+                continue  # already at the watt limit
+
+            result = await async_write_and_verify(
+                entity_id=inv_entity or f"inverter:{inv_id}",
+                desired=desired,
+                writer=lambda _id=inv_id, _w=desired: async_set_grid_export_power_watt(
+                    sensor, _id, _w
+                ),
+                reader=reader_fn,
+            )
+        else:
+            # export_pct == 100 — Allow full export.
+            if (
+                current_pct is not None
+                and not current_is_watt
+                and current_pct == export_pct
+            ):
+                continue  # already at unlimited / 100 %
 
             result = await async_write_and_verify(
                 entity_id=inv_entity or f"inverter:{inv_id}",
@@ -181,22 +212,20 @@ async def async_apply_inverter_power_control(
                 writer=lambda _id=inv_id, _pct=export_pct: (
                     async_set_grid_export_power_pct(sensor, _id, _pct)
                 ),
-                reader=lambda: _parse_power_control_pct(
-                    sensor.hass.states.get(inv_entity).state
-                    if inv_entity and sensor.hass.states.get(inv_entity) is not None
-                    else None
-                ),
+                reader=reader_fn,
             )
-            summary.results.append(result)
 
-            if result.status == ApplyStatus.FAILED:
-                await async_logger(
-                    sensor,
-                    f"Export power % write FAILED for inverter {inv_id} after all retries. "
-                    f"Blocking further writes this cycle.",
-                    "error",
-                )
-                return summary
+        summary.results.append(result)
+
+        if result.status == ApplyStatus.FAILED:
+            mode = "W" if export_pct == 0 else "%"
+            await async_logger(
+                sensor,
+                f"Export power {mode} write FAILED for inverter {inv_id} after all retries. "
+                f"Blocking further writes this cycle.",
+                "error",
+            )
+            return summary
 
     return summary
 
@@ -536,14 +565,18 @@ def _read_select_state(sensor, entity_id: str | None) -> str | None:
 
 
 def _parse_power_control_pct(state: str | None) -> int | None:
-    """Parse the inverter active power control state string into a percentage.
+    """Parse the inverter active power control state string into a numeric value.
+
+    Handles both percentage (``"Limited to 80%"`` → 80) and watt-based
+    (``"Limited to 100W"`` → 100) formats.  ``"Unlimited"`` returns 100.
 
     Args:
-        state: Raw string from the inverter entity (e.g. ``"Unlimited"`` or
-               ``"Limited to 80%"``).
+        state: Raw string from the inverter entity (e.g. ``"Unlimited"``,
+               ``"Limited to 80%"``, or ``"Limited to 100W"``).
 
     Returns:
-        Integer percentage, or ``None`` if the string cannot be parsed.
+        Integer value (percentage or watts), or ``None`` if the string
+        cannot be parsed.
     """
     if not isinstance(state, str):
         return None
@@ -559,18 +592,45 @@ def _parse_power_control_pct(state: str | None) -> int | None:
         "không giới hạn",
     ):
         return 100
-    # Extract numeric percentage regardless of surrounding translated text.
-    # Strategy: strip everything that is not a digit, dot, or minus sign,
-    # then parse the remaining number.  This handles patterns like:
-    #   "Limited to 80%"  →  80
+    # Extract the numeric value regardless of surrounding translated text or
+    # unit suffix (% or W).  This handles patterns like:
+    #   "Limited to 80%"   →  80
+    #   "Limited to 100W"  →  100
     #   "Begrenzt auf 80 %"  →  80
     #   "Beperkt tot 80%"  →  80
-    if "%" in normalized:
-        # Extract the numeric value regardless of surrounding translated text
-        match = re.search(r"(-?\d+(?:\.\d+)?)", normalized)
-        if match:
-            try:
-                return int(round(float(match.group(1))))
-            except (ValueError, TypeError):
-                pass
+    match = re.search(r"(-?\d+(?:\.\d+)?)", normalized)
+    if match:
+        try:
+            return int(round(float(match.group(1))))
+        except (ValueError, TypeError):
+            pass
     return None
+
+
+def _is_watt_limit(state: str | None) -> bool:
+    """Check if the power control state represents a watt-based limit.
+
+    Args:
+        state: Raw string from the inverter entity (e.g. ``"Limited to 100W"``
+               or ``"Limited to 80%"``).
+
+    Returns:
+        ``True`` if the state is a watt-based limit, ``False`` otherwise
+        (percentage-based or unlimited).
+    """
+    if not isinstance(state, str):
+        return False
+    normalized = state.strip().lower()
+    # Unlimited / percentage-based states never contain a watt indicator
+    if normalized in (
+        "unlimited",
+        "ikke begrænset",
+        "onbeperkt",
+        "unbegrenzt",
+        "illimitato",
+        "sin límite",
+        "không giới hạn",
+    ):
+        return False
+    # Look for a number immediately followed (with optional whitespace) by "w"
+    return bool(re.search(r"\d+\s*w", normalized))

--- a/custom_components/hsem/utils/huawei.py
+++ b/custom_components/hsem/utils/huawei.py
@@ -6,6 +6,9 @@ Functions:
     async_set_grid_export_power_pct(self, device_id, power_percentage):
         Asynchronously sets the maximum grid export power percentage for a specified device.
 
+    async_set_grid_export_power_watt(self, device_id, power_watt):
+        Asynchronously sets the maximum grid export power in watts for a specified device.
+
     async_set_tou_periods(self, batteries_id, tou_modes):
         Asynchronously sets the Time-of-Use (TOU) periods for specified batteries.
 
@@ -85,6 +88,66 @@ async def async_set_grid_export_power_pct(self, device_id, power_percentage) -> 
             "(device_id=%s, power_percentage=%s)",
             device_id,
             power_percentage,
+        )
+        raise
+
+
+async def async_set_grid_export_power_watt(self, device_id, power_watt) -> None:
+    """Set the maximum grid export power in watts and handle errors.
+
+    Uses the ``huawei_solar.set_maximum_feed_grid_power`` service to set an
+    absolute power limit in watts (instead of a percentage).  This is used
+    as a soft floor (e.g. 100 W) when the system wants to block exports but
+    the inverter does not handle a 0 % percentage limit well.
+
+    Raises:
+        ServiceNotFound: When the huawei_solar service is not registered in HA.
+        HomeAssistantError: On any other HA-level write failure.
+    """
+
+    # Raise explicitly so callers (write-and-verify) can record the failure.
+    if not self.hass.services.has_service(
+        "huawei_solar", "set_maximum_feed_grid_power"
+    ):
+        raise ServiceNotFound("huawei_solar", "set_maximum_feed_grid_power")
+
+    try:
+        # Send the service call to set the maximum grid export power in watts.
+        # blocking=True propagates service exceptions back to the caller so that
+        # write-and-verify can record the failure and retry.
+        await self.hass.services.async_call(
+            "huawei_solar",
+            "set_maximum_feed_grid_power",
+            {
+                "device_id": device_id,
+                "power": power_watt,
+            },
+            blocking=True,
+        )
+
+        # Log success message
+        _LOGGER.debug(
+            "Updated export power to %s W for device_id %s",
+            power_watt,
+            device_id,
+        )
+
+    except vol.Invalid as err:
+        # Handle validation errors (e.g., invalid device_id or power_watt)
+        _LOGGER.exception(
+            "Invalid input for set_maximum_feed_grid_power "
+            "(device_id=%s, power_watt=%s)",
+            device_id,
+            power_watt,
+        )
+        raise HomeAssistantError(f"Invalid input data: {err}") from err
+
+    except (ServiceNotFound, ServiceValidationError, HomeAssistantError):
+        # Service missing or HA rejected the call
+        _LOGGER.exception(
+            "HA error during set_maximum_feed_grid_power (device_id=%s, power_watt=%s)",
+            device_id,
+            power_watt,
         )
         raise
 


### PR DESCRIPTION
## Summary

The inverter does not handle a 0% grid export limit well. Instead of setting export to 0% via the percentage-based service, this PR implements a 100 W soft floor using the watt-based `huawei_solar.set_maximum_feed_grid_power` service.

## Changes

- **`const.py`** — Added `GRID_EXPORT_LIMIT_WATT = 100` constant
- **`utils/huawei.py`** — Added `async_set_grid_export_power_watt(self, device_id, power_watt)` calling `huawei_solar.set_maximum_feed_grid_power`
- **`custom_sensors/applier.py`**:
  - `_parse_power_control_pct()` — Now extracts numeric values from both `%` and `W` suffixed strings
  - `_is_watt_limit()` — New helper to distinguish watt-based from percentage-based states
  - `async_apply_inverter_power_control()` — When `export_pct == 0` (block export), uses the watt-based writer with `GRID_EXPORT_LIMIT_WATT` instead of setting 0% via the percentage service. Includes proper compare-and-skip logic to avoid false skips between watt and percentage modes.

## Testing

- All three modified files compile without errors (`py_compile` verified)
- `tox -e lint` — All checks passed
- `tox -e quality` — 0 errors, only pre-existing warnings unrelated to this change