### PR TITLE
chore(typing): fix index errors with key guards and casts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ warn_unused_configs = true
 ignore_missing_imports = true
 disallow_incomplete_defs = true
 # Pre-existing type issues tracked for a future cleanup PR:
-disable_error_code = ["index", "name-defined"]
+disable_error_code = ["name-defined"]
 
 [tool.coverage.run]
 source = ["custom_components"]


### PR DESCRIPTION
## Summary

Remove `"index"` from the `disable_error_code` list in `pyproject.toml`.

Mypy reports **0** `index` errors after removal — no code changes were needed.

### Files changed
- `pyproject.toml` — removed `"index"` from `disable_error_code`

### Type ignore usage
Zero `# type: ignore[index]` comments were needed.

### Quality gates
| Gate | Result |
|------|--------|
| `tox -e lint` | ✅ All checks passed |
| `tox -e typing` | ✅ Success: no issues found in 177 source files |
| `tox -e quality` | ✅ 0 errors (24 pre-existing pyright warnings) |
| `tox -e py313` | ❌ 61 collection errors from bcrypt/PyO3 (pre-existing, unrelated to this change) |