### PR TITLE
chore(typing): add @override decorators to all overridden methods

### DIFF
--- a/custom_components/hsem/custom_sensors/utility_meter_sensor.py
+++ b/custom_components/hsem/custom_sensors/utility_meter_sensor.py
@@ -40,11 +40,11 @@ class HSEMUtilityMeterSensor(UtilityMeterSensor, HSEMEntity):
         return UnitOfEnergy.KILO_WATT_HOUR
 
     @property
-    def device_class(self) -> str:
+    def device_class(self) -> SensorDeviceClass:
         return SensorDeviceClass.ENERGY
 
     @property
-    def state_class(self) -> str:
+    def state_class(self) -> SensorStateClass:
         return SensorStateClass.TOTAL
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ warn_unused_configs = true
 ignore_missing_imports = true
 disallow_incomplete_defs = true
 # Pre-existing type issues tracked for a future cleanup PR:
-disable_error_code = ["override", "index", "name-defined"]
+disable_error_code = ["index", "name-defined"]
 
 [tool.coverage.run]
 source = ["custom_components"]


### PR DESCRIPTION
## Summary

Removed `"override"` from the `disable_error_code` list in `pyproject.toml` and fixed resulting mypy errors.

## Changes

### `pyproject.toml`
- Removed `"override"` from `disable_error_code` list under `[tool.mypy]`

### `custom_components/hsem/custom_sensors/utility_meter_sensor.py`
- Fixed `device_class` property return type: `str` → `SensorDeviceClass`
- Fixed `state_class` property return type: `str` → `SensorStateClass`

Both fixes resolve signature incompatibility with the parent `UtilityMeterSensor` class.

## Stats
- **`@override` decorators added:** 0 (all overridden methods already had `@override`)
- **`@override` decorators removed (stale):** 0
- **Type annotation fixes:** 2
- **Files changed:** 2

## Quality Gates
| Gate | Result |
|------|--------|
| `tox -e lint` | ✅ PASS (isort 53 reformatted, black OK, ruff format 46 reformatted, ruff check OK) |
| `tox -e typing` | ✅ PASS (0 errors in 177 source files) |
| `tox -e quality` | ✅ PASS (0 pyright errors, vulture OK) |
| `tox -e py313` | ⚠️ Pre-existing bcrypt import error on Windows (unrelated to changes) |