### PR TITLE
chore(style): audit and complete public method type hints

### DIFF
--- a/custom_components/hsem/config_flow.py
+++ b/custom_components/hsem/config_flow.py
@@ -1,6 +1,9 @@
 """This module defines the configuration flow for the HSEM integration in Home Assistant."""
 
+from typing import Any
+
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.core import callback
 
 from custom_components.hsem.const import DOMAIN, NAME
@@ -73,7 +76,9 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
         super().__init__()
         self._user_input: dict = {}
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         # Set a stable, deterministic unique id so that the guard below
@@ -100,7 +105,9 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
             last_step=False,
         )
 
-    async def async_step_prices(self, user_input=None):
+    async def async_step_prices(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         if user_input is not None:
@@ -118,7 +125,9 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
             last_step=False,
         )
 
-    async def async_step_months(self, user_input=None):
+    async def async_step_months(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         if user_input is not None:
@@ -149,7 +158,9 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
             last_step=False,
         )
 
-    async def async_step_solcast(self, user_input=None):
+    async def async_step_solcast(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         if user_input is not None:
@@ -167,7 +178,9 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
             last_step=False,
         )
 
-    async def async_step_huawei_solar(self, user_input=None):
+    async def async_step_huawei_solar(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         if user_input is not None:
@@ -199,7 +212,9 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
             last_step=False,
         )
 
-    async def async_step_battery_economics(self, user_input=None):
+    async def async_step_battery_economics(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         if user_input is not None:
@@ -217,7 +232,9 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
             last_step=False,
         )
 
-    async def async_step_power(self, user_input=None):
+    async def async_step_power(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         if user_input is not None:
@@ -235,7 +252,9 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
             last_step=False,
         )
 
-    async def async_step_ev(self, user_input=None):
+    async def async_step_ev(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         if user_input is not None:
@@ -257,7 +276,9 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
             last_step=False,
         )
 
-    async def async_step_ev_second(self, user_input=None):
+    async def async_step_ev_second(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         if user_input is not None:
@@ -275,7 +296,9 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
             last_step=False,
         )
 
-    async def async_step_ev_planned_load(self, user_input=None):
+    async def async_step_ev_planned_load(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         if user_input is not None:
@@ -295,7 +318,9 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
             last_step=False,
         )
 
-    async def async_step_ev_second_planned_load(self, user_input=None):
+    async def async_step_ev_second_planned_load(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         if user_input is not None:
@@ -313,7 +338,9 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
             last_step=False,
         )
 
-    async def async_step_batteries_schedules(self, user_input=None):
+    async def async_step_batteries_schedules(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         if user_input is not None:
@@ -333,7 +360,9 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
             last_step=False,
         )
 
-    async def async_step_batteries_excess_export(self, user_input=None):
+    async def async_step_batteries_excess_export(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         if user_input is not None:
@@ -353,7 +382,9 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
             last_step=False,
         )
 
-    async def async_step_weighted_values(self, user_input=None):
+    async def async_step_weighted_values(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         if user_input is not None:

--- a/custom_components/hsem/models/time_series.py
+++ b/custom_components/hsem/models/time_series.py
@@ -43,6 +43,7 @@ Usage example
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import NamedTuple
@@ -595,7 +596,7 @@ class TimeSeriesIndex:
         """Return the total number of slots in the index."""
         return len(self.slots)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[SlotMeta]:
         """Iterate over :class:`SlotMeta` objects in chronological order."""
         return iter(self.slots)
 

--- a/custom_components/hsem/options_flow.py
+++ b/custom_components/hsem/options_flow.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigFlowResult
 
 from custom_components.hsem.const import NAME
 from custom_components.hsem.flows.batteries_excess_export import (
@@ -72,7 +73,9 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
             self._config_entry, data=updated_data
         )
 
-    async def async_step_init(self, user_input=None):
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         if user_input is not None:
@@ -90,7 +93,9 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
             last_step=False,
         )
 
-    async def async_step_prices(self, user_input=None):
+    async def async_step_prices(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         if user_input is not None:
@@ -108,7 +113,9 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
             last_step=False,
         )
 
-    async def async_step_months(self, user_input=None):
+    async def async_step_months(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         if user_input is not None:
@@ -139,7 +146,9 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
             last_step=False,
         )
 
