### PR TITLE
chore(typing): remove final name-defined suppression — all 17 disable_error_code entries removed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,8 +65,6 @@ warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true
 disallow_incomplete_defs = true
-# Pre-existing type issues tracked for a future cleanup PR:
-disable_error_code = ["name-defined"]
 
 [tool.coverage.run]
 source = ["custom_components"]

--- a/tests/test_p0_regression_suite.py
+++ b/tests/test_p0_regression_suite.py
@@ -538,7 +538,7 @@ class TestP006ConcurrentUpdates:
         """Concurrent updates must not trigger more than one hardware write."""
         writes: list[str] = []
 
-        class _WriteTracking(self.__class__._Sensor):
+        class _WriteTracking(TestP006ConcurrentUpdates._Sensor):
             async def _run_cycle(self) -> None:
                 self.cycle_runs += 1
                 writes.append("write")


### PR DESCRIPTION
## Summary

🎉 **THE FINAL PR** — PR 17 of 17 in the type-checking cleanup series!

This PR removes the last remaining `disable_error_code` entry — `"name-defined"` — from `pyproject.toml`, achieving **zero mypy suppressions** across the entire codebase.

## Changes

### `pyproject.toml`
- Removed `disable_error_code = ["name-defined"]` — the final entry.
- The `[tool.mypy]` section now has **no suppressions** of any kind.
- Final state:
  ```toml
  [tool.mypy]
  python_version = "3.13"
  warn_return_any = true
  warn_unused_configs = true
  ignore_missing_imports = true
  disallow_incomplete_defs = true
  ```

### `tests/test_p0_regression_suite.py` (line 541)
- Fixed one `name-defined` error: replaced `self.__class__._Sensor` with the explicit `TestP006ConcurrentUpdates._Sensor` in the `_WriteTracking` inner class definition.
- This was a Pattern B fix — mypy could not resolve the dynamic `self.__class__` reference, but the explicit class name resolves cleanly.

## Quality Gates

| Gate | Result |
|------|--------|
| `tox -e lint` | ✅ PASS (isort + black + ruff format + ruff check) |
| `tox -e typing` | ✅ **0 errors on 177 source files** |
| `tox -e quality` | ✅ PASS (0 errors, 24 pre-existing warnings) |
| `tox -e py313` | ⚠️ Pre-existing bcrypt/PyO3 environment incompatibility (unrelated to this change) |

## Milestone

After 17 PRs, **all `disable_error_code` entries have been removed**:

```
✅ "empty-body"
✅ "union-attr"
✅ "arg-type"
✅ "assignment"
✅ "attr-defined"
✅ "misc"
✅ "call-overload"
✅ "no-any-return"
✅ "index"
✅ "operator"
✅ "no-untyped-def"
✅ "var-annotated"
✅ "return-value"
✅ "call-arg"
✅ "override"
✅ "no-untyped-call"
✅ "name-defined"  ← THIS PR
```

🏆 **mypy passes clean on all 177 source files with zero suppressions.**