### PR TITLE
chore(typing): add missing variable type annotations

### DIFF
--- a/custom_components/hsem/custom_sensors/avg_sensor.py
+++ b/custom_components/hsem/custom_sensors/avg_sensor.py
@@ -54,7 +54,7 @@ class HSEMAvgSensor(SensorEntity, HSEMEntity, RestoreEntity):
         self._config_entry = config_entry
         self._name = name
         self._measurements: dict[str, float] | None = None
-        self._tracked_entities = set()
+        self._tracked_entities: set[str] = set()
         # Unsubscribe callbacks registered by async_track_* helpers.
         self._unsub_callbacks: list = []
 

--- a/custom_components/hsem/custom_sensors/house_consumption_power_sensor.py
+++ b/custom_components/hsem/custom_sensors/house_consumption_power_sensor.py
@@ -125,7 +125,7 @@ class HSEMHouseConsumptionPowerSensor(SensorEntity, HSEMEntity, RestoreEntity):
         self._last_updated: str | None = None
         # Track which derived sensors have already been created to avoid duplicate adds.
         self._derived_sensors_created: set[str] = set()
-        self._tracked_entities = set()
+        self._tracked_entities: set[str] = set()
         # Unsubscribe callbacks registered by async_track_* helpers.
         self._unsub_callbacks: list = []
         self._async_add_entities = async_add_entities

--- a/custom_components/hsem/options_flow.py
+++ b/custom_components/hsem/options_flow.py
@@ -1,5 +1,7 @@
 """This module defines the configuration flow for the HSEM integration in Home Assistant."""
 
+from typing import Any
+
 from homeassistant import config_entries
 
 from custom_components.hsem.const import NAME
@@ -61,7 +63,7 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         self._config_entry = config_entry
-        self._user_input = {}
+        self._user_input: dict[str, Any] = {}
 
     def update_config_entry_data(self) -> None:
         """Update config_entry.data with the latest configuration values from options."""

--- a/custom_components/hsem/utils/misc.py
+++ b/custom_components/hsem/utils/misc.py
@@ -19,7 +19,7 @@ from custom_components.hsem.const import DEFAULT_CONFIG_VALUES, DOMAIN
 # importing it from utils.misc continue to work without changes.
 from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
 
-_entity_id_from_unique_id_cache = {}
+_entity_id_from_unique_id_cache: dict[tuple[str, str, str], str] = {}
 
 
 class EntityNotFoundError(HomeAssistantError):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ warn_unused_configs = true
 ignore_missing_imports = true
 disallow_incomplete_defs = true
 # Pre-existing type issues tracked for a future cleanup PR:
-disable_error_code = ["var-annotated", "method-assign", "annotation-unchecked", "type-var", "attr-defined", "func-returns-value", "override", "index", "name-defined"]
+disable_error_code = ["method-assign", "annotation-unchecked", "type-var", "attr-defined", "func-returns-value", "override", "index", "name-defined"]
 
 [tool.coverage.run]
 source = ["custom_components"]

--- a/tests/planner/test_soc_simulation.py
+++ b/tests/planner/test_soc_simulation.py
@@ -178,7 +178,7 @@ def _make_slots_for_simulation(
 
     tz = ZoneInfo("Europe/Copenhagen")
     t0 = datetime.fromisoformat(now_iso).replace(tzinfo=tz)
-    slots = []
+    slots: list[PlannedSlot] = []
     for i in range(n):
         start = t0 + timedelta(hours=i)
         end = start + timedelta(hours=1)


### PR DESCRIPTION
## Summary

Removes `"var-annotated"` from the mypy `disable_error_code` list and adds type annotations to all previously unannotated module-level and class-level variables.

### Changes

- **pyproject.toml** — Remove `"var-annotated"` from `disable_error_code` (mypy now enforces variable annotations)
- **custom_components/hsem/utils/misc.py** — Annotate `_entity_id_from_unique_id_cache` as `dict[tuple[str, str, str], str]`
- **custom_components/hsem/options_flow.py** — Add `from typing import Any`, annotate `self._user_input` as `dict[str, Any]`
- **custom_components/hsem/custom_sensors/avg_sensor.py** — Annotate `self._tracked_entities` as `set[str]`
- **custom_components/hsem/custom_sensors/house_consumption_power_sensor.py** — Annotate `self._tracked_entities` as `set[str]`
- **tests/planner/test_soc_simulation.py** — Annotate `slots` as `list[PlannedSlot]`

### Type Checking Results

- **var-annotated errors fixed:** 5 → 0
- **mypy:** Success, 0 issues in 177 source files

### Quality Gates

| Gate | Status |
|------|--------|
| ruff format | PASS (180 files already formatted) |
| ruff check | PASS (all checks passed) |
| mypy (custom_components + tests) | PASS (0 errors) |
| pyright | PASS (0 errors, 52 pre-existing warnings) |
| vulture | PASS |
| pytest | 2035 passed, 31 skipped, 10 xfailed, 3 pre-existing failures |

### Any Annotations

- `dict[str, Any]` — `self._user_input` in options_flow.py stores heterogeneous config values from multiple flow steps (strings, ints, bools, lists) — `Any` is the correct type for this heterogeneous dict.

### Notes

- All 3 test failures (`test_no_charge_when_battery_full`, `test_summer_plan_total_equals_sum_of_components`, `test_100pct_efficiency_no_extra_grid_import_for_charging`) are pre-existing on main — none introduced by this PR.
- Pre-existing isort/black formatting issues in other files are not touched.

Fixes #491
