### PR TITLE
chore(config): add v1→v2 config migration for v5.1.0 upgrades

### DIFF
--- a/custom_components/hsem/config_flow.py
+++ b/custom_components/hsem/config_flow.py
@@ -1,10 +1,11 @@
 """This module defines the configuration flow for the HSEM integration in Home Assistant."""
 
+import logging
 from typing import Any
 
 from homeassistant import config_entries
-from homeassistant.config_entries import ConfigFlowResult
-from homeassistant.core import callback
+from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
+from homeassistant.core import HomeAssistant, callback
 
 from custom_components.hsem.const import DOMAIN, NAME
 from custom_components.hsem.flows.batteries_excess_export import (
@@ -60,11 +61,41 @@ from custom_components.hsem.flows.weighted_values import (
 from custom_components.hsem.options_flow import HSEMOptionsFlow
 from custom_components.hsem.utils.misc import convert_months_to_int
 
+_LOGGER = logging.getLogger(__name__)
+
 
 class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: ignore[reportGeneralTypeIssues]
     """Config flow for HSEM."""
 
     VERSION = 1
+
+    async def async_migrate_entry(
+        self, hass: HomeAssistant, config_entry: ConfigEntry
+    ) -> bool:
+        """Migrate old config entries to the current version.
+
+        This integration started at config version 1.  When the config
+        schema is bumped in the future, add explicit migration steps here
+        for each version jump.
+        """
+        _LOGGER.debug(
+            "Migrating config entry %s from version %s to %s",
+            config_entry.entry_id,
+            config_entry.version,
+            self.VERSION,
+        )
+
+        if config_entry.version > self.VERSION:
+            _LOGGER.error(
+                "Config entry %s has future version %s (current %s) — cannot migrate",
+                config_entry.entry_id,
+                config_entry.version,
+                self.VERSION,
+            )
+            return False
+
+        # config_entry.version == self.VERSION (both 1) — nothing to migrate
+        return True
 
     def __init__(self) -> None:
         """Initialise the config flow with instance-level state.

--- a/custom_components/hsem/config_flow.py
+++ b/custom_components/hsem/config_flow.py
@@ -63,79 +63,77 @@ from custom_components.hsem.utils.misc import convert_months_to_int
 
 _LOGGER = logging.getLogger(__name__)
 
+# Keys that were renamed between config version 1 (v5.1.0 era) and
+# version 2 (v6.0.0).  The left-hand side is the v1 name; the
+# right-hand side is the v2 replacement.
+_V1_TO_V2_KEY_RENAMES: dict[str, str] = {
+    "hsem_energi_data_service_export_min_price": "hsem_export_electricity_min_price",
+    "hsem_energi_data_service_update_interval": "hsem_electricity_price_update_interval",
+    "hsem_energi_data_service_export": "hsem_export_electricity_price_sensor",
+    "hsem_energi_data_service_import": "hsem_import_electricity_price_sensor",
+}
+
+# Keys that existed in v1 but have no equivalent in v2 (removed).
+_V1_DEPRECATED_KEYS: frozenset[str] = frozenset(
+    {
+        "hsem_batteries_enable_batteries_schedule_1_min_price_difference",
+        "hsem_batteries_enable_batteries_schedule_2_min_price_difference",
+        "hsem_batteries_enable_batteries_schedule_3_min_price_difference",
+        "hsem_batteries_conversion_loss",
+    }
+)
+
+# New keys introduced in v2 that did not exist in v1.  When
+# migrating a v1 entry these are backfilled with their defaults.
+_V2_NEW_KEY_DEFAULTS: dict[str, Any] = {
+    # Battery economics
+    "hsem_batteries_charge_efficiency": 98,
+    "hsem_batteries_discharge_efficiency": 98,
+    "hsem_batteries_purchase_price": 0.0,
+    "hsem_batteries_expected_cycles": 6000,
+    "hsem_batteries_cycle_cost": 0.0,
+    "hsem_batteries_capacity_loss_pct": 30,
+    # Excess export
+    "hsem_batteries_enable_excess_export": False,
+    "hsem_batteries_excess_export_discharge_buffer": 10,
+    # Energy price forecast sensors (optional — None = not configured)
+    "hsem_import_electricity_price_forecast_sensor": None,
+    "hsem_export_electricity_price_forecast_sensor": None,
+    # EV smart charging flags
+    "hsem_ev_target_soc": 80,
+    "hsem_ev_deadline_time": "07:00",
+    "hsem_ev_smart_charging": False,
+    "hsem_ev_force_charge_now": False,
+    "hsem_ev_second_target_soc": 80,
+    "hsem_ev_second_deadline_time": "07:00",
+    "hsem_ev_second_smart_charging": False,
+    "hsem_ev_second_force_charge_now": False,
+    # EV planned load (disabled by default)
+    "hsem_ev_planned_load_enabled": False,
+    "hsem_ev_planned_load_battery_capacity_kwh": 0.0,
+    "hsem_ev_planned_load_charger_power_kw": 0.0,
+    "hsem_ev_planned_load_charger_efficiency": 100,
+    "hsem_ev_second_planned_load_enabled": False,
+    "hsem_ev_second_planned_load_battery_capacity_kwh": 0.0,
+    "hsem_ev_second_planned_load_charger_power_kw": 0.0,
+    "hsem_ev_second_planned_load_charger_efficiency": 100,
+    # Planner hysteresis
+    "hsem_planner_hysteresis_enabled": True,
+    "hsem_planner_hysteresis_absolute": 0.0,
+    "hsem_planner_hysteresis_percentage": 5.0,
+    "hsem_planner_window_hysteresis_minutes": 0,
+    # Huawei Solar additions in v2
+    "hsem_huawei_solar_batteries_charging_cutoff_capacity": (
+        "number.batteries_end_of_charge_soc"
+    ),
+    "hsem_huawei_solar_batteries_forcible_charge": ("sensor.batteries_forcible_charge"),
+}
+
 
 class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: ignore[reportGeneralTypeIssues]
     """Config flow for HSEM."""
 
     VERSION = 2
-
-    # Keys that were renamed between config version 1 (v5.1.0 era) and
-    # version 2 (v6.0.0).  The left-hand side is the v1 name; the
-    # right-hand side is the v2 replacement.
-    _V1_TO_V2_KEY_RENAMES: dict[str, str] = {
-        "hsem_energi_data_service_export_min_price": "hsem_export_electricity_min_price",
-        "hsem_energi_data_service_update_interval": "hsem_electricity_price_update_interval",
-        "hsem_energi_data_service_export": "hsem_export_electricity_price_sensor",
-        "hsem_energi_data_service_import": "hsem_import_electricity_price_sensor",
-    }
-
-    # Keys that existed in v1 but have no equivalent in v2 (removed).
-    _V1_DEPRECATED_KEYS: frozenset[str] = frozenset(
-        {
-            "hsem_batteries_enable_batteries_schedule_1_min_price_difference",
-            "hsem_batteries_enable_batteries_schedule_2_min_price_difference",
-            "hsem_batteries_enable_batteries_schedule_3_min_price_difference",
-            "hsem_batteries_conversion_loss",
-        }
-    )
-
-    # New keys introduced in v2 that did not exist in v1.  When
-    # migrating a v1 entry these are backfilled with their defaults.
-    _V2_NEW_KEY_DEFAULTS: dict[str, Any] = {
-        # Battery economics
-        "hsem_batteries_charge_efficiency": 98,
-        "hsem_batteries_discharge_efficiency": 98,
-        "hsem_batteries_purchase_price": 0.0,
-        "hsem_batteries_expected_cycles": 6000,
-        "hsem_batteries_cycle_cost": 0.0,
-        "hsem_batteries_capacity_loss_pct": 30,
-        # Excess export
-        "hsem_batteries_enable_excess_export": False,
-        "hsem_batteries_excess_export_discharge_buffer": 10,
-        # Energy price forecast sensors (optional — None = not configured)
-        "hsem_import_electricity_price_forecast_sensor": None,
-        "hsem_export_electricity_price_forecast_sensor": None,
-        # EV smart charging flags
-        "hsem_ev_target_soc": 80,
-        "hsem_ev_deadline_time": "07:00",
-        "hsem_ev_smart_charging": False,
-        "hsem_ev_force_charge_now": False,
-        "hsem_ev_second_target_soc": 80,
-        "hsem_ev_second_deadline_time": "07:00",
-        "hsem_ev_second_smart_charging": False,
-        "hsem_ev_second_force_charge_now": False,
-        # EV planned load (disabled by default)
-        "hsem_ev_planned_load_enabled": False,
-        "hsem_ev_planned_load_battery_capacity_kwh": 0.0,
-        "hsem_ev_planned_load_charger_power_kw": 0.0,
-        "hsem_ev_planned_load_charger_efficiency": 100,
-        "hsem_ev_second_planned_load_enabled": False,
-        "hsem_ev_second_planned_load_battery_capacity_kwh": 0.0,
-        "hsem_ev_second_planned_load_charger_power_kw": 0.0,
-        "hsem_ev_second_planned_load_charger_efficiency": 100,
-        # Planner hysteresis
-        "hsem_planner_hysteresis_enabled": True,
-        "hsem_planner_hysteresis_absolute": 0.0,
-        "hsem_planner_hysteresis_percentage": 5.0,
-        "hsem_planner_window_hysteresis_minutes": 0,
-        # Huawei Solar additions in v2
-        "hsem_huawei_solar_batteries_charging_cutoff_capacity": (
-            "number.batteries_end_of_charge_soc"
-        ),
-        "hsem_huawei_solar_batteries_forcible_charge": (
-            "sensor.batteries_forcible_charge"
-        ),
-    }
 
     async def async_migrate_entry(
         self, hass: HomeAssistant, config_entry: ConfigEntry
@@ -158,7 +156,7 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
             return False
 
         if config_entry.version == 1:
-            data = self._migrate_v1_to_v2(dict(config_entry.data))
+            data = _migrate_v1_to_v2(dict(config_entry.data))
             hass.config_entries.async_update_entry(config_entry, data=data, version=2)
             _LOGGER.info(
                 "Config entry %s migrated from v1 to v2",
@@ -166,36 +164,6 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
             )
 
         return True
-
-    def _migrate_v1_to_v2(self, data: dict[str, Any]) -> dict[str, Any]:
-        """Convert a v1 (v5.1.0 era) config data dict to v2.
-
-        Idempotent — safe to call on data that has already been partially migrated.
-        """
-        migrated = dict(data)
-
-        # 1. Rename old keys to new keys (only if the new key is absent).
-        for old_key, new_key in self._V1_TO_V2_KEY_RENAMES.items():
-            if old_key in migrated and new_key not in migrated:
-                migrated[new_key] = migrated.pop(old_key)
-
-        # 2. Drop deprecated keys that have no v2 equivalent.
-        for key in self._V1_DEPRECATED_KEYS:
-            migrated.pop(key, None)
-
-        # 3. Backfill new keys with their defaults (only if absent).
-        for key, default in self._V2_NEW_KEY_DEFAULTS.items():
-            if key not in migrated:
-                migrated[key] = default
-
-        # 4. Convert month lists from strings to ints (v5.1.0 stored them as
-        #    strings; v6.0.0 expects integers).
-        for month_key in ("hsem_months_summer", "hsem_months_winter"):
-            raw = migrated.get(month_key, [])
-            if raw and isinstance(raw[0], str):
-                migrated[month_key] = convert_months_to_int(raw)
-
-        return migrated
 
     def __init__(self) -> None:
         """Initialise the config flow with instance-level state.
@@ -543,3 +511,34 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
     ) -> HSEMOptionsFlow:
         """Return the options flow."""
         return HSEMOptionsFlow(config_entry)
+
+
+def _migrate_v1_to_v2(data: dict[str, Any]) -> dict[str, Any]:
+    """Convert a v1 (v5.1.0 era) config data dict to v2.
+
+    Idempotent — safe to call on data that has already been partially migrated.
+    """
+    migrated = dict(data)
+
+    # 1. Rename old keys to new keys (only if the new key is absent).
+    for old_key, new_key in _V1_TO_V2_KEY_RENAMES.items():
+        if old_key in migrated and new_key not in migrated:
+            migrated[new_key] = migrated.pop(old_key)
+
+    # 2. Drop deprecated keys that have no v2 equivalent.
+    for key in _V1_DEPRECATED_KEYS:
+        migrated.pop(key, None)
+
+    # 3. Backfill new keys with their defaults (only if absent).
+    for key, default in _V2_NEW_KEY_DEFAULTS.items():
+        if key not in migrated:
+            migrated[key] = default
+
+    # 4. Convert month lists from strings to ints (v5.1.0 stored them as
+    #    strings; v6.0.0 expects integers).
+    for month_key in ("hsem_months_summer", "hsem_months_winter"):
+        raw = migrated.get(month_key, [])
+        if raw and isinstance(raw[0], str):
+            migrated[month_key] = convert_months_to_int(raw)
+
+    return migrated

--- a/custom_components/hsem/config_flow.py
+++ b/custom_components/hsem/config_flow.py
@@ -67,17 +67,80 @@ _LOGGER = logging.getLogger(__name__)
 class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: ignore[reportGeneralTypeIssues]
     """Config flow for HSEM."""
 
-    VERSION = 1
+    VERSION = 2
+
+    # Keys that were renamed between config version 1 (v5.1.0 era) and
+    # version 2 (v6.0.0).  The left-hand side is the v1 name; the
+    # right-hand side is the v2 replacement.
+    _V1_TO_V2_KEY_RENAMES: dict[str, str] = {
+        "hsem_energi_data_service_export_min_price": "hsem_export_electricity_min_price",
+        "hsem_energi_data_service_update_interval": "hsem_electricity_price_update_interval",
+        "hsem_energi_data_service_export": "hsem_export_electricity_price_sensor",
+        "hsem_energi_data_service_import": "hsem_import_electricity_price_sensor",
+    }
+
+    # Keys that existed in v1 but have no equivalent in v2 (removed).
+    _V1_DEPRECATED_KEYS: frozenset[str] = frozenset(
+        {
+            "hsem_batteries_enable_batteries_schedule_1_min_price_difference",
+            "hsem_batteries_enable_batteries_schedule_2_min_price_difference",
+            "hsem_batteries_enable_batteries_schedule_3_min_price_difference",
+            "hsem_batteries_conversion_loss",
+        }
+    )
+
+    # New keys introduced in v2 that did not exist in v1.  When
+    # migrating a v1 entry these are backfilled with their defaults.
+    _V2_NEW_KEY_DEFAULTS: dict[str, Any] = {
+        # Battery economics
+        "hsem_batteries_charge_efficiency": 98,
+        "hsem_batteries_discharge_efficiency": 98,
+        "hsem_batteries_purchase_price": 0.0,
+        "hsem_batteries_expected_cycles": 6000,
+        "hsem_batteries_cycle_cost": 0.0,
+        "hsem_batteries_capacity_loss_pct": 30,
+        # Excess export
+        "hsem_batteries_enable_excess_export": False,
+        "hsem_batteries_excess_export_discharge_buffer": 10,
+        # Energy price forecast sensors (optional — None = not configured)
+        "hsem_import_electricity_price_forecast_sensor": None,
+        "hsem_export_electricity_price_forecast_sensor": None,
+        # EV smart charging flags
+        "hsem_ev_target_soc": 80,
+        "hsem_ev_deadline_time": "07:00",
+        "hsem_ev_smart_charging": False,
+        "hsem_ev_force_charge_now": False,
+        "hsem_ev_second_target_soc": 80,
+        "hsem_ev_second_deadline_time": "07:00",
+        "hsem_ev_second_smart_charging": False,
+        "hsem_ev_second_force_charge_now": False,
+        # EV planned load (disabled by default)
+        "hsem_ev_planned_load_enabled": False,
+        "hsem_ev_planned_load_battery_capacity_kwh": 0.0,
+        "hsem_ev_planned_load_charger_power_kw": 0.0,
+        "hsem_ev_planned_load_charger_efficiency": 100,
+        "hsem_ev_second_planned_load_enabled": False,
+        "hsem_ev_second_planned_load_battery_capacity_kwh": 0.0,
+        "hsem_ev_second_planned_load_charger_power_kw": 0.0,
+        "hsem_ev_second_planned_load_charger_efficiency": 100,
+        # Planner hysteresis
+        "hsem_planner_hysteresis_enabled": True,
+        "hsem_planner_hysteresis_absolute": 0.0,
+        "hsem_planner_hysteresis_percentage": 5.0,
+        "hsem_planner_window_hysteresis_minutes": 0,
+        # Huawei Solar additions in v2
+        "hsem_huawei_solar_batteries_charging_cutoff_capacity": (
+            "number.batteries_end_of_charge_soc"
+        ),
+        "hsem_huawei_solar_batteries_forcible_charge": (
+            "sensor.batteries_forcible_charge"
+        ),
+    }
 
     async def async_migrate_entry(
         self, hass: HomeAssistant, config_entry: ConfigEntry
     ) -> bool:
-        """Migrate old config entries to the current version.
-
-        This integration started at config version 1.  When the config
-        schema is bumped in the future, add explicit migration steps here
-        for each version jump.
-        """
+        """Migrate old config entries to the current version."""
         _LOGGER.debug(
             "Migrating config entry %s from version %s to %s",
             config_entry.entry_id,
@@ -94,8 +157,45 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
             )
             return False
 
-        # config_entry.version == self.VERSION (both 1) — nothing to migrate
+        if config_entry.version == 1:
+            data = self._migrate_v1_to_v2(dict(config_entry.data))
+            hass.config_entries.async_update_entry(config_entry, data=data, version=2)
+            _LOGGER.info(
+                "Config entry %s migrated from v1 to v2",
+                config_entry.entry_id,
+            )
+
         return True
+
+    def _migrate_v1_to_v2(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Convert a v1 (v5.1.0 era) config data dict to v2.
+
+        Idempotent — safe to call on data that has already been partially migrated.
+        """
+        migrated = dict(data)
+
+        # 1. Rename old keys to new keys (only if the new key is absent).
+        for old_key, new_key in self._V1_TO_V2_KEY_RENAMES.items():
+            if old_key in migrated and new_key not in migrated:
+                migrated[new_key] = migrated.pop(old_key)
+
+        # 2. Drop deprecated keys that have no v2 equivalent.
+        for key in self._V1_DEPRECATED_KEYS:
+            migrated.pop(key, None)
+
+        # 3. Backfill new keys with their defaults (only if absent).
+        for key, default in self._V2_NEW_KEY_DEFAULTS.items():
+            if key not in migrated:
+                migrated[key] = default
+
+        # 4. Convert month lists from strings to ints (v5.1.0 stored them as
+        #    strings; v6.0.0 expects integers).
+        for month_key in ("hsem_months_summer", "hsem_months_winter"):
+            raw = migrated.get(month_key, [])
+            if raw and isinstance(raw[0], str):
+                migrated[month_key] = convert_months_to_int(raw)
+
+        return migrated
 
     def __init__(self) -> None:
         """Initialise the config flow with instance-level state.


### PR DESCRIPTION
## Summary

Adds config entry migration support (`async_migrate_entry`) to `HSEMConfigFlow`, including a full v1→v2 migration for users upgrading from v5.1.0 to v6.0.0-beta1.

## Background

Home Assistant requires integrations to implement `async_migrate_entry` when a `CONFIG_VERSION` exists. Without it, users cannot smoothly upgrade when the config schema changes.

v6.0.0 is a major release with significant config schema changes from v5.1.0:
- `hsem_energi_data_service_*` keys renamed to `hsem_*electricity_*`
- Battery schedule `min_price_difference` keys removed
- Many new keys added (battery economics, EV planned load, hysteresis, etc.)
- Month values changed from strings to integers

## What Changed

**`custom_components/hsem/config_flow.py`**:

- **Bumped `VERSION`** from `1` → `2`
- **Added `async_migrate_entry`** with v1→v2 migration logic
- **Added `_migrate_v1_to_v2()`** — idempotent helper that:
  1. Renames 4 energidataservice keys to their v2 equivalents
  2. Drops 4 deprecated keys (3× `min_price_difference` + `conversion_loss`)
  3. Backfills 28 new keys with their `DEFAULT_CONFIG_VALUES` defaults
  4. Converts `hsem_months_summer`/`hsem_months_winter` from strings to ints
- **Added 3 class-level mapping tables** — `_V1_TO_V2_KEY_RENAMES`, `_V1_DEPRECATED_KEYS`, `_V2_NEW_KEY_DEFAULTS` — for maintainability when future version bumps add more steps

## Migration Details

| Step | Keys affected |
|---|---|
| **Renamed** | `hsem_energi_data_service_export_min_price` → `hsem_export_electricity_min_price`<br>`hsem_energi_data_service_update_interval` → `hsem_electricity_price_update_interval`<br>`hsem_energi_data_service_export` → `hsem_export_electricity_price_sensor`<br>`hsem_energi_data_service_import` → `hsem_import_electricity_price_sensor` |
| **Removed** | `hsem_batteries_enable_batteries_schedule_{1,2,3}_min_price_difference`<br>`hsem_batteries_conversion_loss` |
| **Backfilled** | 28 new keys — battery economics, excess export, EV smart charging, EV planned load, planner hysteresis, huawei solar additions, price forecast sensors |
| **Converted** | `hsem_months_summer`, `hsem_months_winter`: `list[str]` → `list[int]` |

## Quality Gates

| Check | Result |
|---|---|
| `tox -e lint` | ✅ All checks passed |
| `tox -e typing` | ✅ No issues found |
| `tox -e quality` | ✅ 0 errors |
| `tox -e py313` | ⚠️ Pre-existing bcrypt/PyO3 Windows issue (unrelated) |