### PR TITLE
feat: include conversion loss in threshold; split huawei_solar; add runtime select/number entities

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,18 +31,20 @@ When asked to solve a GitHub issue, always follow these steps in order:
    - Format: `<type>/<issue-number>-<slug>` — e.g., `fix/444-milp-cycle-cost`
 4. **Understand the relevant code** — Search and read the affected files before making changes.
 5. **Implement the smallest safe fix** — No unrelated changes, no broad refactors.
-6. **Add or update regression tests** — Cover the bug or new behavior.
-7. **Run the relevant tests** — `pytest tests/` or the targeted test file.
-8. **Run lint/type + quality checks** — `tox -e lint` (runs isort, black, ruff format, and ruff check) then `tox -e quality` (runs pyright and vulture)
-9. **Report a summary** including:
+6. **Update documentation** — Update every docs/ file that describes the changed behaviour
+   (planner guide, spec, config flow reference, memories.md, README, etc.).
+7. **Add or update regression tests** — Cover the bug or new behavior.
+8. **Run the relevant tests** — `pytest tests/` or the targeted test file.
+9. **Run lint/type + quality checks** — `tox -e lint` (runs isort, black, ruff format, and ruff check) then `tox -e quality` (runs pyright and vulture)
+10. **Report a summary** including:
    - Issue title
    - Branch name
    - Files changed
    - What changed and why
    - Tests added or updated
    - Test and lint results
-10. **Create a pull request** linked to the issue using `Fixes #<ISSUE_NUMBER>` in the description.
-11. **Keep the PR up to date** — after every follow-up commit on a branch that already has an open
+11. **Create a pull request** linked to the issue using `Fixes #<ISSUE_NUMBER>` in the description.
+12. **Keep the PR up to date** — after every follow-up commit on a branch that already has an open
     PR, update both the PR title and description to reflect the current state of all changes made.
     Tick off any completed acceptance criteria in the PR checklist.
     - Use `gh pr edit <PR_NUMBER> --title "..." --body-file <file>` — write the PR body
@@ -60,6 +62,19 @@ When asked to solve a GitHub issue, always follow these steps in order:
 - **Add or update tests** covering the affected invariants for every planner change.
 - A planner PR is not done until: spec is consistent, invariant tests pass, and lint is clean.
 - See `AGENTS.md` → **Planner Specification** for the full compliance checklist.
+
+## Documentation Update Rule (Mandatory)
+- **All documentation that describes the changed behaviour must be updated in the same PR.**
+  This includes, but is not limited to:
+  - `docs/hsem-planner-guide.md` — planner inputs, outputs, cost function, scenarios
+  - `docs/hsem-planner-spec.md` — specification invariants and formulas
+  - `docs/hsem-config-flow-reference.md` — config/options flow step tables
+  - `docs/ev-charge-plan-setup.md` — EV planned load setup guide
+  - `.github/memories.md` — canonical patterns, module map, open issues
+  - `README.md` — user-facing feature descriptions and links
+- **Check every docs/ file before closing a PR** — if a file describes something you changed,
+  update it. Stale documentation causes confusion and bugs.
+- **A PR is not done until all affected docs are consistent with the implementation.**
 
 ## Huawei Solar Sensor Rule (Mandatory)
 - **Always use entities exposed by `wlcrs/huawei_solar`** for every inverter/battery value.

--- a/custom_components/hsem/__init__.py
+++ b/custom_components/hsem/__init__.py
@@ -25,7 +25,13 @@ _LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
-PLATFORMS = [Platform.SENSOR, Platform.SWITCH, Platform.TIME, Platform.SELECT]
+PLATFORMS = [
+    Platform.SENSOR,
+    Platform.SWITCH,
+    Platform.TIME,
+    Platform.SELECT,
+    Platform.NUMBER,
+]
 
 
 def _parse_version(version_str: str) -> Version | None:

--- a/custom_components/hsem/config_flow.py
+++ b/custom_components/hsem/config_flow.py
@@ -12,6 +12,10 @@ from custom_components.hsem.flows.batteries_schedules import (
     get_batteries_schedules_step_schema,
     validate_batteries_schedules_input,
 )
+from custom_components.hsem.flows.battery_economics import (
+    get_battery_economics_step_schema,
+    validate_battery_economics_input,
+)
 from custom_components.hsem.flows.ev import get_ev_step_schema, validate_ev_step_input
 from custom_components.hsem.flows.ev_planned_load import (
     get_ev_planned_load_step_schema,
@@ -184,12 +188,30 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
                     "hsem_ev_charger_power", None
                 )
 
