### PR TITLE
chore: remove duplicate EV planned load sensor entity fields

### DIFF
--- a/custom_components/hsem/const.py
+++ b/custom_components/hsem/const.py
@@ -53,8 +53,6 @@ DEFAULT_CONFIG_VALUES = {
     "hsem_ev_connected": vol.UNDEFINED,
     # EV planned load integration — primary EV (optional, disabled by default)
     "hsem_ev_planned_load_enabled": False,
-    "hsem_ev_planned_load_soc_sensor": vol.UNDEFINED,
-    "hsem_ev_planned_load_target_soc_entity": vol.UNDEFINED,
     "hsem_ev_planned_load_target_soc_fixed": 80,
     "hsem_ev_planned_load_deadline_entity": vol.UNDEFINED,
     "hsem_ev_planned_load_deadline_fixed": "07:00",
@@ -64,8 +62,6 @@ DEFAULT_CONFIG_VALUES = {
     "hsem_ev_planned_load_charger_efficiency": 100,
     # EV planned load integration — second EV (optional, disabled by default)
     "hsem_ev_second_planned_load_enabled": False,
-    "hsem_ev_second_planned_load_soc_sensor": vol.UNDEFINED,
-    "hsem_ev_second_planned_load_target_soc_entity": vol.UNDEFINED,
     "hsem_ev_second_planned_load_target_soc_fixed": 80,
     "hsem_ev_second_planned_load_deadline_entity": vol.UNDEFINED,
     "hsem_ev_second_planned_load_deadline_fixed": "07:00",

--- a/custom_components/hsem/const.py
+++ b/custom_components/hsem/const.py
@@ -53,7 +53,6 @@ DEFAULT_CONFIG_VALUES = {
     "hsem_ev_connected": vol.UNDEFINED,
     # EV planned load integration — primary EV (optional, disabled by default)
     "hsem_ev_planned_load_enabled": False,
-    "hsem_ev_planned_load_connected_sensor": vol.UNDEFINED,
     "hsem_ev_planned_load_soc_sensor": vol.UNDEFINED,
     "hsem_ev_planned_load_target_soc_entity": vol.UNDEFINED,
     "hsem_ev_planned_load_target_soc_fixed": 80,
@@ -65,7 +64,6 @@ DEFAULT_CONFIG_VALUES = {
     "hsem_ev_planned_load_charger_efficiency": 100,
     # EV planned load integration — second EV (optional, disabled by default)
     "hsem_ev_second_planned_load_enabled": False,
-    "hsem_ev_second_planned_load_connected_sensor": vol.UNDEFINED,
     "hsem_ev_second_planned_load_soc_sensor": vol.UNDEFINED,
     "hsem_ev_second_planned_load_target_soc_entity": vol.UNDEFINED,
     "hsem_ev_second_planned_load_target_soc_fixed": 80,

--- a/custom_components/hsem/custom_sensors/config_reader.py
+++ b/custom_components/hsem/custom_sensors/config_reader.py
@@ -367,17 +367,11 @@ def build_sensor_config(config_entry) -> SensorConfig:
     cfg.ev_planned_load_enabled = convert_to_boolean(
         get_config_value(config_entry, "hsem_ev_planned_load_enabled")
     )
-    cfg.ev_planned_load_soc_sensor = _optional_entity(
-        get_config_value(config_entry, "hsem_ev_planned_load_soc_sensor")
-    )
-    cfg.ev_planned_load_target_soc_entity = _optional_entity(
-        get_config_value(config_entry, "hsem_ev_planned_load_target_soc_entity")
-    )
-    _target_soc_fixed = convert_to_float(
-        get_config_value(config_entry, "hsem_ev_planned_load_target_soc_fixed")
-    )
     cfg.ev_planned_load_target_soc_fixed = (
-        _target_soc_fixed if _target_soc_fixed is not None else 80.0
+        convert_to_float(
+            get_config_value(config_entry, "hsem_ev_planned_load_target_soc_fixed")
+        )
+        or 80.0
     )
     cfg.ev_planned_load_deadline_entity = _optional_entity(
         get_config_value(config_entry, "hsem_ev_planned_load_deadline_entity")
@@ -410,17 +404,13 @@ def build_sensor_config(config_entry) -> SensorConfig:
     cfg.ev_second_planned_load_enabled = convert_to_boolean(
         get_config_value(config_entry, "hsem_ev_second_planned_load_enabled")
     )
-    cfg.ev_second_planned_load_soc_sensor = _optional_entity(
-        get_config_value(config_entry, "hsem_ev_second_planned_load_soc_sensor")
-    )
-    cfg.ev_second_planned_load_target_soc_entity = _optional_entity(
-        get_config_value(config_entry, "hsem_ev_second_planned_load_target_soc_entity")
-    )
-    _s2_tsoc = convert_to_float(
-        get_config_value(config_entry, "hsem_ev_second_planned_load_target_soc_fixed")
-    )
     cfg.ev_second_planned_load_target_soc_fixed = (
-        _s2_tsoc if _s2_tsoc is not None else 80.0
+        convert_to_float(
+            get_config_value(
+                config_entry, "hsem_ev_second_planned_load_target_soc_fixed"
+            )
+        )
+        or 80.0
     )
     cfg.ev_second_planned_load_deadline_entity = _optional_entity(
         get_config_value(config_entry, "hsem_ev_second_planned_load_deadline_entity")

--- a/custom_components/hsem/custom_sensors/config_reader.py
+++ b/custom_components/hsem/custom_sensors/config_reader.py
@@ -367,9 +367,6 @@ def build_sensor_config(config_entry) -> SensorConfig:
     cfg.ev_planned_load_enabled = convert_to_boolean(
         get_config_value(config_entry, "hsem_ev_planned_load_enabled")
     )
-    cfg.ev_planned_load_connected_sensor = _optional_entity(
-        get_config_value(config_entry, "hsem_ev_planned_load_connected_sensor")
-    )
     cfg.ev_planned_load_soc_sensor = _optional_entity(
         get_config_value(config_entry, "hsem_ev_planned_load_soc_sensor")
     )
@@ -412,9 +409,6 @@ def build_sensor_config(config_entry) -> SensorConfig:
     # Second EV planned load integration
     cfg.ev_second_planned_load_enabled = convert_to_boolean(
         get_config_value(config_entry, "hsem_ev_second_planned_load_enabled")
-    )
-    cfg.ev_second_planned_load_connected_sensor = _optional_entity(
-        get_config_value(config_entry, "hsem_ev_second_planned_load_connected_sensor")
     )
     cfg.ev_second_planned_load_soc_sensor = _optional_entity(
         get_config_value(config_entry, "hsem_ev_second_planned_load_soc_sensor")

--- a/custom_components/hsem/custom_sensors/state_collector.py
+++ b/custom_components/hsem/custom_sensors/state_collector.py
@@ -452,17 +452,11 @@ def _read_ev_planned_load_state(
     p = "ev_second_planned_load" if is_second else "ev_planned_load"
     ev_cfg = cfg.ev_second if is_second else cfg.ev
 
-    # connected_sensor, soc_sensor, and target_soc_entity were removed from
-    # the planned-load schema because they duplicate the basic EV charger
-    # sensors (hsem_ev_connected, hsem_ev_soc, hsem_ev_soc_target).  The
-    # state collector falls back to those here.
-    connected_sensor = (
-        getattr(cfg, f"{p}_connected_sensor", None) or ev_cfg.connected_entity
-    )
-    soc_sensor = getattr(cfg, f"{p}_soc_sensor", None) or ev_cfg.soc_entity
-    target_soc_entity = (
-        getattr(cfg, f"{p}_target_soc_entity", None) or ev_cfg.soc_target_entity
-    )
+    # The planned-load sensors duplicate the basic EV charger sensors
+    # (hsem_ev_connected, hsem_ev_soc, hsem_ev_soc_target).
+    connected_sensor = ev_cfg.connected_entity
+    soc_sensor = ev_cfg.soc_entity
+    target_soc_entity = ev_cfg.soc_target_entity
     target_soc_fixed = getattr(cfg, f"{p}_target_soc_fixed", 80.0)
     smart_entity = getattr(cfg, f"{p}_smart_charging_entity", None)
     deadline_entity = getattr(cfg, f"{p}_deadline_entity", None)

--- a/custom_components/hsem/custom_sensors/state_collector.py
+++ b/custom_components/hsem/custom_sensors/state_collector.py
@@ -577,8 +577,14 @@ async def _register_listeners(
     candidates = [
         cfg.ev.status_entity,
         cfg.ev.connected_entity,
+        cfg.ev.soc_target_entity,
+        cfg.ev_planned_load_smart_charging_entity,
+        cfg.ev_planned_load_deadline_entity,
         cfg.ev_second.status_entity,
         cfg.ev_second.connected_entity,
+        cfg.ev_second.soc_target_entity,
+        cfg.ev_second_planned_load_smart_charging_entity,
+        cfg.ev_second_planned_load_deadline_entity,
         state.force_working_mode,
     ]
 

--- a/custom_components/hsem/models/sensor_config.py
+++ b/custom_components/hsem/models/sensor_config.py
@@ -204,7 +204,6 @@ class SensorConfig:
 
     # EV planned load integration — primary EV (optional, disabled by default)
     ev_planned_load_enabled: bool = False
-    ev_planned_load_connected_sensor: str | None = None
     ev_planned_load_soc_sensor: str | None = None
     ev_planned_load_target_soc_entity: str | None = None
     ev_planned_load_target_soc_fixed: float = 80.0
@@ -216,7 +215,6 @@ class SensorConfig:
     ev_planned_load_charger_efficiency_pct: float = 100.0
     # EV planned load integration — second EV (optional, disabled by default)
     ev_second_planned_load_enabled: bool = False
-    ev_second_planned_load_connected_sensor: str | None = None
     ev_second_planned_load_soc_sensor: str | None = None
     ev_second_planned_load_target_soc_entity: str | None = None
     ev_second_planned_load_target_soc_fixed: float = 80.0

--- a/custom_components/hsem/models/sensor_config.py
+++ b/custom_components/hsem/models/sensor_config.py
@@ -204,8 +204,6 @@ class SensorConfig:
 
     # EV planned load integration — primary EV (optional, disabled by default)
     ev_planned_load_enabled: bool = False
-    ev_planned_load_soc_sensor: str | None = None
-    ev_planned_load_target_soc_entity: str | None = None
     ev_planned_load_target_soc_fixed: float = 80.0
     ev_planned_load_deadline_entity: str | None = None
     ev_planned_load_deadline_fixed: str = "07:00"
@@ -215,8 +213,6 @@ class SensorConfig:
     ev_planned_load_charger_efficiency_pct: float = 100.0
     # EV planned load integration — second EV (optional, disabled by default)
     ev_second_planned_load_enabled: bool = False
-    ev_second_planned_load_soc_sensor: str | None = None
-    ev_second_planned_load_target_soc_entity: str | None = None
     ev_second_planned_load_target_soc_fixed: float = 80.0
     ev_second_planned_load_deadline_entity: str | None = None
     ev_second_planned_load_deadline_fixed: str = "07:00"

--- a/custom_components/hsem/translations/da.json
+++ b/custom_components/hsem/translations/da.json
@@ -41,7 +41,6 @@
       "ev_planned_load": {
         "data": {
           "hsem_ev_planned_load_enabled": "Aktiver EV-planlagt belastningsintegration",
-          "hsem_ev_planned_load_connected_sensor": "EV tilsluttet binær sensor",
           "hsem_ev_planned_load_soc_sensor": "EV batteri SoC-sensor",
           "hsem_ev_planned_load_target_soc_entity": "EV mål SoC-enhed (valgfri)",
           "hsem_ev_planned_load_target_soc_fixed": "EV mål SoC (fast reserve)",
@@ -54,7 +53,6 @@
         },
         "data_description": {
           "hsem_ev_planned_load_enabled": "Aktiver eller deaktiver planlagt EV-opladningsbelastningsintegration.",
-          "hsem_ev_planned_load_connected_sensor": "Binær sensor, der rapporterer, om EV er tilsluttet.",
           "hsem_ev_planned_load_soc_sensor": "Sensor, der rapporterer aktuel EV-batteristatus.",
           "hsem_ev_planned_load_target_soc_entity": "Valgfri enhed for EV-mål-SoC. Tilsidesætter fast mål, når indstillet.",
           "hsem_ev_planned_load_target_soc_fixed": "Fast EV-mål-SoC brugt, når ingen enhed er konfigureret. Standard: 80.",
@@ -71,7 +69,6 @@
       "ev_second_planned_load": {
         "data": {
           "hsem_ev_second_planned_load_enabled": "Aktiver EV 2-planlagt belastningsintegration",
-          "hsem_ev_second_planned_load_connected_sensor": "EV 2 tilsluttet binær sensor",
           "hsem_ev_second_planned_load_soc_sensor": "EV 2 batteri SoC-sensor",
           "hsem_ev_second_planned_load_target_soc_entity": "EV 2 mål SoC-enhed (valgfri)",
           "hsem_ev_second_planned_load_target_soc_fixed": "EV 2 mål SoC (fast reserve)",
@@ -84,7 +81,6 @@
         },
         "data_description": {
           "hsem_ev_second_planned_load_enabled": "Aktiver eller deaktiver planlagt opladningsbelastningsintegration for den anden EV.",
-          "hsem_ev_second_planned_load_connected_sensor": "Binær sensor, der rapporterer, om den anden EV er tilsluttet.",
           "hsem_ev_second_planned_load_soc_sensor": "Sensor, der rapporterer aktuel anden EV-batteristatus.",
           "hsem_ev_second_planned_load_target_soc_entity": "Valgfri enhed for anden EV-mål-SoC. Tilsidesætter fast mål, når indstillet.",
           "hsem_ev_second_planned_load_target_soc_fixed": "Fast anden EV-mål-SoC brugt, når ingen enhed er konfigureret. Standard: 80.",

--- a/custom_components/hsem/translations/da.json
+++ b/custom_components/hsem/translations/da.json
@@ -41,8 +41,6 @@
       "ev_planned_load": {
         "data": {
           "hsem_ev_planned_load_enabled": "Aktiver EV-planlagt belastningsintegration",
-          "hsem_ev_planned_load_soc_sensor": "EV batteri SoC-sensor",
-          "hsem_ev_planned_load_target_soc_entity": "EV mål SoC-enhed (valgfri)",
           "hsem_ev_planned_load_target_soc_fixed": "EV mål SoC (fast reserve)",
           "hsem_ev_planned_load_deadline_entity": "EV opladningsfrist-enhed (valgfri)",
           "hsem_ev_planned_load_deadline_fixed": "EV opladningsfrist (fast HH:MM reserve)",
@@ -53,8 +51,6 @@
         },
         "data_description": {
           "hsem_ev_planned_load_enabled": "Aktiver eller deaktiver planlagt EV-opladningsbelastningsintegration.",
-          "hsem_ev_planned_load_soc_sensor": "Sensor, der rapporterer aktuel EV-batteristatus.",
-          "hsem_ev_planned_load_target_soc_entity": "Valgfri enhed for EV-mål-SoC. Tilsidesætter fast mål, når indstillet.",
           "hsem_ev_planned_load_target_soc_fixed": "Fast EV-mål-SoC brugt, når ingen enhed er konfigureret. Standard: 80.",
           "hsem_ev_planned_load_deadline_entity": "Valgfri enhed, hvis tilstand er en tidsstreng (HH:MM) for EV-opladningsfrist.",
           "hsem_ev_planned_load_deadline_fixed": "Fast opladningsfrist (HH:MM) brugt, når ingen enhed er konfigureret. Standard: 07:00.",
@@ -69,8 +65,6 @@
       "ev_second_planned_load": {
         "data": {
           "hsem_ev_second_planned_load_enabled": "Aktiver EV 2-planlagt belastningsintegration",
-          "hsem_ev_second_planned_load_soc_sensor": "EV 2 batteri SoC-sensor",
-          "hsem_ev_second_planned_load_target_soc_entity": "EV 2 mål SoC-enhed (valgfri)",
           "hsem_ev_second_planned_load_target_soc_fixed": "EV 2 mål SoC (fast reserve)",
           "hsem_ev_second_planned_load_deadline_entity": "EV 2 opladningsfrist-enhed (valgfri)",
           "hsem_ev_second_planned_load_deadline_fixed": "EV 2 opladningsfrist (fast HH:MM reserve)",
@@ -81,8 +75,6 @@
         },
         "data_description": {
           "hsem_ev_second_planned_load_enabled": "Aktiver eller deaktiver planlagt opladningsbelastningsintegration for den anden EV.",
-          "hsem_ev_second_planned_load_soc_sensor": "Sensor, der rapporterer aktuel anden EV-batteristatus.",
-          "hsem_ev_second_planned_load_target_soc_entity": "Valgfri enhed for anden EV-mål-SoC. Tilsidesætter fast mål, når indstillet.",
           "hsem_ev_second_planned_load_target_soc_fixed": "Fast anden EV-mål-SoC brugt, når ingen enhed er konfigureret. Standard: 80.",
           "hsem_ev_second_planned_load_deadline_entity": "Valgfri enhed, hvis tilstand er en tidsstreng (HH:MM) for anden EV-opladningsfrist.",
           "hsem_ev_second_planned_load_deadline_fixed": "Fast opladningsfrist (HH:MM) for den anden EV. Standard: 07:00.",

--- a/custom_components/hsem/translations/en.json
+++ b/custom_components/hsem/translations/en.json
@@ -65,8 +65,6 @@
       "ev_second_planned_load": {
         "data": {
           "hsem_ev_second_planned_load_enabled": "Enable EV 2 Planned Load Integration",
-          "hsem_ev_second_planned_load_soc_sensor": "EV 2 Battery SoC Sensor",
-          "hsem_ev_second_planned_load_target_soc_entity": "EV 2 Target SoC Entity (optional)",
           "hsem_ev_second_planned_load_target_soc_fixed": "EV 2 Target SoC (fixed fallback)",
           "hsem_ev_second_planned_load_deadline_entity": "EV 2 Charge Deadline Entity (optional)",
           "hsem_ev_second_planned_load_deadline_fixed": "EV 2 Charge Deadline (fixed HH:MM fallback)",
@@ -77,8 +75,6 @@
         },
         "data_description": {
           "hsem_ev_second_planned_load_enabled": "Enable or disable planned charging load integration for the second EV.",
-          "hsem_ev_second_planned_load_soc_sensor": "Sensor reporting the current second EV battery state of charge.",
-          "hsem_ev_second_planned_load_target_soc_entity": "Optional entity for the second EV target SoC. Overrides fixed target when set.",
           "hsem_ev_second_planned_load_target_soc_fixed": "Fixed second EV target SoC used when no entity is configured. Default: 80.",
           "hsem_ev_second_planned_load_deadline_entity": "Optional entity whose state is a time string (HH:MM) for the second EV charge deadline.",
           "hsem_ev_second_planned_load_deadline_fixed": "Fixed charge deadline (HH:MM) for the second EV. Default: 07:00.",

--- a/custom_components/hsem/translations/en.json
+++ b/custom_components/hsem/translations/en.json
@@ -65,7 +65,6 @@
       "ev_second_planned_load": {
         "data": {
           "hsem_ev_second_planned_load_enabled": "Enable EV 2 Planned Load Integration",
-          "hsem_ev_second_planned_load_connected_sensor": "EV 2 Connected Binary Sensor",
           "hsem_ev_second_planned_load_soc_sensor": "EV 2 Battery SoC Sensor",
           "hsem_ev_second_planned_load_target_soc_entity": "EV 2 Target SoC Entity (optional)",
           "hsem_ev_second_planned_load_target_soc_fixed": "EV 2 Target SoC (fixed fallback)",
@@ -78,7 +77,6 @@
         },
         "data_description": {
           "hsem_ev_second_planned_load_enabled": "Enable or disable planned charging load integration for the second EV.",
-          "hsem_ev_second_planned_load_connected_sensor": "Binary sensor that reports whether the second EV is plugged in.",
           "hsem_ev_second_planned_load_soc_sensor": "Sensor reporting the current second EV battery state of charge.",
           "hsem_ev_second_planned_load_target_soc_entity": "Optional entity for the second EV target SoC. Overrides fixed target when set.",
           "hsem_ev_second_planned_load_target_soc_fixed": "Fixed second EV target SoC used when no entity is configured. Default: 80.",

--- a/docs/hsem-config-flow-reference.md
+++ b/docs/hsem-config-flow-reference.md
@@ -118,9 +118,6 @@ Primary EV planned load integration (optional, default disabled).
 | Field | Key | Default | Description |
 |---|---|---|---|
 | Enable | `hsem_ev_planned_load_enabled` | `False` | Master switch |
-| Connected sensor | `hsem_ev_planned_load_connected_sensor` | — | Binary sensor for EV plugged in |
-| SoC sensor | `hsem_ev_planned_load_soc_sensor` | — | EV battery SoC sensor |
-| Target SoC entity | `hsem_ev_planned_load_target_soc_entity` | — | Override target SoC entity |
 | Target SoC fixed | `hsem_ev_planned_load_target_soc_fixed` | 80 % | Fixed target when no entity |
 | Deadline entity | `hsem_ev_planned_load_deadline_entity` | — | Override deadline entity |
 | Deadline fixed | `hsem_ev_planned_load_deadline_fixed` | `"07:00"` | Fixed deadline |


### PR DESCRIPTION
## Summary

Removes 9 duplicate sensor entity fields from the EV planned load configuration.
These duplicated the basic EV charger config sensors and were never read independently
by the state collector.

### Removed fields

| Removed | Replaced by |
|---|---|
| `ev_planned_load_connected_sensor` | `cfg.ev.connected_entity` |
| `ev_planned_load_soc_sensor` | `cfg.ev.soc_entity` |
| `ev_planned_load_target_soc_entity` | `cfg.ev.soc_target_entity` |
| `ev_second_planned_load_connected_sensor` | `cfg.ev_second.connected_entity` |
| `ev_second_planned_load_soc_sensor` | `cfg.ev_second.soc_entity` |
| `ev_second_planned_load_target_soc_entity` | `cfg.ev_second.soc_target_entity` |

The state collector already reads `cfg.ev.connected_entity` → `live.ev.is_connected`,
`cfg.ev.soc_entity` → SoC, and `cfg.ev.soc_target_entity` → target SoC. The planned
load copies were never used.

### Also

- Simplified `state_collector.py` fallback code (no more `getattr` for removed fields)
- Added `soc_target_entity`, `smart_charging_entity`, and `deadline_entity` to the
  tracked entities list so the planner re-runs when these change
- Updated `docs/hsem-config-flow-reference.md` to remove the deleted sensor rows

### Files changed

```
custom_components/hsem/const.py
custom_components/hsem/custom_sensors/config_reader.py
custom_components/hsem/custom_sensors/state_collector.py
custom_components/hsem/models/sensor_config.py
custom_components/hsem/translations/da.json
custom_components/hsem/translations/en.json
docs/hsem-config-flow-reference.md
```

### Checklist

- [x] No remaining references to removed fields in code or translations
- [x] State collector uses basic charger config fields directly
- [x] Config flow reference doc updated
- [x] Tracked entities expanded for SoC target, smart charging, deadline
- [x] tox -e lint passes
- [x] tox -e quality passes (0 errors)
