### PR TITLE
chore(typing): fix func-returns-value errors with consistent return paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ warn_unused_configs = true
 ignore_missing_imports = true
 disallow_incomplete_defs = true
 # Pre-existing type issues tracked for a future cleanup PR:
-disable_error_code = ["func-returns-value", "override", "index", "name-defined"]
+disable_error_code = ["override", "index", "name-defined"]
 
 [tool.coverage.run]
 source = ["custom_components"]

--- a/tests/test_config_flow_single_entry_guard.py
+++ b/tests/test_config_flow_single_entry_guard.py
@@ -118,12 +118,18 @@ class TestUniqueIdIsSetEarly:
         """async_set_unique_id must be called before _abort_if_unique_id_configured."""
         call_order: list[str] = []
 
+        def _set_unique_id_side_effect(uid: str) -> None:
+            call_order.append("set_unique_id")
+
+        def _abort_guard_side_effect() -> None:
+            call_order.append("abort_guard")
+
         flow = _make_flow()
         flow.async_set_unique_id = AsyncMock(  # type: ignore[method-assign]
-            side_effect=lambda uid: call_order.append("set_unique_id") or None
+            side_effect=_set_unique_id_side_effect
         )
         flow._abort_if_unique_id_configured = MagicMock(  # type: ignore[method-assign]
-            side_effect=lambda: call_order.append("abort_guard") or None
+            side_effect=_abort_guard_side_effect
         )
         flow.async_show_form = MagicMock(  # type: ignore[method-assign]
             return_value={"type": "form", "step_id": "user", "errors": {}}
@@ -141,9 +147,12 @@ class TestUniqueIdIsSetEarly:
         """The unique id value must equal the DOMAIN constant, not a random uuid."""
         recorded_uid: list[Any] = []
 
+        def _record_uid_side_effect(uid: str) -> None:
+            recorded_uid.append(uid)
+
         flow = _make_flow()
         flow.async_set_unique_id = AsyncMock(  # type: ignore[method-assign]
-            side_effect=lambda uid: recorded_uid.append(uid) or None
+            side_effect=_record_uid_side_effect
         )
         flow.async_show_form = MagicMock(  # type: ignore[method-assign]
             return_value={"type": "form", "step_id": "user", "errors": {}}


### PR DESCRIPTION
## Summary

Removes `"func-returns-value"` from `disable_error_code` in `pyproject.toml`, enabling mypy to detect functions with inconsistent return behavior.

## Changes

### `pyproject.toml`
- Removed `"func-returns-value"` from the `disable_error_code` list under `[tool.mypy]`.

### `tests/test_config_flow_single_entry_guard.py`
- Replaced 3 `lambda ... or None` patterns (which triggered `func-returns-value` because `list.append()` returns `None`) with properly-typed inner helper functions `-> None`.

## Error Count

- **3 errors fixed** across 1 file.

## Breakdown by Pattern

| Pattern | Count | Description |
|---------|-------|-------------|
| D (restructure) | 3 | Replaced lambdas with `-> None` helper functions |

## Return Type Widening

No return types were widened to include `| None`.

## Quality Gates

| Gate | Result |
|------|--------|
| `tox -e lint` | ✅ PASS |
| `tox -e typing` | ✅ PASS (0 errors) |
| `tox -e quality` | ✅ PASS (0 errors) |
| `tox -e py313` | ⚠️ Pre-existing bcrypt/PyO3 env issue |

Fixes #491