### PR TITLE
chore(style): audit and fix entity base class inheritance

### DIFF
--- a/custom_components/hsem/custom_sensors/applier_status_sensor.py
+++ b/custom_components/hsem/custom_sensors/applier_status_sensor.py
@@ -54,9 +54,9 @@ _VALID_STATES = {s.value for s in ApplyStatus} | {_PENDING}
 
 class HSEMApplierStatusSensor(
     HSEMCoordinatorEntity,
+    RestoreEntity,
     SensorEntity,
     HSEMEntity,
-    RestoreEntity,
 ):
     """Diagnostic sensor exposing the last hardware-write cycle outcome.
 

--- a/custom_components/hsem/custom_sensors/avg_sensor.py
+++ b/custom_components/hsem/custom_sensors/avg_sensor.py
@@ -20,7 +20,7 @@ from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
 from custom_components.hsem.utils.misc import ha_get_entity_state_and_convert
 
 
-class HSEMAvgSensor(SensorEntity, HSEMEntity, RestoreEntity):
+class HSEMAvgSensor(RestoreEntity, SensorEntity, HSEMEntity):
     """Rolling N-day average of a utility-meter energy reading (kWh)."""
 
     _attr_icon = "mdi:calculator"

--- a/custom_components/hsem/custom_sensors/battery_soc_sensor.py
+++ b/custom_components/hsem/custom_sensors/battery_soc_sensor.py
@@ -44,9 +44,9 @@ from custom_components.hsem.utils.sensornames import (
 
 class HSEMBatterySoCSensor(
     HSEMCoordinatorEntity,
+    RestoreEntity,
     SensorEntity,
     HSEMEntity,
-    RestoreEntity,
 ):
     """Diagnostic sensor mirroring the battery SoC snapshot from the last cycle.
 

