### PR TITLE
chore(sensor): replace hardcoded strings with homeassistant.const imports

### DIFF
--- a/custom_components/hsem/custom_sensors/applier.py
+++ b/custom_components/hsem/custom_sensors/applier.py
@@ -33,6 +33,8 @@ from __future__ import annotations
 
 import re
 
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+
 from custom_components.hsem.const import (
     DEFAULT_HSEM_BATTERIES_WAIT_MODE,
     DEFAULT_HSEM_EV_CHARGER_TOU_MODES,
@@ -326,8 +328,8 @@ async def async_apply_battery_settings(
         fc_state = live.huawei_batteries_forcible_charge_state or ""
         if fc_state and fc_state.lower() not in (
             "stopped",
-            "unavailable",
-            "unknown",
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
             "",
         ):
             await async_stop_forcible_discharge(
@@ -529,7 +531,7 @@ async def _async_apply_forcible_discharge(
         if not bat_fc_entity:
             return None
         state = sensor.hass.states.get(bat_fc_entity)
-        if state is None or state.state in ("unknown", "unavailable", ""):
+        if state is None or state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE, ""):
             return None
         if state.state.lower() == "stopped":
             return None
@@ -577,7 +579,7 @@ def _read_number_state(sensor, entity_id: str | None) -> float | None:
     if not entity_id:
         return None
     state = sensor.hass.states.get(entity_id)
-    if state is None or state.state in ("unknown", "unavailable", None):
+    if state is None or state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE, None):
         return None
     try:
         return float(state.state)
@@ -598,7 +600,7 @@ def _read_select_state(sensor, entity_id: str | None) -> str | None:
     if not entity_id:
         return None
     state = sensor.hass.states.get(entity_id)
-    if state is None or state.state in ("unknown", "unavailable", None):
+    if state is None or state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE, None):
         return None
     return str(state.state)
 

--- a/custom_components/hsem/custom_sensors/battery_soc_sensor.py
+++ b/custom_components/hsem/custom_sensors/battery_soc_sensor.py
@@ -21,7 +21,12 @@ from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.sensor.const import SensorDeviceClass
-from homeassistant.const import PERCENTAGE, EntityCategory
+from homeassistant.const import (
+    PERCENTAGE,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    EntityCategory,
+)
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from custom_components.hsem.coordinator import (
@@ -147,8 +152,8 @@ class HSEMBatterySoCSensor(
         await super().async_added_to_hass()
         restored = await self.async_get_last_state()
         if restored is not None and restored.state not in {
-            "unavailable",
-            "unknown",
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
             None,
         }:
             self._restored_state = restored.state

--- a/custom_components/hsem/custom_sensors/ev_charging_sensor.py
+++ b/custom_components/hsem/custom_sensors/ev_charging_sensor.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.const import EntityCategory
+from homeassistant.const import STATE_OFF, STATE_ON, EntityCategory
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from custom_components.hsem.coordinator import (
@@ -34,7 +34,7 @@ from custom_components.hsem.utils.sensornames import (
     get_ev_charging_sensor_unique_id,
 )
 
-_VALID_STATES = {"on", "off"}
+_VALID_STATES = {STATE_ON, STATE_OFF}
 
 
 class HSEMEVChargingSensor(
@@ -97,8 +97,8 @@ class HSEMEVChargingSensor(
         """Return ``'on'`` when any EV charger is active, ``'off'`` otherwise."""
         data: CoordinatorData | None = self.coordinator.data
         if data is None or data.live is None:
-            return self._restored_state or "off"
-        return "on" if data.live.any_ev_charging else "off"
+            return self._restored_state or STATE_OFF
+        return STATE_ON if data.live.any_ev_charging else STATE_OFF
 
     @property
     def should_poll(self) -> bool:

--- a/custom_components/hsem/custom_sensors/ev_optimal_charging_plan_sensor.py
+++ b/custom_components/hsem/custom_sensors/ev_optimal_charging_plan_sensor.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.const import EntityCategory
+from homeassistant.const import STATE_UNAVAILABLE, EntityCategory
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from custom_components.hsem.coordinator import (
@@ -46,7 +46,7 @@ _VALID_STATES = {
     "fully_charged",
     "charging",
     "waiting",
-    "unavailable",
+    STATE_UNAVAILABLE,
 }
 
 
@@ -106,12 +106,12 @@ class HSEMEVOptimalChargingPlanSensor(
         """Return the current EV charging plan state."""
         data: CoordinatorData | None = self.coordinator.data
         if data is None:
-            return self._restored_state or "unavailable"
+            return self._restored_state or STATE_UNAVAILABLE
         plan = data.ev_charging_plan
         if plan is None:
-            return "unavailable"
+            return STATE_UNAVAILABLE
         state = plan.state
-        return state if state in _VALID_STATES else "unavailable"
+        return state if state in _VALID_STATES else STATE_UNAVAILABLE
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/custom_components/hsem/custom_sensors/ev_second_optimal_charging_plan_sensor.py
+++ b/custom_components/hsem/custom_sensors/ev_second_optimal_charging_plan_sensor.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.const import EntityCategory
+from homeassistant.const import STATE_UNAVAILABLE, EntityCategory
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from custom_components.hsem.coordinator import (
@@ -31,7 +31,7 @@ _VALID_STATES = {
     "fully_charged",
     "charging",
     "waiting",
-    "unavailable",
+    STATE_UNAVAILABLE,
 }
 
 
@@ -78,12 +78,12 @@ class HSEMEVSecondOptimalChargingPlanSensor(
         """Return the current second EV charging plan state."""
         data: CoordinatorData | None = self.coordinator.data
         if data is None:
-            return self._restored_state or "unavailable"
+            return self._restored_state or STATE_UNAVAILABLE
         plan = data.ev_second_charging_plan
         if plan is None:
-            return "unavailable"
+            return STATE_UNAVAILABLE
         state = plan.state
-        return state if state in _VALID_STATES else "unavailable"
+        return state if state in _VALID_STATES else STATE_UNAVAILABLE
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/custom_components/hsem/custom_sensors/force_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/force_mode_sensor.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.const import EntityCategory
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, EntityCategory
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from custom_components.hsem.coordinator import (
@@ -138,8 +138,8 @@ class HSEMForceModeSensor(
         await super().async_added_to_hass()
         restored = await self.async_get_last_state()
         if restored is not None and restored.state not in {
-            "unavailable",
-            "unknown",
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
             None,
         }:
             self._restored_state = restored.state

--- a/custom_components/hsem/custom_sensors/forecast_accuracy_sensor.py
+++ b/custom_components/hsem/custom_sensors/forecast_accuracy_sensor.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.const import EntityCategory
+from homeassistant.const import EntityCategory, UnitOfEnergy
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from custom_components.hsem.coordinator import (
@@ -139,7 +139,7 @@ class HSEMForecastAccuracySensor(
     @property
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit of measurement."""
-        return "kWh"
+        return UnitOfEnergy.KILO_WATT_HOUR
 
     # ------------------------------------------------------------------
     # HA lifecycle — reboot persistence

--- a/custom_components/hsem/custom_sensors/last_updated_sensor.py
+++ b/custom_components/hsem/custom_sensors/last_updated_sensor.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.const import EntityCategory
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, EntityCategory
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from custom_components.hsem.coordinator import (
@@ -124,8 +124,8 @@ class HSEMLastUpdatedSensor(
         await super().async_added_to_hass()
         restored = await self.async_get_last_state()
         if restored is not None and restored.state not in {
-            "unavailable",
-            "unknown",
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
             None,
         }:
             self._restored_state = restored.state

--- a/custom_components/hsem/custom_sensors/missing_entities_sensor.py
+++ b/custom_components/hsem/custom_sensors/missing_entities_sensor.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.const import EntityCategory
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, EntityCategory
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from custom_components.hsem.coordinator import (
@@ -136,8 +136,8 @@ class HSEMMissingEntitiesSensor(
         await super().async_added_to_hass()
         restored = await self.async_get_last_state()
         if restored is not None and restored.state not in {
-            "unavailable",
-            "unknown",
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
             None,
         }:
             self._restored_state = restored.state

--- a/custom_components/hsem/custom_sensors/net_consumption_sensor.py
+++ b/custom_components/hsem/custom_sensors/net_consumption_sensor.py
@@ -21,7 +21,12 @@ from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.sensor.const import SensorDeviceClass
-from homeassistant.const import EntityCategory, UnitOfPower
+from homeassistant.const import (
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    EntityCategory,
+    UnitOfPower,
+)
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from custom_components.hsem.coordinator import (
@@ -148,8 +153,8 @@ class HSEMNetConsumptionSensor(
         await super().async_added_to_hass()
         restored = await self.async_get_last_state()
         if restored is not None and restored.state not in {
-            "unavailable",
-            "unknown",
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
             None,
         }:
             self._restored_state = restored.state

--- a/custom_components/hsem/custom_sensors/next_update_sensor.py
+++ b/custom_components/hsem/custom_sensors/next_update_sensor.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.const import EntityCategory
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, EntityCategory
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from custom_components.hsem.coordinator import (
@@ -129,8 +129,8 @@ class HSEMNextUpdateSensor(
         await super().async_added_to_hass()
         restored = await self.async_get_last_state()
         if restored is not None and restored.state not in {
-            "unavailable",
-            "unknown",
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
             None,
         }:
             self._restored_state = restored.state

--- a/custom_components/hsem/custom_sensors/plan_explanation_sensor.py
+++ b/custom_components/hsem/custom_sensors/plan_explanation_sensor.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.const import EntityCategory
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, EntityCategory
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from custom_components.hsem.coordinator import (
@@ -215,7 +215,7 @@ class HSEMPlanExplanationSensor(
         restored = await self.async_get_last_state()
         if restored is not None and restored.state not in (
             None,
-            "unavailable",
-            "unknown",
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
         ):
             self._restored_state = restored.state

--- a/custom_components/hsem/custom_sensors/recommendation_interval_sensor.py
+++ b/custom_components/hsem/custom_sensors/recommendation_interval_sensor.py
@@ -22,7 +22,12 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.const import EntityCategory, UnitOfTime
+from homeassistant.const import (
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    EntityCategory,
+    UnitOfTime,
+)
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from custom_components.hsem.coordinator import (
@@ -146,8 +151,8 @@ class HSEMRecommendationIntervalSensor(
         await super().async_added_to_hass()
         restored = await self.async_get_last_state()
         if restored is not None and restored.state not in {
-            "unavailable",
-            "unknown",
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
             None,
         }:
             self._restored_state = restored.state

--- a/custom_components/hsem/custom_sensors/update_interval_sensor.py
+++ b/custom_components/hsem/custom_sensors/update_interval_sensor.py
@@ -18,7 +18,12 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.const import EntityCategory, UnitOfTime
+from homeassistant.const import (
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    EntityCategory,
+    UnitOfTime,
+)
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from custom_components.hsem.coordinator import (
@@ -139,8 +144,8 @@ class HSEMUpdateIntervalSensor(
         await super().async_added_to_hass()
         restored = await self.async_get_last_state()
         if restored is not None and restored.state not in {
-            "unavailable",
-            "unknown",
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
             None,
         }:
             self._restored_state = restored.state

--- a/custom_components/hsem/flows/batteries_excess_export.py
+++ b/custom_components/hsem/flows/batteries_excess_export.py
@@ -1,6 +1,7 @@
 """Flow configuration for battery excess energy export optimization."""
 
 import voluptuous as vol
+from homeassistant.const import PERCENTAGE
 from homeassistant.helpers.selector import selector
 
 from custom_components.hsem.utils.config_validator import merge_errors, validate_price
@@ -43,7 +44,7 @@ async def get_batteries_excess_export_step_schema(
                         "max": 50,
                         "step": 1,
                         "mode": "slider",
-                        "unit_of_measurement": "%",
+                        "unit_of_measurement": PERCENTAGE,
                     }
                 }
             ),

--- a/custom_components/hsem/flows/battery_economics.py
+++ b/custom_components/hsem/flows/battery_economics.py
@@ -7,6 +7,7 @@ and charge/discharge efficiency.
 """
 
 import voluptuous as vol
+from homeassistant.const import PERCENTAGE
 from homeassistant.helpers.selector import selector
 
 from custom_components.hsem.utils.config_validator import merge_errors, validate_price
@@ -77,7 +78,7 @@ async def get_battery_economics_step_schema(config_entry) -> vol.Schema:
                         "min": 10,
                         "max": 50,
                         "step": 1,
-                        "unit_of_measurement": "%",
+                        "unit_of_measurement": PERCENTAGE,
                         "mode": "slider",
                     }
                 }
@@ -93,7 +94,7 @@ async def get_battery_economics_step_schema(config_entry) -> vol.Schema:
                         "min": 50,
                         "max": 100,
                         "step": 1,
-                        "unit_of_measurement": "%",
+                        "unit_of_measurement": PERCENTAGE,
                         "mode": "slider",
                     }
                 }
@@ -109,7 +110,7 @@ async def get_battery_economics_step_schema(config_entry) -> vol.Schema:
                         "min": 50,
                         "max": 100,
                         "step": 1,
-                        "unit_of_measurement": "%",
+                        "unit_of_measurement": PERCENTAGE,
                         "mode": "slider",
                     }
                 }

--- a/custom_components/hsem/flows/ev_planned_load_helpers.py
+++ b/custom_components/hsem/flows/ev_planned_load_helpers.py
@@ -19,6 +19,7 @@ Public API
 from __future__ import annotations
 
 import voluptuous as vol
+from homeassistant.const import PERCENTAGE, UnitOfEnergy, UnitOfPower
 from homeassistant.helpers.selector import selector
 
 from custom_components.hsem.utils.config_validator import (
@@ -37,7 +38,7 @@ _CAPACITY_SELECTOR = selector(
             "min": 1.0,
             "max": 200.0,
             "step": 0.5,
-            "unit_of_measurement": "kWh",
+            "unit_of_measurement": UnitOfEnergy.KILO_WATT_HOUR,
             "mode": "box",
         }
     }
@@ -49,7 +50,7 @@ _POWER_KW_SELECTOR = selector(
             "min": 0.1,
             "max": 50.0,
             "step": 0.1,
-            "unit_of_measurement": "kW",
+            "unit_of_measurement": UnitOfPower.KILO_WATT,
             "mode": "box",
         }
     }
@@ -61,7 +62,7 @@ _EFFICIENCY_SELECTOR = selector(
             "min": 50,
             "max": 100,
             "step": 1,
-            "unit_of_measurement": "%",
+            "unit_of_measurement": PERCENTAGE,
             "mode": "slider",
         }
     }

--- a/custom_components/hsem/flows/weighted_values.py
+++ b/custom_components/hsem/flows/weighted_values.py
@@ -1,4 +1,5 @@
 import voluptuous as vol
+from homeassistant.const import PERCENTAGE
 from homeassistant.helpers.selector import selector
 
 from custom_components.hsem.utils.config_validator import validate_consumption_weights
@@ -20,7 +21,7 @@ async def get_weighted_values_step_schema(config_entry) -> vol.Schema:
                         "min": 0,
                         "max": 100,
                         "step": 1,
-                        "unit_of_measurement": "%",
+                        "unit_of_measurement": PERCENTAGE,
                         "mode": "slider",
                     }
                 }
@@ -36,7 +37,7 @@ async def get_weighted_values_step_schema(config_entry) -> vol.Schema:
                         "min": 0,
                         "max": 100,
                         "step": 1,
-                        "unit_of_measurement": "%",
+                        "unit_of_measurement": PERCENTAGE,
                         "mode": "slider",
                     }
                 }
@@ -52,7 +53,7 @@ async def get_weighted_values_step_schema(config_entry) -> vol.Schema:
                         "min": 0,
                         "max": 100,
                         "step": 1,
-                        "unit_of_measurement": "%",
+                        "unit_of_measurement": PERCENTAGE,
                         "mode": "slider",
                     }
                 }
