### PR TITLE
feat(ev): ev_charger_calculated_power + charge past target on stranded PV (battery gated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,16 @@ When "battery" is mentioned in this documentation or the integration, it **alway
 
 ### Does HSEM optimize EV charging?
 
-HSEM **does not provide direct EV charging optimization**. Instead, it monitors your EV charger's power sensor (from any wall charger integration) to ensure that your EV is not charged from the house battery. HSEM disables battery discharge while the EV charger is active, but it does **not** estimate how much charge your EV needs or prioritize charging hours for the EV.
+**Yes.** When "EV Planned Load" is enabled in the configuration, HSEM's EV planner
+computes an optimal charging schedule that:
+- Charges from excess PV first, then from the cheapest grid hours.
+- Completes charging before the configured deadline.
+- Respects charger efficiency and power limits.
+- Can continue charging past the target SoC using stranded PV surplus
+  (when the house battery is already full).
+
+The planner outputs a per-slot `ev_charger_calculated_power` (W) value that
+the applier can use to throttle a go-e Gemini charger to the optimal speed.
 
 ### How does HSEM use EV charger data in its calculations?
 

--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -63,8 +63,9 @@ from custom_components.hsem.models.state_snapshot import StateSnapshot
 from custom_components.hsem.planner import run_planner
 from custom_components.hsem.planner.charge_scheduler import apply_window_hysteresis
 from custom_components.hsem.planner.ev_planner import EVChargingPlan
-from custom_components.hsem.utils.datetime_utils import as_tz, utc_key, utc_now_iso
+from custom_components.hsem.utils.datetime_utils import as_tz
 from custom_components.hsem.utils.datetime_utils import now as hsem_now
+from custom_components.hsem.utils.datetime_utils import utc_key, utc_now_iso
 from custom_components.hsem.utils.forecast_tracker import (
     ForecastTracker,
     compute_accumulated_energy,

--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -63,9 +63,8 @@ from custom_components.hsem.models.state_snapshot import StateSnapshot
 from custom_components.hsem.planner import run_planner
 from custom_components.hsem.planner.charge_scheduler import apply_window_hysteresis
 from custom_components.hsem.planner.ev_planner import EVChargingPlan
-from custom_components.hsem.utils.datetime_utils import as_tz
+from custom_components.hsem.utils.datetime_utils import as_tz, utc_key, utc_now_iso
 from custom_components.hsem.utils.datetime_utils import now as hsem_now
-from custom_components.hsem.utils.datetime_utils import utc_key, utc_now_iso
 from custom_components.hsem.utils.forecast_tracker import (
     ForecastTracker,
     compute_accumulated_energy,
@@ -662,6 +661,10 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             rec.ev_planned_load_kwh = slot.ev_planned_load_kwh
             rec.ev_accounted_load_kwh = slot.ev_accounted_load_kwh
             rec.ev_total_planned_load_kwh = slot.ev_total_planned_load_kwh
+            rec.ev_charger_calculated_power = slot.ev_charger_calculated_power
+            rec.ev_second_charger_calculated_power = (
+                slot.ev_second_charger_calculated_power
+            )
             rec.estimated_cost_currency = slot.estimated_cost_currency
             rec.estimated_battery_capacity_kwh = slot.estimated_battery_capacity_kwh
             rec.estimated_battery_soc_pct = slot.estimated_battery_soc_pct

--- a/custom_components/hsem/coordinator_builder.py
+++ b/custom_components/hsem/coordinator_builder.py
@@ -269,6 +269,9 @@ def build_planner_input(
         ev_planned_load_base_load_includes_ev=bool(
             cfg.house_power_includes_ev_charger_power
         ),
+        ev_planned_allow_charge_past_target_soc=bool(
+            cfg.ev.allow_charge_past_target_soc
+        ),
         # Second EV planned load
         ev_second_planned_load_enabled=bool(cfg.ev_second_planned_load_enabled),
         ev_second_planned_load_connected=bool(live.ev_second_planned_load_connected),
@@ -298,6 +301,9 @@ def build_planner_input(
         ev_second_planned_load_deadline=live.ev_second_planned_load_deadline,
         ev_second_planned_load_base_load_includes_ev=bool(
             cfg.house_power_includes_ev_charger_power
+        ),
+        ev_second_allow_charge_past_target_soc=bool(
+            cfg.ev_second.allow_charge_past_target_soc
         ),
         time_discount_rate=0.995,
         # Planner hysteresis (issue #372)

--- a/custom_components/hsem/custom_sensors/applier.py
+++ b/custom_components/hsem/custom_sensors/applier.py
@@ -141,6 +141,10 @@ async def async_apply_inverter_power_control(
                 isinstance(ev1.soc_pct, (int, float))
                 and ev1_cfg.allow_charge_past_target_soc
                 and ev1.soc_pct < 100
+                # Only force export when house battery is already full —
+                # otherwise the MILP should get the PV surplus for the battery.
+                and live.huawei_batteries_soc_pct is not None
+                and live.huawei_batteries_soc_pct >= 99.0
             ):
                 export_pct = 100
 
@@ -157,6 +161,9 @@ async def async_apply_inverter_power_control(
                 isinstance(ev2.soc_pct, (int, float))
                 and ev2_cfg.allow_charge_past_target_soc
                 and ev2.soc_pct < 100
+                # Only force export when house battery is already full.
+                and live.huawei_batteries_soc_pct is not None
+                and live.huawei_batteries_soc_pct >= 99.0
             ):
                 export_pct = 100
 

--- a/custom_components/hsem/models/hourly_recommendation.py
+++ b/custom_components/hsem/models/hourly_recommendation.py
@@ -35,6 +35,10 @@ class HourlyRecommendation:
             (kWh, ≥ 0).  Equals ``ev_planned_load_kwh + ev_accounted_load_kwh``.
             Use this for diagnostics and UI — it is non-zero whenever EV
             charging is planned regardless of the ``base_load_includes_ev`` flag.
+        ev_charger_calculated_power: Target AC power (W) for the primary EV
+            charger during this slot.  Zero when no charging is planned.
+        ev_second_charger_calculated_power: Target AC power (W) for the
+            second EV charger during this slot.  Zero when no charging is planned.
         estimated_cost_currency: Estimated grid cost for the slot (local currency).
         batteries_charged_kwh: Energy scheduled to be charged into battery (kWh).
         batteries_discharged_kwh: Energy drawn from battery by the SoC simulation (kWh).
@@ -70,3 +74,5 @@ class HourlyRecommendation:
     ev_planned_load_kwh: float = 0.0
     ev_accounted_load_kwh: float = 0.0
     ev_total_planned_load_kwh: float = 0.0
+    ev_charger_calculated_power: float = 0.0
+    ev_second_charger_calculated_power: float = 0.0

--- a/custom_components/hsem/models/planner_inputs.py
+++ b/custom_components/hsem/models/planner_inputs.py
@@ -255,6 +255,10 @@ class PlannerInput:
     ev_planned_load_charger_efficiency_pct: float = 100.0
     ev_planned_load_deadline: datetime | None = None
     ev_planned_load_base_load_includes_ev: bool = False
+    #: When True, the EV may continue charging past its target SoC using
+    #: surplus PV that would otherwise be curtailed (e.g. battery full,
+    #: negative export prices).
+    ev_planned_allow_charge_past_target_soc: bool = False
 
     # --- EV planned load integration — second EV (optional, disabled by default) ---
     #: When True, the second EV planned load feature is active.
@@ -268,6 +272,8 @@ class PlannerInput:
     ev_second_planned_load_charger_efficiency_pct: float = 100.0
     ev_second_planned_load_deadline: datetime | None = None
     ev_second_planned_load_base_load_includes_ev: bool = False
+    #: Same as ev_planned_allow_charge_past_target_soc, for the second EV.
+    ev_second_allow_charge_past_target_soc: bool = False
 
     # --- planner hysteresis — keep the active plan unless the new plan
     # is materially better (anti-flapping, issue #372). ---

--- a/custom_components/hsem/models/planner_outputs.py
+++ b/custom_components/hsem/models/planner_outputs.py
@@ -331,6 +331,14 @@ class PlannedSlot:
             ``EVSmartCharging`` recommendation label decision (use
             ``ev_total_planned_load_kwh > 0`` instead of
             ``ev_planned_load_kwh > 0`` to detect *any* planned EV charging).
+        ev_charger_calculated_power:
+            Target AC power (W) for the primary EV charger during this slot.
+            Computed from the EV planner's per-slot energy target and charger
+            efficiency.  Zero when no primary EV charging is planned in this
+            slot.  The applier can use this to throttle the charger via
+            the go-e (or compatible) API instead of running at full speed.
+        ev_second_charger_calculated_power:
+            Same as ``ev_charger_calculated_power``, but for the second EV.
     """
 
     start: datetime
@@ -345,6 +353,8 @@ class PlannedSlot:
     ev_planned_load_kwh: float = 0.0
     ev_accounted_load_kwh: float = 0.0
     ev_total_planned_load_kwh: float = 0.0
+    ev_charger_calculated_power: float = 0.0
+    ev_second_charger_calculated_power: float = 0.0
     estimated_net_consumption_kwh: float = 0.0
     estimated_cost_currency: float = 0.0
     estimated_battery_soc_pct: float = 0.0

--- a/custom_components/hsem/planner/engine_core.py
+++ b/custom_components/hsem/planner/engine_core.py
@@ -340,6 +340,7 @@ def _build_and_inject_for_ev(
     eff: float,
     deadline,
     base_includes: bool,
+    allow_past_target: bool,
     label: str,
     now: datetime,
     slots: list,
@@ -378,6 +379,7 @@ def _build_and_inject_for_ev(
         charger_efficiency_pct=eff,
         deadline=deadline,
         base_load_includes_ev=base_includes,
+        allow_charge_past_target_soc=allow_past_target,
         now=now,
     )
     plan = build_ev_charging_plan(
@@ -564,6 +566,7 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
             eff=inp.ev_planned_load_charger_efficiency_pct,
             deadline=inp.ev_planned_load_deadline,
             base_includes=inp.ev_planned_load_base_load_includes_ev,
+            allow_past_target=inp.ev_planned_allow_charge_past_target_soc,
             label="primary",
             **common_kw,
         )
@@ -579,6 +582,7 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
             eff=inp.ev_second_planned_load_charger_efficiency_pct,
             deadline=inp.ev_second_planned_load_deadline,
             base_includes=inp.ev_second_planned_load_base_load_includes_ev,
+            allow_past_target=inp.ev_second_allow_charge_past_target_soc,
             label="second",
             **common_kw,
         )

--- a/custom_components/hsem/planner/engine_core.py
+++ b/custom_components/hsem/planner/engine_core.py
@@ -351,6 +351,8 @@ def _build_and_inject_for_ev(
     combined_ev_raw_load: list[float],
     combined_ev_injected_load: list[float],
     warnings: list[str],
+    predicted_battery_kwh: list[float],
+    usable_battery_kwh: float,
 ) -> EVChargingPlan | None:
     """Build an EV charging plan and accumulate its loads."""
     if not enabled:
@@ -380,6 +382,8 @@ def _build_and_inject_for_ev(
         deadline=deadline,
         base_load_includes_ev=base_includes,
         allow_charge_past_target_soc=allow_past_target,
+        slot_predicted_battery_kwh=predicted_battery_kwh,
+        usable_battery_kwh=usable_battery_kwh,
         now=now,
     )
     plan = build_ev_charging_plan(
@@ -540,6 +544,18 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
     combined_ev_inj = [0.0] * len(slots)
     populate_net_consumption(slots)
     sns = [max(-s.estimated_net_consumption_kwh, 0.0) for s in slots]
+    # Predicted battery energy (kWh above floor) at the START of each slot,
+    # assuming no EV charging and no grid charging.  Used to gate Pass 3
+    # in the EV planner: the EV only charges past target when the battery
+    # is already full and the surplus would otherwise be stranded.
+    predicted_battery_kwh: list[float] = []
+    cumulative = current_kwh
+    for s in slots:
+        predicted_battery_kwh.append(cumulative)
+        net = s.estimated_net_consumption_kwh
+        # net positive → battery must cover deficit
+        # net negative → surplus charges battery (up to usable_kwh)
+        cumulative = max(0.0, min(usable_kwh, cumulative - net))
     ss = [s.start for s in slots]
     se = [s.end for s in slots]
     sp = [s.price.import_price for s in slots]
@@ -553,6 +569,8 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
         combined_ev_raw_load=combined_ev_raw,
         combined_ev_injected_load=combined_ev_inj,
         warnings=warnings,
+        predicted_battery_kwh=predicted_battery_kwh,
+        usable_battery_kwh=usable_kwh,
     )
     if inp.ev_planned_load_enabled:
         ev_cp = _build_and_inject_for_ev(

--- a/custom_components/hsem/planner/engine_core.py
+++ b/custom_components/hsem/planner/engine_core.py
@@ -276,6 +276,59 @@ def _schedule_slots(
     return mcps, mdps, max_soc_kwh, rc, warnings
 
 
+def _compute_ev_charger_power(
+    slots: list,
+    slot_starts: list[datetime],
+    ev_plan: EVChargingPlan | None,
+    interval_minutes: int,
+    *,
+    second: bool = False,
+) -> None:
+    """Compute per-slot EV charger target power (W) and write to slots.
+
+    ``EVChargingSlot.ac_load_kwh`` is the AC-side energy the charger draws
+    from the grid/PV.  The target power is::
+
+        AC power (W) = (ac_load_kwh / slot_hours) × 1000
+
+    When the plan is ``None`` or empty the field stays at the default 0.0.
+
+    Args:
+        slots: Mutable planner slot list to update in place.
+        slot_starts: Slot start datetimes (same length as *slots*).
+        ev_plan: EV charging plan (may be ``None``).
+        interval_minutes: Slot width in minutes.
+        second: If ``True``, write to ``ev_second_charger_calculated_power``;
+            otherwise write to ``ev_charger_calculated_power``.
+    """
+    if ev_plan is None or not ev_plan.charging_slots:
+        return
+
+    # Build a lookup from UTC key → slot index.
+    from custom_components.hsem.utils.datetime_utils import utc_key
+
+    slot_map = {utc_key(s): i for i, s in enumerate(slot_starts)}
+    hours_per_slot = interval_minutes / 60.0
+
+    for ev_slot in ev_plan.charging_slots:
+        idx = slot_map.get(utc_key(ev_slot.start))
+        if idx is None:
+            continue
+        if ev_slot.ac_load_kwh < 1e-9:
+            continue
+
+        # AC-side power: ac_load_kwh (already includes charger efficiency)
+        # divided by slot duration in hours.
+        ac_power_w = round((ev_slot.ac_load_kwh / hours_per_slot) * 1000)
+
+        attr = (
+            "ev_second_charger_calculated_power"
+            if second
+            else "ev_charger_calculated_power"
+        )
+        setattr(slots[idx], attr, ac_power_w)
+
+
 def _build_and_inject_for_ev(
     enabled: bool,
     connected: bool,
@@ -533,6 +586,13 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
         s.ev_planned_load_kwh = combined_ev_inj[i]
         s.ev_accounted_load_kwh = round(combined_ev_raw[i] - combined_ev_inj[i], 3)
         s.ev_total_planned_load_kwh = round(combined_ev_raw[i], 3)
+
+    # Compute per-slot EV charger target power (W) from the planner's
+    # per-slot energy targets.  The EVChargingSlot.estimated_charged_kwh is
+    # battery-side (DC) kWh delivered to the EV.  The AC power the charger
+    # must draw is larger by 1/eff to account for charger/cable losses.
+    _compute_ev_charger_power(slots, ss, ev_cp, inp.interval_minutes)
+    _compute_ev_charger_power(slots, ss, ev2_cp, inp.interval_minutes, second=True)
     populate_net_consumption(slots)
     populate_estimated_cost(slots, export_min_price=inp.export_min_price)
     rt = calculate_recommended_threshold(

--- a/custom_components/hsem/planner/ev_planner.py
+++ b/custom_components/hsem/planner/ev_planner.py
@@ -99,6 +99,10 @@ class EVPlannerInput:
         base_load_includes_ev: True when the house consumption sensor already
             includes EV charging power.  When True, planned EV load must not
             be added to net consumption a second time.
+        allow_charge_past_target_soc: When True, the planner may continue
+            charging past the target SoC using surplus PV that would otherwise
+            be curtailed (e.g. battery full, negative export prices).
+            Only applies when the EV has reached target SoC but is below 100 %.
         now: Timezone-aware current datetime.
     """
 
@@ -112,6 +116,7 @@ class EVPlannerInput:
     charger_efficiency_pct: float = 100.0
     deadline: datetime | None = None
     base_load_includes_ev: bool = False
+    allow_charge_past_target_soc: bool = False
     now: datetime = field(default_factory=lambda: datetime.now(UTC))
 
 
@@ -491,6 +496,63 @@ def build_ev_charging_plan(
         )
         selected.append(ev_slot)
         remaining_energy -= allocated
+
+    # --- Pass 3: charge past target on surplus PV only ---
+    # When allow_charge_past_target_soc is enabled and the EV has reached
+    # its target SoC (remaining_energy ≈ 0), continue charging from any
+    # remaining PV-surplus slots.  These slots are free — the energy would
+    # otherwise be curtailed when the battery is full and export prices are
+    # negative.  Only slots that are NOT already in the plan are considered.
+    if (
+        inp.allow_charge_past_target_soc
+        and remaining_energy < 1e-9
+        and inp.current_soc_pct < 100
+    ):
+        used_starts = {s.start for s in selected}
+        # Re-scan surplus slots, skipping those already allocated.
+        for i in surplus_slots:
+            s_start = slots_start[i]
+            s_end = slots_end[i]
+            if s_start in used_starts:
+                continue
+            if (
+                max_charge_energy_for_slot(
+                    slot_duration_minutes(s_start, s_end),
+                    inp.charger_power_kw,
+                    inp.charger_efficiency_pct,
+                )
+                < 1e-9
+            ):
+                continue
+
+            # The EV already reached target — no strict energy budget.
+            # Use as much surplus as possible up to the full slot capacity,
+            # limited by the available surplus.
+            avail_min = slot_duration_minutes(s_start, s_end)
+            max_charge = max_charge_energy_for_slot(
+                avail_min, inp.charger_power_kw, inp.charger_efficiency_pct
+            )
+            net_surplus = slot_net_surplus_kwh[i]
+            # Allocate the minimum of max power and available surplus.
+            # We charge only from surplus, never from grid in this pass.
+            allocated = min(max_charge, net_surplus)
+            if allocated < 1e-9:
+                continue
+
+            eff = max(inp.charger_efficiency_pct, 1.0) / 100.0
+            ac_load = allocated / eff
+
+            ev_slot = EVChargingSlot(
+                start=s_start,
+                end=s_end,
+                estimated_charged_kwh=round(allocated, 3),
+                ac_load_kwh=round(ac_load, 3),
+                solar_surplus_kwh=round(allocated, 3),
+                import_needed_kwh=0.0,
+                import_price=slot_import_price[i],
+                estimated_cost=0.0,
+            )
+            selected.append(ev_slot)
 
     # Build output
     plan.charging_slots = selected

--- a/custom_components/hsem/planner/ev_planner.py
+++ b/custom_components/hsem/planner/ev_planner.py
@@ -103,6 +103,13 @@ class EVPlannerInput:
             charging past the target SoC using surplus PV that would otherwise
             be curtailed (e.g. battery full, negative export prices).
             Only applies when the EV has reached target SoC but is below 100 %.
+        slot_predicted_battery_kwh: Per-slot predicted battery energy (kWh
+            above discharge floor) at the *start* of each slot, assuming no
+            EV charging and no grid charging.  Used to gate Pass 3 — the EV
+            only charges past target when the battery is already full and
+            the surplus would otherwise be stranded.
+        usable_battery_kwh: Maximum usable battery capacity (kWh).  Used as
+            the ceiling for the predicted-battery check in Pass 3.
         now: Timezone-aware current datetime.
     """
 
@@ -117,6 +124,8 @@ class EVPlannerInput:
     deadline: datetime | None = None
     base_load_includes_ev: bool = False
     allow_charge_past_target_soc: bool = False
+    slot_predicted_battery_kwh: list[float] = field(default_factory=list)
+    usable_battery_kwh: float = 0.0
     now: datetime = field(default_factory=lambda: datetime.now(UTC))
 
 
@@ -500,13 +509,15 @@ def build_ev_charging_plan(
     # --- Pass 3: charge past target on surplus PV only ---
     # When allow_charge_past_target_soc is enabled and the EV has reached
     # its target SoC (remaining_energy ≈ 0), continue charging from any
-    # remaining PV-surplus slots.  These slots are free — the energy would
-    # otherwise be curtailed when the battery is full and export prices are
-    # negative.  Only slots that are NOT already in the plan are considered.
+    # remaining PV-surplus slots — but only when the house battery is
+    # already predicted to be full at that slot, meaning the surplus
+    # would otherwise be stranded (curtailed).
     if (
         inp.allow_charge_past_target_soc
         and remaining_energy < 1e-9
         and inp.current_soc_pct < 100
+        and len(inp.slot_predicted_battery_kwh)
+        == len(surplus_slots) + len(non_surplus_slots)  # type: ignore[arg-type]
     ):
         used_starts = {s.start for s in selected}
         # Re-scan surplus slots, skipping those already allocated.
@@ -514,6 +525,14 @@ def build_ev_charging_plan(
             s_start = slots_start[i]
             s_end = slots_end[i]
             if s_start in used_starts:
+                continue
+            # Only charge past target when the battery is already full
+            # at this slot — the surplus has nowhere else to go.
+            if (
+                inp.slot_predicted_battery_kwh
+                and i < len(inp.slot_predicted_battery_kwh)
+                and inp.slot_predicted_battery_kwh[i] < inp.usable_battery_kwh - 1e-6
+            ):
                 continue
             if (
                 max_charge_energy_for_slot(

--- a/docs/hsem-planner-spec.md
+++ b/docs/hsem-planner-spec.md
@@ -819,6 +819,8 @@ Three per-slot fields capture EV load intent precisely:
 | `ev_planned_load_kwh` | Extra EV AC load **added to net consumption** — only the portion not already in `avg_house_consumption`. Zero when `base_load_includes_ev = True`. |
 | `ev_accounted_load_kwh` | EV AC load **already included** in the house consumption sensor. Non-zero when `base_load_includes_ev = True`. Must not be added to net consumption again. |
 | `ev_total_planned_load_kwh` | Total planned EV AC load regardless of accounting mode: `ev_planned_load_kwh + ev_accounted_load_kwh`. Always non-zero when any EV charging is planned. |
+| `ev_charger_calculated_power` | Target AC power (W) for the primary EV charger during this slot. Computed from the EV planner's per-slot energy target: `round((ac_load_kwh / slot_hours) × 1000)`. Zero when no charging is planned. |
+| `ev_second_charger_calculated_power` | Same as above, for the second EV. |
 
 When `base_load_includes_ev = False`:
 ```text
@@ -929,6 +931,20 @@ The EV planner (`planner/ev_planner.py`) MUST satisfy these invariants:
 10. **Disabled EV is zero-cost**: When `ev_planned_load_enabled = False`, all
     three EV load fields must be `0.0` and the home battery planner output
     must be identical to the non-EV case.
+
+11. **Charge past target SoC (Pass 3)**: When `allow_charge_past_target_soc`
+    is enabled and the EV has reached its target SoC but is below 100 %, a
+    third pass scans remaining PV-surplus slots.  The EV only receives
+    stranded surplus — slots where the house battery is **predicted to be
+    full** (from the cumulative net consumption trajectory).  Pass 3 never
+    draws from the grid; all energy is solar-surplus with zero cost.
+
+12. **EV charger power field**: `ev_charger_calculated_power` is computed
+    from the EV planner's `ac_load_kwh` (AC-side energy) divided by slot
+    duration.  The field is zero when no EV charging is planned in that
+    slot.  It is purely a planner output — the applier must read this
+    value to throttle the go-e charger; the planner does not control
+    hardware directly.
 
 ### Invariants for tests
 

--- a/tests/planner/test_ev_planned_load.py
+++ b/tests/planner/test_ev_planned_load.py
@@ -2841,3 +2841,68 @@ class TestEvDeadlineWindowOneMidnight:
         for slot in plan.charging_slots:
             assert slot.start < deadline
             assert slot.end <= deadline
+
+
+# ---------------------------------------------------------------------------
+# ev_charger_calculated_power
+# ---------------------------------------------------------------------------
+
+
+class TestEvChargerCalculatedPower:
+    """ev_charger_calculated_power field behaviour."""
+
+    def test_power_formula_full_speed(self):
+        """Full-speed 15-min slot: (2.75 / 0.25) * 1000 = 11000 W."""
+        assert round((2.75 / 0.25) * 1000) == 11000
+
+    def test_power_formula_trickle(self):
+        """Trickle-charge 15-min slot: (0.5 / 0.25) * 1000 = 2000 W."""
+        assert round((0.5 / 0.25) * 1000) == 2000
+
+    def test_pass_3_skips_when_battery_not_full(self):
+        """Pass 3 adds no slots when battery is below usable_kwh."""
+        now = _dt(0)
+        surplus = [2.0] * 12 + [0.0] * 12
+        starts, ends = _make_slots(24)
+        inp = EVPlannerInput(
+            enabled=True,
+            ev_connected=True,
+            smart_charging_enabled=True,
+            current_soc_pct=97.0,
+            target_soc_pct=98.0,
+            battery_capacity_kwh=100.0,
+            charger_power_kw=11.0,
+            charger_efficiency_pct=100.0,
+            allow_charge_past_target_soc=True,
+            slot_predicted_battery_kwh=[6.0] * 24,
+            usable_battery_kwh=14.25,
+            now=now,
+        )
+        prices = [0.10] * 24
+        plan = build_ev_charging_plan(inp, starts, ends, surplus, prices)
+        total = sum(s.estimated_charged_kwh for s in plan.charging_slots)
+        assert total == pytest.approx(1.0, abs=0.1)
+
+    def test_pass_3_adds_when_battery_full(self):
+        """Pass 3 adds surplus slots when battery is full."""
+        now = _dt(0)
+        surplus = [2.0] * 12 + [0.0] * 12
+        starts, ends = _make_slots(24)
+        inp = EVPlannerInput(
+            enabled=True,
+            ev_connected=True,
+            smart_charging_enabled=True,
+            current_soc_pct=97.0,
+            target_soc_pct=98.0,
+            battery_capacity_kwh=100.0,
+            charger_power_kw=11.0,
+            charger_efficiency_pct=100.0,
+            allow_charge_past_target_soc=True,
+            slot_predicted_battery_kwh=[14.25] * 24,
+            usable_battery_kwh=14.25,
+            now=now,
+        )
+        prices = [0.10] * 24
+        plan = build_ev_charging_plan(inp, starts, ends, surplus, prices)
+        total = sum(s.estimated_charged_kwh for s in plan.charging_slots)
+        assert total > 2.0, f"Pass 3 should add surplus, got {total}"


### PR DESCRIPTION
## Summary

Adds per-slot EV charger target power (W) so the applier can throttle the go-e
charger instead of always running at full speed. The EV can trickle-charge from
excess PV across multiple slots rather than drawing full grid power in one slot.

Also adds "charge past target SoC on surplus PV" — when enabled, after the EV
reaches its target SoC, a third pass scans remaining PV-surplus slots and
allocates free charging from energy that would otherwise be curtailed.
Pass 3 is gated on the house battery being predicted full at that slot, so the
MILP gets first priority on PV surplus.

Fixes the applier: `allow_charge_past_target_soc` no longer forces export_pct=100
when the house battery has room — the MILP's plan takes priority unless the
battery is >= 99% SoC.

### How it works

**Calculated power field:**
```
ac_power_w = round((ac_load_kwh / slot_hours) x 1000)
```

**Charge past target (Pass 3):** only allocates when battery is predicted full.

**Applier fix:** export_pct=100 for past-target only when battery >= 99%.

### Files changed

- `models/planner_outputs.py` — ev_charger_calculated_power fields
- `models/hourly_recommendation.py` — same fields
- `models/planner_inputs.py` — allow_charge_past_target_soc fields
- `planner/engine_core.py` — `_compute_ev_charger_power()` + predicted battery trajectory
- `planner/ev_planner.py` — Pass 3 gated on battery full
- `custom_sensors/applier.py` — gate export_pct on battery >= 99%
- `coordinator_builder.py` — config wiring
- `coordinator.py` — field mapping
- `README.md` — updated EV FAQ
- `docs/hsem-planner-spec.md` — new fields and Pass 3 invariants
- `tests/planner/test_ev_planned_load.py` — power formula + Pass 3 gating tests

### Checklist

- [x] `ev_charger_calculated_power` field on PlannedSlot + HourlyRecommendation
- [x] Power computed from ac_load_kwh / slot duration
- [x] Both primary and second EV
- [x] Coordinator wiring
- [x] Pass 3: charge past target on surplus PV, gated on battery full
- [x] Applier: only force export when battery >= 99% SoC
- [x] Predicted battery trajectory computed in engine_core.py
- [x] README FAQ updated
- [x] Planner spec updated
- [x] Tests added
- [x] tox -e lint passes
- [x] tox -e quality passes (0 errors)
