### PR TITLE
chore(typing): fix misc mypy errors across the codebase

### DIFF
--- a/custom_components/hsem/custom_sensors/applier.py
+++ b/custom_components/hsem/custom_sensors/applier.py
@@ -203,7 +203,7 @@ async def async_apply_inverter_power_control(
             result = await async_write_and_verify(
                 entity_id=inv_entity or f"inverter:{inv_id}",
                 desired=desired,
-                writer=lambda _id=inv_id, _w=desired: async_set_grid_export_power_watt(
+                writer=lambda _id=inv_id, _w=desired: async_set_grid_export_power_watt(  # type: ignore[misc]  # mypy cannot infer lambda types with default parameters
                     sensor, _id, _w
                 ),
                 reader=reader_fn,
@@ -220,7 +220,7 @@ async def async_apply_inverter_power_control(
             result = await async_write_and_verify(
                 entity_id=inv_entity or f"inverter:{inv_id}",
                 desired=export_pct,
-                writer=lambda _id=inv_id, _pct=export_pct: (
+                writer=lambda _id=inv_id, _pct=export_pct: (  # type: ignore[misc]  # mypy cannot infer lambda types with default parameters
                     async_set_grid_export_power_pct(sensor, _id, _pct)
                 ),
                 reader=reader_fn,

--- a/custom_components/hsem/custom_sensors/applier_status_sensor.py
+++ b/custom_components/hsem/custom_sensors/applier_status_sensor.py
@@ -113,7 +113,7 @@ class HSEMApplierStatusSensor(
         """Return the unique ID."""
         return self._attr_unique_id
 
-    @property
+    @property  # type: ignore[misc]  # HA stub declares state as @final
     def state(self) -> str:
         """Return the worst-case apply status for the last cycle.
 

--- a/custom_components/hsem/custom_sensors/avg_sensor.py
+++ b/custom_components/hsem/custom_sensors/avg_sensor.py
@@ -71,11 +71,11 @@ class HSEMAvgSensor(SensorEntity, HSEMEntity, RestoreEntity):
             "measurements": self._measurements,
         }
 
-    @property
+    @property  # type: ignore[misc]  # HA stub declares state as @final
     def state(self) -> float | None:
         return self._state
 
-    @property
+    @property  # type: ignore[misc]  # HA stub declares unit_of_measurement as @final
     def unit_of_measurement(self) -> str:
         return UnitOfEnergy.KILO_WATT_HOUR
 

--- a/custom_components/hsem/custom_sensors/degraded_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/degraded_mode_sensor.py
@@ -108,7 +108,7 @@ class HSEMDegradedModeSensor(
         """Return the unique ID."""
         return self._attr_unique_id
 
-    @property
+    @property  # type: ignore[misc]  # HA stub declares state as @final
     def state(self) -> str:
         """Return the current health state string."""
         data: CoordinatorData | None = self.coordinator.data

--- a/custom_components/hsem/custom_sensors/ev_charging_sensor.py
+++ b/custom_components/hsem/custom_sensors/ev_charging_sensor.py
@@ -93,7 +93,7 @@ class HSEMEVChargingSensor(
         """Return the unique ID."""
         return self._attr_unique_id
 
-    @property
+    @property  # type: ignore[misc]  # HA stub declares state as @final
     def state(self) -> str:
         """Return ``'on'`` when any EV charger is active, ``'off'`` otherwise."""
         data: CoordinatorData | None = self.coordinator.data

--- a/custom_components/hsem/custom_sensors/ev_optimal_charging_plan_sensor.py
+++ b/custom_components/hsem/custom_sensors/ev_optimal_charging_plan_sensor.py
@@ -102,7 +102,7 @@ class HSEMEVOptimalChargingPlanSensor(
         """Return the unique ID."""
         return self._attr_unique_id
 
-    @property
+    @property  # type: ignore[misc]  # HA stub declares state as @final
     def state(self) -> str:
         """Return the current EV charging plan state."""
         data: CoordinatorData | None = self.coordinator.data

--- a/custom_components/hsem/custom_sensors/ev_second_optimal_charging_plan_sensor.py
+++ b/custom_components/hsem/custom_sensors/ev_second_optimal_charging_plan_sensor.py
@@ -74,7 +74,7 @@ class HSEMEVSecondOptimalChargingPlanSensor(
         """Return the unique ID."""
         return self._attr_unique_id
 
-    @property
+    @property  # type: ignore[misc]  # HA stub declares state as @final
     def state(self) -> str:
         """Return the current second EV charging plan state."""
         data: CoordinatorData | None = self.coordinator.data

--- a/custom_components/hsem/custom_sensors/force_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/force_mode_sensor.py
@@ -93,7 +93,7 @@ class HSEMForceModeSensor(
         """Return the unique ID."""
         return self._attr_unique_id
 
-    @property
+    @property  # type: ignore[misc]  # HA stub declares state as @final
     def state(self) -> str:
         """Return the force-mode select value (``'auto'`` when not overriding)."""
         data: CoordinatorData | None = self.coordinator.data

--- a/custom_components/hsem/custom_sensors/hardware_writes_sensor.py
+++ b/custom_components/hsem/custom_sensors/hardware_writes_sensor.py
@@ -98,7 +98,7 @@ class HSEMHardwareWritesSensor(
         """Return the unique ID."""
         return self._attr_unique_id
 
-    @property
+    @property  # type: ignore[misc]  # HA stub declares state as @final
     def state(self) -> str:
         """Return ``'allowed'`` or ``'blocked'`` based on degraded-mode state."""
         data: CoordinatorData | None = self.coordinator.data

--- a/custom_components/hsem/custom_sensors/house_consumption_power_sensor.py
+++ b/custom_components/hsem/custom_sensors/house_consumption_power_sensor.py
@@ -142,7 +142,7 @@ class HSEMHouseConsumptionPowerSensor(SensorEntity, HSEMEntity, RestoreEntity):
     def unique_id(self) -> str | None:
         return self._attr_unique_id
 
-    @property
+    @property  # type: ignore[misc]  # HA stub declares state as @final
     def state(self) -> float | None:
         return self._state
 

--- a/custom_components/hsem/custom_sensors/last_updated_sensor.py
+++ b/custom_components/hsem/custom_sensors/last_updated_sensor.py
@@ -88,7 +88,7 @@ class HSEMLastUpdatedSensor(
         """Return the unique ID."""
         return self._attr_unique_id
 
-    @property
+    @property  # type: ignore[misc]  # HA stub declares state as @final
     def state(self) -> str | None:
         """Return the last-updated ISO timestamp."""
         data: CoordinatorData | None = self.coordinator.data

--- a/custom_components/hsem/custom_sensors/missing_entities_sensor.py
+++ b/custom_components/hsem/custom_sensors/missing_entities_sensor.py
@@ -93,7 +93,7 @@ class HSEMMissingEntitiesSensor(
         """Return the unique ID."""
         return self._attr_unique_id
 
-    @property
+    @property  # type: ignore[misc]  # HA stub declares state as @final
     def state(self) -> int:
         """Return the number of missing input entities."""
         data: CoordinatorData | None = self.coordinator.data

--- a/custom_components/hsem/custom_sensors/next_update_sensor.py
+++ b/custom_components/hsem/custom_sensors/next_update_sensor.py
@@ -88,7 +88,7 @@ class HSEMNextUpdateSensor(
         """Return the unique ID."""
         return self._attr_unique_id
 
-    @property
+    @property  # type: ignore[misc]  # HA stub declares state as @final
     def state(self) -> str | None:
         """Return the next-update ISO timestamp."""
         data: CoordinatorData | None = self.coordinator.data

--- a/custom_components/hsem/custom_sensors/plan_explanation_sensor.py
+++ b/custom_components/hsem/custom_sensors/plan_explanation_sensor.py
@@ -126,7 +126,7 @@ class HSEMPlanExplanationSensor(
         """Return the unique ID."""
         return self._attr_unique_id
 
-    @property
+    @property  # type: ignore[misc]  # HA stub declares state as @final
     def state(self) -> str:
         """Return the currently active plan strategy.
 

--- a/custom_components/hsem/custom_sensors/read_only_sensor.py
+++ b/custom_components/hsem/custom_sensors/read_only_sensor.py
@@ -91,7 +91,7 @@ class HSEMReadOnlySensor(
         """Return the unique ID."""
         return self._attr_unique_id
 
-    @property
+    @property  # type: ignore[misc]  # HA stub declares state as @final
     def state(self) -> str:
         """Return ``'on'`` when read-only mode is active, ``'off'`` otherwise."""
         data: CoordinatorData | None = self.coordinator.data

--- a/custom_components/hsem/custom_sensors/utility_meter_sensor.py
+++ b/custom_components/hsem/custom_sensors/utility_meter_sensor.py
@@ -35,7 +35,7 @@ class HSEMUtilityMeterSensor(UtilityMeterSensor, HSEMEntity):
     def unique_id(self) -> str | None:
         return self._attr_unique_id
 
-    @property
+    @property  # type: ignore[misc]  # HA stub declares unit_of_measurement as @final
     def unit_of_measurement(self) -> str:
         return UnitOfEnergy.KILO_WATT_HOUR
 

--- a/custom_components/hsem/custom_sensors/working_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/working_mode_sensor.py
@@ -106,7 +106,7 @@ class HSEMWorkingModeSensor(HSEMCoordinatorEntity, SensorEntity, HSEMEntity):
         """Return the unique ID."""
         return self._attr_unique_id
 
-    @property
+    @property  # type: ignore[misc]  # HA stub declares state as @final
     def state(self) -> str | None:
         """Return the working-mode recommendation for the current slot."""
         if self.coordinator.data is None:

--- a/custom_components/hsem/planner/slot_population.py
+++ b/custom_components/hsem/planner/slot_population.py
@@ -137,16 +137,18 @@ def populate_prices(
     if tsi is not None:
         # Use (day_offset, hour) keys when any entry carries a non-zero
         # day_offset so that tomorrow's prices are not overwritten by today's.
+        imp_prices: dict[int, float] | dict[tuple[int, int], float]
+        exp_prices: dict[int, float] | dict[tuple[int, int], float]
         if any(pp.day_offset != 0 for pp in price_points):
-            imp_prices: dict[tuple[int, int], float] = {
+            imp_prices = {
                 (pp.day_offset, pp.hour): pp.import_price for pp in price_points
             }
-            exp_prices: dict[tuple[int, int], float] = {
+            exp_prices = {
                 (pp.day_offset, pp.hour): pp.export_price for pp in price_points
             }
         else:
-            imp_prices = {pp.hour: pp.import_price for pp in price_points}  # type: ignore[assignment]
-            exp_prices = {pp.hour: pp.export_price for pp in price_points}  # type: ignore[assignment]
+            imp_prices = {pp.hour: pp.import_price for pp in price_points}
+            exp_prices = {pp.hour: pp.export_price for pp in price_points}
         aligned_imp, aligned_exp = tsi.align_hourly_prices(imp_prices, exp_prices)
         for slot, imp, exp in zip(slots, aligned_imp, aligned_exp):
             # Missing hours (NaN sentinel) fall back to 0.0 — preserve
@@ -196,12 +198,13 @@ def populate_solcast(
     if tsi is not None:
         # Use (day_offset, hour) keys when any entry carries a non-zero
         # day_offset so that tomorrow's PV forecast is not shadowed by today's.
+        pv_by_hour: dict[int, float] | dict[tuple[int, int], float]
         if any(sc.day_offset != 0 for sc in solcast_slots):
-            pv_by_hour: dict[tuple[int, int], float] = {
+            pv_by_hour = {
                 (sc.day_offset, sc.hour): sc.pv_estimate for sc in solcast_slots
             }
         else:
-            pv_by_hour = {sc.hour: sc.pv_estimate for sc in solcast_slots}  # type: ignore[assignment]
+            pv_by_hour = {sc.hour: sc.pv_estimate for sc in solcast_slots}
         aligned = tsi.align_hourly_pv(pv_by_hour)
         for slot, val in zip(slots, aligned):
             slot.solcast_pv_estimate_kwh = 0.0 if math.isnan(val) else round(val, 3)
@@ -254,24 +257,20 @@ def populate_consumption(
         # Use (day_offset, hour) keys when any entry carries a non-zero
         # day_offset so that tomorrow's consumption forecast is not overwritten
         # by today's cyclical averages.
+        avg_1d: dict[int, float] | dict[tuple[int, int], float]
+        avg_3d: dict[int, float] | dict[tuple[int, int], float]
+        avg_7d: dict[int, float] | dict[tuple[int, int], float]
+        avg_14d: dict[int, float] | dict[tuple[int, int], float]
         if any(ca.day_offset != 0 for ca in averages):
-            avg_1d: dict[tuple[int, int], float] = {
-                (ca.day_offset, ca.hour): ca.avg_1d for ca in averages
-            }
-            avg_3d: dict[tuple[int, int], float] = {
-                (ca.day_offset, ca.hour): ca.avg_3d for ca in averages
-            }
-            avg_7d: dict[tuple[int, int], float] = {
-                (ca.day_offset, ca.hour): ca.avg_7d for ca in averages
-            }
-            avg_14d: dict[tuple[int, int], float] = {
-                (ca.day_offset, ca.hour): ca.avg_14d for ca in averages
-            }
+            avg_1d = {(ca.day_offset, ca.hour): ca.avg_1d for ca in averages}
+            avg_3d = {(ca.day_offset, ca.hour): ca.avg_3d for ca in averages}
+            avg_7d = {(ca.day_offset, ca.hour): ca.avg_7d for ca in averages}
+            avg_14d = {(ca.day_offset, ca.hour): ca.avg_14d for ca in averages}
         else:
-            avg_1d = {ca.hour: ca.avg_1d for ca in averages}  # type: ignore[assignment]
-            avg_3d = {ca.hour: ca.avg_3d for ca in averages}  # type: ignore[assignment]
-            avg_7d = {ca.hour: ca.avg_7d for ca in averages}  # type: ignore[assignment]
-            avg_14d = {ca.hour: ca.avg_14d for ca in averages}  # type: ignore[assignment]
+            avg_1d = {ca.hour: ca.avg_1d for ca in averages}
+            avg_3d = {ca.hour: ca.avg_3d for ca in averages}
+            avg_7d = {ca.hour: ca.avg_7d for ca in averages}
+            avg_14d = {ca.hour: ca.avg_14d for ca in averages}
         aligned_1d = tsi.align_hourly_load(avg_1d)
         aligned_3d = tsi.align_hourly_load(avg_3d)
         aligned_7d = tsi.align_hourly_load(avg_7d)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ warn_unused_configs = true
 ignore_missing_imports = true
 disallow_incomplete_defs = true
 # Pre-existing type issues tracked for a future cleanup PR:
-disable_error_code = ["misc", "return-value", "assignment", "operator", "no-any-return", "var-annotated", "method-assign", "annotation-unchecked", "type-var", "attr-defined", "func-returns-value", "override", "index", "name-defined"]
+disable_error_code = ["return-value", "assignment", "operator", "no-any-return", "var-annotated", "method-assign", "annotation-unchecked", "type-var", "attr-defined", "func-returns-value", "override", "index", "name-defined"]
 
 [tool.coverage.run]
 source = ["custom_components"]


### PR DESCRIPTION
## Summary

Removes `"misc"` from the `disable_error_code` list in `pyproject.toml` and fixes all 26 resulting `misc` mypy errors across 19 files.

This is **PR 4 of 17** in the type-checking cleanup series (#491).

## Changes

### 1. `pyproject.toml`
- Removed `"misc"` from `disable_error_code` under `[tool.mypy]`. No other entries were changed.

### 2. Dictionary comprehension key type mismatches (7 errors in `slot_population.py`)
- **Problem**: Variables were annotated as `dict[tuple[int, int], float]` in one branch and assigned `dict[int, float]` in the else branch, causing `misc` errors on the dict comprehension keys.
- **Fix**: Moved type annotations to before the if/else blocks using union types (`dict[int, float] | dict[tuple[int, int], float]`), matching the actual parameter types of the `TimeSeriesIndex` methods (`align_hourly_prices`, `align_hourly_pv`, `align_hourly_load`).
- Removed obsolete `# type: ignore[assignment]` comments.

### 3. Lambda type inference (2 errors in `applier.py`)
- **Problem**: Mypy cannot infer types of lambdas with default parameters.
- **Fix**: Added `# type: ignore[misc]` with justification `# mypy cannot infer lambda types with default parameters`. This is a known mypy limitation.

### 4. `@final` attribute overrides (17 errors across 16 sensor files)
- **Problem**: HA stubs declare `state` and `unit_of_measurement` as `@final` in `SensorEntity`, but these sensors legitimately override them as computed `@property` accessors.
- **Fix**: Added `# type: ignore[misc]` on the `@property` decorator line with justification `# HA stub declares state as @final` / `# HA stub declares unit_of_measurement as @final`.
- **Files**: `working_mode_sensor.py`, `utility_meter_sensor.py`, `read_only_sensor.py`, `plan_explanation_sensor.py`, `next_update_sensor.py`, `missing_entities_sensor.py`, `last_updated_sensor.py`, `hardware_writes_sensor.py`, `force_mode_sensor.py`, `ev_second_optimal_charging_plan_sensor.py`, `ev_optimal_charging_plan_sensor.py`, `ev_charging_sensor.py`, `degraded_mode_sensor.py`, `avg_sensor.py` (2x), `applier_status_sensor.py`, `house_consumption_power_sensor.py`

## Error Breakdown

| Category | Count | Fix |
|---|---|---|
| `@final` attribute override (HA stub incompatibility) | 17 | `# type: ignore[misc]` on `@property` decorator |
| Dictionary comprehension key type mismatch | 7 | Union type annotations before if/else |
| Lambda type inference (mypy limitation) | 2 | `# type: ignore[misc]` on lambda lines |
| **Total** | **26** | |

## `# type: ignore[misc]` Justifications

All 19 `# type: ignore[misc]` comments are justified false positives:

1. **16 sensor files (17 instances)**: HA stubs declare `state`/`unit_of_measurement` as `@final` on `SensorEntity`, but these sensors legitimately override them as computed properties — this is a common HA integration pattern.
2. **`applier.py` (2 instances)**: Mypy cannot infer types of lambdas with default parameters — a known mypy limitation.

## Bugs Discovered

None.

## Quality Gates

| Gate | Status |
|---|---|
| Ruff check | ✅ All checks passed |
| Mypy (typing) | ✅ 0 issues in 105 source files |
| Pyright (quality) | ✅ 0 errors (3 pre-existing warnings unrelated) |
| Pytest (py313) | ⚠️ Cannot run — pre-existing `bcrypt` PyO3 incompatibility with Python 3.13 |
| No behavior changes | ✅ Types only |

## Files Changed (19)

- `pyproject.toml`
- `custom_components/hsem/planner/slot_population.py`
- `custom_components/hsem/custom_sensors/applier.py`
- `custom_components/hsem/custom_sensors/applier_status_sensor.py`
- `custom_components/hsem/custom_sensors/avg_sensor.py`
- `custom_components/hsem/custom_sensors/degraded_mode_sensor.py`
- `custom_components/hsem/custom_sensors/ev_charging_sensor.py`
- `custom_components/hsem/custom_sensors/ev_optimal_charging_plan_sensor.py`
- `custom_components/hsem/custom_sensors/ev_second_optimal_charging_plan_sensor.py`
- `custom_components/hsem/custom_sensors/force_mode_sensor.py`
- `custom_components/hsem/custom_sensors/hardware_writes_sensor.py`
- `custom_components/hsem/custom_sensors/house_consumption_power_sensor.py`
- `custom_components/hsem/custom_sensors/last_updated_sensor.py`
- `custom_components/hsem/custom_sensors/missing_entities_sensor.py`
- `custom_components/hsem/custom_sensors/next_update_sensor.py`
- `custom_components/hsem/custom_sensors/plan_explanation_sensor.py`
- `custom_components/hsem/custom_sensors/read_only_sensor.py`
- `custom_components/hsem/custom_sensors/utility_meter_sensor.py`
- `custom_components/hsem/custom_sensors/working_mode_sensor.py`