-    async def async_step_solcast(self, user_input=None):
+    async def async_step_solcast(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         if user_input is not None:
@@ -157,7 +166,9 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
             last_step=False,
         )
 
-    async def async_step_huawei_solar(self, user_input=None):
+    async def async_step_huawei_solar(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         if user_input is not None:
@@ -175,7 +186,9 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
             last_step=False,
         )
 
-    async def async_step_battery_economics(self, user_input=None):
+    async def async_step_battery_economics(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         if user_input is not None:
@@ -193,7 +206,9 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
             last_step=False,
         )
 
-    async def async_step_power(self, user_input=None):
+    async def async_step_power(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         if user_input is not None:
@@ -211,7 +226,9 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
             last_step=False,
         )
 
-    async def async_step_ev(self, user_input=None):
+    async def async_step_ev(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         if user_input is not None:
@@ -233,7 +250,9 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
             last_step=False,
         )
 
-    async def async_step_ev_second(self, user_input=None):
+    async def async_step_ev_second(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         if user_input is not None:
@@ -251,7 +270,9 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
             last_step=False,
         )
 
-    async def async_step_ev_planned_load(self, user_input=None):
+    async def async_step_ev_planned_load(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         if user_input is not None:
@@ -271,7 +292,9 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
             last_step=False,
         )
 
-    async def async_step_ev_second_planned_load(self, user_input=None):
+    async def async_step_ev_second_planned_load(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         if user_input is not None:
@@ -289,7 +312,9 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
             last_step=False,
         )
 
-    async def async_step_batteries_schedules(self, user_input=None):
+    async def async_step_batteries_schedules(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         if user_input is not None:
@@ -309,7 +334,9 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
             last_step=False,
         )
 
-    async def async_step_batteries_excess_export(self, user_input=None):
+    async def async_step_batteries_excess_export(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         if user_input is not None:
@@ -329,7 +356,9 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
             last_step=False,
         )
 
-    async def async_step_weighted_values(self, user_input=None):
+    async def async_step_weighted_values(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         errors = {}
 
         if user_input is not None:

--- a/tests/test_config_flow_single_entry_guard.py
+++ b/tests/test_config_flow_single_entry_guard.py
@@ -200,7 +200,8 @@ class TestFirstSetupProceeds:
         flow = _make_flow(already_configured=False)
         result = await flow.async_step_user(user_input=None)
 
-        assert "base" not in result["errors"]
+        errors: dict[str, str] = result["errors"]  # type: ignore[assignment]
+        assert "base" not in errors
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Targeted audit of all public functions/methods in the HSEM codebase to ensure complete type hints for both parameters and return types, per Home Assistant development style guidelines.

### Audit Results

| Metric | Count |
|--------|-------|
| Total public methods scanned | All Python files in `custom_components/hsem/` |
| Already had complete type hints | Vast majority (PR #493 already added ~175 annotations) |
| Gaps found and fixed | **29** (28 config/options flow methods + 1 dunder) |

### What Changed

1. **`custom_components/hsem/config_flow.py`** — Added `dict[str, Any] | None` parameter type and `ConfigFlowResult` return type to all 14 `async_step_*` methods in `HSEMConfigFlow`.

2. **`custom_components/hsem/options_flow.py`** — Same treatment for all 14 `async_step_*` methods in `HSEMOptionsFlow`.

3. **`custom_components/hsem/models/time_series.py`** — Added `-> Iterator[SlotMeta]` return type to `TimeSeriesIndex.__iter__` and imported `Iterator` from `collections.abc`.

4. **`tests/test_config_flow_single_entry_guard.py`** — Narrowed `result["errors"]` type to satisfy mypy after the `ConfigFlowResult` return type became explicit (mypy now knows `errors` could be `None`).

### Quality Gates

| Gate | Result |
|------|--------|
| `tox -e lint` | ✅ Passed |
| `tox -e typing` | ✅ Passed (0 errors) |
| `tox -e quality` | ✅ Passed (0 errors) |
| `tox -e py313` | ❌ Pre-existing Windows env issue (bcrypt PyO3) — same on main branch |

### Checklist

- [x] No logic changes — annotation-only
- [x] No unrelated refactoring
- [x] Conventional Commits format
- [x] All 4 tox checks run (3 pass; py313 env issue is pre-existing)
- [x] Branch follows naming convention