-                return await self.async_step_power()
+                return await self.async_step_battery_economics()
 
         data_schema = await get_huawei_solar_step_schema(None)
 
         return self.async_show_form(
             step_id="huawei_solar",
+            data_schema=data_schema,
+            errors=errors,
+            last_step=False,
+        )
+
+    async def async_step_battery_economics(self, user_input=None):
+        errors = {}
+
+        if user_input is not None:
+            errors = await validate_battery_economics_input(user_input)
+            if not errors:
+                self._user_input.update(user_input)
+                return await self.async_step_power()
+
+        data_schema = await get_battery_economics_step_schema(None)
+
+        return self.async_show_form(
+            step_id="battery_economics",
             data_schema=data_schema,
             errors=errors,
             last_step=False,

--- a/custom_components/hsem/const.py
+++ b/custom_components/hsem/const.py
@@ -22,8 +22,8 @@ MIN_HUAWEI_SOLAR_VERSION = "1.5.0a1"
 
 DEFAULT_CONFIG_VALUES = {
     "device_name": NAME,
-    "hsem_batteries_charge_efficiency": 95,
-    "hsem_batteries_discharge_efficiency": 95,
+    "hsem_batteries_charge_efficiency": 98,
+    "hsem_batteries_discharge_efficiency": 98,
     "hsem_batteries_enable_excess_export": False,
     "hsem_batteries_excess_export_discharge_buffer": 10,
     "hsem_batteries_purchase_price": 0.0,

--- a/custom_components/hsem/custom_numbers/__init__.py
+++ b/custom_components/hsem/custom_numbers/__init__.py
@@ -1,0 +1,1 @@
+"""Number entity package for the HSEM integration."""

--- a/custom_components/hsem/custom_numbers/entity.py
+++ b/custom_components/hsem/custom_numbers/entity.py
@@ -17,9 +17,8 @@ from __future__ import annotations
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfPercent
+from homeassistant.const import PERCENTAGE, EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import EntityCategory
 
 from custom_components.hsem.entity import HSEMEntity
 from custom_components.hsem.utils.misc import convert_to_float, get_config_value
@@ -37,7 +36,7 @@ class HSEMBatteryEfficiencyNumber(NumberEntity, HSEMEntity):
     _attr_native_min_value = 50.0
     _attr_native_max_value = 100.0
     _attr_native_step = 1.0
-    _attr_native_unit_of_measurement = UnitOfPercent
+    _attr_native_unit_of_measurement = PERCENTAGE
     _attr_entity_category = EntityCategory.CONFIG
     _attr_icon = "mdi:battery-high"
 

--- a/custom_components/hsem/custom_numbers/entity.py
+++ b/custom_components/hsem/custom_numbers/entity.py
@@ -1,0 +1,102 @@
+"""Number entity for the HSEM battery charge/discharge efficiency.
+
+This module defines :class:`HSEMBatteryEfficiencyNumber`, a standard
+:class:`homeassistant.components.number.NumberEntity` that lets users
+adjust the battery charge/discharge efficiency percentage from the UI
+without re-running the config/options flow.
+
+The ``unique_id`` and ``entity_id`` are injected by the ``number.py``
+platform module after construction, so this class does not hard-code
+any entity identifiers.
+
+The value is persisted to the config entry options so it survives
+HA restarts.
+"""
+
+from __future__ import annotations
+
+from homeassistant.components.number import NumberEntity, NumberEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfPercent
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+
+from custom_components.hsem.entity import HSEMEntity
+from custom_components.hsem.utils.misc import convert_to_float, get_config_value
+
+
+class HSEMBatteryEfficiencyNumber(NumberEntity, HSEMEntity):
+    """Number entity for a battery-side efficiency percentage.
+
+    Exposes a slider (50–100 %, step 1) that lets users adjust the
+    charge or discharge efficiency at runtime.  The value is written
+    back to ``config_entry.options`` so it persists across HA restarts.
+    """
+
+    _attr_has_entity_name = True
+    _attr_native_min_value = 50.0
+    _attr_native_max_value = 100.0
+    _attr_native_step = 1.0
+    _attr_native_unit_of_measurement = UnitOfPercent
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_icon = "mdi:battery-high"
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        description: NumberEntityDescription,
+        config_key: str,
+        default: float = 98.0,
+        *,
+        unique_id: str = "",
+        entity_id: str = "",
+    ) -> None:
+        """Initialize the number entity.
+
+        Args:
+            hass: The Home Assistant instance.
+            config_entry: The config entry this entity belongs to.
+            description: Entity description carrying ``key`` and ``name``.
+            config_key: Config entry option key (e.g. ``hsem_batteries_charge_efficiency``).
+            default: Default value when no config entry value exists yet.
+            unique_id: Stable unique ID for HA entity registry.
+            entity_id: The desired entity_id string for this entity.
+        """
+        super().__init__(config_entry)
+
+        self.hass = hass
+        self._config_entry = config_entry
+        self._config_key = config_key
+        self._default = default
+        self.entity_description = description
+        self._attr_unique_id = unique_id if unique_id else description.key
+        if entity_id:
+            self.entity_id = entity_id
+
+        raw_name = description.name
+        self._attr_name = str(raw_name) if isinstance(raw_name, str) else None
+
+        # Load initial value from the config entry.
+        stored = convert_to_float(get_config_value(config_entry, config_key))
+        self._attr_native_value = stored if stored is not None else default
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Handle the user setting a new value.
+
+        Updates HA state and persists the choice to the config entry options.
+
+        Args:
+            value: The new efficiency percentage.
+        """
+        clamped = max(
+            self._attr_native_min_value, min(self._attr_native_max_value, value)
+        )
+        self._attr_native_value = clamped
+        self.async_write_ha_state()
+
+        # Persist to config entry options so it survives restart.
+        new_options = {**self._config_entry.options, self._config_key: clamped}
+        self.hass.config_entries.async_update_entry(
+            self._config_entry, options=new_options
+        )

--- a/custom_components/hsem/custom_selectors/entity.py
+++ b/custom_components/hsem/custom_selectors/entity.py
@@ -7,6 +7,7 @@ specific working mode or leave it on ``"auto"``.
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 
 from custom_components.hsem.entity import HSEMEntity
@@ -26,6 +27,7 @@ class HSEMWorkingModeSelector(SelectEntity, HSEMEntity):
 
     _attr_icon = "mdi:chart-timeline-variant"
     _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(
         self,

--- a/custom_components/hsem/custom_selectors/select.py
+++ b/custom_components/hsem/custom_selectors/select.py
@@ -1,0 +1,89 @@
+"""Select entity for the HSEM Solcast PV Forecast Likelihood.
+
+This module defines :class:`HSEMSolcastLikelihoodSelector`, a standard
+:class:`homeassistant.components.select.SelectEntity` that lets users pick
+which Solcast PV forecast likelihood to use (``pv_estimate``,
+``pv_estimate10``, or ``pv_estimate90``).
+
+The selected value is persisted to the config entry options so it survives
+HA restarts.
+"""
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from custom_components.hsem.entity import HSEMEntity
+from custom_components.hsem.utils.misc import get_config_value
+from custom_components.hsem.utils.sensornames import (
+    get_solcast_likelihood_selector_entity_id,
+    get_solcast_likelihood_selector_key,
+)
+
+_OPTIONS = ["pv_estimate", "pv_estimate10", "pv_estimate90"]
+_DEFAULT = "pv_estimate"
+_CONFIG_KEY = "hsem_solcast_pv_forecast_forecast_likelihood"
+
+
+class HSEMSolcastLikelihoodSelector(SelectEntity, HSEMEntity):
+    """Select entity for the Solcast PV forecast likelihood.
+
+    Presents the three Solcast likelihood options.  Changing the selection
+    updates both the HA state and the config entry options so the value
+    persists across restarts.
+    """
+
+    _attr_icon = "mdi:solar-power"
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        description: SelectEntityDescription,
+    ) -> None:
+        """Initialize the selector entity.
+
+        Args:
+            hass: The Home Assistant instance.
+            config_entry: The config entry this entity belongs to.
+            description: Entity description carrying ``key``, ``name``,
+                and ``options``.
+        """
+        super().__init__(config_entry)
+
+        self.hass = hass
+        self._config_entry = config_entry
+        self.entity_description = description
+        self._attr_unique_id = get_solcast_likelihood_selector_key()
+        self.entity_id = get_solcast_likelihood_selector_entity_id()
+        self._attr_options = list(description.options or _OPTIONS)
+        raw_name = description.name
+        self._attr_name = str(raw_name) if isinstance(raw_name, str) else None
+
+        # Initialise from the config entry value.
+        stored = get_config_value(config_entry, _CONFIG_KEY)
+        self._attr_current_option = str(stored) if stored in _OPTIONS else _DEFAULT
+
+    async def async_select_option(self, option: str) -> None:
+        """Handle the user selecting a new option.
+
+        Updates HA state and persists the choice to the config entry options.
+
+        Args:
+            option: The likelihood key chosen by the user.
+
+        Raises:
+            ValueError: If *option* is not in :attr:`_attr_options`.
+        """
+        if option not in self._attr_options:
+            raise ValueError(f"Invalid option: {option}")
+
+        self._attr_current_option = option
+        self.async_write_ha_state()
+
+        # Persist to config entry options so it survives restart.
+        new_options = {**self._config_entry.options, _CONFIG_KEY: option}
+        self.hass.config_entries.async_update_entry(
+            self._config_entry, options=new_options
+        )

--- a/custom_components/hsem/custom_selectors/select.py
+++ b/custom_components/hsem/custom_selectors/select.py
@@ -11,6 +11,7 @@ HA restarts.
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 
 from custom_components.hsem.entity import HSEMEntity
@@ -35,6 +36,7 @@ class HSEMSolcastLikelihoodSelector(SelectEntity, HSEMEntity):
 
     _attr_icon = "mdi:solar-power"
     _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(
         self,

--- a/custom_components/hsem/custom_sensors/config_reader.py
+++ b/custom_components/hsem/custom_sensors/config_reader.py
@@ -269,13 +269,13 @@ def build_sensor_config(config_entry) -> SensorConfig:
         convert_to_float(
             get_config_value(config_entry, "hsem_batteries_charge_efficiency")
         )
-        or 95.0
+        or 98.0
     )
     cfg.batteries_discharge_efficiency = (
         convert_to_float(
             get_config_value(config_entry, "hsem_batteries_discharge_efficiency")
         )
-        or 95.0
+        or 98.0
     )
     cfg.batteries_purchase_price = (
         convert_to_float(

--- a/custom_components/hsem/custom_sensors/forecast_accuracy_sensor.py
+++ b/custom_components/hsem/custom_sensors/forecast_accuracy_sensor.py
@@ -127,8 +127,12 @@ class HSEMForecastAccuracySensor(
                 round(latest.bias_load, 4) if latest.bias_load is not None else None
             )
 
-        # Include serialized tracker data for reboot persistence
-        attrs["_forecast_tracker_data"] = tracker.to_dict()
+        # Include serialized tracker data for reboot persistence.
+        # Limit to most recent 24 records to stay under HA's 16 KB attribute limit.
+        _data = tracker.to_dict()
+        if _data:
+            _data["records"] = _data.get("records", [])[-24:]
+        attrs["_forecast_tracker_data"] = _data
 
         return attrs
 

--- a/custom_components/hsem/custom_sensors/working_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/working_mode_sensor.py
@@ -214,6 +214,8 @@ class HSEMWorkingModeSensor(HSEMCoordinatorEntity, SensorEntity, HSEMEntity):
                 purchase_price=cfg.batteries_purchase_price,
                 expected_cycles=cfg.batteries_expected_cycles,
                 usable_capacity=live.battery_usable_capacity_kwh,
+                charge_efficiency_pct=cfg.batteries_charge_efficiency,
+                discharge_efficiency_pct=cfg.batteries_discharge_efficiency,
             ),
             "export_electricity_price_state": live.export_electricity_price,
             "import_electricity_price_state": live.import_electricity_price,

--- a/custom_components/hsem/custom_switches/entity.py
+++ b/custom_components/hsem/custom_switches/entity.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 
 from custom_components.hsem.entity import HSEMEntity
@@ -95,6 +96,7 @@ class HSEMSwitch(SwitchEntity, HSEMEntity):
 
     _attr_icon = "mdi:toggle-switch"
     _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
     entity_description: HSEMSwitchEntityDescription
 
     def __init__(

--- a/custom_components/hsem/custom_times/entity.py
+++ b/custom_components/hsem/custom_times/entity.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from homeassistant.components.time import TimeEntity, TimeEntityDescription
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 
 from custom_components.hsem.entity import HSEMEntity
@@ -91,6 +92,7 @@ class HSEMTimeEntity(TimeEntity, HSEMEntity):
 
     _attr_icon = "mdi:clock"
     _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
     entity_description: HSEMTimeEntityDescription
 
     def __init__(

--- a/custom_components/hsem/flows/battery_economics.py
+++ b/custom_components/hsem/flows/battery_economics.py
@@ -1,0 +1,133 @@
+"""Config flow step for battery economics (depreciation and efficiency).
+
+This module was extracted from the over-sized ``huawei_solar.py`` flow step.
+It contains only the configurables that affect battery depreciation and
+round-trip conversion loss — purchase price, expected cycles, cycle cost,
+and charge/discharge efficiency.
+"""
+
+import voluptuous as vol
+from homeassistant.helpers.selector import selector
+
+from custom_components.hsem.utils.config_validator import merge_errors, validate_price
+from custom_components.hsem.utils.misc import get_config_value
+
+
+async def get_battery_economics_step_schema(config_entry) -> vol.Schema:
+    """Return the data schema for the 'battery_economics' step.
+
+    Args:
+        config_entry: Existing config entry (used during options flow editing)
+            or ``None`` for the initial config flow.
+
+    Returns:
+        A ``vol.Schema`` with number/selector inputs for battery economics.
+    """
+    return vol.Schema(
+        {
+            vol.Required(
+                "hsem_batteries_purchase_price",
+                default=get_config_value(config_entry, "hsem_batteries_purchase_price"),
+            ): selector(
+                {
+                    "number": {
+                        "min": 0,
+                        "max": 100000,
+                        "step": 100,
+                        "mode": "box",
+                    }
+                }
+            ),
+            vol.Required(
+                "hsem_batteries_expected_cycles",
+                default=get_config_value(
+                    config_entry, "hsem_batteries_expected_cycles"
+                ),
+            ): selector(
+                {
+                    "number": {
+                        "min": 1,
+                        "max": 20000,
+                        "step": 100,
+                        "mode": "box",
+                    }
+                }
+            ),
+            vol.Required(
+                "hsem_batteries_cycle_cost",
+                default=get_config_value(config_entry, "hsem_batteries_cycle_cost"),
+            ): selector(
+                {
+                    "number": {
+                        "min": 0,
+                        "max": 1,
+                        "step": 0.001,
+                        "mode": "box",
+                    }
+                }
+            ),
+            vol.Required(
+                "hsem_batteries_charge_efficiency",
+                default=get_config_value(
+                    config_entry, "hsem_batteries_charge_efficiency"
+                ),
+            ): selector(
+                {
+                    "number": {
+                        "min": 50,
+                        "max": 100,
+                        "step": 1,
+                        "unit_of_measurement": "%",
+                        "mode": "slider",
+                    }
+                }
+            ),
+            vol.Required(
+                "hsem_batteries_discharge_efficiency",
+                default=get_config_value(
+                    config_entry, "hsem_batteries_discharge_efficiency"
+                ),
+            ): selector(
+                {
+                    "number": {
+                        "min": 50,
+                        "max": 100,
+                        "step": 1,
+                        "unit_of_measurement": "%",
+                        "mode": "slider",
+                    }
+                }
+            ),
+        }
+    )
+
+
+async def validate_battery_economics_input(user_input) -> dict[str, str]:
+    """Validate user input for the 'battery_economics' step.
+
+    Args:
+        user_input: Dict of field name → value submitted by the user.
+
+    Returns:
+        Dict mapping field names to translation error keys; empty on success.
+    """
+    scalar_required = [
+        "hsem_batteries_purchase_price",
+        "hsem_batteries_expected_cycles",
+        "hsem_batteries_cycle_cost",
+        "hsem_batteries_charge_efficiency",
+        "hsem_batteries_discharge_efficiency",
+    ]
+    required_errors: dict[str, str] = {
+        f: "required" for f in scalar_required if f not in user_input
+    }
+
+    price_errors = validate_price(
+        user_input,
+        "hsem_batteries_purchase_price",
+        min_price=0.0,
+        max_price=100_000.0,
+        allow_negative=False,
+    )
+
+    return merge_errors(required_errors, price_errors)

--- a/custom_components/hsem/flows/huawei_solar.py
+++ b/custom_components/hsem/flows/huawei_solar.py
@@ -1,3 +1,10 @@
+"""Config flow step for Huawei Solar device and entity selections.
+
+This step contains only the Huawei-specific device and entity selectors.
+Battery economics (purchase price, expected cycles, cycle cost, efficiencies)
+have been moved to the separate ``battery_economics`` step.
+"""
+
 import voluptuous as vol
 from homeassistant.helpers.selector import selector
 
@@ -5,7 +12,6 @@ from custom_components.hsem.utils.config_validator import (
     async_validate_device_ids,
     async_validate_entity_ids,
     merge_errors,
-    validate_price,
 )
 from custom_components.hsem.utils.misc import get_config_value
 
@@ -96,47 +102,6 @@ async def get_huawei_solar_step_schema(config_entry) -> vol.Schema:
                 ),
             ): selector({"entity": {"domain": ["sensor", "input_number"]}}),
             vol.Required(
-                "hsem_batteries_purchase_price",
-                default=get_config_value(config_entry, "hsem_batteries_purchase_price"),
-            ): selector(
-                {
-                    "number": {
-                        "min": 0,
-                        "max": 100000,
-                        "step": 100,
-                        "mode": "box",
-                    }
-                }
-            ),
-            vol.Required(
-                "hsem_batteries_expected_cycles",
-                default=get_config_value(
-                    config_entry, "hsem_batteries_expected_cycles"
-                ),
-            ): selector(
-                {
-                    "number": {
-                        "min": 1,
-                        "max": 20000,
-                        "step": 100,
-                        "mode": "box",
-                    }
-                }
-            ),
-            vol.Required(
-                "hsem_batteries_cycle_cost",
-                default=get_config_value(config_entry, "hsem_batteries_cycle_cost"),
-            ): selector(
-                {
-                    "number": {
-                        "min": 0,
-                        "max": 1,
-                        "step": 0.001,
-                        "mode": "box",
-                    }
-                }
-            ),
-            vol.Required(
                 "hsem_huawei_solar_batteries_excess_pv_energy_use_in_tou",
                 default=get_config_value(
                     config_entry,
@@ -149,15 +114,6 @@ async def get_huawei_solar_step_schema(config_entry) -> vol.Schema:
 
 async def validate_huawei_solar_input(hass, user_input) -> dict[str, str]:
     """Validate user input for the 'huawei_solar' step."""
-    # --- required scalar fields (no HA lookup needed) ---
-    scalar_required = [
-        "hsem_batteries_purchase_price",
-        "hsem_batteries_expected_cycles",
-    ]
-    required_errors: dict[str, str] = {
-        f: "required" for f in scalar_required if f not in user_input
-    }
-
     # --- entity existence ---
     entity_errors = await async_validate_entity_ids(
         hass,
@@ -190,13 +146,4 @@ async def validate_huawei_solar_input(hass, user_input) -> dict[str, str]:
         ],
     )
 
-    # --- price validation for purchase price ---
-    price_errors = validate_price(
-        user_input,
-        "hsem_batteries_purchase_price",
-        min_price=0.0,
-        max_price=100_000.0,
-        allow_negative=False,
-    )
-
-    return merge_errors(required_errors, entity_errors, device_errors, price_errors)
+    return merge_errors(entity_errors, device_errors)

--- a/custom_components/hsem/models/sensor_config.py
+++ b/custom_components/hsem/models/sensor_config.py
@@ -166,8 +166,8 @@ class SensorConfig:
     ev_second: EVChargerConfig = field(default_factory=EVChargerConfig)
 
     # Battery economics
-    batteries_charge_efficiency: float = 97.0
-    batteries_discharge_efficiency: float = 97.0
+    batteries_charge_efficiency: float = 98.0
+    batteries_discharge_efficiency: float = 98.0
     batteries_purchase_price: float = 0.0
     batteries_expected_cycles: int = 6000
     #: User-configured per-kWh cycle cost. When > 0 it is added directly to

--- a/custom_components/hsem/number.py
+++ b/custom_components/hsem/number.py
@@ -1,0 +1,76 @@
+"""Number platform for the HSEM integration.
+
+Exposes ``NumberEntity`` instances that let users adjust integration
+settings (battery charge/discharge efficiency) from the entity page,
+without re-running the config/options flow.
+"""
+
+from homeassistant.components.number import NumberEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from custom_components.hsem.custom_numbers.entity import HSEMBatteryEfficiencyNumber
+from custom_components.hsem.utils.sensornames import (
+    get_charge_efficiency_number_entity_id,
+    get_charge_efficiency_number_key,
+    get_charge_efficiency_number_name,
+    get_charge_efficiency_number_unique_id,
+    get_discharge_efficiency_number_entity_id,
+    get_discharge_efficiency_number_key,
+    get_discharge_efficiency_number_name,
+    get_discharge_efficiency_number_unique_id,
+)
+
+# Entity descriptions for each number entity in this platform.
+NUMBER_DESCRIPTIONS: tuple[NumberEntityDescription, ...] = (
+    NumberEntityDescription(
+        key=get_charge_efficiency_number_key(),
+        name=get_charge_efficiency_number_name(),
+        icon="mdi:battery-plus",
+        entity_category=EntityCategory.CONFIG,
+    ),
+    NumberEntityDescription(
+        key=get_discharge_efficiency_number_key(),
+        name=get_discharge_efficiency_number_name(),
+        icon="mdi:battery-minus",
+        entity_category=EntityCategory.CONFIG,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up HSEM number entities from a config entry."""
+    config_keys = {
+        get_charge_efficiency_number_key(): "hsem_batteries_charge_efficiency",
+        get_discharge_efficiency_number_key(): "hsem_batteries_discharge_efficiency",
+    }
+
+    _id_map = {
+        get_charge_efficiency_number_key(): (
+            get_charge_efficiency_number_unique_id(),
+            get_charge_efficiency_number_entity_id(),
+        ),
+        get_discharge_efficiency_number_key(): (
+            get_discharge_efficiency_number_unique_id(),
+            get_discharge_efficiency_number_entity_id(),
+        ),
+    }
+
+    entities = [
+        HSEMBatteryEfficiencyNumber(
+            hass,
+            config_entry,
+            description,
+            config_key=config_keys[description.key],
+            unique_id=_id_map[description.key][0],
+            entity_id=_id_map[description.key][1],
+        )
+        for description in NUMBER_DESCRIPTIONS
+    ]
+    async_add_entities(entities)

--- a/custom_components/hsem/options_flow.py
+++ b/custom_components/hsem/options_flow.py
@@ -11,6 +11,10 @@ from custom_components.hsem.flows.batteries_schedules import (
     get_batteries_schedules_step_schema,
     validate_batteries_schedules_input,
 )
+from custom_components.hsem.flows.battery_economics import (
+    get_battery_economics_step_schema,
+    validate_battery_economics_input,
+)
 from custom_components.hsem.flows.ev import get_ev_step_schema, validate_ev_step_input
 from custom_components.hsem.flows.ev_planned_load import (
     get_ev_planned_load_step_schema,
@@ -158,12 +162,30 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
             errors = await validate_huawei_solar_input(self.hass, user_input)
             if not errors:
                 self._user_input.update(user_input)
-                return await self.async_step_power()
+                return await self.async_step_battery_economics()
 
         data_schema = await get_huawei_solar_step_schema(self._config_entry)
 
         return self.async_show_form(
             step_id="huawei_solar",
+            data_schema=data_schema,
+            errors=errors,
+            last_step=False,
+        )
+
+    async def async_step_battery_economics(self, user_input=None):
+        errors = {}
+
+        if user_input is not None:
+            errors = await validate_battery_economics_input(user_input)
+            if not errors:
+                self._user_input.update(user_input)
+                return await self.async_step_power()
+
+        data_schema = await get_battery_economics_step_schema(self._config_entry)
+
+        return self.async_show_form(
+            step_id="battery_economics",
             data_schema=data_schema,
             errors=errors,
             last_step=False,

--- a/custom_components/hsem/planner/discharge_scheduler.py
+++ b/custom_components/hsem/planner/discharge_scheduler.py
@@ -9,7 +9,6 @@ All functions are pure — no I/O, no Home Assistant imports.  They mutate the
 
 from __future__ import annotations
 
-import logging
 from datetime import datetime, timedelta
 
 from custom_components.hsem.const import NEAR_ZERO_CONSUMPTION_THRESHOLD_KWH
@@ -22,8 +21,6 @@ from custom_components.hsem.utils.recommendations import (
     DISCHARGE_RECS as _DISCHARGE_RECS,
 )
 from custom_components.hsem.utils.recommendations import Recommendations
-
-_LOGGER = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Discharge schedule detection
@@ -386,7 +383,8 @@ def concentrate_discharge_on_expensive_slots(
 
     for s in discharge_slots:
         if id(s) not in keep_set:
-            _LOGGER.debug(
+            log_planner(
+                "debug",
                 "concentrate: clearing discharge at %s\u2192%s  price=%.4f  "
                 "(battery can only cover %d of %d slots)",
                 s.start.strftime("%d %H:%M"),

--- a/custom_components/hsem/planner/engine_core.py
+++ b/custom_components/hsem/planner/engine_core.py
@@ -187,6 +187,12 @@ def _schedule_slots(
     dd = inp.battery_discharge_efficiency_pct / 100.0
     rlp = (1.0 - cd * dd) * 100.0
     mcphi = (inp.battery_max_charge_power_w / 1000 * cd) / (60 / inp.interval_minutes)
+    # `rt` already includes conversion loss from calculate_recommended_threshold().
+    # For `apply_arbitrage_grid_charge` we need the depreciation-only portion
+    # because that pass adds its own price-proportional conversion loss via
+    # `conversion_loss_pct`.  Recompute the fixed add-on to subtract it.
+    conv_loss_addon = 1.0 / (cd * dd) - 1.0 if cd > 0 and dd > 0 else 0.0
+    rt_depr = max(rt - conv_loss_addon, 0.0)
     apply_charge_schedules(
         slots,
         inp.battery_schedules,
@@ -215,7 +221,7 @@ def _schedule_slots(
         mcphi,
         conversion_loss_pct=rlp,
         cycle_cost_per_kwh=inp.battery_cycle_cost_per_kwh,
-        recommended_threshold=rt,
+        recommended_threshold=rt_depr,
     )
     mcps = (inp.battery_max_charge_power_w / 1000 * cd) / (60 / inp.interval_minutes)
     mdps: float | None = None
@@ -529,6 +535,8 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
         purchase_price=inp.battery_purchase_price,
         expected_cycles=inp.battery_expected_cycles,
         usable_capacity=usable_kwh,
+        charge_efficiency_pct=inp.battery_charge_efficiency_pct,
+        discharge_efficiency_pct=inp.battery_discharge_efficiency_pct,
     )
     if rt > 0:
         warnings.append(

--- a/custom_components/hsem/select.py
+++ b/custom_components/hsem/select.py
@@ -1,7 +1,8 @@
 """Select platform for the HSEM integration.
 
-Exposes a ``SelectEntity`` that lets users force a specific working mode or
-leave the planner in ``"auto"`` mode.
+Exposes ``SelectEntity`` instances that let users configure integration
+settings from a dropdown on the entity page, without re-running the
+config/options flow.
 """
 
 from homeassistant.components.select import SelectEntityDescription
@@ -10,10 +11,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from custom_components.hsem.custom_selectors.entity import HSEMWorkingModeSelector
+from custom_components.hsem.custom_selectors.select import HSEMSolcastLikelihoodSelector
 from custom_components.hsem.utils.recommendations import Recommendations
 from custom_components.hsem.utils.sensornames import (
     get_force_working_mode_selector_key,
     get_force_working_mode_selector_name,
+    get_solcast_likelihood_selector_key,
+    get_solcast_likelihood_selector_name,
 )
 
 # Selectable working modes exposed to the user.
@@ -41,6 +45,13 @@ SELECTOR_DESCRIPTIONS: tuple[SelectEntityDescription, ...] = (
         icon="mdi:chart-timeline-variant",
         options=[_DEFAULT_OPTION] + _RECOMMENDATION_OPTIONS,
     ),
+    SelectEntityDescription(
+        key=get_solcast_likelihood_selector_key(),
+        name=get_solcast_likelihood_selector_name(),
+        icon="mdi:solar-power",
+        options=["pv_estimate", "pv_estimate10", "pv_estimate90"],
+        translation_key="pv_estimate_likelihood",
+    ),
 )
 
 
@@ -50,14 +61,23 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up HSEM select entities from a config entry."""
-    async_add_entities(
-        [
-            HSEMWorkingModeSelector(
-                hass,
-                config_entry,
-                description,
-                _DEFAULT_OPTION,
+    entities: list = []
+    for description in SELECTOR_DESCRIPTIONS:
+        if description.key == get_force_working_mode_selector_key():
+            entities.append(
+                HSEMWorkingModeSelector(
+                    hass,
+                    config_entry,
+                    description,
+                    _DEFAULT_OPTION,
+                )
             )
-            for description in SELECTOR_DESCRIPTIONS
-        ]
-    )
+        elif description.key == get_solcast_likelihood_selector_key():
+            entities.append(
+                HSEMSolcastLikelihoodSelector(
+                    hass,
+                    config_entry,
+                    description,
+                )
+            )
+    async_add_entities(entities)

--- a/custom_components/hsem/translations/da.json
+++ b/custom_components/hsem/translations/da.json
@@ -219,8 +219,8 @@
           "hsem_huawei_solar_inverter_active_power_control": "Huawei-vekselretter aktiv effektkontrolsensor"
         },
         "data_description": {
-          "hsem_batteries_charge_efficiency": "Angiv batteriets opladningseffektivitet som en procentdel (0–100). Energi lagret i batteriet = inputenergi × denne faktor. Typiske lithium-batterier opnår 95–98%. Standard: 97%.",
-          "hsem_batteries_discharge_efficiency": "Angiv batteriets afladningseffektivitet som en procentdel (0–100). Energi leveret til huset = fjernet batterienergi × denne faktor. Typiske lithium-batterier opnår 95–98%. Standard: 97%.",
+          "hsem_batteries_charge_efficiency": "Angiv batteriets opladningseffektivitet som en procentdel (0–100). Energi lagret i batteriet = inputenergi × denne faktor. Typiske lithium-batterier opnår 95–98%. Standard: 98%.",
+          "hsem_batteries_discharge_efficiency": "Angiv batteriets afladningseffektivitet som en procentdel (0–100). Energi leveret til huset = fjernet batterienergi × denne faktor. Typiske lithium-batterier opnår 95–98%. Standard: 98%.",
           "hsem_batteries_cycle_cost": "Valgfri ekstra per-kWh-omkostning ved at cykle batteriet (EUR/kWh). Tilføjes oven på den automatisk beregnede afskrivningstærskel. Sæt til 0 for kun at stole på afskrivningsbeskyttelsen.",
           "hsem_batteries_expected_cycles": "Indtast det forventede antal fulde opladnings-/afladningscyklusser i batteriets levetid. Bruges til at beregne afskrivningsomkostning pr. kWh. Typiske LiFePO4-batterier understøtter 4000–8000 cyklusser.",
           "hsem_batteries_purchase_price": "Indtast den samlede købspris for dit batterisystem i EUR. Bruges sammen med forventede cyklusser og brugbar kapacitet til at beregne afskrivningsomkostning pr. kWh.",
@@ -241,6 +241,24 @@
         },
         "description": "Konfigurer arbejdstilstanden for Huawei-solcellebatterier.",
         "title": "Huawei Solar-sensorer"
+      },
+      "battery_economics": {
+        "data": {
+          "hsem_batteries_purchase_price": "Batteri-købspris (EUR)",
+          "hsem_batteries_expected_cycles": "Forventede battericyklusser",
+          "hsem_batteries_cycle_cost": "Batteri-cyklusomkostning (EUR/kWh)",
+          "hsem_batteries_charge_efficiency": "Batteri-opladningseffektivitet (%)",
+          "hsem_batteries_discharge_efficiency": "Batteri-afladningseffektivitet (%)"
+        },
+        "data_description": {
+          "hsem_batteries_purchase_price": "Indtast den samlede købspris for dit batterisystem i EUR. Bruges sammen med forventede cyklusser og brugbar kapacitet til at beregne afskrivningsomkostning pr. kWh.",
+          "hsem_batteries_expected_cycles": "Indtast det forventede antal fulde opladnings-/afladningscyklusser i batteriets levetid. Bruges til at beregne afskrivningsomkostning pr. kWh. Typiske LiFePO4-batterier understøtter 4000–8000 cyklusser.",
+          "hsem_batteries_cycle_cost": "Valgfri ekstra per-kWh-omkostning ved at cykle batteriet (EUR/kWh). Tilføjes oven på den automatisk beregnede afskrivningstærskel. Sæt til 0 for kun at stole på afskrivningsbeskyttelsen.",
+          "hsem_batteries_charge_efficiency": "Angiv batteriets opladningseffektivitet som en procentdel (0–100). Energi lagret i batteriet = inputenergi × denne faktor. Typiske lithium-batterier opnår 95–98%. Standard: 98%.",
+          "hsem_batteries_discharge_efficiency": "Angiv batteriets afladningseffektivitet som en procentdel (0–100). Energi leveret til huset = fjernet batterienergi × denne faktor. Typiske lithium-batterier opnår 95–98%. Standard: 98%."
+        },
+        "description": "Konfigurer batteriøkonomiske parametre, der påvirker afskrivningsberegninger og rundturseffektivitet.",
+        "title": "Batteriøkonomi"
       },
       "init": {
         "data": {

--- a/custom_components/hsem/translations/en.json
+++ b/custom_components/hsem/translations/en.json
@@ -235,8 +235,8 @@
           "hsem_huawei_solar_inverter_active_power_control": "Huawei Inverter Active Power Control Sensor"
         },
         "data_description": {
-          "hsem_batteries_charge_efficiency": "Specify the charge-side efficiency of your battery as a percentage (0–100). Energy stored in the battery equals the input energy multiplied by this factor. Typical lithium batteries achieve 95–98 %. Defaults to 97 %.",
-          "hsem_batteries_discharge_efficiency": "Specify the discharge-side efficiency of your battery as a percentage (0–100). Energy delivered to the house equals the battery energy removed multiplied by this factor. Typical lithium batteries achieve 95–98 %. Defaults to 97 %.",
+          "hsem_batteries_charge_efficiency": "Specify the charge-side efficiency of your battery as a percentage (0–100). Energy stored in the battery equals the input energy multiplied by this factor. Typical lithium batteries achieve 95–98 %. Defaults to 98 %.",
+          "hsem_batteries_discharge_efficiency": "Specify the discharge-side efficiency of your battery as a percentage (0–100). Energy delivered to the house equals the battery energy removed multiplied by this factor. Typical lithium batteries achieve 95–98 %. Defaults to 98 %.",
           "hsem_batteries_cycle_cost": "Optional extra per-kWh cost of cycling the battery (EUR/kWh). Added on top of the auto-calculated depreciation threshold. Set to 0 to rely solely on the depreciation guard. Example: 0.02 means the planner requires 2 cent extra spread per kWh cycled before approving grid charging.",
           "hsem_batteries_expected_cycles": "Enter the expected number of full charge/discharge cycles over the battery's lifetime. Used to calculate depreciation cost per kWh and the recommended minimum export price threshold. Typical LiFePO4 batteries support 4000–8000 cycles.",
           "hsem_batteries_purchase_price": "Enter the total purchase price of your battery system in EUR. Used together with expected cycles and usable capacity to calculate the depreciation cost per kWh and the recommended minimum export price threshold.",
@@ -257,6 +257,24 @@
         },
         "description": "Configure the working mode for Huawei solar batteries.",
         "title": "Huawei Solar Sensors"
+      },
+      "battery_economics": {
+        "data": {
+          "hsem_batteries_purchase_price": "Battery Purchase Price (EUR)",
+          "hsem_batteries_expected_cycles": "Expected Battery Cycles",
+          "hsem_batteries_cycle_cost": "Battery Cycle Cost (EUR/kWh)",
+          "hsem_batteries_charge_efficiency": "Battery Charge Efficiency (%)",
+          "hsem_batteries_discharge_efficiency": "Battery Discharge Efficiency (%)"
+        },
+        "data_description": {
+          "hsem_batteries_purchase_price": "Enter the total purchase price of your battery system in EUR. Used together with expected cycles and usable capacity to calculate the depreciation cost per kWh and the recommended minimum export price threshold.",
+          "hsem_batteries_expected_cycles": "Enter the expected number of full charge/discharge cycles over the battery's lifetime. Used to calculate depreciation cost per kWh and the recommended minimum export price threshold. Typical LiFePO4 batteries support 4000–8000 cycles.",
+          "hsem_batteries_cycle_cost": "Optional extra per-kWh cost of cycling the battery (EUR/kWh). Added on top of the auto-calculated depreciation threshold. Set to 0 to rely solely on the depreciation guard. Example: 0.02 means the planner requires 2 cent extra spread per kWh cycled before approving grid charging.",
+          "hsem_batteries_charge_efficiency": "Specify the charge-side efficiency of your battery as a percentage (0–100). Energy stored in the battery equals the input energy multiplied by this factor. Typical lithium batteries achieve 95–98 %. Defaults to 98 %.",
+          "hsem_batteries_discharge_efficiency": "Specify the discharge-side efficiency of your battery as a percentage (0–100). Energy delivered to the house equals the battery energy removed multiplied by this factor. Typical lithium batteries achieve 95–98 %. Defaults to 98 %."
+        },
+        "description": "Configure battery economics parameters that affect depreciation calculations and round-trip efficiency.",
+        "title": "Battery Economics"
       },
       "init": {
         "data": {
@@ -608,8 +626,8 @@
           "hsem_huawei_solar_inverter_active_power_control": "Huawei Inverter Active Power Control Sensor"
         },
         "data_description": {
-          "hsem_batteries_charge_efficiency": "Specify the charge-side efficiency of your battery as a percentage (0–100). Energy stored in the battery equals the input energy multiplied by this factor. Typical lithium batteries achieve 95–98 %. Defaults to 97 %.",
-          "hsem_batteries_discharge_efficiency": "Specify the discharge-side efficiency of your battery as a percentage (0–100). Energy delivered to the house equals the battery energy removed multiplied by this factor. Typical lithium batteries achieve 95–98 %. Defaults to 97 %.",
+          "hsem_batteries_charge_efficiency": "Specify the charge-side efficiency of your battery as a percentage (0–100). Energy stored in the battery equals the input energy multiplied by this factor. Typical lithium batteries achieve 95–98 %. Defaults to 98 %.",
+          "hsem_batteries_discharge_efficiency": "Specify the discharge-side efficiency of your battery as a percentage (0–100). Energy delivered to the house equals the battery energy removed multiplied by this factor. Typical lithium batteries achieve 95–98 %. Defaults to 98 %.",
           "hsem_batteries_cycle_cost": "Optional extra per-kWh cost of cycling the battery (EUR/kWh). Added on top of the auto-calculated depreciation threshold. Set to 0 to rely solely on the depreciation guard. Example: 0.02 means the planner requires 2 cent extra spread per kWh cycled before approving grid charging.",
           "hsem_batteries_expected_cycles": "Enter the expected number of full charge/discharge cycles over the battery's lifetime. Used to calculate depreciation cost per kWh and the recommended minimum export price threshold. Typical LiFePO4 batteries support 4000–8000 cycles.",
           "hsem_batteries_purchase_price": "Enter the total purchase price of your battery system in EUR. Used together with expected cycles and usable capacity to calculate the depreciation cost per kWh and the recommended minimum export price threshold.",
@@ -630,6 +648,24 @@
         },
         "description": "Configure the working mode for Huawei solar batteries.",
         "title": "Huawei Solar Sensors"
+      },
+      "battery_economics": {
+        "data": {
+          "hsem_batteries_purchase_price": "Battery Purchase Price (EUR)",
+          "hsem_batteries_expected_cycles": "Expected Battery Cycles",
+          "hsem_batteries_cycle_cost": "Battery Cycle Cost (EUR/kWh)",
+          "hsem_batteries_charge_efficiency": "Battery Charge Efficiency (%)",
+          "hsem_batteries_discharge_efficiency": "Battery Discharge Efficiency (%)"
+        },
+        "data_description": {
+          "hsem_batteries_purchase_price": "Enter the total purchase price of your battery system in EUR. Used together with expected cycles and usable capacity to calculate the depreciation cost per kWh and the recommended minimum export price threshold.",
+          "hsem_batteries_expected_cycles": "Enter the expected number of full charge/discharge cycles over the battery's lifetime. Used to calculate depreciation cost per kWh and the recommended minimum export price threshold. Typical LiFePO4 batteries support 4000–8000 cycles.",
+          "hsem_batteries_cycle_cost": "Optional extra per-kWh cost of cycling the battery (EUR/kWh). Added on top of the auto-calculated depreciation threshold. Set to 0 to rely solely on the depreciation guard. Example: 0.02 means the planner requires 2 cent extra spread per kWh cycled before approving grid charging.",
+          "hsem_batteries_charge_efficiency": "Specify the charge-side efficiency of your battery as a percentage (0–100). Energy stored in the battery equals the input energy multiplied by this factor. Typical lithium batteries achieve 95–98 %. Defaults to 98 %.",
+          "hsem_batteries_discharge_efficiency": "Specify the discharge-side efficiency of your battery as a percentage (0–100). Energy delivered to the house equals the battery energy removed multiplied by this factor. Typical lithium batteries achieve 95–98 %. Defaults to 98 %."
+        },
+        "description": "Configure battery economics parameters that affect depreciation calculations and round-trip efficiency.",
+        "title": "Battery Economics"
       },
       "init": {
         "data": {

--- a/custom_components/hsem/utils/misc.py
+++ b/custom_components/hsem/utils/misc.py
@@ -506,28 +506,31 @@ def calculate_recommended_threshold(
     expected_cycles: int,
     usable_capacity: float,
     capacity_loss_pct: float = 30.0,
+    charge_efficiency_pct: float | None = None,
+    discharge_efficiency_pct: float | None = None,
 ) -> float:
-    """Calculate the recommended price threshold based on battery depreciation.
+    """Calculate the recommended price threshold based on battery depreciation
+    and (optionally) round-trip conversion loss.
 
-    This threshold represents the minimum import price spread required for
-    grid charging to be economically rational (depreciation-only, excluding
-    conversion loss — that is added by callers when relevant).
+    The threshold represents the minimum import price spread required for
+    grid charging to be economically rational.
 
-    The ``2×`` factor in the denominator accounts for the fact that one full
-    battery cycle involves energy flow in *both* directions:
+    **Depreciation term** (always included)::
 
-        throughput_per_cycle = 2 × usable_capacity
-                              (charge once + discharge once)
+        depreciation = (purchase_price × capacity_loss_pct)
+                       / (2 × usable_capacity × expected_cycles)
 
-    Since ``purchase_price / expected_cycles`` is the cost *per full cycle*
-    and the cycle cost is expressed *per kWh of throughput*, the cost must
-    be spread over the total lifetime throughput:
+    The ``2×`` factor accounts for one full cycle (charge + discharge).
 
-        threshold = (purchase_price * capacity_loss_pct)
-                    / (2 × usable_capacity × expected_cycles)
+    **Conversion-loss term** (included when both ``charge_efficiency_pct`` and
+    ``discharge_efficiency_pct`` are provided)::
 
-    This is the same formula as ``_resolve_cycle_cost`` in ``cost_function.py``,
-    which also uses ``2 × usable_kwh × expected_cycles`` in the denominator.
+        conversion_loss = 1 / (charge_eff × discharge_eff) - 1
+
+    This is a fixed per-kWh add-on representing the cost of energy lost to
+    heat during a full round-trip.  At the default 98 % efficiency the term
+    is approximately 0.042 EUR/kWh — too large to ignore in the profitability
+    guard.
 
     Args:
         purchase_price: Total battery system cost in local currency.
@@ -537,6 +540,12 @@ def calculate_recommended_threshold(
             of original capacity (0-100).  LiFePO4 EOL is typically defined at
             80% retained capacity = 20% loss.  Defaults to 30% to account for
             both EOL degradation and calendar ageing.
+        charge_efficiency_pct: Charge-side efficiency (0-100).  When provided
+            together with ``discharge_efficiency_pct`` the round-trip conversion
+            loss is added to the threshold.
+        discharge_efficiency_pct: Discharge-side efficiency (0-100).  When
+            provided together with ``charge_efficiency_pct`` the round-trip
+            conversion loss is added to the threshold.
     """
     if purchase_price <= 0 or expected_cycles <= 0 or usable_capacity <= 0:
         return 0.0
@@ -545,7 +554,21 @@ def calculate_recommended_threshold(
     # The 2× factor accounts for charge + discharge per full cycle.
     # Capacity loss accounts for residual value at end-of-life.
     capacity_loss_dec = max(min(capacity_loss_pct, 100.0), 0.0) / 100.0
-    return round(
-        (purchase_price * capacity_loss_dec) / (2 * expected_cycles * usable_capacity),
-        3,
+    depr = (purchase_price * capacity_loss_dec) / (
+        2 * expected_cycles * usable_capacity
     )
+
+    # Round-trip conversion loss — added as a fixed per-kWh term when both
+    # efficiencies are provided.
+    conv_loss = 0.0
+    if (
+        charge_efficiency_pct is not None
+        and discharge_efficiency_pct is not None
+        and charge_efficiency_pct > 0
+        and discharge_efficiency_pct > 0
+    ):
+        ce = max(min(charge_efficiency_pct, 100.0), 1.0) / 100.0
+        de = max(min(discharge_efficiency_pct, 100.0), 1.0) / 100.0
+        conv_loss = 1.0 / (ce * de) - 1.0
+
+    return round(depr + conv_loss, 3)

--- a/custom_components/hsem/utils/sensornames.py
+++ b/custom_components/hsem/utils/sensornames.py
@@ -1,4 +1,4 @@
-from homeassistant.components import select, sensor, switch, time
+from homeassistant.components import number, select, sensor, switch, time
 from homeassistant.util import slugify as s
 
 from custom_components.hsem.const import DOMAIN
@@ -514,6 +514,64 @@ def get_force_working_mode_selector_name() -> str:
 def get_force_working_mode_selector_entity_id() -> str:
     """Return the entity_id for the force-working-mode select entity."""
     return select.ENTITY_ID_FORMAT.format(s(f"{DOMAIN}_force_working_mode"))
+
+
+# Solcast PV Forecast Likelihood Selector
+def get_solcast_likelihood_selector_key() -> str:
+    """Return the entity description key for the solcast likelihood select entity."""
+    return f"{DOMAIN}_solcast_likelihood"
+
+
+def get_solcast_likelihood_selector_name() -> str:
+    """Return the display name for the solcast likelihood select entity."""
+    return "Solcast PV Forecast Likelihood"
+
+
+def get_solcast_likelihood_selector_entity_id() -> str:
+    """Return the entity_id for the solcast likelihood select entity."""
+    return select.ENTITY_ID_FORMAT.format(s(f"{DOMAIN}_solcast_likelihood"))
+
+
+# Battery Charge Efficiency Number
+def get_charge_efficiency_number_key() -> str:
+    """Return the entity description key for the charge efficiency number entity."""
+    return f"{DOMAIN}_charge_efficiency"
+
+
+def get_charge_efficiency_number_name() -> str:
+    """Return the display name for the charge efficiency number entity."""
+    return "Battery Charge Efficiency"
+
+
+def get_charge_efficiency_number_unique_id() -> str:
+    """Return the unique_id for the charge efficiency number entity."""
+    return f"{DOMAIN}_battery_charge_efficiency"
+
+
+def get_charge_efficiency_number_entity_id() -> str:
+    """Return the entity_id for the charge efficiency number entity."""
+    return number.ENTITY_ID_FORMAT.format(s(f"{DOMAIN}_battery_charge_efficiency"))
+
+
+# Battery Discharge Efficiency Number
+def get_discharge_efficiency_number_key() -> str:
+    """Return the entity description key for the discharge efficiency number entity."""
+    return f"{DOMAIN}_discharge_efficiency"
+
+
+def get_discharge_efficiency_number_name() -> str:
+    """Return the display name for the discharge efficiency number entity."""
+    return "Battery Discharge Efficiency"
+
+
+def get_discharge_efficiency_number_unique_id() -> str:
+    """Return the unique_id for the discharge efficiency number entity."""
+    return f"{DOMAIN}_battery_discharge_efficiency"
+
+
+def get_discharge_efficiency_number_entity_id() -> str:
+    """Return the entity_id for the discharge efficiency number entity."""
+    return number.ENTITY_ID_FORMAT.format(s(f"{DOMAIN}_battery_discharge_efficiency"))
 
 
 # Applier Status Sensor

--- a/docs/hsem-config-flow-reference.md
+++ b/docs/hsem-config-flow-reference.md
@@ -57,7 +57,7 @@ PV forecast sensor configuration.
 
 ### Step: `huawei_solar`
 
-Huawei Solar inverter and battery entity configuration.
+Huawei Solar inverter and battery entity configuration (device selectors and entity sensors only).
 
 | Field | Key | Default | Description |
 |---|---|---|---|
@@ -75,6 +75,18 @@ Huawei Solar inverter and battery entity configuration.
 | TOU periods | `hsem_huawei_solar_batteries_tou_charging_and_discharging_periods` | `sensor.batteries_tou_charging_and_discharging_periods` | TOU period schedule |
 | Excess PV use | `hsem_huawei_solar_batteries_excess_pv_energy_use_in_tou` | `select.batteries_excess_pv_energy_use_in_tou` | Excess PV mode in TOU |
 | Active power control | `hsem_huawei_solar_inverter_active_power_control` | `sensor.inverter_active_power_control` | Export power control mode |
+
+### Step: `battery_economics`
+
+Battery depreciation and efficiency parameters.
+
+| Field | Key | Default | Description |
+|---|---|---|---|
+| Purchase price | `hsem_batteries_purchase_price` | 0 | Battery system cost (EUR) |
+| Expected cycles | `hsem_batteries_expected_cycles` | 6000 | Total expected lifetime cycles |
+| Cycle cost | `hsem_batteries_cycle_cost` | 0 | Extra per-kWh wear margin (EUR/kWh) |
+| Charge efficiency | `hsem_batteries_charge_efficiency` | 98 % | Charge-side efficiency |
+| Discharge efficiency | `hsem_batteries_discharge_efficiency` | 98 % | Discharge-side efficiency |
 
 ### Step: `power`
 

--- a/docs/hsem-planner-guide.md
+++ b/docs/hsem-planner-guide.md
@@ -94,13 +94,26 @@ max_charge_per_slot_kwh = battery_max_charge_power_w / 1000 * (interval_minutes 
 | `battery_purchase_price` | `float` | Purchase price of the battery (local currency) |
 | `battery_expected_cycles` | `int` | Expected total lifetime cycles |
 | `battery_cycle_cost_per_kwh` | `float` | Explicit depreciation cost per kWh cycled |
+| `battery_charge_efficiency_pct` | `float` | Charge-side efficiency (%), e.g. 98 |
+| `battery_discharge_efficiency_pct` | `float` | Discharge-side efficiency (%), e.g. 98 |
 
 When `battery_cycle_cost_per_kwh` is `0.0`, the planner auto-derives cycle cost from
-purchase price, rated capacity, and expected cycles:
+purchase price, rated capacity, expected cycles, and round-trip conversion loss:
 
 ```text
-cycle_cost_per_kwh = purchase_price / (rated_capacity_kwh × expected_cycles)
+depreciation      = purchase_price / (rated_capacity_kwh × expected_cycles)
+conversion_loss   = 1 / (charge_eff × discharge_eff) − 1
+threshold         = depreciation + conversion_loss
 ```
+
+The depreciation term recovers the battery's purchase cost over its lifetime throughput.
+The conversion-loss term accounts for energy lost to heat during a full round-trip
+(charge then discharge). At 98 % efficiency on each side the loss is ~0.042 per kWh
+cycled — significant enough to include in the profitability guard.
+
+The `excess_export_price_threshold` and the schedule profitability guard both use this
+combined threshold.  Users who want extra margin can set `battery_cycle_cost_per_kwh`
+to a positive value, which is added on top.
 
 ### Consumption prediction
 
@@ -680,8 +693,18 @@ Auto-derived cycle cost (when not explicitly configured):
 cycle_cost_per_kwh = purchase_price / (rated_capacity_kwh × expected_cycles)
 ```
 
-**Example:** A 10 kWh battery bought for 30 000 DKK with 6 000 expected cycles costs
-`30000 / (10 × 6000) = 0.50 DKK/kWh` of throughput.
+The price threshold used by the profitability guard adds round-trip conversion
+loss on top of depreciation:
+
+```text
+price_threshold = cycle_cost_per_kwh + conversion_loss
+conversion_loss = 1 / (charge_eff × discharge_eff) − 1
+```
+
+**Depreciation example:** A 10 kWh battery bought for 30 000 DKK with 6 000 expected
+cycles costs `30000 / (10 × 6000) = 0.50 DKK/kWh` of throughput.
+**With 98 % efficiency:** conversion loss adds ~0.042 DKK/kWh, giving a combined
+threshold of ~0.542 DKK/kWh.
 
 ### SoC penalties
 

--- a/docs/hsem-planner-spec.md
+++ b/docs/hsem-planner-spec.md
@@ -68,7 +68,7 @@ in the same layer must not change it.
 **Opportunistic grid charge** (outside any schedule):
 
 1. Import price < 0 → `batteries_charge_grid`
-2. Import price ≤ depreciation threshold − cycle cost → `batteries_charge_grid`
+2. Import price ≤ depreciation + conversion loss threshold − cycle cost → `batteries_charge_grid`
 
 **Excess export** (only when enabled):
 

--- a/tests/test_platform_entity_refactor.py
+++ b/tests/test_platform_entity_refactor.py
@@ -551,10 +551,10 @@ class TestTimePlatformSetupExtended:
 
 
 class TestSelectPlatformSetup:
-    """async_setup_entry must register exactly one selector entity."""
+    """async_setup_entry must register exactly two selector entities."""
 
     @pytest.mark.asyncio
-    async def test_setup_creates_one_selector(self) -> None:
+    async def test_setup_creates_two_selectors(self) -> None:
         from custom_components.hsem.select import (
             SELECTOR_DESCRIPTIONS,
             async_setup_entry,
@@ -562,7 +562,7 @@ class TestSelectPlatformSetup:
 
         hass = _mock_hass()
         config_entry = _mock_config_entry()
-        added: list[HSEMWorkingModeSelector] = []
+        added: list = []
 
         def add_entities(entities: list, _update_before_add: bool = False) -> None:
             added.extend(entities)
@@ -570,7 +570,7 @@ class TestSelectPlatformSetup:
         await async_setup_entry(hass, config_entry, add_entities)
 
         assert len(added) == len(SELECTOR_DESCRIPTIONS)
-        assert len(added) == 1
+        assert len(added) == 2
 
     @pytest.mark.asyncio
     async def test_setup_entity_is_select_entity(self) -> None:
@@ -586,7 +586,6 @@ class TestSelectPlatformSetup:
         await async_setup_entry(hass, config_entry, add_entities)
 
         for entity in added:
-            assert isinstance(entity, HSEMWorkingModeSelector)
             assert isinstance(entity, SelectEntity)
 
     @pytest.mark.asyncio
@@ -595,13 +594,14 @@ class TestSelectPlatformSetup:
 
         hass = _mock_hass()
         config_entry = _mock_config_entry()
-        added: list[HSEMWorkingModeSelector] = []
+        added: list = []
 
         def add_entities(entities: list, _update_before_add: bool = False) -> None:
             added.extend(entities)
 
         await async_setup_entry(hass, config_entry, add_entities)
 
+        # First selector is the working-mode selector (default = "auto").
         assert added[0].current_option == "auto"
 
     @pytest.mark.asyncio
@@ -610,13 +610,14 @@ class TestSelectPlatformSetup:
 
         hass = _mock_hass()
         config_entry = _mock_config_entry()
-        added: list[HSEMWorkingModeSelector] = []
+        added: list = []
 
         def add_entities(entities: list, _update_before_add: bool = False) -> None:
             added.extend(entities)
 
         await async_setup_entry(hass, config_entry, add_entities)
 
+        # First selector is the working-mode selector (includes "auto").
         assert "auto" in added[0].options
 
 


### PR DESCRIPTION
## Summary

Seven changes on this branch:

### 1. Conversion loss included in threshold
`calculate_recommended_threshold()` now accepts `charge_efficiency_pct` and `discharge_efficiency_pct`. Round-trip conversion loss is added to the price threshold.

### 2. Default efficiencies 95% → 98%
Updated all defaults to match Huawei LUNA2000 specs.

### 3. Battery economics flow step
New `battery_economics` config/options step with sliders for charge/discharge efficiency, extracted from the oversized `huawei_solar.py`.

### 4. Runtime solcast likelihood selector
New `HSEMSolcastLikelihoodSelector` select entity lets users switch between `pv_estimate`, `pv_estimate10`, and `pv_estimate90` from the HA UI without re-configuring.

### 5. Runtime efficiency number entities
New `HSEMBatteryEfficiencyNumber` entities (charge + discharge) expose sliders (50–100%) at runtime. Persist to config entry options.

### 6. Forecast sensor attribute size fix
Limited `_forecast_tracker_data` to 24 records to stay under 16 KB.

### 7. Blocking logger call fix
Replaced `_LOGGER.debug()` with `log_planner()` in discharge_scheduler.

### Documentation
- Added **Documentation Update Rule** to copilot-instructions.md.
- Updated `docs/hsem-planner-guide.md`, `docs/hsem-planner-spec.md`, `docs/hsem-config-flow-reference.md`.

### Files changed (24 files)
`.github/copilot-instructions.md`, `utils/misc.py`, `const.py`, `models/sensor_config.py`, `custom_sensors/config_reader.py`, `custom_sensors/working_mode_sensor.py`, `custom_sensors/forecast_accuracy_sensor.py`, `planner/engine_core.py`, `planner/discharge_scheduler.py`, `flows/huawei_solar.py`, `flows/battery_economics.py` (new), `config_flow.py`, `options_flow.py`, `translations/en.json`, `translations/da.json`, `select.py`, `number.py` (new), `custom_selectors/select.py` (new), `custom_numbers/entity.py` (new), `utils/sensornames.py`, `tests/test_platform_entity_refactor.py`, `docs/*`

### Verification
- 2057 tests pass
- `tox -e lint` passes
- `tox -e quality` passes (0 errors)

Fixes #478