### PR TITLE
chore(planner): remove union-attr mypy suppression and fix type narrowing

### DIFF
--- a/custom_components/hsem/planner/candidate_selector.py
+++ b/custom_components/hsem/planner/candidate_selector.py
@@ -281,15 +281,15 @@ def select_best_candidate(
 
         # Sort by score ascending, then total_cost ascending (real savings),
         # then name for determinism. Baseline gets no positional advantage.
-        eligible_sorted = sorted(
-            eligible,
-            key=lambda c: (
-                c._cost.score,
-                c._cost.total_cost,
-                c.name,
-            ),
-        )
+        # All eligible candidates have been scored above; the sort key
+        # function asserts this invariant for the type checker.
+        def _sort_key(c: CandidatePlan) -> tuple[float, float, str]:
+            assert c._cost is not None
+            return (c._cost.score, c._cost.total_cost, c.name)
+
+        eligible_sorted = sorted(eligible, key=_sort_key)
         winner = eligible_sorted[0]
+        assert winner._cost is not None
         log_planner(
             "debug",
             "[selector] SELECTED candidate=%-20s  score=%.4f  total_cost=%.4f",
@@ -309,16 +309,17 @@ def select_best_candidate(
         new_score=getattr(getattr(winner, "_cost", None), "score", 0.0),
     )
 
+    winner_cost = winner._cost
     if (
         hysteresis_enabled
         and previous_winner_name is not None
-        and getattr(winner, "_cost", None) is not None
+        and winner_cost is not None
     ):
         # Find the previous winner's candidate in the current candidate list
         prev_candidate = _find_by_name(candidates, previous_winner_name)
         if prev_candidate is not None and prev_candidate is not winner:
             prev_score = getattr(getattr(prev_candidate, "_cost", None), "score", None)
-            new_score = winner._cost.score
+            new_score = winner_cost.score
             if prev_score is not None:
                 hysteresis_result.previous_score = prev_score
                 hysteresis_result.new_score = new_score

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ warn_unused_configs = true
 ignore_missing_imports = true
 disallow_incomplete_defs = true
 # Pre-existing type issues tracked for a future cleanup PR:
-disable_error_code = ["union-attr", "arg-type", "misc", "return-value", "assignment", "operator", "no-any-return", "var-annotated", "method-assign", "annotation-unchecked", "type-var", "attr-defined", "func-returns-value", "override", "index", "name-defined"]
+disable_error_code = ["arg-type", "misc", "return-value", "assignment", "operator", "no-any-return", "var-annotated", "method-assign", "annotation-unchecked", "type-var", "attr-defined", "func-returns-value", "override", "index", "name-defined"]
 
 [tool.coverage.run]
 source = ["custom_components"]

--- a/tests/planner/test_roundtrip_efficiency.py
+++ b/tests/planner/test_roundtrip_efficiency.py
@@ -467,6 +467,7 @@ class TestPlannerInputEfficiencyFields:
         # The plan should have a valid cost (not NaN)
         import math
 
+        assert output.plan_cost is not None
         assert not math.isnan(output.plan_cost.total)
 
     def test_100pct_efficiency_no_extra_grid_import_for_charging(self) -> None:

--- a/tests/test_entity_platform_classes.py
+++ b/tests/test_entity_platform_classes.py
@@ -159,6 +159,7 @@ class TestHSEMTimeEntityConstruction:
     def test_unique_id_ends_with_time_suffix(self) -> None:
         """unique_id uses the '_time' suffix to avoid collisions with other platforms."""
         entity = self._make_entity()
+        assert entity.unique_id is not None
         assert entity.unique_id.endswith("_time")
 
     def test_extra_state_attributes_contains_description(self) -> None:

--- a/tests/test_ha_mock_integration.py
+++ b/tests/test_ha_mock_integration.py
@@ -928,6 +928,7 @@ class TestEntityStateAfterCoordinatorPush:
         config_entry = make_fake_config_entry()
         coord = make_bare_coordinator(config_entry=config_entry)
         data = self._make_populated_data()
+        assert data.live is not None
         data.live.add_missing_entity(
             "Critical: batteries_state_of_capacity unavailable"
         )
@@ -970,6 +971,7 @@ class TestEntityStateAfterCoordinatorPush:
         config_entry = make_fake_config_entry()
         coord = make_bare_coordinator(config_entry=config_entry)
         data = self._make_populated_data()
+        assert data.live is not None
         data.live.add_missing_entity(
             "Critical: batteries_state_of_capacity unavailable"
         )

--- a/tests/test_platform_entity_refactor.py
+++ b/tests/test_platform_entity_refactor.py
@@ -634,6 +634,7 @@ class TestSelectorUniqueId:
 
     def test_unique_id_includes_hsem_prefix(self) -> None:
         entity = _make_selector(key="hsem_force_working_mode")
+        assert entity.unique_id is not None
         assert entity.unique_id.startswith("hsem_")
 
     def test_unique_id_equals_canonical_key(self) -> None:


### PR DESCRIPTION
## Summary

PR 2 of 17 in the type-checking cleanup series (#491). Removes `union-attr` from the `disable_error_code` list in `pyproject.toml` and fixes all resulting type errors across source and test files.

## Changes

### `pyproject.toml`
- Removed `"union-attr"` from `[tool.mypy].disable_error_code`

### `custom_components/hsem/planner/candidate_selector.py` (5 errors)
| Pattern | Count | Description |
|---|---|---|
| **assert** | 3 | Added `assert c._cost is not None` inside named sort key function (`_sort_key`) and `assert winner._cost is not None` before logging. All candidates in `eligible` are guaranteed to have `_cost` set by the preceding `score_plan()` loop. |
| **local-variable narrowing** | 2 | Replaced `getattr(winner, "_cost", None) is not None` with `winner_cost = winner._cost` + `winner_cost is not None` for proper type narrowing. Used `winner_cost.score` inside the guarded hysteresis block. |

### Test files (5 errors)
| File | Line | Pattern | Description |
|---|---|---|---|
| `tests/planner/test_roundtrip_efficiency.py` | 470 | **assert** | `assert output.plan_cost is not None` before `.total` |
| `tests/test_ha_mock_integration.py` | 931, 973 | **assert** | `assert data.live is not None` before `.add_missing_entity()` (2 occurrences) |
| `tests/test_entity_platform_classes.py` | 161 | **assert** | `assert entity.unique_id is not None` before `.endswith()` |
| `tests/test_platform_entity_refactor.py` | 637 | **assert** | `assert entity.unique_id is not None` before `.startswith()` |

### Behavior
No runtime behavior changes. All accesses were already guarded at runtime — the asserts document invariants for the type checker.

## Validation

- ✅ `mypy --enable-error-code union-attr` — **0 errors on 177 source files**
- ✅ `mypy` (default) — 0 errors on 177 source files
- ✅ `ruff check` — passes on all changed files

Fixes #491