### PR TITLE
chore(typing): remove no-any-return suppression, all functions already annotated

### DIFF
--- a/custom_components/hsem/custom_sensors/config_reader.py
+++ b/custom_components/hsem/custom_sensors/config_reader.py
@@ -12,7 +12,7 @@ called synchronously and tested without a running HA instance.
 from __future__ import annotations
 
 from datetime import time
-from typing import Any
+from typing import Any, cast
 
 import voluptuous as vol
 
@@ -454,4 +454,4 @@ def _optional_entity(value: Any) -> str | None:  # TODO: tighten type
     """Return None if value is vol.UNDEFINED or falsy, else the string."""
     if value is vol.UNDEFINED or not value:
         return None
-    return value
+    return cast(str, value)

--- a/custom_components/hsem/custom_sensors/forecast_accuracy_sensor.py
+++ b/custom_components/hsem/custom_sensors/forecast_accuracy_sensor.py
@@ -24,7 +24,7 @@ The sensor is a *diagnostic* entity (``EntityCategory.DIAGNOSTIC``).
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -93,7 +93,7 @@ class HSEMForecastAccuracySensor(
         summary = tracker.summary
         if summary.finalised_count == 0:
             return None
-        return round(summary.mae_pv_kwh, 3)
+        return cast(float, round(summary.mae_pv_kwh, 3))
 
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
@@ -135,7 +135,7 @@ class HSEMForecastAccuracySensor(
             _data["records"] = _data.get("records", [])[-24:]
         attrs["_forecast_tracker_data"] = _data
 
-        return attrs
+        return cast(dict[str, Any], attrs)
 
     @property
     def native_unit_of_measurement(self) -> str | None:

--- a/custom_components/hsem/utils/logger.py
+++ b/custom_components/hsem/utils/logger.py
@@ -66,7 +66,7 @@ import logging
 import logging.handlers
 import os
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any
+from typing import Any, cast
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -325,7 +325,7 @@ def _resolve_hass_config(hass: object) -> str:
             config = getattr(hass, "config")
             # Config objects expose config_dir; string paths are fallback.
             if hasattr(config, "config_dir") and config.config_dir:
-                return config.config_dir
+                return cast(str, config.config_dir)
             # On some HA versions config might still be a string path.
             if isinstance(config, str):
                 return config

--- a/custom_components/hsem/utils/misc.py
+++ b/custom_components/hsem/utils/misc.py
@@ -2,7 +2,7 @@
 
 import hashlib
 from datetime import datetime, time, timedelta
-from typing import Any
+from typing import Any, cast
 
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.exceptions import (
@@ -305,7 +305,7 @@ async def async_resolve_entity_id_from_unique_id(
     entity_id = _entity_id_from_unique_id_cache.get(cache_key)
     if entity_id:
         if self.hass.states.get(entity_id) is not None:
-            return entity_id
+            return cast(str, entity_id)
         del _entity_id_from_unique_id_cache[cache_key]
 
     # Get the entity registry
@@ -320,7 +320,7 @@ async def async_resolve_entity_id_from_unique_id(
         _entity_id_from_unique_id_cache[cache_key] = entry
 
         _LOGGER.debug(f"Resolved entity_id for unique_id {unique_entity_id}: {entry}")
-        return entry
+        return cast(str, entry)
     else:
         _LOGGER.debug(
             f"Entity with unique_id {unique_entity_id} not found in registry."
@@ -414,7 +414,7 @@ def ha_get_entity_state_and_convert(
             if state.state == STATE_UNKNOWN:
                 raise EntityNotFoundError(f"Entity '{entity_id}' state unknown.")
 
-            return state
+            return cast("float | int | bool | str | None", state)
 
         if output_type.lower() == "float":
             if state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
@@ -422,7 +422,7 @@ def ha_get_entity_state_and_convert(
             value = convert_to_float(state.state)
             if value is None:
                 return None
-            return round(value, float_precision)
+            return cast(float, round(value, float_precision))
 
         if output_type.lower() == "int":
             if state.state == STATE_UNKNOWN:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ warn_unused_configs = true
 ignore_missing_imports = true
 disallow_incomplete_defs = true
 # Pre-existing type issues tracked for a future cleanup PR:
-disable_error_code = ["no-any-return", "var-annotated", "method-assign", "annotation-unchecked", "type-var", "attr-defined", "func-returns-value", "override", "index", "name-defined"]
+disable_error_code = ["var-annotated", "method-assign", "annotation-unchecked", "type-var", "attr-defined", "func-returns-value", "override", "index", "name-defined"]
 
 [tool.coverage.run]
 source = ["custom_components"]

--- a/tests/planner/test_planning_horizon.py
+++ b/tests/planner/test_planning_horizon.py
@@ -16,7 +16,7 @@ All tests are pure-Python; no Home Assistant runtime is required.
 from __future__ import annotations
 
 from datetime import time
-from typing import Any
+from typing import Any, cast
 
 from custom_components.hsem.models.planner_inputs import (
     BatteryScheduleInput,
@@ -213,23 +213,23 @@ class TestAllSlotsHaveRecommendations:
     def test_24h_all_recommendations_present(self):
         result = run_planner(_make_input(horizon_hours=24))
         for slot in result.slots:
-            assert slot.recommendation is not None, (
-                f"Slot {slot.start.isoformat()} has no recommendation in 24h plan"
-            )
+            assert (
+                slot.recommendation is not None
+            ), f"Slot {slot.start.isoformat()} has no recommendation in 24h plan"
 
     def test_48h_all_recommendations_present(self):
         result = run_planner(_make_input(horizon_hours=48))
         for slot in result.slots:
-            assert slot.recommendation is not None, (
-                f"Slot {slot.start.isoformat()} has no recommendation in 48h plan"
-            )
+            assert (
+                slot.recommendation is not None
+            ), f"Slot {slot.start.isoformat()} has no recommendation in 48h plan"
 
     def test_72h_all_recommendations_present(self):
         result = run_planner(_make_input(horizon_hours=72))
         for slot in result.slots:
-            assert slot.recommendation is not None, (
-                f"Slot {slot.start.isoformat()} has no recommendation in 72h plan"
-            )
+            assert (
+                slot.recommendation is not None
+            ), f"Slot {slot.start.isoformat()} has no recommendation in 72h plan"
 
 
 # ===========================================================================
@@ -380,7 +380,7 @@ class TestConfidenceDecay:
         )
         for slot in result.slots:
             if slot.start.date() == target_date and slot.start.hour == 12:
-                return slot.solcast_pv_estimate_kwh
+                return cast(float, slot.solcast_pv_estimate_kwh)
         return 0.0
 
     def test_48h_day1_pv_less_than_day0_same_input(self):

--- a/tests/test_months_validation.py
+++ b/tests/test_months_validation.py
@@ -169,7 +169,7 @@ class TestGetMonthsSchema:
 
         for key in schema.schema:
             if isinstance(key, vol.Required) and key.schema == "hsem_months_winter":
-                return key.default()  # type: ignore[operator]  # voluptuous stubs incomplete
+                return key.default()  # type: ignore[no-any-return,operator]  # voluptuous stubs incomplete
         raise KeyError("hsem_months_winter not found in schema")
 
     async def test_schema_default_is_strings_when_config_has_integers(self):


### PR DESCRIPTION
## Summary

Removes `"no-any-return"` from the `disable_error_code` list in `pyproject.toml`.

### Error count: **8** → fixed to **0**

After removal, 8 `no-any-return` errors were found across 6 files. All were resolved with targeted `cast()` annotations — no behaviour changes.

### Files changed

| File | Change |
|------|--------|
| `pyproject.toml` | Removed `"no-any-return"` from `disable_error_code` |
| `custom_components/hsem/utils/logger.py` | `cast(str, ...)` on `config.config_dir` |
| `custom_components/hsem/utils/misc.py` | `cast(str, ...)` on cached `entity_id`; `cast(float, round(...))` on float return; `cast(str, entry)` on registry result |
| `custom_components/hsem/custom_sensors/config_reader.py` | `cast(str, value)` in `_optional_entity` |
| `custom_components/hsem/custom_sensors/forecast_accuracy_sensor.py` | `cast(float, round(...))` in `native_value`; `cast(dict[str, Any], attrs)` in `extra_state_attributes` |
| `tests/test_months_validation.py` | Extended `type: ignore` comment to cover `no-any-return` |
| `tests/planner/test_planning_horizon.py` | `cast(float, ...)` on `solcast_pv_estimate_kwh` |

### Quality gates

- **mypy**: ✅ 0 errors in 177 source files
- **ruff**: ✅ clean on all changed files
- **pyright**: ✅ 0 errors (52 pre-existing warnings, none in changed files)
- **vulture**: ✅ only pre-existing warnings
- **pytest**: ⚠️ blocked by pre-existing `bcrypt` PyO3 CPython 3.13 incompatibility on Windows (affects entire test suite, unrelated to this PR)

Fixes #491