@@ -68,7 +69,7 @@ async def get_weighted_values_step_schema(config_entry) -> vol.Schema:
                         "min": 0,
                         "max": 100,
                         "step": 1,
-                        "unit_of_measurement": "%",
+                        "unit_of_measurement": PERCENTAGE,
                         "mode": "slider",
                     }
                 }

--- a/custom_components/hsem/utils/misc.py
+++ b/custom_components/hsem/utils/misc.py
@@ -3,6 +3,7 @@
 import hashlib
 from datetime import datetime, time, timedelta
 
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.exceptions import (
     HomeAssistantError,
     ServiceNotFound,
@@ -12,7 +13,6 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 
 from custom_components.hsem.const import DEFAULT_CONFIG_VALUES, DOMAIN
-
 # Re-export async_logger from its dedicated module so that existing callers
 # importing it from utils.misc continue to work without changes.
 from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
@@ -150,7 +150,7 @@ def convert_to_float(state) -> float | None:
 
     if isinstance(state, str):
         stripped = state.strip()
-        if stripped == "" or stripped.lower() in ("unknown", "unavailable"):
+        if stripped == "" or stripped.lower() in (STATE_UNKNOWN, STATE_UNAVAILABLE):
             return None
         try:
             return float(stripped)
@@ -179,7 +179,7 @@ def convert_to_int(state) -> int | None:
 
     if isinstance(state, str):
         stripped = state.strip().lower()
-        if stripped in ("unknown", "unavailable", ""):
+        if stripped in (STATE_UNKNOWN, STATE_UNAVAILABLE, ""):
             return None
         try:
             return int(float(stripped))
@@ -229,18 +229,18 @@ def convert_to_boolean(state) -> bool:
         return state != 0
 
     state_map = {
-        "on": True,
+        STATE_ON: True,
         "true": True,
         "1": True,
-        "off": False,
+        STATE_OFF: False,
         "false": False,
         "0": False,
         "charging": True,
         "not_charging": False,
         "notcharging": False,
-        "unknown": False,
+        STATE_UNKNOWN: False,
         "available": True,
-        "unavailable": False,
+        STATE_UNAVAILABLE: False,
         "ready": True,
         "notready": False,
         "not_ready": False,
@@ -406,13 +406,13 @@ def ha_get_entity_state_and_convert(
 
     try:
         if output_type is None:
-            if state.state == "unknown":
+            if state.state == STATE_UNKNOWN:
                 raise EntityNotFoundError(f"Entity '{entity_id}' state unknown.")
 
             return state
 
         if output_type.lower() == "float":
-            if state.state in ("unknown", "unavailable"):
+            if state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
                 return None
             value = convert_to_float(state.state)
             if value is None:
@@ -420,12 +420,12 @@ def ha_get_entity_state_and_convert(
             return round(value, float_precision)
 
         if output_type.lower() == "int":
-            if state.state == "unknown":
+            if state.state == STATE_UNKNOWN:
                 raise EntityNotFoundError(f"Entity '{entity_id}' state unknown.")
             return convert_to_int(state.state)
 
         if output_type.lower() == "boolean":
-            if state.state == "unknown":
+            if state.state == STATE_UNKNOWN:
                 raise EntityNotFoundError(f"Entity '{entity_id}' state unknown.")
 
             return convert_to_boolean(state.state)


### PR DESCRIPTION
## Summary

Tackles the first acceptance criterion of #491: **use constants from `homeassistant/const.py` instead of defining our own**.

Replaces all hardcoded state/unit string literals across 19 files with canonical HA constants imported from `homeassistant.const`.

Fixes #491

---

## What changed

### State constants (`STATE_ON`, `STATE_OFF`, `STATE_UNAVAILABLE`, `STATE_UNKNOWN`)

Replaced in 15 sensor files + `utils/misc.py`:

- `"on"` / `"off"` → `STATE_ON` / `STATE_OFF` (in ev_charging_sensor, misc.py)
- `"unknown"` / `"unavailable"` → `STATE_UNKNOWN` / `STATE_UNAVAILABLE` (in restored-state checks across 12 sensors, applier state verification, and misc.py utility functions)

### Unit constants (`UnitOfEnergy`, `UnitOfPower`, `PERCENTAGE`)

Replaced in 1 sensor file + 4 flow files:

- `"kWh"` → `UnitOfEnergy.KILO_WATT_HOUR` (forecast_accuracy_sensor, ev_planned_load_helpers)
- `"kW"` → `UnitOfPower.KILO_WATT` (ev_planned_load_helpers)
- `"%"` → `PERCENTAGE` (4 flow files: batteries_excess_export, battery_economics, ev_planned_load_helpers, weighted_values)

### What was NOT changed

- HSEM-specific constants in `const.py` (e.g. `hsem_batteries_purchase_price`, `DOMAIN`) — these are HSEM's own config keys, not HA core duplicates
- Domain-specific state values like `_UNKNOWN_STRATEGY = "unknown"` (plan_explanation_sensor) and `EVChargingPlan.state = "unavailable"` (ev_planner) — these are HSEM domain concepts, not HA platform states
- Version fallback strings (`"unknown"` as version)

---

## Files changed (19)

| File | Changes |
|---|---|
| `custom_sensors/forecast_accuracy_sensor.py` | `"kWh"` → `UnitOfEnergy.KILO_WATT_HOUR` |
| `custom_sensors/ev_charging_sensor.py` | `"on"`/`"off"` → `STATE_ON`/`STATE_OFF` |
| `custom_sensors/ev_optimal_charging_plan_sensor.py` | `"unavailable"` → `STATE_UNAVAILABLE` |
| `custom_sensors/ev_second_optimal_charging_plan_sensor.py` | `"unavailable"` → `STATE_UNAVAILABLE` |
| `custom_sensors/applier.py` | `"unknown"`/`"unavailable"` → `STATE_UNKNOWN`/`STATE_UNAVAILABLE` |
| `custom_sensors/battery_soc_sensor.py` | State constants in restored-state checks |
| `custom_sensors/force_mode_sensor.py` | State constants in restored-state checks |
| `custom_sensors/last_updated_sensor.py` | State constants in restored-state checks |
| `custom_sensors/missing_entities_sensor.py` | State constants in restored-state checks |
| `custom_sensors/net_consumption_sensor.py` | State constants in restored-state checks |
| `custom_sensors/next_update_sensor.py` | State constants in restored-state checks |
| `custom_sensors/plan_explanation_sensor.py` | State constants in restored-state checks |
| `custom_sensors/recommendation_interval_sensor.py` | State constants in restored-state checks |
| `custom_sensors/update_interval_sensor.py` | State constants in restored-state checks |
| `utils/misc.py` | All state comparisons + `convert_to_boolean` state_map use HA constants |
| `flows/batteries_excess_export.py` | `"%"` → `PERCENTAGE` |
| `flows/battery_economics.py` | `"%"` → `PERCENTAGE` (x3) |
| `flows/ev_planned_load_helpers.py` | `"%"`/`"kW"`/`"kWh"` → `PERCENTAGE`/`UnitOfPower`/`UnitOfEnergy` |
| `flows/weighted_values.py` | `"%"` → `PERCENTAGE` (x4) |

---

## Checklist

- [x] Replace hardcoded strings with `homeassistant.const` imports — all 19 files
- [x] `tox -e lint` — isort ✅, ruff check ✅
- [x] `tox -e quality` — pyright ✅ (0 errors), vulture ✅
- [x] All 104 Python files compile cleanly
- [x] No behavioural changes — constants resolve to identical string values
- [ ] `tox -e typing` — not run (tox env timeout)
- [ ] `tox -e py313` (pytest) — not run (pre-existing bcrypt PyO3 venv issue)