### PR TITLE
chore(typing): fix operator errors with guards and conversions

### DIFF
--- a/custom_components/hsem/planner/cost_function.py
+++ b/custom_components/hsem/planner/cost_function.py
@@ -598,6 +598,9 @@ def score_plan(
         # discount = discount_rate ^ hours_from_now
         # Past slots are already skipped above, so hours_ahead >= 0.
         if use_discount:
+            assert (
+                now is not None
+            )  # guarded by use_discount = discount_rate < 1.0 and now is not None
             slot_mid = slot.start + (slot.end - slot.start) / 2
             hours_ahead = max((slot_mid - now).total_seconds() / 3600.0, 0.0)
             discount = discount_rate**hours_ahead

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ warn_unused_configs = true
 ignore_missing_imports = true
 disallow_incomplete_defs = true
 # Pre-existing type issues tracked for a future cleanup PR:
-disable_error_code = ["operator", "no-any-return", "var-annotated", "method-assign", "annotation-unchecked", "type-var", "attr-defined", "func-returns-value", "override", "index", "name-defined"]
+disable_error_code = ["no-any-return", "var-annotated", "method-assign", "annotation-unchecked", "type-var", "attr-defined", "func-returns-value", "override", "index", "name-defined"]
 
 [tool.coverage.run]
 source = ["custom_components"]

--- a/tests/test_entity_platform_classes.py
+++ b/tests/test_entity_platform_classes.py
@@ -68,15 +68,15 @@ class TestEntityBaseClasses:
 
     def test_time_entity_inherits_from_time_entity(self) -> None:
         """HSEMTimeEntity must extend TimeEntity, not ToggleEntity."""
-        assert issubclass(HSEMTimeEntity, TimeEntity), (
-            "HSEMTimeEntity should inherit from homeassistant.components.time.TimeEntity"
-        )
+        assert issubclass(
+            HSEMTimeEntity, TimeEntity
+        ), "HSEMTimeEntity should inherit from homeassistant.components.time.TimeEntity"
 
     def test_time_entity_does_not_inherit_from_toggle_entity(self) -> None:
         """HSEMTimeEntity must NOT extend ToggleEntity (the old incorrect base)."""
-        assert not issubclass(HSEMTimeEntity, ToggleEntity), (
-            "HSEMTimeEntity must not inherit from ToggleEntity"
-        )
+        assert not issubclass(
+            HSEMTimeEntity, ToggleEntity
+        ), "HSEMTimeEntity must not inherit from ToggleEntity"
 
     def test_switch_entity_inherits_from_switch_entity(self) -> None:
         """HSEMSwitch must extend SwitchEntity."""
@@ -154,6 +154,7 @@ class TestHSEMTimeEntityConstruction:
         """unique_id is derived from the config-entry key."""
         key = "hsem_batteries_enable_batteries_schedule_1_start"
         entity = self._make_entity(key=key)
+        assert entity.unique_id is not None
         assert key in entity.unique_id
 
     def test_unique_id_ends_with_time_suffix(self) -> None:

--- a/tests/test_months_validation.py
+++ b/tests/test_months_validation.py
@@ -169,7 +169,7 @@ class TestGetMonthsSchema:
 
         for key in schema.schema:
             if isinstance(key, vol.Required) and key.schema == "hsem_months_winter":
-                return key.default()
+                return key.default()  # type: ignore[operator]  # voluptuous stubs incomplete
         raise KeyError("hsem_months_winter not found in schema")
 
     async def test_schema_default_is_strings_when_config_has_integers(self):


### PR DESCRIPTION
## Summary

Removed `"operator"` from the `disable_error_code` list in `pyproject.toml` and fixed all 3 resulting mypy operator errors.

## Error count

**3 operator errors** fixed across 2 source files + 1 test file.

## Breakdown by fix pattern

| Pattern | Count | Description |
|---------|-------|-------------|
| **A: Guard** | 2 | Added `is not None` assertion before the operation |
| **E: type: ignore** | 1 | `# type: ignore[operator]` for voluptuous stubs |

## Details

1. **`planner/cost_function.py:602`** — `slot_mid - now` where `now` is `datetime | None`. 
   - Fix: Added `assert now is not None` inside the `if use_discount:` block (already guarded by `use_discount = discount_rate < 1.0 and now is not None`, mypy just can't narrow through the boolean). **Pattern A.**

2. **`tests/test_months_validation.py:172`** — `key.default()` where voluptuous stubs describe `default` as `Undefined` rather than callable. 
   - Fix: Added `# type: ignore[operator]`. This is a third-party stubs issue — the code is correct at runtime. **Pattern E.**

3. **`tests/test_entity_platform_classes.py:157`** — `key in entity.unique_id` where `unique_id` is `str | None`. 
   - Fix: Added `assert entity.unique_id is not None` before the `in` operator. **Pattern A.**

## `# type: ignore[operator]` justifications

- **`tests/test_months_validation.py:172`**: `voluptuous.Required.default` is a callable that returns the default value when one was set. The voluptuous type stubs don't model this correctly, describing it as `Undefined`. Runtime behavior is correct.

## No bugs discovered

All fixes are type-narrowing guards or stubs workarounds. No behavioral changes.

## Quality gates

| Gate | Result |
|------|--------|
| `tox -e typing` | ✅ **Success — 0 issues in 177 source files** |
| `tox -e lint` | ⚠️ Timed out (pre-existing env setup issue) — but individual ruff/isort/black checks on changed files pass |
| `tox -e quality` | ⚠️ Timed out (pre-existing env setup issue) |
| `tox -e py313` | ⚠️ Pre-existing bcrypt import error on Windows (unrelated to this PR) |