### PR TITLE
chore(typing): fix type-var errors in generic type usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ warn_unused_configs = true
 ignore_missing_imports = true
 disallow_incomplete_defs = true
 # Pre-existing type issues tracked for a future cleanup PR:
-disable_error_code = ["type-var", "attr-defined", "func-returns-value", "override", "index", "name-defined"]
+disable_error_code = ["attr-defined", "func-returns-value", "override", "index", "name-defined"]
 
 [tool.coverage.run]
 source = ["custom_components"]


### PR DESCRIPTION
## Summary

Removed `"type-var"` from the `disable_error_code` list in `pyproject.toml`. Zero `type-var` errors were found — HSEM does not define its own generic types with `TypeVar` that mypy would flag.

## Files Changed

| File | Change |
|---|---|
| `pyproject.toml` | Removed `"type-var"` from `disable_error_code` list |

## Error Count: **0**

No code changes were needed — only the suppression was removed.

## Quality Gates

| Gate | Result |
|---|---|
| `tox -e lint` | ✅ Passed |
| `tox -e typing` | ✅ Passed (0 issues in 177 files) |
| `tox -e quality` | ✅ Passed (0 errors, 51 pre-existing warnings) |
| `tox -e py313` | ⚠️ Pre-existing Windows bcrypt/PyO3 incompatibility (unrelated to this change) |

Fixes #491