### PR TITLE
chore(typing): fix annotation-unchecked errors from opaque decorators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ warn_unused_configs = true
 ignore_missing_imports = true
 disallow_incomplete_defs = true
 # Pre-existing type issues tracked for a future cleanup PR:
-disable_error_code = ["annotation-unchecked", "type-var", "attr-defined", "func-returns-value", "override", "index", "name-defined"]
+disable_error_code = ["type-var", "attr-defined", "func-returns-value", "override", "index", "name-defined"]
 
 [tool.coverage.run]
 source = ["custom_components"]


### PR DESCRIPTION
## Summary

PR 11 of 17 in the type-checking cleanup series. Removes `"annotation-unchecked"` from the `disable_error_code` list in `pyproject.toml`.

## What Changed

- **`pyproject.toml`**: Removed `"annotation-unchecked"` from `[tool.mypy].disable_error_code` list (1 line removed).

## Error Count

**0 `annotation-unchecked` errors** — the previous PRs in this series (#480–#490) already addressed all annotation-unchecked issues in the codebase. No code changes were needed; this is a configuration-only change.

## Breakdown by Fix Pattern

No fix patterns needed — zero errors.

## Quality Gates

| Gate | Result |
|------|--------|
| `tox -e lint` | ✅ PASS |
| `tox -e typing` | ✅ PASS — `Success: no issues found in 177 source files` |
| `tox -e quality` | ✅ PASS — 0 errors, 51 pre-existing warnings |
| `tox -e py313` | ⚠️ Pre-existing bcrypt PyO3 import failure (Windows/Python 3.13), unrelated to this change |

## Justification

After the previous 10 PRs in this series cleaned up all annotation-unchecked patterns (decorator issues, `@property` annotations, test fixtures, etc.), the `"annotation-unchecked"` suppression is no longer needed. Removing it ensures future code additions are subject to full mypy annotation checking.