### PR TITLE
chore(typing): add missing type annotations to remove no-untyped-def suppression

### DIFF
--- a/custom_components/hsem/config_flow.py
+++ b/custom_components/hsem/config_flow.py
@@ -376,6 +376,8 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry) -> HSEMOptionsFlow:
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> HSEMOptionsFlow:
         """Return the options flow."""
         return HSEMOptionsFlow(config_entry)

--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -34,7 +34,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant
 from homeassistant.helpers.event import (
     async_track_time_change,
     async_track_time_interval,
@@ -57,15 +57,18 @@ from custom_components.hsem.custom_sensors.state_collector import (  # noqa: F40
 from custom_components.hsem.models.hourly_recommendation import HourlyRecommendation
 from custom_components.hsem.models.live_state import LiveState
 from custom_components.hsem.models.planner_inputs import PlannerInput
-from custom_components.hsem.models.planner_outputs import DataQuality, PlanExplanation
+from custom_components.hsem.models.planner_outputs import (
+    DataQuality,
+    PlanExplanation,
+    PlannerOutput,
+)
 from custom_components.hsem.models.sensor_config import SensorConfig
 from custom_components.hsem.models.state_snapshot import StateSnapshot
 from custom_components.hsem.planner import run_planner
 from custom_components.hsem.planner.charge_scheduler import apply_window_hysteresis
 from custom_components.hsem.planner.ev_planner import EVChargingPlan
-from custom_components.hsem.utils.datetime_utils import as_tz
+from custom_components.hsem.utils.datetime_utils import as_tz, utc_key, utc_now_iso
 from custom_components.hsem.utils.datetime_utils import now as hsem_now
-from custom_components.hsem.utils.datetime_utils import utc_key, utc_now_iso
 from custom_components.hsem.utils.forecast_tracker import (
     ForecastTracker,
     compute_accumulated_energy,
@@ -274,7 +277,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
     # Internal update pipeline
     # ------------------------------------------------------------------
 
-    async def _async_handle_update(self, event=None) -> None:
+    async def _async_handle_update(self, event: Event | None = None) -> None:
         """Drop concurrent updates; run the update cycle while holding the lock."""
         if self._update_lock.locked():
             await async_logger(
@@ -688,7 +691,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
     # Planner bridge helpers
     # ------------------------------------------------------------------
 
-    def _apply_planner_output(self, output) -> None:
+    def _apply_planner_output(self, output: PlannerOutput) -> None:
         """Write :class:`PlannerOutput` decisions back into the recommendation list.
 
         The lookup normalises both sides to UTC with ``microsecond=0`` so that
@@ -823,7 +826,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         # Finalise any slots whose end time has passed.
         self._forecast_tracker.finalise_past_records(now)
 
-    def _register_forecasts_from_planner(self, output) -> None:
+    def _register_forecasts_from_planner(self, output: PlannerOutput) -> None:
         """Register PV and load forecasts from planner output into the tracker.
 
         This is called after the planner runs successfully.  Forecast values

--- a/custom_components/hsem/custom_sensors/applier.py
+++ b/custom_components/hsem/custom_sensors/applier.py
@@ -32,6 +32,7 @@ to Home Assistant.
 from __future__ import annotations
 
 import re
+from typing import Any
 
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 
@@ -71,7 +72,7 @@ from custom_components.hsem.utils.workingmodes import WorkingModes
 
 
 async def async_apply_inverter_power_control(
-    sensor,
+    sensor: Any,  # TODO: tighten type
     cfg: SensorConfig,
     live: LiveState,
 ) -> CycleApplySummary:
@@ -241,7 +242,7 @@ async def async_apply_inverter_power_control(
 
 
 async def async_apply_battery_settings(
-    sensor,
+    sensor: Any,  # TODO: tighten type
     cfg: SensorConfig,
     live: LiveState,
     rec: HourlyRecommendation,
@@ -497,7 +498,7 @@ async def async_apply_battery_settings(
 
 
 async def _async_apply_forcible_discharge(
-    sensor,
+    sensor: Any,  # TODO: tighten type
     cfg: SensorConfig,
     live: LiveState,
     current_required_kwh: float,
@@ -566,7 +567,9 @@ async def _async_apply_forcible_discharge(
 # ---------------------------------------------------------------------------
 
 
-def _read_number_state(sensor, entity_id: str | None) -> float | None:
+def _read_number_state(
+    sensor: Any, entity_id: str | None
+) -> float | None:  # TODO: tighten type on sensor
     """Read a number entity state from HA and return it as float, or None.
 
     Args:
@@ -587,7 +590,9 @@ def _read_number_state(sensor, entity_id: str | None) -> float | None:
         return None
 
 
-def _read_select_state(sensor, entity_id: str | None) -> str | None:
+def _read_select_state(
+    sensor: Any, entity_id: str | None
+) -> str | None:  # TODO: tighten type on sensor
     """Read a select entity state from HA and return it as a string, or None.
 
     Args:

--- a/custom_components/hsem/custom_sensors/applier_status_sensor.py
+++ b/custom_components/hsem/custom_sensors/applier_status_sensor.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.helpers.restore_state import RestoreEntity
 
@@ -79,7 +80,7 @@ class HSEMApplierStatusSensor(
 
     def __init__(
         self,
-        config_entry,
+        config_entry: ConfigEntry,
         coordinator: HSEMDataUpdateCoordinator,
     ) -> None:
         """Initialise the applier-status sensor.

--- a/custom_components/hsem/custom_sensors/avg_sensor.py
+++ b/custom_components/hsem/custom_sensors/avg_sensor.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 from typing import Any
 
 import homeassistant.util.dt as dt_util
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.sensor.const import SensorDeviceClass, SensorStateClass
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfEnergy
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.event import (
@@ -30,14 +33,14 @@ class HSEMAvgSensor(SensorEntity, HSEMEntity, RestoreEntity):
 
     def __init__(
         self,
-        config_entry,
-        hour_start,
-        hour_end,
-        avg,
-        tracked_entity,
-        name,
-        unique_id,
-        entity_id,
+        config_entry: ConfigEntry,
+        hour_start: int,
+        hour_end: int,
+        avg: int,
+        tracked_entity: str,
+        name: str,
+        unique_id: str,
+        entity_id: str,
     ) -> None:
         super().__init__(config_entry)
         self._hour_start = hour_start
@@ -96,11 +99,11 @@ class HSEMAvgSensor(SensorEntity, HSEMEntity, RestoreEntity):
     def should_poll(self) -> bool:
         return True
 
-    async def async_update(self, event=None) -> None:
+    async def async_update(self, event: Any | None = None) -> None:
         """Manually trigger the sensor update."""
         return await self._async_handle_update(event)
 
-    def parse_date(self, date_str) -> str:
+    def parse_date(self, date_str: str) -> str:
         # Strip any time component if it exists
         date_part = date_str.split("T")[0] if "T" in date_str else date_str
         return datetime.strptime(date_part, "%Y-%m-%d").date().isoformat()
@@ -154,7 +157,7 @@ class HSEMAvgSensor(SensorEntity, HSEMEntity, RestoreEntity):
                 self._unsub_callbacks.append(unsub)
                 self._tracked_entities.add(self._tracked_entity)
 
-    async def _async_handle_update(self, event=None) -> None:
+    async def _async_handle_update(self, event: Any | None = None) -> None:
         """Handle updates to the source sensor."""
         self._state = 0.00
 

--- a/custom_components/hsem/custom_sensors/battery_soc_sensor.py
+++ b/custom_components/hsem/custom_sensors/battery_soc_sensor.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.sensor.const import SensorDeviceClass
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
     STATE_UNAVAILABLE,
@@ -65,7 +66,7 @@ class HSEMBatterySoCSensor(
 
     def __init__(
         self,
-        config_entry,
+        config_entry: ConfigEntry,
         coordinator: HSEMDataUpdateCoordinator,
     ) -> None:
         """Initialise the battery-SoC sensor.

--- a/custom_components/hsem/custom_sensors/config_reader.py
+++ b/custom_components/hsem/custom_sensors/config_reader.py
@@ -12,6 +12,7 @@ called synchronously and tested without a running HA instance.
 from __future__ import annotations
 
 from datetime import time
+from typing import Any
 
 import voluptuous as vol
 
@@ -31,7 +32,7 @@ from custom_components.hsem.utils.misc import (
 )
 
 
-def build_sensor_config(config_entry) -> SensorConfig:
+def build_sensor_config(config_entry: Any) -> SensorConfig:  # TODO: tighten type
     """Read all config-entry options and return a populated :class:`SensorConfig`.
 
     This is a pure synchronous function that reads from ``config_entry.options``
@@ -455,7 +456,7 @@ def build_battery_schedules(cfg: SensorConfig) -> list[BatterySchedule]:
 # ---------------------------------------------------------------------------
 
 
-def _optional_entity(value) -> str | None:
+def _optional_entity(value: Any) -> str | None:  # TODO: tighten type
     """Return None if value is vol.UNDEFINED or falsy, else the string."""
     if value is vol.UNDEFINED or not value:
         return None

--- a/custom_components/hsem/custom_sensors/degraded_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/degraded_mode_sensor.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.helpers.restore_state import RestoreEntity
 
@@ -72,7 +73,7 @@ class HSEMDegradedModeSensor(
 
     def __init__(
         self,
-        config_entry,
+        config_entry: ConfigEntry,
         coordinator: HSEMDataUpdateCoordinator,
     ) -> None:
         """Initialise the sensor with an ``ok`` state.

--- a/custom_components/hsem/custom_sensors/ev_charging_sensor.py
+++ b/custom_components/hsem/custom_sensors/ev_charging_sensor.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OFF, STATE_ON, EntityCategory
 from homeassistant.helpers.restore_state import RestoreEntity
 
@@ -58,7 +59,7 @@ class HSEMEVChargingSensor(
 
     def __init__(
         self,
-        config_entry,
+        config_entry: ConfigEntry,
         coordinator: HSEMDataUpdateCoordinator,
     ) -> None:
         """Initialise the EV-charging sensor.

--- a/custom_components/hsem/custom_sensors/ev_optimal_charging_plan_sensor.py
+++ b/custom_components/hsem/custom_sensors/ev_optimal_charging_plan_sensor.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNAVAILABLE, EntityCategory
 from homeassistant.helpers.restore_state import RestoreEntity
 
@@ -68,7 +69,7 @@ class HSEMEVOptimalChargingPlanSensor(
 
     def __init__(
         self,
-        config_entry,
+        config_entry: ConfigEntry,
         coordinator: HSEMDataUpdateCoordinator,
     ) -> None:
         """Initialise the EV optimal charging plan sensor.

--- a/custom_components/hsem/custom_sensors/ev_second_optimal_charging_plan_sensor.py
+++ b/custom_components/hsem/custom_sensors/ev_second_optimal_charging_plan_sensor.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNAVAILABLE, EntityCategory
 from homeassistant.helpers.restore_state import RestoreEntity
 
@@ -49,7 +50,7 @@ class HSEMEVSecondOptimalChargingPlanSensor(
 
     def __init__(
         self,
-        config_entry,
+        config_entry: ConfigEntry,
         coordinator: HSEMDataUpdateCoordinator,
     ) -> None:
         """Initialise the second EV optimal charging plan sensor."""

--- a/custom_components/hsem/custom_sensors/force_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/force_mode_sensor.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, EntityCategory
 from homeassistant.helpers.restore_state import RestoreEntity
 
@@ -58,7 +59,7 @@ class HSEMForceModeSensor(
 
     def __init__(
         self,
-        config_entry,
+        config_entry: ConfigEntry,
         coordinator: HSEMDataUpdateCoordinator,
     ) -> None:
         """Initialise the force-mode sensor.

--- a/custom_components/hsem/custom_sensors/forecast_accuracy_sensor.py
+++ b/custom_components/hsem/custom_sensors/forecast_accuracy_sensor.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory, UnitOfEnergy
 from homeassistant.helpers.restore_state import RestoreEntity
 
@@ -61,7 +62,7 @@ class HSEMForecastAccuracySensor(
 
     def __init__(
         self,
-        config_entry,
+        config_entry: ConfigEntry,
         coordinator: HSEMDataUpdateCoordinator,
     ) -> None:
         """Initialise the sensor.

--- a/custom_components/hsem/custom_sensors/hardware_writes_sensor.py
+++ b/custom_components/hsem/custom_sensors/hardware_writes_sensor.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.helpers.restore_state import RestoreEntity
 
@@ -63,7 +64,7 @@ class HSEMHardwareWritesSensor(
 
     def __init__(
         self,
-        config_entry,
+        config_entry: ConfigEntry,
         coordinator: HSEMDataUpdateCoordinator,
     ) -> None:
         """Initialise the hardware-writes sensor.

--- a/custom_components/hsem/custom_sensors/hourly_data_populator.py
+++ b/custom_components/hsem/custom_sensors/hourly_data_populator.py
@@ -14,7 +14,7 @@ side-effects beyond that.  No hardware writes occur here.
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, tzinfo
 from typing import Any
 
 from homeassistant.exceptions import HomeAssistantError
@@ -37,10 +37,10 @@ from custom_components.hsem.utils.sensornames import get_energy_average_sensor_u
 
 
 async def async_populate_price_and_solcast(
-    sensor,
+    sensor: Any,  # TODO: tighten type
     recommendations: list[HourlyRecommendation],
     cfg: SensorConfig,
-    tz,
+    tz: tzinfo | None,
 ) -> None:
     """Populate import/export prices and Solcast PV estimates into recommendation slots.
 
@@ -152,7 +152,7 @@ async def async_populate_price_and_solcast(
 
 
 async def async_populate_avg_house_consumption(
-    sensor,
+    sensor: Any,  # TODO: tighten type
     recommendations: list[HourlyRecommendation],
     cfg: SensorConfig,
     entity_id_cache: dict[str, str],
@@ -279,7 +279,7 @@ async def async_populate_avg_house_consumption(
 
 
 async def _resolve_cached(
-    sensor,
+    sensor: Any,  # TODO: tighten type
     cache: dict[str, str],
     unique_id: str,
 ) -> str | None:
@@ -292,13 +292,13 @@ async def _resolve_cached(
 
 
 async def _async_update_hourly_field(
-    sensor,
+    sensor: Any,  # TODO: tighten type
     recommendations: list[HourlyRecommendation],
     sensor_id: str | None,
     field_name: str,
     share: float,
     solcast_likelihood_key: str,
-    tz,
+    tz: tzinfo | None,
 ) -> None:
     """Match sensor attribute data to recommendation slots and write one field.
 
@@ -401,7 +401,7 @@ def populate_price_and_solcast_from_snapshot(
     recommendations: list[HourlyRecommendation],
     snapshot: StateSnapshot,
     cfg: SensorConfig,
-    tz,
+    tz: tzinfo | None,
 ) -> None:
     """Populate prices and Solcast PV estimates using a pre-collected snapshot.
 
@@ -481,7 +481,7 @@ def _update_hourly_field_from_attrs(
     field_name: str,
     share: float,
     solcast_likelihood_key: str,
-    tz,
+    tz: tzinfo | None,
 ) -> None:
     """Match pre-read sensor attribute data to recommendation slots.
 

--- a/custom_components/hsem/custom_sensors/house_consumption_power_sensor.py
+++ b/custom_components/hsem/custom_sensors/house_consumption_power_sensor.py
@@ -22,6 +22,8 @@ Functions:
     async_update(event=None): Manually triggers the sensor update.
 """
 
+from __future__ import annotations
+
 from datetime import timedelta
 from typing import Any
 
@@ -33,6 +35,7 @@ from homeassistant.components.utility_meter.const import (
     DATA_TARIFF_SENSORS,
     DATA_UTILITY,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfPower, UnitOfTime
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.event import async_track_state_change_event
@@ -93,7 +96,13 @@ class HSEMHouseConsumptionPowerSensor(SensorEntity, HSEMEntity, RestoreEntity):
         ]
     )
 
-    def __init__(self, config_entry, hour_start, hour_end, async_add_entities) -> None:
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        hour_start: int,
+        hour_end: int,
+        async_add_entities: Any,
+    ) -> None:
         super().__init__(config_entry)
         self._available = False
         self._missing_input_entities = True
@@ -171,11 +180,11 @@ class HSEMHouseConsumptionPowerSensor(SensorEntity, HSEMEntity, RestoreEntity):
             "unique_id": self._attr_unique_id,
         }
 
-    async def async_update(self, event=None) -> None:
+    async def async_update(self, event: Any | None = None) -> None:
         """Manually trigger the sensor update."""
         await self._async_handle_update(event)
 
-    async def async_options_updated(self, config_entry) -> None:
+    async def async_options_updated(self, config_entry: ConfigEntry) -> None:
         """Handle options update from configuration change."""
 
         self._update_settings()
@@ -239,7 +248,7 @@ class HSEMHouseConsumptionPowerSensor(SensorEntity, HSEMEntity, RestoreEntity):
             self._config_entry, "hsem_house_power_includes_ev_charger_power"
         )
 
-    async def _async_handle_update(self, event=None) -> None:
+    async def _async_handle_update(self, event: Any | None = None) -> None:
         """Handle updates to the source sensor.
 
         ``_state`` is reset to ``None`` at the start of every cycle so that a

--- a/custom_components/hsem/custom_sensors/integration_sensor.py
+++ b/custom_components/hsem/custom_sensors/integration_sensor.py
@@ -1,5 +1,10 @@
+from __future__ import annotations
+
+from typing import Any
+
 from homeassistant.components.integration.sensor import IntegrationSensor
 from homeassistant.components.sensor.const import SensorDeviceClass, SensorStateClass
+from homeassistant.config_entries import ConfigEntry
 
 from custom_components.hsem.entity import HSEMEntity
 
@@ -14,7 +19,14 @@ class HSEMIntegrationSensor(IntegrationSensor, HSEMEntity):
 
     _attr_icon = "mdi:chart-histogram"
 
-    def __init__(self, *args, id: str, e_id: str, config_entry=None, **kwargs) -> None:
+    def __init__(
+        self,
+        *args: Any,
+        id: str,
+        e_id: str,
+        config_entry: ConfigEntry | None = None,
+        **kwargs: Any,
+    ) -> None:
         IntegrationSensor.__init__(self, *args, **kwargs)
         HSEMEntity.__init__(self, config_entry)
         self._attr_unique_id = id

--- a/custom_components/hsem/custom_sensors/last_updated_sensor.py
+++ b/custom_components/hsem/custom_sensors/last_updated_sensor.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, EntityCategory
 from homeassistant.helpers.restore_state import RestoreEntity
 
@@ -53,7 +54,7 @@ class HSEMLastUpdatedSensor(
 
     def __init__(
         self,
-        config_entry,
+        config_entry: ConfigEntry,
         coordinator: HSEMDataUpdateCoordinator,
     ) -> None:
         """Initialise the last-updated sensor.

--- a/custom_components/hsem/custom_sensors/missing_entities_sensor.py
+++ b/custom_components/hsem/custom_sensors/missing_entities_sensor.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, EntityCategory
 from homeassistant.helpers.restore_state import RestoreEntity
 
@@ -58,7 +59,7 @@ class HSEMMissingEntitiesSensor(
 
     def __init__(
         self,
-        config_entry,
+        config_entry: ConfigEntry,
         coordinator: HSEMDataUpdateCoordinator,
     ) -> None:
         """Initialise the missing-entities sensor.

--- a/custom_components/hsem/custom_sensors/net_consumption_sensor.py
+++ b/custom_components/hsem/custom_sensors/net_consumption_sensor.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.sensor.const import SensorDeviceClass
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
@@ -66,7 +67,7 @@ class HSEMNetConsumptionSensor(
 
     def __init__(
         self,
-        config_entry,
+        config_entry: ConfigEntry,
         coordinator: HSEMDataUpdateCoordinator,
     ) -> None:
         """Initialise the net-consumption sensor.

--- a/custom_components/hsem/custom_sensors/next_update_sensor.py
+++ b/custom_components/hsem/custom_sensors/next_update_sensor.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, EntityCategory
 from homeassistant.helpers.restore_state import RestoreEntity
 
@@ -53,7 +54,7 @@ class HSEMNextUpdateSensor(
 
     def __init__(
         self,
-        config_entry,
+        config_entry: ConfigEntry,
         coordinator: HSEMDataUpdateCoordinator,
     ) -> None:
         """Initialise the next-update sensor.

--- a/custom_components/hsem/custom_sensors/plan_explanation_sensor.py
+++ b/custom_components/hsem/custom_sensors/plan_explanation_sensor.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, EntityCategory
 from homeassistant.helpers.restore_state import RestoreEntity
 
@@ -91,7 +92,7 @@ class HSEMPlanExplanationSensor(
 
     def __init__(
         self,
-        config_entry,
+        config_entry: ConfigEntry,
         coordinator: HSEMDataUpdateCoordinator,
     ) -> None:
         """Initialise the sensor.

--- a/custom_components/hsem/custom_sensors/read_only_sensor.py
+++ b/custom_components/hsem/custom_sensors/read_only_sensor.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.helpers.restore_state import RestoreEntity
 
@@ -55,7 +56,7 @@ class HSEMReadOnlySensor(
 
     def __init__(
         self,
-        config_entry,
+        config_entry: ConfigEntry,
         coordinator: HSEMDataUpdateCoordinator,
     ) -> None:
         """Initialise the read-only mode sensor.

--- a/custom_components/hsem/custom_sensors/recommendation_interval_sensor.py
+++ b/custom_components/hsem/custom_sensors/recommendation_interval_sensor.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
@@ -65,7 +66,7 @@ class HSEMRecommendationIntervalSensor(
 
     def __init__(
         self,
-        config_entry,
+        config_entry: ConfigEntry,
         coordinator: HSEMDataUpdateCoordinator,
     ) -> None:
         """Initialise the recommendation-interval sensor.

--- a/custom_components/hsem/custom_sensors/state_collector.py
+++ b/custom_components/hsem/custom_sensors/state_collector.py
@@ -15,6 +15,9 @@ so that downstream population functions never need additional
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import Any
+
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.event import async_track_state_change_event
 
@@ -56,7 +59,7 @@ from custom_components.hsem.utils.sensornames import (
 
 
 async def async_collect_live_state(
-    sensor,
+    sensor: Any,  # TODO: tighten type
     cfg: SensorConfig,
     force_working_mode_cache: str | None,
     tracked_entities: set[str],
@@ -92,8 +95,11 @@ async def async_collect_live_state(
     state.force_working_mode = fwm_entity
 
     def _read(
-        entity_id: str | None, conv_type=None, decimals: int = 3, label: str = ""
-    ):
+        entity_id: str | None,
+        conv_type: str | None = None,
+        decimals: int = 3,
+        label: str = "",
+    ) -> Any:  # TODO: tighten type
         """Read one entity state, recording it as missing on any failure."""
         if not entity_id:
             state.add_missing_entity(f"Missing entity: {label or entity_id}")
@@ -443,7 +449,11 @@ def _compute_net_consumption(state: LiveState, cfg: SensorConfig) -> None:
 
 
 def _read_ev_planned_load_state(
-    sensor, state: LiveState, cfg, _read, is_second: bool
+    sensor: Any,  # TODO: tighten type
+    state: LiveState,
+    cfg: SensorConfig,
+    _read: Callable[..., Any],
+    is_second: bool,
 ) -> None:
     """Read EV planned load live state into ``state`` for primary or second EV.
 
@@ -571,7 +581,7 @@ def _resolve_ev_deadline_from_params(sensor, deadline_entity, deadline_fixed):
 
 
 async def _register_listeners(
-    sensor,
+    sensor: Any,  # TODO: tighten type
     cfg: SensorConfig,
     state: LiveState,
     tracked_entities: set[str],
@@ -621,7 +631,7 @@ async def _register_listeners(
 
 
 async def async_collect_all_states(
-    sensor,
+    sensor: Any,  # TODO: tighten type
     cfg: SensorConfig,
     force_working_mode_cache: str | None,
     tracked_entities: set[str],
@@ -726,7 +736,7 @@ async def async_collect_all_states(
 
 
 async def _resolve_cached(
-    sensor,
+    sensor: Any,  # TODO: tighten type
     cache: dict[str, str],
     unique_id: str,
 ) -> str | None:

--- a/custom_components/hsem/custom_sensors/update_interval_sensor.py
+++ b/custom_components/hsem/custom_sensors/update_interval_sensor.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
@@ -62,7 +63,7 @@ class HSEMUpdateIntervalSensor(
 
     def __init__(
         self,
-        config_entry,
+        config_entry: ConfigEntry,
         coordinator: HSEMDataUpdateCoordinator,
     ) -> None:
         """Initialise the update-interval sensor.

--- a/custom_components/hsem/custom_sensors/utility_meter_sensor.py
+++ b/custom_components/hsem/custom_sensors/utility_meter_sensor.py
@@ -1,5 +1,10 @@
+from __future__ import annotations
+
+from typing import Any
+
 from homeassistant.components.sensor.const import SensorDeviceClass, SensorStateClass
 from homeassistant.components.utility_meter.sensor import UtilityMeterSensor
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfEnergy
 
 from custom_components.hsem.entity import HSEMEntity
@@ -10,7 +15,14 @@ class HSEMUtilityMeterSensor(UtilityMeterSensor, HSEMEntity):
 
     _attr_icon = "mdi:counter"
 
-    def __init__(self, *args, id: str, e_id: str, config_entry=None, **kwargs) -> None:
+    def __init__(
+        self,
+        *args: Any,
+        id: str,
+        e_id: str,
+        config_entry: ConfigEntry | None = None,
+        **kwargs: Any,
+    ) -> None:
         UtilityMeterSensor.__init__(self, *args, **kwargs)
         HSEMEntity.__init__(self, config_entry)
         self._attr_unique_id = id

--- a/custom_components/hsem/custom_sensors/working_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/working_mode_sensor.py
@@ -19,6 +19,7 @@ import asyncio
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import MATCH_ALL
 
 from custom_components.hsem.coordinator import (
@@ -68,7 +69,7 @@ class HSEMWorkingModeSensor(HSEMCoordinatorEntity, SensorEntity, HSEMEntity):
 
     def __init__(
         self,
-        config_entry,
+        config_entry: ConfigEntry,
         coordinator: HSEMDataUpdateCoordinator,
     ) -> None:
         """Initialise the working-mode sensor.
@@ -432,7 +433,7 @@ class HSEMWorkingModeSensor(HSEMCoordinatorEntity, SensorEntity, HSEMEntity):
     # Legacy compatibility
     # ------------------------------------------------------------------
 
-    async def async_update(self, event=None) -> None:
+    async def async_update(self, event: Any | None = None) -> None:
         """Manually request a coordinator refresh.
 
         Kept for backwards compatibility with any callers that invoke
@@ -440,7 +441,7 @@ class HSEMWorkingModeSensor(HSEMCoordinatorEntity, SensorEntity, HSEMEntity):
         """
         await self.coordinator.async_request_refresh()
 
-    async def async_options_updated(self, config_entry) -> None:
+    async def async_options_updated(self, config_entry: ConfigEntry) -> None:
         """Handle options update from configuration change.
 
         Delegates to the coordinator so all entities benefit simultaneously.

--- a/custom_components/hsem/entity.py
+++ b/custom_components/hsem/entity.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import homeassistant.helpers.device_registry as dr
 import homeassistant.helpers.entity_registry as er
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -25,7 +26,7 @@ class HSEMEntity(Entity):
     _attr_icon = "mdi:flash"
     _attr_has_entity_name = True
 
-    def __init__(self, config_entry) -> None:
+    def __init__(self, config_entry: ConfigEntry) -> None:
         """Initialize the HSEM entity."""
         super().__init__()
         self._config = config_entry

--- a/custom_components/hsem/flows/batteries_excess_export.py
+++ b/custom_components/hsem/flows/batteries_excess_export.py
@@ -1,7 +1,9 @@
 """Flow configuration for battery excess energy export optimization."""
 
 import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.selector import selector
 
 from custom_components.hsem.utils.config_validator import merge_errors, validate_price
@@ -9,7 +11,9 @@ from custom_components.hsem.utils.misc import get_config_value
 
 
 async def get_batteries_excess_export_step_schema(
-    config_entry, user_input: dict | None = None, hass=None
+    config_entry: ConfigEntry | None,
+    user_input: dict | None = None,
+    hass: HomeAssistant | None = None,
 ) -> vol.Schema:
     """Return the data schema for the 'batteries_excess_export' step.
 
@@ -52,7 +56,7 @@ async def get_batteries_excess_export_step_schema(
     )
 
 
-async def validate_batteries_excess_export_input(user_input) -> dict[str, str]:
+async def validate_batteries_excess_export_input(user_input: dict) -> dict[str, str]:
     """Validate user input for batteries excess export configuration.
 
     The price threshold is auto-calculated at runtime from battery

--- a/custom_components/hsem/flows/batteries_schedule_1.py
+++ b/custom_components/hsem/flows/batteries_schedule_1.py
@@ -6,6 +6,8 @@ construction and validation logic lives there.
 """
 
 import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 
 from custom_components.hsem.flows.schedule_helpers import (
     build_batteries_schedule_step_schema,
@@ -20,7 +22,9 @@ _resolve_usable_capacity_kwh = resolve_usable_capacity_kwh
 
 
 async def get_batteries_schedule_1_step_schema(
-    config_entry, hass=None, user_input: dict | None = None
+    config_entry: ConfigEntry | None,
+    hass: HomeAssistant | None = None,
+    user_input: dict | None = None,
 ) -> vol.Schema:
     """Return the data schema for the batteries_schedule_1 flow step."""
     return await build_batteries_schedule_step_schema(
@@ -28,6 +32,6 @@ async def get_batteries_schedule_1_step_schema(
     )
 
 
-async def validate_batteries_schedule_1_input(user_input) -> dict[str, str]:
+async def validate_batteries_schedule_1_input(user_input: dict) -> dict[str, str]:
     """Validate user input for the battery schedule 1 step."""
     return await validate_batteries_schedule_input(1, user_input)

--- a/custom_components/hsem/flows/batteries_schedule_2.py
+++ b/custom_components/hsem/flows/batteries_schedule_2.py
@@ -6,6 +6,8 @@ construction and validation logic lives there.
 """
 
 import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 
 from custom_components.hsem.flows.schedule_helpers import (
     build_batteries_schedule_step_schema,
@@ -14,7 +16,9 @@ from custom_components.hsem.flows.schedule_helpers import (
 
 
 async def get_batteries_schedule_2_step_schema(
-    config_entry, hass=None, user_input: dict | None = None
+    config_entry: ConfigEntry | None,
+    hass: HomeAssistant | None = None,
+    user_input: dict | None = None,
 ) -> vol.Schema:
     """Return the data schema for the batteries_schedule_2 flow step."""
     return await build_batteries_schedule_step_schema(
@@ -22,6 +26,6 @@ async def get_batteries_schedule_2_step_schema(
     )
 
 
-async def validate_batteries_schedule_2_input(user_input) -> dict[str, str]:
+async def validate_batteries_schedule_2_input(user_input: dict) -> dict[str, str]:
     """Validate user input for the battery schedule 2 step."""
     return await validate_batteries_schedule_input(2, user_input)

--- a/custom_components/hsem/flows/batteries_schedule_3.py
+++ b/custom_components/hsem/flows/batteries_schedule_3.py
@@ -6,6 +6,8 @@ construction and validation logic lives there.
 """
 
 import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 
 from custom_components.hsem.flows.schedule_helpers import (
     build_batteries_schedule_step_schema,
@@ -14,7 +16,9 @@ from custom_components.hsem.flows.schedule_helpers import (
 
 
 async def get_batteries_schedule_3_step_schema(
-    config_entry, hass=None, user_input: dict | None = None
+    config_entry: ConfigEntry | None,
+    hass: HomeAssistant | None = None,
+    user_input: dict | None = None,
 ) -> vol.Schema:
     """Return the data schema for the batteries_schedule_3 flow step."""
     return await build_batteries_schedule_step_schema(
@@ -22,6 +26,6 @@ async def get_batteries_schedule_3_step_schema(
     )
 
 
-async def validate_batteries_schedule_3_input(user_input) -> dict[str, str]:
+async def validate_batteries_schedule_3_input(user_input: dict) -> dict[str, str]:
     """Validate user input for the battery schedule 3 step."""
     return await validate_batteries_schedule_input(3, user_input)

--- a/custom_components/hsem/flows/batteries_schedules.py
+++ b/custom_components/hsem/flows/batteries_schedules.py
@@ -7,6 +7,8 @@ validation reuse the shared helpers in :mod:`schedule_helpers`.
 """
 
 import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 
 from custom_components.hsem.flows.schedule_helpers import (
     build_batteries_schedule_step_schema,
@@ -20,7 +22,9 @@ _resolve_usable_capacity_kwh = resolve_usable_capacity_kwh
 
 
 async def get_batteries_schedules_step_schema(
-    config_entry, hass=None, user_input: dict | None = None
+    config_entry: ConfigEntry | None,
+    hass: HomeAssistant | None = None,
+    user_input: dict | None = None,
 ) -> vol.Schema:
     """Return the data schema for the merged batteries_schedules step.
 
@@ -44,7 +48,7 @@ async def get_batteries_schedules_step_schema(
     return vol.Schema(merged)
 
 
-async def validate_batteries_schedules_input(user_input) -> dict[str, str]:
+async def validate_batteries_schedules_input(user_input: dict) -> dict[str, str]:
     """Validate user input for the merged batteries_schedules step.
 
     Delegates to the shared validator for each of the three schedules.

--- a/custom_components/hsem/flows/battery_economics.py
+++ b/custom_components/hsem/flows/battery_economics.py
@@ -7,6 +7,7 @@ and charge/discharge efficiency.
 """
 
 import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE
 from homeassistant.helpers.selector import selector
 
@@ -14,7 +15,9 @@ from custom_components.hsem.utils.config_validator import merge_errors, validate
 from custom_components.hsem.utils.misc import get_config_value
 
 
-async def get_battery_economics_step_schema(config_entry) -> vol.Schema:
+async def get_battery_economics_step_schema(
+    config_entry: ConfigEntry | None,
+) -> vol.Schema:
     """Return the data schema for the 'battery_economics' step.
 
     Args:
@@ -119,7 +122,7 @@ async def get_battery_economics_step_schema(config_entry) -> vol.Schema:
     )
 
 
-async def validate_battery_economics_input(user_input) -> dict[str, str]:
+async def validate_battery_economics_input(user_input: dict) -> dict[str, str]:
     """Validate user input for the 'battery_economics' step.
 
     Args:

--- a/custom_components/hsem/flows/ev.py
+++ b/custom_components/hsem/flows/ev.py
@@ -6,6 +6,8 @@ and validation logic lives there.
 """
 
 import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 
 from custom_components.hsem.flows.ev_helpers import (
     build_ev_charger_schema,
@@ -13,7 +15,7 @@ from custom_components.hsem.flows.ev_helpers import (
 )
 
 
-async def get_ev_step_schema(config_entry) -> vol.Schema:
+async def get_ev_step_schema(config_entry: ConfigEntry | None) -> vol.Schema:
     """Return the data schema for the primary EV charger flow step."""
     return await build_ev_charger_schema(
         config_entry,
@@ -22,7 +24,9 @@ async def get_ev_step_schema(config_entry) -> vol.Schema:
     )
 
 
-async def validate_ev_step_input(hass, user_input) -> dict[str, str]:
+async def validate_ev_step_input(
+    hass: HomeAssistant, user_input: dict
+) -> dict[str, str]:
     """Validate user input for the primary EV charger flow step."""
     return await validate_ev_charger_input(
         hass,

--- a/custom_components/hsem/flows/ev_helpers.py
+++ b/custom_components/hsem/flows/ev_helpers.py
@@ -19,6 +19,8 @@ Public API
 """
 
 import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.selector import selector
 
 from custom_components.hsem.utils.config_validator import (
@@ -47,7 +49,7 @@ _DISCHARGE_POWER_SELECTOR = selector(
 
 
 async def build_ev_charger_schema(
-    config_entry,
+    config_entry: ConfigEntry | None,
     prefix: str,
     include_primary_fields: bool = False,
 ) -> vol.Schema:
@@ -143,7 +145,7 @@ async def build_ev_charger_schema(
 
 
 async def validate_ev_charger_input(
-    hass,
+    hass: HomeAssistant,
     user_input: dict,
     prefix: str,
     extra_required_fields: list[str] | None = None,

--- a/custom_components/hsem/flows/ev_planned_load.py
+++ b/custom_components/hsem/flows/ev_planned_load.py
@@ -11,6 +11,8 @@ all fields are ignored by the planner and state collector.
 from __future__ import annotations
 
 import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 
 from custom_components.hsem.flows.ev_planned_load_helpers import (
     build_ev_planned_load_schema,
@@ -20,11 +22,15 @@ from custom_components.hsem.flows.ev_planned_load_helpers import (
 _PREFIX = "hsem_ev_planned_load"
 
 
-async def get_ev_planned_load_step_schema(config_entry) -> vol.Schema:
+async def get_ev_planned_load_step_schema(
+    config_entry: ConfigEntry | None,
+) -> vol.Schema:
     """Return the data schema for the primary EV planned load config flow step."""
     return await build_ev_planned_load_schema(config_entry, _PREFIX)
 
 
-async def validate_ev_planned_load_input(hass, user_input: dict) -> dict[str, str]:
+async def validate_ev_planned_load_input(
+    hass: HomeAssistant, user_input: dict
+) -> dict[str, str]:
     """Validate user input for the primary EV planned load flow step."""
     return await validate_ev_planned_load_schema_input(hass, user_input, _PREFIX)

--- a/custom_components/hsem/flows/ev_planned_load_helpers.py
+++ b/custom_components/hsem/flows/ev_planned_load_helpers.py
@@ -18,8 +18,12 @@ Public API
 
 from __future__ import annotations
 
+from typing import Any
+
 import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE, UnitOfEnergy, UnitOfPower
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.selector import selector
 
 from custom_components.hsem.utils.config_validator import (
@@ -69,7 +73,9 @@ _EFFICIENCY_SELECTOR = selector(
 )
 
 
-async def build_ev_planned_load_schema(config_entry, prefix: str) -> vol.Schema:
+async def build_ev_planned_load_schema(
+    config_entry: ConfigEntry | None, prefix: str
+) -> vol.Schema:
     """Return the data schema for an EV planned load config flow step.
 
     Args:
@@ -84,7 +90,7 @@ async def build_ev_planned_load_schema(config_entry, prefix: str) -> vol.Schema:
     def _k(suffix: str) -> str:
         return f"{prefix}_{suffix}"
 
-    def _v(suffix: str):
+    def _v(suffix: str) -> Any:  # TODO: tighten type
         return get_config_value(config_entry, _k(suffix))
 
     return vol.Schema(
@@ -114,7 +120,7 @@ async def build_ev_planned_load_schema(config_entry, prefix: str) -> vol.Schema:
 
 
 async def validate_ev_planned_load_schema_input(
-    hass, user_input: dict, prefix: str
+    hass: HomeAssistant, user_input: dict, prefix: str
 ) -> dict[str, str]:
     """Validate user input for an EV planned load flow step.
 

--- a/custom_components/hsem/flows/ev_second.py
+++ b/custom_components/hsem/flows/ev_second.py
@@ -6,6 +6,8 @@ and validation logic lives there.
 """
 
 import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 
 from custom_components.hsem.flows.ev_helpers import (
     build_ev_charger_schema,
@@ -13,7 +15,7 @@ from custom_components.hsem.flows.ev_helpers import (
 )
 
 
-async def get_ev_second_step_schema(config_entry) -> vol.Schema:
+async def get_ev_second_step_schema(config_entry: ConfigEntry | None) -> vol.Schema:
     """Return the data schema for the second EV charger flow step."""
     return await build_ev_charger_schema(
         config_entry,
@@ -22,7 +24,9 @@ async def get_ev_second_step_schema(config_entry) -> vol.Schema:
     )
 
 
-async def validate_ev_second_step_input(hass, user_input) -> dict[str, str]:
+async def validate_ev_second_step_input(
+    hass: HomeAssistant, user_input: dict
+) -> dict[str, str]:
     """Validate user input for the second EV charger flow step."""
     return await validate_ev_charger_input(
         hass,

--- a/custom_components/hsem/flows/ev_second_planned_load.py
+++ b/custom_components/hsem/flows/ev_second_planned_load.py
@@ -8,6 +8,8 @@ lives in the shared helpers module.
 from __future__ import annotations
 
 import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 
 from custom_components.hsem.flows.ev_planned_load_helpers import (
     build_ev_planned_load_schema,
@@ -17,13 +19,15 @@ from custom_components.hsem.flows.ev_planned_load_helpers import (
 _PREFIX = "hsem_ev_second_planned_load"
 
 
-async def get_ev_second_planned_load_step_schema(config_entry) -> vol.Schema:
+async def get_ev_second_planned_load_step_schema(
+    config_entry: ConfigEntry | None,
+) -> vol.Schema:
     """Return the data schema for the second EV planned load config flow step."""
     return await build_ev_planned_load_schema(config_entry, _PREFIX)
 
 
 async def validate_ev_second_planned_load_input(
-    hass, user_input: dict
+    hass: HomeAssistant, user_input: dict
 ) -> dict[str, str]:
     """Validate user input for the second EV planned load flow step."""
     return await validate_ev_planned_load_schema_input(hass, user_input, _PREFIX)

--- a/custom_components/hsem/flows/huawei_solar.py
+++ b/custom_components/hsem/flows/huawei_solar.py
@@ -6,6 +6,8 @@ have been moved to the separate ``battery_economics`` step.
 """
 
 import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.selector import selector
 
 from custom_components.hsem.utils.config_validator import (
@@ -16,7 +18,7 @@ from custom_components.hsem.utils.config_validator import (
 from custom_components.hsem.utils.misc import get_config_value
 
 
-async def get_huawei_solar_step_schema(config_entry) -> vol.Schema:
+async def get_huawei_solar_step_schema(config_entry: ConfigEntry | None) -> vol.Schema:
     """Return the data schema for the 'huawei_solar' step."""
     return vol.Schema(
         {
@@ -118,7 +120,9 @@ async def get_huawei_solar_step_schema(config_entry) -> vol.Schema:
     )
 
 
-async def validate_huawei_solar_input(hass, user_input) -> dict[str, str]:
+async def validate_huawei_solar_input(
+    hass: HomeAssistant, user_input: dict
+) -> dict[str, str]:
     """Validate user input for the 'huawei_solar' step."""
     # --- entity existence ---
     entity_errors = await async_validate_entity_ids(

--- a/custom_components/hsem/flows/init.py
+++ b/custom_components/hsem/flows/init.py
@@ -1,10 +1,11 @@
 import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.selector import selector
 
 from custom_components.hsem.utils.misc import get_config_value
 
 
-async def get_init_step_schema(config_entry) -> vol.Schema:
+async def get_init_step_schema(config_entry: ConfigEntry | None) -> vol.Schema:
     """Return the data schema for the 'init' step."""
     return vol.Schema(
         {
@@ -87,7 +88,7 @@ async def get_init_step_schema(config_entry) -> vol.Schema:
     )
 
 
-async def validate_init_step_input(user_input) -> dict[str, str]:
+async def validate_init_step_input(user_input: dict) -> dict[str, str]:
     """Validate user input for the 'init' step."""
     errors = {}
 

--- a/custom_components/hsem/flows/months.py
+++ b/custom_components/hsem/flows/months.py
@@ -1,15 +1,17 @@
 import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.selector import selector
 
 from custom_components.hsem.utils.config_validator import validate_months
 from custom_components.hsem.utils.misc import get_config_value
 
 
-def _month_options():
+def _month_options() -> list[str]:
     return [str(i) for i in range(1, 13)]
 
 
-async def get_months_schema(config_entry) -> vol.Schema:
+async def get_months_schema(config_entry: ConfigEntry | None) -> vol.Schema:
     """Return the data schema for the 'power' step."""
 
     # Stored months are integers; the multi-select selector requires string
@@ -36,6 +38,8 @@ async def get_months_schema(config_entry) -> vol.Schema:
     )
 
 
-async def validate_months_input(hass, user_input) -> dict[str, str]:
+async def validate_months_input(
+    hass: HomeAssistant, user_input: dict
+) -> dict[str, str]:
     """Validate user input for the 'months' step."""
     return validate_months(user_input)

--- a/custom_components/hsem/flows/power.py
+++ b/custom_components/hsem/flows/power.py
@@ -1,11 +1,13 @@
 import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.selector import selector
 
 from custom_components.hsem.utils.config_validator import async_validate_entity_ids
 from custom_components.hsem.utils.misc import get_config_value
 
 
-async def get_power_step_schema(config_entry) -> vol.Schema:
+async def get_power_step_schema(config_entry: ConfigEntry | None) -> vol.Schema:
     """Return the data schema for the 'power' step."""
     return vol.Schema(
         {
@@ -21,7 +23,9 @@ async def get_power_step_schema(config_entry) -> vol.Schema:
     )
 
 
-async def validate_power_step_input(hass, user_input) -> dict[str, str]:
+async def validate_power_step_input(
+    hass: HomeAssistant, user_input: dict
+) -> dict[str, str]:
     """Validate user input for the 'power' step."""
     return await async_validate_entity_ids(
         hass,

--- a/custom_components/hsem/flows/prices.py
+++ b/custom_components/hsem/flows/prices.py
@@ -16,6 +16,8 @@ or any other price source share the same configuration step.
 from __future__ import annotations
 
 import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.selector import selector
 
 from custom_components.hsem.utils.config_validator import (
@@ -26,7 +28,7 @@ from custom_components.hsem.utils.config_validator import (
 from custom_components.hsem.utils.misc import get_config_value
 
 
-async def get_prices_step_schema(config_entry) -> vol.Schema:
+async def get_prices_step_schema(config_entry: ConfigEntry | None) -> vol.Schema:
     """Return the data schema for the 'prices' step.
 
     Args:
@@ -106,7 +108,9 @@ async def get_prices_step_schema(config_entry) -> vol.Schema:
     )
 
 
-async def validate_prices_input(hass, user_input) -> dict[str, str]:
+async def validate_prices_input(
+    hass: HomeAssistant, user_input: dict
+) -> dict[str, str]:
     """Validate user input for the 'prices' step.
 
     Args:

--- a/custom_components/hsem/flows/schedule_helpers.py
+++ b/custom_components/hsem/flows/schedule_helpers.py
@@ -14,6 +14,8 @@ Public API
 """
 
 import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.selector import selector
 
 from custom_components.hsem.utils.config_validator import validate_time_window
@@ -21,8 +23,8 @@ from custom_components.hsem.utils.misc import convert_to_float, get_config_value
 
 
 def resolve_usable_capacity_kwh(
-    hass,
-    config_entry,
+    hass: HomeAssistant | None,
+    config_entry: ConfigEntry | None,
     user_input: dict | None = None,
 ) -> float:
     """Return the usable battery capacity in kWh for threshold preview calculations.
@@ -62,8 +64,8 @@ def resolve_usable_capacity_kwh(
 
 async def build_batteries_schedule_step_schema(
     schedule_number: int,
-    config_entry,
-    hass=None,
+    config_entry: ConfigEntry | None,
+    hass: HomeAssistant | None = None,
     user_input: dict | None = None,
 ) -> vol.Schema:
     """Return the voluptuous schema for a numbered battery schedule step.

--- a/custom_components/hsem/flows/solcast.py
+++ b/custom_components/hsem/flows/solcast.py
@@ -1,11 +1,13 @@
 import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.selector import selector
 
 from custom_components.hsem.utils.config_validator import async_validate_entity_ids
 from custom_components.hsem.utils.misc import get_config_value
 
 
-async def get_solcast_step_schema(config_entry) -> vol.Schema:
+async def get_solcast_step_schema(config_entry: ConfigEntry | None) -> vol.Schema:
     """Return the data schema for the 'solcast' step."""
     return vol.Schema(
         {
@@ -40,7 +42,9 @@ async def get_solcast_step_schema(config_entry) -> vol.Schema:
     )
 
 
-async def validate_solcast_step_input(hass, user_input) -> dict[str, str]:
+async def validate_solcast_step_input(
+    hass: HomeAssistant, user_input: dict
+) -> dict[str, str]:
     """Validate user input for the 'solcast' step."""
     return await async_validate_entity_ids(
         hass,

--- a/custom_components/hsem/flows/weighted_values.py
+++ b/custom_components/hsem/flows/weighted_values.py
@@ -1,4 +1,5 @@
 import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE
 from homeassistant.helpers.selector import selector
 
@@ -6,7 +7,9 @@ from custom_components.hsem.utils.config_validator import validate_consumption_w
 from custom_components.hsem.utils.misc import get_config_value
 
 
-async def get_weighted_values_step_schema(config_entry) -> vol.Schema:
+async def get_weighted_values_step_schema(
+    config_entry: ConfigEntry | None,
+) -> vol.Schema:
     """Return the data schema for the 'weighted_values' step."""
     return vol.Schema(
         {
@@ -78,7 +81,7 @@ async def get_weighted_values_step_schema(config_entry) -> vol.Schema:
     )
 
 
-async def validate_weighted_values_input(user_input) -> dict[str, str]:
+async def validate_weighted_values_input(user_input: dict) -> dict[str, str]:
     """Validate user input for the 'weighted_values' step."""
     required_fields = [
         "hsem_house_consumption_energy_weight_1d",

--- a/custom_components/hsem/options_flow.py
+++ b/custom_components/hsem/options_flow.py
@@ -59,7 +59,7 @@ from custom_components.hsem.utils.misc import convert_months_to_int
 class HSEMOptionsFlow(config_entries.OptionsFlow):
     """Options flow for HSEM."""
 
-    def __init__(self, config_entry) -> None:
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         self._config_entry = config_entry
         self._user_input = {}
 

--- a/custom_components/hsem/planner/engine_core.py
+++ b/custom_components/hsem/planner/engine_core.py
@@ -12,6 +12,7 @@ from datetime import datetime
 
 from custom_components.hsem.models.planner_inputs import PlannerInput
 from custom_components.hsem.models.planner_outputs import DataQuality, PlannerOutput
+from custom_components.hsem.models.time_series import TimeSeriesIndex
 from custom_components.hsem.planner.candidate_generator import generate_candidates
 from custom_components.hsem.planner.candidate_selector import (
     replacement_price_from_next_discharge,
@@ -68,7 +69,11 @@ def _parse_now(now_iso: str) -> datetime:
 
 
 def _populate_slots(
-    slots: list, inp: PlannerInput, tsi, warnings: list[str], missing_inputs: list[str]
+    slots: list,
+    inp: PlannerInput,
+    tsi: TimeSeriesIndex,
+    warnings: list[str],
+    missing_inputs: list[str],
 ) -> tuple[DataQuality, list[str], list[str]]:
     """Populate price/PV/consumption data, data-quality diagnostics, confidence decay."""
     log_planner(
@@ -338,7 +343,7 @@ def _build_and_inject_for_ev(
     cap_kwh: float,
     pwr_kw: float,
     eff: float,
-    deadline,
+    deadline: datetime | None,
     base_includes: bool,
     allow_past_target: bool,
     label: str,

--- a/custom_components/hsem/utils/config_validator.py
+++ b/custom_components/hsem/utils/config_validator.py
@@ -19,6 +19,7 @@ Design principles
 
 import re
 from datetime import datetime as _datetime
+from typing import Any
 
 from custom_components.hsem.utils.misc import (
     async_device_exists,
@@ -105,7 +106,7 @@ def validate_entity_id_fields(
 
 
 async def async_validate_entity_ids(
-    hass,
+    hass: Any,
     user_input: dict,
     required_fields: list[str],
     optional_fields: list[str] | None = None,
@@ -145,7 +146,7 @@ async def async_validate_entity_ids(
 
 
 async def async_validate_device_ids(
-    hass,
+    hass: Any,
     user_input: dict,
     required_fields: list[str],
     optional_fields: list[str] | None = None,

--- a/custom_components/hsem/utils/huawei.py
+++ b/custom_components/hsem/utils/huawei.py
@@ -24,6 +24,8 @@ Usage:
     "huawei_solar" integration and manage errors appropriately.
 """
 
+from typing import Any
+
 import voluptuous as vol
 from homeassistant.exceptions import (
     HomeAssistantError,
@@ -34,7 +36,9 @@ from homeassistant.exceptions import (
 from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
 
 
-async def async_set_grid_export_power_pct(self, device_id, power_percentage) -> None:
+async def async_set_grid_export_power_pct(
+    self: Any, device_id: str, power_percentage: int
+) -> None:
     """Set the maximum grid export power percentage and handle errors.
 
     Raises:
@@ -90,7 +94,9 @@ async def async_set_grid_export_power_pct(self, device_id, power_percentage) -> 
         raise
 
 
-async def async_set_grid_export_power_watt(self, device_id, power_watt) -> None:
+async def async_set_grid_export_power_watt(
+    self: Any, device_id: str, power_watt: int
+) -> None:
     """Set the maximum grid export power in watts and handle errors.
 
     Uses the ``huawei_solar.set_maximum_feed_grid_power`` service to set an
@@ -150,7 +156,9 @@ async def async_set_grid_export_power_watt(self, device_id, power_watt) -> None:
         raise
 
 
-async def async_set_tou_periods(self, batteries_id, tou_modes) -> None:
+async def async_set_tou_periods(
+    self: Any, batteries_id: str, tou_modes: list[str]
+) -> None:
     """Set the TOU modes for the specified batteries.
 
     Raises:
@@ -204,7 +212,7 @@ async def async_set_tou_periods(self, batteries_id, tou_modes) -> None:
 
 
 async def async_set_forcible_discharge(
-    self, device_id: str, target_soc: int, power: int
+    self: Any, device_id: str, target_soc: int, power: int
 ) -> None:
     """Set forcible discharge for the battery at specified power and target SOC.
 
@@ -273,7 +281,7 @@ async def async_set_forcible_discharge(
         raise
 
 
-async def async_stop_forcible_discharge(self, device_id: str) -> None:
+async def async_stop_forcible_discharge(self: Any, device_id: str) -> None:
     """Stop any active forcible charge or discharge on the battery.
 
     Args:

--- a/custom_components/hsem/utils/logger.py
+++ b/custom_components/hsem/utils/logger.py
@@ -66,6 +66,7 @@ import logging
 import logging.handlers
 import os
 from concurrent.futures import ThreadPoolExecutor
+from typing import Any
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -186,7 +187,7 @@ async def async_close_hsem_logger() -> None:
 # ---------------------------------------------------------------------------
 
 
-async def async_logger(self, msg: str, level: str = "debug") -> None:
+async def async_logger(self: Any, msg: str, level: str = "debug") -> None:
     """Emit *msg* through the HSEM file logger if verbose logging is on.
 
     The write is delegated to a ``ThreadPoolExecutor`` so that the

--- a/custom_components/hsem/utils/misc.py
+++ b/custom_components/hsem/utils/misc.py
@@ -2,6 +2,7 @@
 
 import hashlib
 from datetime import datetime, time, timedelta
+from typing import Any
 
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.exceptions import (
@@ -13,6 +14,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 
 from custom_components.hsem.const import DEFAULT_CONFIG_VALUES, DOMAIN
+
 # Re-export async_logger from its dedicated module so that existing callers
 # importing it from utils.misc continue to work without changes.
 from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
@@ -24,12 +26,12 @@ class EntityNotFoundError(HomeAssistantError):
     """Exception raised when an entity is not found."""
 
 
-def generate_hash(input_sensor) -> str:
+def generate_hash(input_sensor: str) -> str:
     """Generate an SHA-256 hash based on the input sensor's name."""
     return hashlib.sha256(input_sensor.encode("utf-8")).hexdigest()
 
 
-def get_config_value(config_entry, key) -> str | None:
+def get_config_value(config_entry: Any | None, key: str) -> str | None:
     """Get the configuration value from options or fall back to the initial data."""
     if key not in DEFAULT_CONFIG_VALUES:
         raise KeyError(f"Key '{key}' not found in DEFAULT_VALUES")
@@ -50,7 +52,7 @@ def get_config_value(config_entry, key) -> str | None:
     return data
 
 
-def convert_to_time(time_value) -> time:
+def convert_to_time(time_value: str | time) -> time:
     """Convert a time value (str or datetime.time) to a datetime.time object."""
     if isinstance(time_value, time):
         return time_value
@@ -128,7 +130,7 @@ def interval_ends_before_window_start(
     return interval_end <= next_window_start_dt(now, window_start)
 
 
-def convert_to_float(state) -> float | None:
+def convert_to_float(state: Any) -> float | None:
     """Resolve the input sensor state and cast it to a float.
 
     Returns ``None`` for values that cannot be meaningfully interpreted as a
@@ -163,7 +165,7 @@ def convert_to_float(state) -> float | None:
         return None
 
 
-def convert_to_int(state) -> int | None:
+def convert_to_int(state: Any) -> int | None:
     """Cast *state* to an integer, distinguishing real zero from invalid input.
 
     Returns:
@@ -216,7 +218,7 @@ def convert_months_to_int(months: list) -> list[int]:
     return result
 
 
-def convert_to_boolean(state) -> bool:
+def convert_to_boolean(state: Any) -> bool:
     """Resolve the input sensor state and cast it to a boolean."""
 
     if state is None:
@@ -283,7 +285,7 @@ def clamp_efficiency(pct: float) -> float:
 
 
 async def async_resolve_entity_id_from_unique_id(
-    self, unique_entity_id, domain="sensor"
+    self: Any, unique_entity_id: str, domain: str = "sensor"
 ) -> str | None:
     """Resolve the entity_id from the unique_id using the entity registry.
 
@@ -326,7 +328,7 @@ async def async_resolve_entity_id_from_unique_id(
         return None
 
 
-async def async_set_number_value(self, entity_id, value) -> None:
+async def async_set_number_value(self: Any, entity_id: str, value: float | int) -> None:
     """Set the value for a number entity.
 
     Parameters:
@@ -360,7 +362,7 @@ async def async_set_number_value(self, entity_id, value) -> None:
         raise
 
 
-async def async_set_select_option(self, entity_id, option) -> None:
+async def async_set_select_option(self: Any, entity_id: str, option: str) -> None:
     """Set the selected option for an entity."""
 
     # Check if entity_id exists
@@ -392,7 +394,10 @@ async def async_set_select_option(self, entity_id, option) -> None:
 
 
 def ha_get_entity_state_and_convert(
-    self, entity_id, output_type=None, float_precision=2
+    self: Any,
+    entity_id: str | None,
+    output_type: str | None = None,
+    float_precision: int = 2,
 ) -> float | int | bool | str | None:
     """Get the state of an entity."""
 
@@ -444,7 +449,7 @@ def ha_get_entity_state_and_convert(
         )
 
 
-async def async_remove_entity_from_ha(self, entity_unique_id) -> bool:
+async def async_remove_entity_from_ha(self: Any, entity_unique_id: str) -> bool:
     """Remove an existing entity in Home Assistant based on its unique ID.
 
     :param entity_unique_id: The unique ID of the entity to be removed.
@@ -471,12 +476,12 @@ async def async_remove_entity_from_ha(self, entity_unique_id) -> bool:
         return False
 
 
-async def async_entity_exists(hass, entity_id) -> bool:
+async def async_entity_exists(hass: Any, entity_id: str) -> bool:
     """Check if an entity exists in Home Assistant."""
     return hass.states.get(entity_id) is not None
 
 
-async def async_device_exists(hass, device_id) -> bool:
+async def async_device_exists(hass: Any, device_id: str) -> bool:
     """Check if a device exists in Home Assistant."""
     device_registry = dr.async_get(hass)
     return device_registry.async_get(device_id) is not None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ warn_unused_configs = true
 ignore_missing_imports = true
 disallow_incomplete_defs = true
 # Pre-existing type issues tracked for a future cleanup PR:
-disable_error_code = ["no-untyped-def", "union-attr", "arg-type", "misc", "return-value", "assignment", "operator", "no-any-return", "var-annotated", "method-assign", "annotation-unchecked", "type-var", "attr-defined", "func-returns-value", "override", "index", "name-defined"]
+disable_error_code = ["union-attr", "arg-type", "misc", "return-value", "assignment", "operator", "no-any-return", "var-annotated", "method-assign", "annotation-unchecked", "type-var", "attr-defined", "func-returns-value", "override", "index", "name-defined"]
 
 [tool.coverage.run]
 source = ["custom_components"]

--- a/tests/planner/test_arbitrage_grid_charge.py
+++ b/tests/planner/test_arbitrage_grid_charge.py
@@ -22,6 +22,7 @@ Acceptance criteria verified here:
 from __future__ import annotations
 
 from datetime import time
+from typing import Any
 
 import pytest
 
@@ -137,7 +138,7 @@ def _make_arbitrage_input(
     )
 
 
-def _slot_at_hour(slots, hour: int):
+def _slot_at_hour(slots: list[Any], hour: int) -> Any:
     for s in slots:
         if s.start.hour == hour:
             return s

--- a/tests/planner/test_ev_planned_load.py
+++ b/tests/planner/test_ev_planned_load.py
@@ -14,6 +14,7 @@ TestPlannerEngineEVIntegration — full engine runs with EV planned load
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 import pytest
 
@@ -40,12 +41,12 @@ from custom_components.hsem.planner.ev_planner import (
 _UTC = UTC
 
 
-def _dt(h: int, tz=_UTC) -> datetime:
+def _dt(h: int, tz: Any = _UTC) -> datetime:
     """Return a datetime on 2024-06-15 at hour h in tz."""
     return datetime(2024, 6, 15, h, 0, 0, tzinfo=tz)
 
 
-def _make_slots(n: int = 24, tz=_UTC):
+def _make_slots(n: int = 24, tz: Any = _UTC) -> tuple[list[datetime], list[datetime]]:
     """Return n 1-hour slot (start, end) pairs starting at 00:00."""
     starts = [_dt(h, tz) for h in range(n)]
     ends = [_dt(h + 1 if h < 23 else 0, tz) for h in range(n)]
@@ -201,7 +202,7 @@ class TestMaxChargeEnergy:
 class TestBuildEvChargingPlanGuards:
     """Test guard conditions in build_ev_charging_plan."""
 
-    def _make_inp(self, **kwargs) -> EVPlannerInput:
+    def _make_inp(self, **kwargs: Any) -> EVPlannerInput:
         now = _dt(14)
         deadline = now + timedelta(hours=8)
         base = EVPlannerInput(
@@ -2632,7 +2633,9 @@ class TestEvLoadDoesNotInflateChargeNeeded:
 # ---------------------------------------------------------------------------
 
 
-def _make_slots_48(now: datetime, tz=_UTC):
+def _make_slots_48(
+    now: datetime, tz: Any = _UTC
+) -> tuple[list[datetime], list[datetime]]:
     """Return 48 contiguous 1-hour slot ``(start, end)`` pairs anchored at ``now``.
 
     Slot ``i`` runs ``[now + i h, now + (i+1) h]``.  This mimics a 48-hour

--- a/tests/planner/test_invariants.py
+++ b/tests/planner/test_invariants.py
@@ -1940,7 +1940,9 @@ class TestPastSlotSocPenaltyExclusion:
     cost differences between strategies.
     """
 
-    def _make_slots_with_past(self, n_past: int = 10, n_future: int = 5):
+    def _make_slots_with_past(
+        self, n_past: int = 10, n_future: int = 5
+    ) -> list[PlannedSlot]:
         """Return a mixed list with *n_past* past slots and *n_future* future slots."""
         tz = ZoneInfo("Europe/Copenhagen")
         base = datetime(2024, 6, 15, 8, 0, tzinfo=tz)

--- a/tests/planner/test_mid_hour_planner.py
+++ b/tests/planner/test_mid_hour_planner.py
@@ -23,6 +23,7 @@ All tests are synchronous and import nothing from Home Assistant's runtime.
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -33,6 +34,7 @@ from custom_components.hsem.models.planner_inputs import (
     PricePoint,
     SolcastSlot,
 )
+from custom_components.hsem.models.planner_outputs import PlannerOutput
 from custom_components.hsem.planner import run_planner
 from custom_components.hsem.utils.recommendations import Recommendations
 from tests.planner.fixtures import make_summer_day_input
@@ -60,14 +62,14 @@ _START_CURRENT_KWH = min(
 # ---------------------------------------------------------------------------
 
 
-def _first_future_slot(result):
+def _first_future_slot(result: PlannerOutput) -> Any:
     """Return the first slot not marked as TimePassed."""
     return next(
         s for s in result.slots if s.recommendation != Recommendations.TimePassed.value
     )
 
 
-def _time_passed_count(result) -> int:
+def _time_passed_count(result: PlannerOutput) -> int:
     """Count slots marked as TimePassed."""
     return sum(
         1 for s in result.slots if s.recommendation == Recommendations.TimePassed.value

--- a/tests/planner/test_planning_horizon.py
+++ b/tests/planner/test_planning_horizon.py
@@ -16,6 +16,7 @@ All tests are pure-Python; no Home Assistant runtime is required.
 from __future__ import annotations
 
 from datetime import time
+from typing import Any
 
 from custom_components.hsem.models.planner_inputs import (
     BatteryScheduleInput,
@@ -366,7 +367,7 @@ class TestCompleteFutureData:
 class TestConfidenceDecay:
     """PV estimates for day+1 and day+2 must be lower due to confidence decay."""
 
-    def _get_solar_noon_pv(self, result, day_offset: int) -> float:
+    def _get_solar_noon_pv(self, result: Any, day_offset: int) -> float:
         """Return the solar-noon (12:00) PV estimate for a given day_offset."""
         from datetime import date
 

--- a/tests/sensors/test_plan_explanation_sensor.py
+++ b/tests/sensors/test_plan_explanation_sensor.py
@@ -14,6 +14,7 @@ Acceptance criteria
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -72,7 +73,7 @@ _CONTEXT_ATTR_KEYS = {
 }
 
 
-def _make_explanation(**kwargs) -> PlanExplanation:
+def _make_explanation(**kwargs: Any) -> PlanExplanation:
     """Return a PlanExplanation with sensible defaults overridable by kwargs."""
     defaults = dict(
         selected_strategy="charge_grid_discharge_peak",
@@ -245,7 +246,7 @@ class TestSensorState:
             "solar_charge_only",
         ],
     )
-    def test_state_for_all_known_strategies(self, strategy: str):
+    def test_state_for_all_known_strategies(self, strategy: str) -> None:
         """All known strategy values round-trip correctly through state."""
         sensor = _make_sensor(
             _make_coordinator_data(_make_explanation(selected_strategy=strategy))

--- a/tests/sensors/test_recommendation_resolver.py
+++ b/tests/sensors/test_recommendation_resolver.py
@@ -7,6 +7,7 @@ tested with plain dataclasses — no Home Assistant required.
 from __future__ import annotations
 
 from datetime import UTC
+from typing import Any
 
 from custom_components.hsem.custom_sensors.recommendation_resolver import (
     resolve_current_recommendation,
@@ -20,7 +21,7 @@ from custom_components.hsem.utils.recommendations import Recommendations
 # ---------------------------------------------------------------------------
 
 
-def _make_rec(recommendation=None) -> HourlyRecommendation:
+def _make_rec(recommendation: str | None = None) -> HourlyRecommendation:
     """Return a minimal HourlyRecommendation with a given recommendation value."""
     from datetime import datetime
 
@@ -189,7 +190,7 @@ class TestDataStateSync:
         planner_recommendation: str,
         resolved_recommendation: str,
         live: LiveState,
-    ):
+    ) -> Any:
         """Return a CoordinatorData-like namespace simulating the sync behaviour.
 
         The ``resolved_recommendation`` parameter is passed by callers as

--- a/tests/sensors/test_state_collector.py
+++ b/tests/sensors/test_state_collector.py
@@ -7,6 +7,7 @@ which can be exercised without a running Home Assistant instance.
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -25,7 +26,7 @@ from custom_components.hsem.models.sensor_config import SensorConfig
 # ---------------------------------------------------------------------------
 
 
-def _make_config_entry(**overrides) -> MagicMock:
+def _make_config_entry(**overrides: Any) -> MagicMock:
     """Return a minimal mock ConfigEntry whose options contain the given overrides."""
     defaults = {
         "hsem_read_only": False,

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -35,7 +35,7 @@ from custom_components.hsem.utils.config_validator import (
 # ---------------------------------------------------------------------------
 
 
-def _hass_with_states(*entity_ids: str):
+def _hass_with_states(*entity_ids: str) -> MagicMock:
     """Return a minimal hass mock where the given entity IDs exist."""
     hass = MagicMock()
 

--- a/tests/test_convert_to_float_none.py
+++ b/tests/test_convert_to_float_none.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import pytest
 
+from custom_components.hsem.models.live_state import LiveState
 from custom_components.hsem.utils.misc import convert_to_float, convert_to_int
 
 # ---------------------------------------------------------------------------
@@ -44,7 +45,7 @@ class TestConvertToFloatInvalidValues:
             None,
         ],
     )
-    def test_returns_none(self, bad_input) -> None:
+    def test_returns_none(self, bad_input: str | None) -> None:
         """Every HA sentinel / non-numeric value must yield None."""
         assert convert_to_float(bad_input) is None
 
@@ -63,7 +64,7 @@ class TestConvertToFloatRealZero:
             "  0  ",
         ],
     )
-    def test_zero_returns_zero(self, zero_input) -> None:
+    def test_zero_returns_zero(self, zero_input: int | float | str) -> None:
         """Real zero is a valid, non-missing measurement."""
         result = convert_to_float(zero_input)
         assert result == pytest.approx(0.0)
@@ -85,7 +86,9 @@ class TestConvertToFloatNumericRoundTrip:
             ("1e3", 1000.0),
         ],
     )
-    def test_numeric_round_trip(self, value, expected: float) -> None:
+    def test_numeric_round_trip(
+        self, value: int | float | str, expected: float
+    ) -> None:
         result = convert_to_float(value)
         assert result == pytest.approx(expected)
 
@@ -98,10 +101,8 @@ class TestConvertToFloatNumericRoundTrip:
 class TestCriticalSensorNoneSetsMissingFlag:
     """When a critical battery sensor returns None the LiveState must flag it."""
 
-    def _make_live_with_none_soc(self):
+    def _make_live_with_none_soc(self) -> LiveState:
         """Simulate state_collector behaviour for a None battery SoC."""
-        from custom_components.hsem.models.live_state import LiveState
-
         state = LiveState()
         soc_pct = convert_to_float(
             "unavailable"
@@ -127,8 +128,7 @@ class TestCriticalSensorNoneSetsMissingFlag:
         state = self._make_live_with_none_soc()
         assert any("SoC" in label for label in state.missing_entities_list)
 
-    def _make_live_with_valid_soc(self, raw: str = "75.0"):
-        from custom_components.hsem.models.live_state import LiveState
+    def _make_live_with_valid_soc(self, raw: str = "75.0") -> LiveState:
 
         state = LiveState()
         soc_pct = convert_to_float(raw)
@@ -290,7 +290,7 @@ class TestConvertToIntInvalidValues:
             None,
         ],
     )
-    def test_returns_none(self, bad_input) -> None:
+    def test_returns_none(self, bad_input: str | None) -> None:
         """Every HA sentinel / non-numeric value must yield None."""
         assert convert_to_int(bad_input) is None
 
@@ -308,7 +308,7 @@ class TestConvertToIntRealZero:
             "  0  ",
         ],
     )
-    def test_zero_returns_zero(self, zero_input) -> None:
+    def test_zero_returns_zero(self, zero_input: int | float | str) -> None:
         """Real zero is a valid, non-missing value."""
         result = convert_to_int(zero_input)
         assert result == 0
@@ -332,7 +332,7 @@ class TestConvertToIntNumericRoundTrip:
             (3.9, 3),
         ],
     )
-    def test_numeric_round_trip(self, value, expected: int) -> None:
+    def test_numeric_round_trip(self, value: int | float | str, expected: int) -> None:
         result = convert_to_int(value)
         assert result == expected
 
@@ -393,7 +393,7 @@ class TestCoordinatorConfigNullSafeDefaults:
     """
 
     @staticmethod
-    def _apply_weight_default(raw, default: int) -> int:
+    def _apply_weight_default(raw: str | int | None, default: int) -> int:
         """Mirror the coordinator pattern: v if (v := convert_to_int(raw)) is not None else default."""
         v = convert_to_int(raw)
         return v if v is not None else default
@@ -411,7 +411,9 @@ class TestCoordinatorConfigNullSafeDefaults:
             (0, 6000, 0),  # zero cycles is valid (unusual but not corrupt)
         ],
     )
-    def test_weight_default_logic(self, raw, default: int, expected: int) -> None:
+    def test_weight_default_logic(
+        self, raw: str | int | None, default: int, expected: int
+    ) -> None:
         assert self._apply_weight_default(raw, default) == expected
 
     def test_zero_expected_cycles_preserved(self) -> None:
@@ -488,7 +490,7 @@ class TestFlowExpectedCyclesNullSafety:
     """
 
     @staticmethod
-    def _flow_expected_cycles(raw_config_value) -> int:
+    def _flow_expected_cycles(raw_config_value: str | int | None) -> int:
         """Mirror the fixed flow pattern used in all four flow files."""
         _v = convert_to_int(raw_config_value)
         return _v if _v is not None else 6000
@@ -506,7 +508,7 @@ class TestFlowExpectedCyclesNullSafety:
             (0, 0),  # integer zero must survive
         ],
     )
-    def test_flow_cycles_never_none(self, raw, expected: int) -> None:
+    def test_flow_cycles_never_none(self, raw: str | int | None, expected: int) -> None:
         """Invalid raw values always fall back to 6000; real zero is preserved."""
         result = self._flow_expected_cycles(raw)
         assert result == expected

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -148,7 +149,7 @@ class _StubCoordinator:
         self._cfg = MagicMock()
         self._cfg.verbose_logging = False
 
-    async def _async_handle_update(self, event=None) -> None:
+    async def _async_handle_update(self, event: Any = None) -> None:
         """Identical guard logic to the production coordinator."""
         if self._update_lock.locked():
             self._skip_count += 1

--- a/tests/test_datetime_utils.py
+++ b/tests/test_datetime_utils.py
@@ -23,10 +23,14 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime, timedelta, timezone
+from typing import Any
 from unittest.mock import MagicMock, patch
 from zoneinfo import ZoneInfo
 
 import pytest
+
+from custom_components.hsem.models.hourly_recommendation import HourlyRecommendation
+from custom_components.hsem.models.planner_outputs import PlannedSlot, PlannerOutput
 
 # ---------------------------------------------------------------------------
 # Helpers – build lightweight planner/coordinator objects for testing
@@ -51,9 +55,8 @@ def _make_bare_coordinator():
     return coord
 
 
-def _make_planned_slot(start: datetime, end: datetime, **kwargs):
+def _make_planned_slot(start: datetime, end: datetime, **kwargs: Any) -> PlannedSlot:
     """Return a minimal ``PlannedSlot`` for testing."""
-    from custom_components.hsem.models.planner_outputs import PlannedSlot
     from custom_components.hsem.utils.prices import SlotPrice
 
     defaults = {
@@ -75,9 +78,10 @@ def _make_planned_slot(start: datetime, end: datetime, **kwargs):
     return PlannedSlot(start=start, end=end, **defaults)
 
 
-def _make_hourly_recommendation(start: datetime, end: datetime, **kwargs):
+def _make_hourly_recommendation(
+    start: datetime, end: datetime, **kwargs: Any
+) -> HourlyRecommendation:
     """Return a minimal ``HourlyRecommendation`` for testing."""
-    from custom_components.hsem.models.hourly_recommendation import HourlyRecommendation
 
     defaults = {
         "avg_house_consumption_kwh": 1.0,
@@ -258,7 +262,7 @@ class TestNormalizeSlotStart15Min:
             (59, 45),
         ],
     )
-    def test_floor_to_15min_boundary(self, minute_in: int, minute_out: int):
+    def test_floor_to_15min_boundary(self, minute_in: int, minute_out: int) -> None:
         """22:mm:ss → 22:floored:00 for various minutes."""
         from custom_components.hsem.utils.datetime_utils import normalize_slot_start
 
@@ -297,7 +301,7 @@ class TestNormalizeSlotStart60Min:
         "minute_in",
         [0, 1, 17, 30, 42, 59],
     )
-    def test_floor_to_60min_boundary(self, minute_in: int):
+    def test_floor_to_60min_boundary(self, minute_in: int) -> None:
         """Any 22:mm:ss → 22:00:00 for 60-min slots."""
         from custom_components.hsem.utils.datetime_utils import normalize_slot_start
 
@@ -405,9 +409,8 @@ class TestEvPlannedLoadReachesRecommendation:
 
     def _build_slots_and_recs(
         self, midnight: datetime, ev_hours: dict[int, float], interval_minutes: int = 60
-    ):
+    ) -> tuple[list[Any], PlannerOutput]:
         """Build matching slots and recs for the given horizon."""
-        from custom_components.hsem.models.planner_outputs import PlannerOutput
 
         recs = []
         slots = []

--- a/tests/test_dst_transitions.py
+++ b/tests/test_dst_transitions.py
@@ -15,10 +15,12 @@ Timezone under test: ``Europe/Copenhagen``
 from __future__ import annotations
 
 from datetime import datetime, time, timedelta
+from typing import Any
 from zoneinfo import ZoneInfo
 
 import pytest
 
+from custom_components.hsem.models.planner_inputs import PlannerInput
 from custom_components.hsem.planner.engine_core import _parse_now
 from custom_components.hsem.planner.slot_population import build_slots
 from custom_components.hsem.utils.misc import (
@@ -109,7 +111,7 @@ class TestBuildSlotsDst:
 
     def _make_input_stub(
         self, interval_minutes: int = 60, interval_length_hours: int = 24
-    ):
+    ) -> Any:
         """Return a minimal object with the fields build_slots needs."""
 
         class _Stub:
@@ -310,12 +312,11 @@ class TestIntervalEndsDst:
 class TestPlannerRunsDstDays:
     """run_planner must complete without raising on both DST transition days."""
 
-    def _base_input(self, now_iso: str):
+    def _base_input(self, now_iso: str) -> PlannerInput:
         """Return a minimal PlannerInput for a 24-hour summer-like day."""
         from custom_components.hsem.models.planner_inputs import (
             BatteryScheduleInput,
             HourlyConsumptionAverage,
-            PlannerInput,
             PricePoint,
             SolcastSlot,
         )

--- a/tests/test_entity_platform_classes.py
+++ b/tests/test_entity_platform_classes.py
@@ -14,6 +14,7 @@ for time entities without requiring a live Home Assistant instance.
 from __future__ import annotations
 
 from datetime import time
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -291,7 +292,7 @@ class TestTimePlatformSetup:
 
         added: list[HSEMTimeEntity] = []
 
-        def add_entities(entities, _update_before_add: bool = False) -> None:
+        def add_entities(entities: Any, _update_before_add: bool = False) -> None:
             added.extend(entities)
 
         with patch(
@@ -320,7 +321,7 @@ class TestTimePlatformSetup:
         )
         added: list = []
 
-        def add_entities(entities, _update_before_add: bool = False) -> None:
+        def add_entities(entities: Any, _update_before_add: bool = False) -> None:
             added.extend(entities)
 
         with patch(
@@ -353,7 +354,7 @@ class TestTimePlatformSetup:
         )
         added: list = []
 
-        def add_entities(entities, _update_before_add: bool = False) -> None:
+        def add_entities(entities: Any, _update_before_add: bool = False) -> None:
             added.extend(entities)
 
         with patch(

--- a/tests/test_flow_helpers.py
+++ b/tests/test_flow_helpers.py
@@ -58,7 +58,7 @@ class TestBuildBatteriesScheduleStepSchema:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("n", [1, 2, 3])
-    async def test_schema_contains_three_fields(self, n: int):
+    async def test_schema_contains_three_fields(self, n: int) -> None:
         """All expected keys must be present in the built schema."""
         from custom_components.hsem.flows.schedule_helpers import (
             build_batteries_schedule_step_schema,
@@ -74,7 +74,7 @@ class TestBuildBatteriesScheduleStepSchema:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("n", [1, 2, 3])
-    async def test_schema_keys_match_original_numbered_wrappers(self, n: int):
+    async def test_schema_keys_match_original_numbered_wrappers(self, n: int) -> None:
         """Schema keys produced by the helper must equal those of the original
         numbered modules — ensuring no config migration is needed."""
         # Import the numbered wrapper (which now delegates to the helper)
@@ -156,7 +156,7 @@ class TestValidateBatteriesScheduleInput:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("n", [1, 2, 3])
-    async def test_disabled_schedule_passes_with_invalid_times(self, n: int):
+    async def test_disabled_schedule_passes_with_invalid_times(self, n: int) -> None:
         """Disabled schedule must skip time validation entirely."""
         from custom_components.hsem.flows.schedule_helpers import (
             validate_batteries_schedule_input,
@@ -175,7 +175,7 @@ class TestValidateBatteriesScheduleInput:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("n", [1, 2, 3])
-    async def test_zero_length_active_schedule_is_rejected(self, n: int):
+    async def test_zero_length_active_schedule_is_rejected(self, n: int) -> None:
         """start == end when enabled must produce a base error."""
         from custom_components.hsem.flows.schedule_helpers import (
             validate_batteries_schedule_input,
@@ -194,7 +194,7 @@ class TestValidateBatteriesScheduleInput:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("n", [1, 2, 3])
-    async def test_valid_cross_midnight_window_accepted(self, n: int):
+    async def test_valid_cross_midnight_window_accepted(self, n: int) -> None:
         """A valid cross-midnight window must pass with no errors."""
         from custom_components.hsem.flows.schedule_helpers import (
             validate_batteries_schedule_input,
@@ -213,7 +213,7 @@ class TestValidateBatteriesScheduleInput:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("n", [1, 2, 3])
-    async def test_invalid_time_format_rejected(self, n: int):
+    async def test_invalid_time_format_rejected(self, n: int) -> None:
         """An unparseable time string must produce an ``invalid_time_format`` error."""
         from custom_components.hsem.flows.schedule_helpers import (
             validate_batteries_schedule_input,
@@ -232,7 +232,7 @@ class TestValidateBatteriesScheduleInput:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("n", [1, 2, 3])
-    async def test_helper_output_matches_numbered_wrapper(self, n: int):
+    async def test_helper_output_matches_numbered_wrapper(self, n: int) -> None:
         """Helper and numbered wrapper must return identical errors for the same input."""
         import importlib
 
@@ -492,7 +492,7 @@ class TestSchemaRoundTrip:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("n", [1, 2, 3])
-    async def test_schedule_schema_accepts_valid_input(self, n: int):
+    async def test_schedule_schema_accepts_valid_input(self, n: int) -> None:
         from custom_components.hsem.flows.schedule_helpers import (
             build_batteries_schedule_step_schema,
         )

--- a/tests/test_ha_mock_integration.py
+++ b/tests/test_ha_mock_integration.py
@@ -1784,7 +1784,9 @@ class TestApplyPlannerOutputEvLoad:
     # Helpers
     # ------------------------------------------------------------------
 
-    def _make_coord_with_recs(self, interval_minutes: int = 60, total_hours: int = 24):
+    def _make_coord_with_recs(
+        self, interval_minutes: int = 60, total_hours: int = 24
+    ) -> Any:
         """Return a bare coordinator whose _hourly_recommendations are pre-generated."""
         coord = make_bare_coordinator()
         coord._batteries_schedules = []
@@ -1795,11 +1797,11 @@ class TestApplyPlannerOutputEvLoad:
 
     def _make_output_from_recs(
         self,
-        recs,
+        recs: list[Any],
         ev_load_by_hour: dict[int, float],
         ev_accounted_by_hour: dict[int, float] | None = None,
         ev_total_by_hour: dict[int, float] | None = None,
-    ):
+    ) -> Any:
         """Build a PlannerOutput whose slot starts exactly match *recs*.
 
         Args:
@@ -2383,7 +2385,7 @@ class TestEvFieldsEndToEnd:
     fields must be visible in hourly_recommendations.
     """
 
-    def _run_end_to_end(self, base_includes_ev: bool):
+    def _run_end_to_end(self, base_includes_ev: bool) -> Any:
         """Run planner + apply_planner_output and return (coordinator, output)."""
         from datetime import datetime, timedelta
 

--- a/tests/test_house_consumption_sensor_lifecycle.py
+++ b/tests/test_house_consumption_sensor_lifecycle.py
@@ -28,6 +28,7 @@ Key invariants verified here:
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -56,7 +57,7 @@ from custom_components.hsem.utils.sensornames import (
 # ---------------------------------------------------------------------------
 
 
-def _mock_config_entry(**overrides) -> MagicMock:
+def _mock_config_entry(**overrides: Any) -> MagicMock:
     """Return a minimal config-entry mock."""
     import voluptuous as vol
 
@@ -73,7 +74,7 @@ def _mock_config_entry(**overrides) -> MagicMock:
 
 
 def _make_sensor(
-    hour_start: int = 14, *, config_entry=None
+    hour_start: int = 14, *, config_entry: MagicMock | None = None
 ) -> tuple[
     HSEMHouseConsumptionPowerSensor,
     list,
@@ -449,7 +450,12 @@ class TestPowerSensorActiveWindow:
 
 
 def _fake_integration_init(
-    self_inner, *args, id, e_id, config_entry=None, **kwargs
+    self_inner: Any,
+    *args: Any,
+    id: Any,
+    e_id: Any,
+    config_entry: Any = None,
+    **kwargs: Any,
 ) -> None:
     """Minimal HSEMIntegrationSensor init that bypasses the real HA bootstrap."""
     self_inner._attr_unique_id = id
@@ -457,14 +463,14 @@ def _fake_integration_init(
 
 
 def _fake_utility_init(
-    self_inner,
-    *args,
-    id,
-    e_id,
-    config_entry=None,
-    source_entity=None,
-    _parent_meter=None,
-    **kwargs,
+    self_inner: Any,
+    *args: Any,
+    id: Any,
+    e_id: Any,
+    config_entry: Any = None,
+    source_entity: Any = None,
+    _parent_meter: Any = None,
+    **kwargs: Any,
 ) -> None:
     """Minimal HSEMUtilityMeterSensor init that bypasses the real HA bootstrap."""
     self_inner._attr_unique_id = id
@@ -631,14 +637,14 @@ class TestDerivedSensorLifecycle:
         captured_source: list[str] = []
 
         def capturing_utility_init(
-            self_inner,
-            *args,
-            id,
-            e_id,
-            config_entry=None,
-            source_entity=None,
-            _parent_meter=None,
-            **kwargs,
+            self_inner: Any,
+            *args: Any,
+            id: Any,
+            e_id: Any,
+            config_entry: Any = None,
+            source_entity: Any = None,
+            _parent_meter: Any = None,
+            **kwargs: Any,
         ) -> None:
             self_inner._attr_unique_id = id
             self_inner.entity_id = e_id

--- a/tests/test_huawei_service_calls.py
+++ b/tests/test_huawei_service_calls.py
@@ -16,6 +16,7 @@ Acceptance criteria
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -37,7 +38,7 @@ from custom_components.hsem.utils.huawei import (
 # ---------------------------------------------------------------------------
 
 
-def _make_sensor(has_service: bool = True, service_exception=None):
+def _make_sensor(has_service: bool = True, service_exception: Any = None) -> Any:
     """Return a minimal sensor mock whose ``hass`` object mimics HA services.
 
     Args:

--- a/tests/test_import_integrity.py
+++ b/tests/test_import_integrity.py
@@ -17,7 +17,7 @@ import inspect
 # ---------------------------------------------------------------------------
 
 
-def _public_names(module) -> set[str]:
+def _public_names(module: object) -> set[str]:
     """Return the set of public names exported by *module*."""
     if hasattr(module, "__all__"):
         return set(module.__all__)

--- a/tests/test_listener_cleanup.py
+++ b/tests/test_listener_cleanup.py
@@ -23,7 +23,7 @@ import pytest
 # ---------------------------------------------------------------------------
 
 
-def _make_config_entry(**overrides) -> MagicMock:
+def _make_config_entry(**overrides: object) -> MagicMock:
     """Minimal mock ConfigEntry used by HSEMAvgSensor and HSEMHouseConsumption."""
     defaults = {
         "entry_id": "test_entry_id",

--- a/tests/test_logger_no_file_handler.py
+++ b/tests/test_logger_no_file_handler.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import io
 import logging
 from logging.handlers import RotatingFileHandler
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -47,7 +48,7 @@ def _attach_capture_handler() -> logging.Handler:
 class TestLoggerHandlerHygiene:
     """Verify the HSEM logger uses its dedicated file handler."""
 
-    def test_logger_owns_rotating_file_handler(self, tmp_path) -> None:
+    def test_logger_owns_rotating_file_handler(self, tmp_path: Path) -> None:
         """HSEM_LOGGER must have a RotatingFileHandler after init."""
         config_dir = str(tmp_path)
         logger_module.init_hsem_logger_sync(config_dir)
@@ -88,7 +89,9 @@ class TestLoggerHandlerHygiene:
         assert hasattr(logger_module, "_HSEM_LOG_FILENAME")
         assert logger_module._HSEM_LOG_FILENAME == "hsem.log"
 
-    def test_logger_has_no_duplicate_handlers_after_reinit(self, tmp_path) -> None:
+    def test_logger_has_no_duplicate_handlers_after_reinit(
+        self, tmp_path: Path
+    ) -> None:
         """Calling init twice must not produce duplicate handlers."""
         config_dir = str(tmp_path)
         logger_module.init_hsem_logger_sync(config_dir)

--- a/tests/test_months_validation.py
+++ b/tests/test_months_validation.py
@@ -1,7 +1,10 @@
 """Tests for month validation and month matching logic."""
 
+from __future__ import annotations
+
 # Mock the logging to avoid file creation errors during testing
 from logging.handlers import RotatingFileHandler
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -160,7 +163,7 @@ class TestValidateMonthsInput:
 class TestGetMonthsSchema:
     """Test that get_months_schema converts stored integers back to strings for the UI."""
 
-    def _get_default(self, schema) -> list:
+    def _get_default(self, schema: Any) -> list:
         """Extract the default value for hsem_months_winter from a vol.Schema."""
         import voluptuous as vol
 

--- a/tests/test_p0_regression_suite.py
+++ b/tests/test_p0_regression_suite.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime, time, timedelta
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -498,7 +499,7 @@ class TestP006ConcurrentUpdates:
             self.cycle_runs: int = 0
             self.skipped: int = 0
 
-        async def _async_handle_update(self, event=None) -> None:
+        async def _async_handle_update(self, event: Any = None) -> None:
             if self._update_lock.locked():
                 self.skipped += 1
                 return

--- a/tests/test_safety_gates.py
+++ b/tests/test_safety_gates.py
@@ -374,7 +374,7 @@ class TestWorkingModeSensorTopLevelGate:
         *,
         read_only: bool = False,
         degraded_mode: DegradedMode = DegradedMode.OK,
-    ):
+    ) -> MagicMock:
         """Build a minimal CoordinatorData-like object for gate testing."""
         cfg = _make_cfg(read_only=read_only)
         live = _make_live(degraded_mode=degraded_mode)

--- a/tests/test_update_loop_lock.py
+++ b/tests/test_update_loop_lock.py
@@ -9,7 +9,10 @@ These tests exercise ``_async_handle_update`` in isolation, using a minimal
 stub sensor so that no Home Assistant runtime or real inverter is required.
 """
 
+from __future__ import annotations
+
 import asyncio
+from typing import Any
 
 import pytest
 
@@ -30,7 +33,7 @@ class _StubSensor:
     async def _async_logger(self, msg: str) -> None:  # noqa: D102 (no docstring needed)
         pass
 
-    async def _async_handle_update(self, event=None) -> None:
+    async def _async_handle_update(self, event: Any = None) -> None:
         """Exact copy of the production guard logic."""
         if self._update_lock.locked():
             await self._async_logger(
@@ -42,7 +45,7 @@ class _StubSensor:
         async with self._update_lock:
             await self._async_run_update_cycle(event)
 
-    async def _async_run_update_cycle(self, event=None) -> None:
+    async def _async_run_update_cycle(self, event: Any = None) -> None:
         """Simulates a slow update cycle (2 event-loop ticks)."""
         self._cycle_call_count += 1
         # Yield control so a concurrent caller can attempt to acquire the lock.
@@ -114,7 +117,7 @@ class TestUpdateLoopLock:
         write_calls: list[str] = []
 
         class _WriteTrackingSensor(_StubSensor):
-            async def _async_run_update_cycle(self, event=None) -> None:  # type: ignore[override]
+            async def _async_run_update_cycle(self, event: Any = None) -> None:  # type: ignore[override]
                 self._cycle_call_count += 1
                 write_calls.append("write")
                 # Simulate async I/O latency so the second caller can arrive.


### PR DESCRIPTION
## Summary

PR 1 of 17 in the type-checking cleanup series (issue #491). This PR removes `"no-untyped-def"` from the `disable_error_code` list in `pyproject.toml` and adds missing return type and parameter type annotations across all modules.

## Changes

- **`pyproject.toml`**: Removed `"no-untyped-def"` from `disable_error_code` list
- **~175 functions/methods annotated** across **81 files**
- All directories covered: `custom_components/hsem/*.py`, `planner/`, `utils/`, `models/`, `flows/`, `custom_sensors/`, `tests/`
- Used Python 3.10+ union syntax (`| None`) consistently
- Used `from __future__ import annotations` where needed for forward references
- Used `Any` with `# TODO: tighten type` comments in a handful of cases (freestanding utility functions with `self: Any`, voluptuous validators)
- **Zero logic changes** — annotation-only

## Quality Checks

| Check | Result |
|---|---|
| `mypy custom_components tests` | ✅ 0 errors (177 source files) |
| `ruff check` | ✅ All checks passed |
| `ruff format --check` | ✅ 177 files already formatted |

## `-> Any` fallbacks

- **`utils/misc.py`**, **`utils/huawei.py`**, **`utils/config_validator.py`**, **`utils/logger.py`**: Freestanding module-level functions receive `self: Any` and `hass: Any` to avoid circular HA import dependencies (same pattern already used in sensor code)
- **`custom_sensors/applier.py`**, **`custom_sensors/state_collector.py`**: `sensor: Any` parameters — called with different concrete types at different call sites
- **`flows/ev_planned_load_helpers.py`**: Inner function `_v` returns `-> Any` (result of `get_config_value()` which can be `bool | str | int | float | None`)