--- a/custom_components/hsem/custom_sensors/degraded_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/degraded_mode_sensor.py
@@ -54,9 +54,9 @@ from custom_components.hsem.utils.sensornames import (
 
 class HSEMDegradedModeSensor(
     HSEMCoordinatorEntity,
+    RestoreEntity,
     SensorEntity,
     HSEMEntity,
-    RestoreEntity,
 ):
     """Diagnostic sensor exposing the current HSEM system-health state.
 

--- a/custom_components/hsem/custom_sensors/ev_charging_sensor.py
+++ b/custom_components/hsem/custom_sensors/ev_charging_sensor.py
@@ -40,9 +40,9 @@ _VALID_STATES = {STATE_ON, STATE_OFF}
 
 class HSEMEVChargingSensor(
     HSEMCoordinatorEntity,
+    RestoreEntity,
     SensorEntity,
     HSEMEntity,
-    RestoreEntity,
 ):
     """Diagnostic sensor exposing whether any HSEM-managed EV charger is active.
 

--- a/custom_components/hsem/custom_sensors/ev_optimal_charging_plan_sensor.py
+++ b/custom_components/hsem/custom_sensors/ev_optimal_charging_plan_sensor.py
@@ -53,9 +53,9 @@ _VALID_STATES = {
 
 class HSEMEVOptimalChargingPlanSensor(
     HSEMCoordinatorEntity,
+    RestoreEntity,
     SensorEntity,
     HSEMEntity,
-    RestoreEntity,
 ):
     """Sensor exposing the HSEM EV optimal charging plan state and attributes.
 

--- a/custom_components/hsem/custom_sensors/ev_second_optimal_charging_plan_sensor.py
+++ b/custom_components/hsem/custom_sensors/ev_second_optimal_charging_plan_sensor.py
@@ -38,9 +38,9 @@ _VALID_STATES = {
 
 class HSEMEVSecondOptimalChargingPlanSensor(
     HSEMCoordinatorEntity,
+    RestoreEntity,
     SensorEntity,
     HSEMEntity,
-    RestoreEntity,
 ):
     """Sensor exposing the HSEM second EV optimal charging plan state and attributes."""
 

--- a/custom_components/hsem/custom_sensors/force_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/force_mode_sensor.py
@@ -40,9 +40,9 @@ from custom_components.hsem.utils.sensornames import (
 
 class HSEMForceModeSensor(
     HSEMCoordinatorEntity,
+    RestoreEntity,
     SensorEntity,
     HSEMEntity,
-    RestoreEntity,
 ):
     """Diagnostic sensor exposing the current force-working-mode state.
 

--- a/custom_components/hsem/custom_sensors/forecast_accuracy_sensor.py
+++ b/custom_components/hsem/custom_sensors/forecast_accuracy_sensor.py
@@ -46,9 +46,9 @@ from custom_components.hsem.utils.sensornames import (
 
 class HSEMForecastAccuracySensor(
     HSEMCoordinatorEntity,
+    RestoreEntity,
     SensorEntity,
     HSEMEntity,
-    RestoreEntity,
 ):
     """Diagnostic sensor exposing forecast-vs-actual accuracy metrics.
 

--- a/custom_components/hsem/custom_sensors/hardware_writes_sensor.py
+++ b/custom_components/hsem/custom_sensors/hardware_writes_sensor.py
@@ -45,9 +45,9 @@ _VALID_STATES = {_ALLOWED, _BLOCKED}
 
 class HSEMHardwareWritesSensor(
     HSEMCoordinatorEntity,
+    RestoreEntity,
     SensorEntity,
     HSEMEntity,
-    RestoreEntity,
 ):
     """Diagnostic sensor exposing whether HSEM hardware writes are allowed.
 

--- a/custom_components/hsem/custom_sensors/house_consumption_power_sensor.py
+++ b/custom_components/hsem/custom_sensors/house_consumption_power_sensor.py
@@ -72,7 +72,7 @@ from custom_components.hsem.utils.sensornames import (
 )
 
 
-class HSEMHouseConsumptionPowerSensor(SensorEntity, HSEMEntity, RestoreEntity):
+class HSEMHouseConsumptionPowerSensor(RestoreEntity, SensorEntity, HSEMEntity):
     """Representation of a sensor that tracks power consumption per hour block."""
 
     _attr_icon = "mdi:flash"

--- a/custom_components/hsem/custom_sensors/last_updated_sensor.py
+++ b/custom_components/hsem/custom_sensors/last_updated_sensor.py
@@ -35,9 +35,9 @@ from custom_components.hsem.utils.sensornames import (
 
 class HSEMLastUpdatedSensor(
     HSEMCoordinatorEntity,
+    RestoreEntity,
     SensorEntity,
     HSEMEntity,
-    RestoreEntity,
 ):
     """Diagnostic sensor exposing the timestamp of the last HSEM update cycle.
 

--- a/custom_components/hsem/custom_sensors/missing_entities_sensor.py
+++ b/custom_components/hsem/custom_sensors/missing_entities_sensor.py
@@ -39,9 +39,9 @@ from custom_components.hsem.utils.sensornames import (
 
 class HSEMMissingEntitiesSensor(
     HSEMCoordinatorEntity,
+    RestoreEntity,
     SensorEntity,
     HSEMEntity,
-    RestoreEntity,
 ):
     """Diagnostic sensor exposing the count of missing HSEM input entities.
 

--- a/custom_components/hsem/custom_sensors/net_consumption_sensor.py
+++ b/custom_components/hsem/custom_sensors/net_consumption_sensor.py
@@ -44,9 +44,9 @@ from custom_components.hsem.utils.sensornames import (
 
 class HSEMNetConsumptionSensor(
     HSEMCoordinatorEntity,
+    RestoreEntity,
     SensorEntity,
     HSEMEntity,
-    RestoreEntity,
 ):
     """Diagnostic sensor exposing the instantaneous net power consumption (W).
 

--- a/custom_components/hsem/custom_sensors/next_update_sensor.py
+++ b/custom_components/hsem/custom_sensors/next_update_sensor.py
@@ -35,9 +35,9 @@ from custom_components.hsem.utils.sensornames import (
 
 class HSEMNextUpdateSensor(
     HSEMCoordinatorEntity,
+    RestoreEntity,
     SensorEntity,
     HSEMEntity,
-    RestoreEntity,
 ):
     """Diagnostic sensor exposing the next scheduled HSEM update timestamp.
 

--- a/custom_components/hsem/custom_sensors/plan_explanation_sensor.py
+++ b/custom_components/hsem/custom_sensors/plan_explanation_sensor.py
@@ -75,9 +75,9 @@ def _determine_forecast_mode(
 
 class HSEMPlanExplanationSensor(
     HSEMCoordinatorEntity,
+    RestoreEntity,
     SensorEntity,
     HSEMEntity,
-    RestoreEntity,
 ):
     """Diagnostic sensor exposing the active HSEM planner strategy.
 

--- a/custom_components/hsem/custom_sensors/read_only_sensor.py
+++ b/custom_components/hsem/custom_sensors/read_only_sensor.py
@@ -37,9 +37,9 @@ from custom_components.hsem.utils.sensornames import (
 
 class HSEMReadOnlySensor(
     HSEMCoordinatorEntity,
+    RestoreEntity,
     SensorEntity,
     HSEMEntity,
-    RestoreEntity,
 ):
     """Diagnostic sensor exposing whether HSEM is in read-only mode.
 

--- a/custom_components/hsem/custom_sensors/recommendation_interval_sensor.py
+++ b/custom_components/hsem/custom_sensors/recommendation_interval_sensor.py
@@ -45,9 +45,9 @@ from custom_components.hsem.utils.sensornames import (
 
 class HSEMRecommendationIntervalSensor(
     HSEMCoordinatorEntity,
+    RestoreEntity,
     SensorEntity,
     HSEMEntity,
-    RestoreEntity,
 ):
     """Diagnostic sensor exposing the HSEM recommendation slot-width in minutes.
 

--- a/custom_components/hsem/custom_sensors/update_interval_sensor.py
+++ b/custom_components/hsem/custom_sensors/update_interval_sensor.py
@@ -41,9 +41,9 @@ from custom_components.hsem.utils.sensornames import (
 
 class HSEMUpdateIntervalSensor(
     HSEMCoordinatorEntity,
+    RestoreEntity,
     SensorEntity,
     HSEMEntity,
-    RestoreEntity,
 ):
     """Diagnostic sensor exposing the current HSEM update interval in minutes.
 


### PR DESCRIPTION
## Summary

Audit and fix entity base class inheritance MRO across all HSEM entities to comply with Home Assistant development guidelines.

### Audit Results

- **Total entities audited**: 30
- **Already correct**: 11
- **Fixed (MRO)**: 19

### Fix Applied

**Issue**: `RestoreEntity` mixin placed after `SensorEntity` base class — Home Assistant convention requires mixins before the main entity base.

**Fix**: Reorder MRO to `HSEMCoordinatorEntity, RestoreEntity, SensorEntity, HSEMEntity` (for coordinator-backed sensors) or `RestoreEntity, SensorEntity, HSEMEntity` (for non-coordinator sensors).

### Entities Fixed (19)

| Entity | Before | After |
|---|---|---|
| `HSEMAvgSensor` | `SensorEntity, HSEMEntity, RestoreEntity` | `RestoreEntity, SensorEntity, HSEMEntity` |
| `HSEMHouseConsumptionPowerSensor` | `SensorEntity, HSEMEntity, RestoreEntity` | `RestoreEntity, SensorEntity, HSEMEntity` |
| `HSEMBatterySoCSensor` | `HSEMCoordinatorEntity, SensorEntity, HSEMEntity, RestoreEntity` | `HSEMCoordinatorEntity, RestoreEntity, SensorEntity, HSEMEntity` |
| `HSEMApplierStatusSensor` | `HSEMCoordinatorEntity, SensorEntity, HSEMEntity, RestoreEntity` | `HSEMCoordinatorEntity, RestoreEntity, SensorEntity, HSEMEntity` |
| `HSEMDegradedModeSensor` | `HSEMCoordinatorEntity, SensorEntity, HSEMEntity, RestoreEntity` | `HSEMCoordinatorEntity, RestoreEntity, SensorEntity, HSEMEntity` |
| `HSEMEVChargingSensor` | `HSEMCoordinatorEntity, SensorEntity, HSEMEntity, RestoreEntity` | `HSEMCoordinatorEntity, RestoreEntity, SensorEntity, HSEMEntity` |
| `HSEMEVOptimalChargingPlanSensor` | `HSEMCoordinatorEntity, SensorEntity, HSEMEntity, RestoreEntity` | `HSEMCoordinatorEntity, RestoreEntity, SensorEntity, HSEMEntity` |
| `HSEMEVSecondOptimalChargingPlanSensor` | `HSEMCoordinatorEntity, SensorEntity, HSEMEntity, RestoreEntity` | `HSEMCoordinatorEntity, RestoreEntity, SensorEntity, HSEMEntity` |
| `HSEMForceModeSensor` | `HSEMCoordinatorEntity, SensorEntity, HSEMEntity, RestoreEntity` | `HSEMCoordinatorEntity, RestoreEntity, SensorEntity, HSEMEntity` |
| `HSEMForecastAccuracySensor` | `HSEMCoordinatorEntity, SensorEntity, HSEMEntity, RestoreEntity` | `HSEMCoordinatorEntity, RestoreEntity, SensorEntity, HSEMEntity` |
| `HSEMHardwareWritesSensor` | `HSEMCoordinatorEntity, SensorEntity, HSEMEntity, RestoreEntity` | `HSEMCoordinatorEntity, RestoreEntity, SensorEntity, HSEMEntity` |
| `HSEMLastUpdatedSensor` | `HSEMCoordinatorEntity, SensorEntity, HSEMEntity, RestoreEntity` | `HSEMCoordinatorEntity, RestoreEntity, SensorEntity, HSEMEntity` |
| `HSEMMissingEntitiesSensor` | `HSEMCoordinatorEntity, SensorEntity, HSEMEntity, RestoreEntity` | `HSEMCoordinatorEntity, RestoreEntity, SensorEntity, HSEMEntity` |
| `HSEMNetConsumptionSensor` | `HSEMCoordinatorEntity, SensorEntity, HSEMEntity, RestoreEntity` | `HSEMCoordinatorEntity, RestoreEntity, SensorEntity, HSEMEntity` |
| `HSEMNextUpdateSensor` | `HSEMCoordinatorEntity, SensorEntity, HSEMEntity, RestoreEntity` | `HSEMCoordinatorEntity, RestoreEntity, SensorEntity, HSEMEntity` |
| `HSEMPlanExplanationSensor` | `HSEMCoordinatorEntity, SensorEntity, HSEMEntity, RestoreEntity` | `HSEMCoordinatorEntity, RestoreEntity, SensorEntity, HSEMEntity` |
| `HSEMReadOnlySensor` | `HSEMCoordinatorEntity, SensorEntity, HSEMEntity, RestoreEntity` | `HSEMCoordinatorEntity, RestoreEntity, SensorEntity, HSEMEntity` |
| `HSEMRecommendationIntervalSensor` | `HSEMCoordinatorEntity, SensorEntity, HSEMEntity, RestoreEntity` | `HSEMCoordinatorEntity, RestoreEntity, SensorEntity, HSEMEntity` |
| `HSEMUpdateIntervalSensor` | `HSEMCoordinatorEntity, SensorEntity, HSEMEntity, RestoreEntity` | `HSEMCoordinatorEntity, RestoreEntity, SensorEntity, HSEMEntity` |

### Entities Already Correct (11)

- `HSEMEntity` — base mixin (correct `Entity` base)
- `HSEMCoordinatorEntity` — typed `CoordinatorEntity` base
- `HSEMWorkingModeSensor` — correct `HSEMCoordinatorEntity, SensorEntity, HSEMEntity`
- `HSEMIntegrationSensor` — correct `IntegrationSensor, HSEMEntity` (HSEMEntity after base for `device_info` override)
- `HSEMUtilityMeterSensor` — correct `UtilityMeterSensor, HSEMEntity` (same pattern)
- `HSEMBatteryEfficiencyNumber` — correct `NumberEntity, HSEMEntity`
- `HSEMEVTargetSocNumber` — correct `NumberEntity, HSEMEntity`
- `HSEMSolcastLikelihoodSelector` — correct `SelectEntity, HSEMEntity`
- `HSEMWorkingModeSelector` — correct `SelectEntity, HSEMEntity`
- `HSEMSwitch` — correct `SwitchEntity, HSEMEntity`
- `HSEMTimeEntity` — correct `TimeEntity, HSEMEntity`

### Quality Gates

- ✅ `tox -e lint` — all checks passed (177 files)
- ✅ `tox -e typing` — 0 errors (177 source files)
- ✅ `tox -e quality` — 0 errors (23 pre-existing warnings in test files)
- ⚠️ `tox -e py313` — pre-existing bcrypt PyO3 import error on Windows (unrelated to changes)