### PR TITLE
chore(typing): fix attr-defined errors with annotations and casts

### DIFF
--- a/custom_components/hsem/utils/forecast_tracker.py
+++ b/custom_components/hsem/utils/forecast_tracker.py
@@ -12,6 +12,7 @@ plain ``pytest``.
 
 from __future__ import annotations
 
+import math
 import statistics
 from dataclasses import dataclass
 from datetime import datetime
@@ -272,12 +273,12 @@ class ForecastTracker:
         )  # type: ignore[misc]
 
         # RMSE
-        rmse_pv = statistics.sqrt(
+        rmse_pv = math.sqrt(
             statistics.mean(
                 (r.forecast_pv_kwh - r.actual_pv_kwh) ** 2 for r in finalised
             )
         )
-        rmse_load = statistics.sqrt(
+        rmse_load = math.sqrt(
             statistics.mean(
                 (r.forecast_load_kwh - r.actual_load_kwh) ** 2 for r in finalised
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ warn_unused_configs = true
 ignore_missing_imports = true
 disallow_incomplete_defs = true
 # Pre-existing type issues tracked for a future cleanup PR:
-disable_error_code = ["attr-defined", "func-returns-value", "override", "index", "name-defined"]
+disable_error_code = ["func-returns-value", "override", "index", "name-defined"]
 
 [tool.coverage.run]
 source = ["custom_components"]

--- a/tests/test_config_flow_single_entry_guard.py
+++ b/tests/test_config_flow_single_entry_guard.py
@@ -111,7 +111,7 @@ class TestUniqueIdIsSetEarly:
         ):
             await flow.async_step_user(user_input=None)
 
-        flow.async_set_unique_id.assert_awaited_once_with(DOMAIN)
+        flow.async_set_unique_id.assert_awaited_once_with(DOMAIN)  # type: ignore[attr-defined]
 
     @pytest.mark.asyncio
     async def test_unique_id_is_called_before_abort_guard(self) -> None:
@@ -219,7 +219,7 @@ class TestDuplicateFlowAbortsEarly:
         with pytest.raises(AbortFlow):
             await flow.async_step_user(user_input=None)
 
-        flow.async_show_form.assert_not_called()
+        flow.async_show_form.assert_not_called()  # type: ignore[attr-defined]
 
     @pytest.mark.asyncio
     async def test_duplicate_flow_aborts_before_user_input_is_processed(
@@ -242,7 +242,7 @@ class TestDuplicateFlowAbortsEarly:
         with pytest.raises(AbortFlow):
             await flow.async_step_user(user_input=None)
 
-        flow.async_set_unique_id.assert_awaited_once_with(DOMAIN)
+        flow.async_set_unique_id.assert_awaited_once_with(DOMAIN)  # type: ignore[attr-defined]
 
 
 # ---------------------------------------------------------------------------
@@ -264,7 +264,7 @@ class TestGuardMechanism:
         flow = _make_flow(already_configured=False)
         await flow.async_step_user(user_input=None)
 
-        flow.hass.config_entries.async_entries.assert_not_called()
+        flow.hass.config_entries.async_entries.assert_not_called()  # type: ignore[attr-defined]
 
     @pytest.mark.asyncio
     async def test_abort_guard_called_exactly_once_per_step(self) -> None:
@@ -272,4 +272,4 @@ class TestGuardMechanism:
         flow = _make_flow(already_configured=False)
         await flow.async_step_user(user_input=None)
 
-        flow._abort_if_unique_id_configured.assert_called_once()
+        flow._abort_if_unique_id_configured.assert_called_once()  # type: ignore[attr-defined]

--- a/tests/test_dst_transitions.py
+++ b/tests/test_dst_transitions.py
@@ -115,7 +115,8 @@ class TestBuildSlotsDst:
         """Return a minimal object with the fields build_slots needs."""
 
         class _Stub:
-            pass
+            interval_minutes: int
+            interval_length_hours: int
 
         stub = _Stub()
         stub.interval_minutes = interval_minutes

--- a/tests/test_entity_platform_classes.py
+++ b/tests/test_entity_platform_classes.py
@@ -211,8 +211,8 @@ class TestHSEMTimeEntitySetValue:
         entity.async_write_ha_state = MagicMock()  # type: ignore[method-assign]
         new_time = time(21, 30, 0)
         await entity.async_set_value(new_time)
-        entity.hass.config_entries.async_update_entry.assert_called_once()
-        call_kwargs = entity.hass.config_entries.async_update_entry.call_args
+        entity.hass.config_entries.async_update_entry.assert_called_once()  # type: ignore[attr-defined]
+        call_kwargs = entity.hass.config_entries.async_update_entry.call_args  # type: ignore[attr-defined]
         updated_options = call_kwargs[1]["options"]
         assert (
             updated_options["hsem_batteries_enable_batteries_schedule_1_start"]

--- a/tests/test_ha_mock_integration.py
+++ b/tests/test_ha_mock_integration.py
@@ -881,7 +881,7 @@ class TestEntityStateAfterCoordinatorPush:
         cfg.update_interval = 5
         cfg.batteries_purchase_price = 0.0
         cfg.batteries_expected_cycles = 6000
-        cfg.batteries_conversion_loss = 10
+        cfg.batteries_conversion_loss = 10  # type: ignore[attr-defined]
         cfg.export_electricity_min_price = 0.0
         cfg.electricity_price_update_interval = 15
 

--- a/tests/test_house_consumption_sensor_lifecycle.py
+++ b/tests/test_house_consumption_sensor_lifecycle.py
@@ -151,7 +151,7 @@ class TestIntegrationSensorMetadata:
         )
         # Spot-check by calling it via the descriptor protocol with a minimal mock.
         mock_instance = MagicMock(spec=HSEMIntegrationSensor)
-        result = HSEMIntegrationSensor.state_class.fget(mock_instance)
+        result = HSEMIntegrationSensor.state_class.fget(mock_instance)  # type: ignore[attr-defined]
         assert result == SensorStateClass.TOTAL_INCREASING
 
     def test_device_class_is_energy(self) -> None:
@@ -160,7 +160,7 @@ class TestIntegrationSensorMetadata:
             "device_class must be a @property on HSEMIntegrationSensor"
         )
         mock_instance = MagicMock(spec=HSEMIntegrationSensor)
-        result = HSEMIntegrationSensor.device_class.fget(mock_instance)
+        result = HSEMIntegrationSensor.device_class.fget(mock_instance)  # type: ignore[attr-defined]
         assert result == SensorDeviceClass.ENERGY
 
 
@@ -173,21 +173,21 @@ class TestAvgSensorMetadata:
             "device_class must be a @property on HSEMAvgSensor"
         )
         mock_instance = MagicMock(spec=HSEMAvgSensor)
-        result = HSEMAvgSensor.device_class.fget(mock_instance)
+        result = HSEMAvgSensor.device_class.fget(mock_instance)  # type: ignore[attr-defined]
         assert result == SensorDeviceClass.ENERGY
 
     def test_state_class_is_measurement(self) -> None:
         prop = HSEMAvgSensor.__dict__.get("state_class")
         assert prop is not None and isinstance(prop, property)
         mock_instance = MagicMock(spec=HSEMAvgSensor)
-        result = HSEMAvgSensor.state_class.fget(mock_instance)
+        result = HSEMAvgSensor.state_class.fget(mock_instance)  # type: ignore[attr-defined]
         assert result == SensorStateClass.MEASUREMENT
 
     def test_unit_is_kwh(self) -> None:
         prop = HSEMAvgSensor.__dict__.get("unit_of_measurement")
         assert prop is not None and isinstance(prop, property)
         mock_instance = MagicMock(spec=HSEMAvgSensor)
-        result = HSEMAvgSensor.unit_of_measurement.fget(mock_instance)
+        result = HSEMAvgSensor.unit_of_measurement.fget(mock_instance)  # type: ignore[attr-defined]
         assert result == UnitOfEnergy.KILO_WATT_HOUR
 
 

--- a/tests/test_logger_no_file_handler.py
+++ b/tests/test_logger_no_file_handler.py
@@ -34,7 +34,7 @@ from custom_components.hsem.utils.logger import HSEM_LOGGER, async_logger
 _ORIGINAL = HSEM_LOGGER.handlers.copy()
 
 
-def _attach_capture_handler() -> logging.Handler:
+def _attach_capture_handler() -> logging.StreamHandler:
     """Attach a memory handler to HSEM_LOGGER for test assertions.
 
     Returns the handler so callers can close/remove it after the test.

--- a/tests/test_platform_entity_refactor.py
+++ b/tests/test_platform_entity_refactor.py
@@ -267,8 +267,8 @@ class TestSwitchState:
         entity = _make_switch(key="hsem_read_only", is_on=False)
         entity.async_write_ha_state = MagicMock()  # type: ignore[method-assign]
         await entity.async_turn_on()
-        entity.hass.config_entries.async_update_entry.assert_called_once()
-        opts = entity.hass.config_entries.async_update_entry.call_args[1]["options"]
+        entity.hass.config_entries.async_update_entry.assert_called_once()  # type: ignore[attr-defined]
+        opts = entity.hass.config_entries.async_update_entry.call_args[1]["options"]  # type: ignore[attr-defined]
         assert opts["hsem_read_only"] is True
 
     @pytest.mark.asyncio
@@ -276,7 +276,7 @@ class TestSwitchState:
         entity = _make_switch(key="hsem_read_only", is_on=True)
         entity.async_write_ha_state = MagicMock()  # type: ignore[method-assign]
         await entity.async_turn_off()
-        opts = entity.hass.config_entries.async_update_entry.call_args[1]["options"]
+        opts = entity.hass.config_entries.async_update_entry.call_args[1]["options"]  # type: ignore[attr-defined]
         assert opts["hsem_read_only"] is False
 
     @pytest.mark.asyncio

--- a/tests/test_safety_gates.py
+++ b/tests/test_safety_gates.py
@@ -378,7 +378,7 @@ class TestWorkingModeSensorTopLevelGate:
         """Build a minimal CoordinatorData-like object for gate testing."""
         cfg = _make_cfg(read_only=read_only)
         live = _make_live(degraded_mode=degraded_mode)
-        live.energi_data_service_export_price = 1.0
+        live.energi_data_service_export_price = 1.0  # type: ignore[attr-defined]
 
         data = MagicMock()
         data.cfg = cfg


### PR DESCRIPTION
## Summary

Removes `"attr-defined"` from the `disable_error_code` list in `pyproject.toml` and fixes all resulting mypy errors across the production code and test suite.

**Error count fixed:** 25 `attr-defined` errors across 9 files (2 in production, 23 in tests).

## Breakdown by fix pattern

### Pattern A — Class-level annotation (2 errors)
- `tests/test_dst_transitions.py`: Added `interval_minutes: int` and `interval_length_hours: int` to the `_Stub` class.

### Pattern B — Fixed incorrect API usage (2 errors)
- `custom_components/hsem/utils/forecast_tracker.py`: Changed `statistics.sqrt()` to `math.sqrt()` — the `statistics` module has no `sqrt` function.

### Pattern D — Fixed return type annotation (6 errors)
- `tests/test_logger_no_file_handler.py`: Changed `_attach_capture_handler()` return type from `logging.Handler` to `logging.StreamHandler` so `.stream` attribute access is recognized.

### Pattern C — `# type: ignore[attr-defined]` with justification (15 errors)

**HA stub limitations — mock assertion methods (10 errors):**
- `tests/test_config_flow_single_entry_guard.py` (5): `assert_awaited_once_with`, `assert_not_called`, `assert_called_once` on HA flow methods (`async_set_unique_id`, `async_show_form`, `async_entries`, `_abort_if_unique_id_configured`). These are MagicMock assertion methods; mypy sees the original HA function types.
- `tests/test_platform_entity_refactor.py` (3): `assert_called_once`, `call_args` on `hass.config_entries.async_update_entry` (MagicMock).
- `tests/test_entity_platform_classes.py` (2): Same pattern — mock assertions on `async_update_entry`.

**HA stub limitations — dynamic test attributes (2 errors):**
- `tests/test_safety_gates.py` (1): `live.energi_data_service_export_price` — test dynamically sets an attribute not declared on `LiveState` model.
- `tests/test_ha_mock_integration.py` (1): `cfg.batteries_conversion_loss` — test dynamically sets an attribute not in `SensorConfig` model.

**HA stub limitations — property descriptor `.fget` (5 errors):**
- `tests/test_house_consumption_sensor_lifecycle.py` (5): `HSEMIntegrationSensor.state_class.fget(...)`, `HSEMIntegrationSensor.device_class.fget(...)`, `HSEMAvgSensor.device_class.fget(...)`, `HSEMAvgSensor.state_class.fget(...)`, `HSEMAvgSensor.unit_of_measurement.fget(...)`. Mypy sees these as `Callable` types (the property's getter type), not `property` instances, so `.fget` is not recognized.

## Quality gates

| Gate | Result |
|------|--------|
| `tox -e lint` | ✅ Passed (isort + black + ruff format + ruff check) |
| `tox -e typing` | ✅ Passed (0 errors) |
| `tox -e quality` | ✅ Passed (0 errors, 24 pre-existing warnings) |
| `tox -e py313` | ❌ Pre-existing Windows `bcrypt` PyO3 import error (all 61 collection errors) |

## Files changed

1. `pyproject.toml` — removed `"attr-defined"` from `disable_error_code`
2. `custom_components/hsem/utils/forecast_tracker.py` — import `math`, use `math.sqrt`
3. `tests/test_logger_no_file_handler.py` — return type `StreamHandler`
4. `tests/test_dst_transitions.py` — class-level annotations on `_Stub`
5. `tests/test_config_flow_single_entry_guard.py` — 5× `# type: ignore[attr-defined]`
6. `tests/test_safety_gates.py` — 1× `# type: ignore[attr-defined]`
7. `tests/test_ha_mock_integration.py` — 1× `# type: ignore[attr-defined]`
8. `tests/test_platform_entity_refactor.py` — 3× `# type: ignore[attr-defined]`
9. `tests/test_house_consumption_sensor_lifecycle.py` — 5× `# type: ignore[attr-defined]`
10. `tests/test_entity_platform_classes.py` — 2× `# type: ignore[attr-defined]`

Fixes #491