### PR TITLE
docs(sensors): add HA-convention docstrings to all custom sensor modules

### DIFF
--- a/custom_components/hsem/custom_sensors/avg_sensor.py
+++ b/custom_components/hsem/custom_sensors/avg_sensor.py
@@ -1,3 +1,13 @@
+"""Rolling N-day energy average sensor for HSEM hour-block consumption.
+
+Computes a moving average of daily utility-meter energy readings (kWh)
+over a configurable number of days.  Used by the planner to estimate
+expected house consumption per hour block.
+
+Created dynamically by :class:`HSEMHouseConsumptionPowerSensor` for each
+hour block and average period (1, 3, 7, or 14 days).
+"""
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta
@@ -42,6 +52,18 @@ class HSEMAvgSensor(RestoreEntity, SensorEntity, HSEMEntity):
         unique_id: str,
         entity_id: str,
     ) -> None:
+        """Initialize the rolling average sensor.
+
+        Args:
+            config_entry: The HSEM config entry.
+            hour_start: Start hour (0-23) of the consumption block.
+            hour_end: End hour (0-23) of the consumption block.
+            avg: Number of days over which to compute the rolling average.
+            tracked_entity: Entity ID of the utility meter to track.
+            name: Display name for the sensor.
+            unique_id: Unique ID for the HA entity registry.
+            entity_id: Entity ID for the sensor.
+        """
         super().__init__(config_entry)
         self._hour_start = hour_start
         self._hour_end = hour_end
@@ -104,6 +126,14 @@ class HSEMAvgSensor(RestoreEntity, SensorEntity, HSEMEntity):
         return await self._async_handle_update(event)
 
     def parse_date(self, date_str: str) -> str:
+        """Normalize an ISO date string to YYYY-MM-DD format.
+
+        Args:
+            date_str: ISO datetime string (e.g. ``"2025-01-15T12:00:00"``).
+
+        Returns:
+            Normalized date string in ``YYYY-MM-DD`` format.
+        """
         # Strip any time component if it exists
         date_part = date_str.split("T")[0] if "T" in date_str else date_str
         return datetime.strptime(date_part, "%Y-%m-%d").date().isoformat()
@@ -147,6 +177,7 @@ class HSEMAvgSensor(RestoreEntity, SensorEntity, HSEMEntity):
         await super().async_will_remove_from_hass()
 
     async def _async_track_entities(self) -> None:
+        """Register a state-change listener for the tracked utility meter."""
         if self._tracked_entity:
             if self._tracked_entity not in self._tracked_entities:
                 unsub = async_track_state_change_event(

--- a/custom_components/hsem/custom_sensors/house_consumption_power_sensor.py
+++ b/custom_components/hsem/custom_sensors/house_consumption_power_sensor.py
@@ -1,25 +1,14 @@
-"""Module for the HouseConsumptionPowerSensor class.
+"""Per-hour-block house consumption power sensor for HSEM.
 
-This module defines the HouseConsumptionPowerSensor class, which represents a sensor
-that tracks power consumption per hour block in a Home Assistant environment.
+Tracks the instantaneous power drawn by the house during a specific
+one-hour window (e.g. 13:00–14:00) and dynamically creates derived
+child sensors:
 
-Classes:
-    HouseConsumptionPowerSensor: A sensor entity that tracks power consumption per hour block.
+- :class:`HSEMIntegrationSensor` — converts power (W) to energy (kWh).
+- :class:`HSEMUtilityMeterSensor` — daily-resetting energy meter.
+- :class:`HSEMAvgSensor` — rolling 1/3/7/14-day energy averages.
 
-Functions:
-    set_hsem_house_consumption_power(value): Sets the house consumption power entity.
-    set_hsem_house_power_includes_ev_charger_power(value): Sets whether house power includes EV charger power.
-    set_hsem_ev_charger_power(value): Sets the EV charger power entity.
-    name: Returns the name of the sensor.
-    unit_of_measurement: Returns the unit of measurement for the sensor.
-    device_class: Returns the device class of the sensor.
-    unique_id: Returns the unique ID of the sensor.
-    state: Returns the current state of the sensor.
-    extra_state_attributes: Returns the extra state attributes of the sensor.
-    _update_settings(): Fetches updated settings from config_entry options.
-    async_added_to_hass(): Handles when the sensor is added to Home Assistant.
-    _async_handle_update(event): Handles updates to the source sensor.
-    async_update(event=None): Manually triggers the sensor update.
+These derived sensors feed the planner's house-consumption estimates.
 """
 
 from __future__ import annotations
@@ -73,7 +62,11 @@ from custom_components.hsem.utils.sensornames import (
 
 
 class HSEMHouseConsumptionPowerSensor(RestoreEntity, SensorEntity, HSEMEntity):
-    """Representation of a sensor that tracks power consumption per hour block."""
+    """Sensor that tracks power consumption for a specific one-hour block.
+
+    Measures the house power draw (minus EV when configured) during the
+    active hour window and dynamically creates derived energy sensors.
+    """
 
     _attr_icon = "mdi:flash"
     _attr_has_entity_name = True
@@ -104,6 +97,14 @@ class HSEMHouseConsumptionPowerSensor(RestoreEntity, SensorEntity, HSEMEntity):
         hour_end: int,
         async_add_entities: Any,
     ) -> None:
+        """Initialize the house consumption power sensor.
+
+        Args:
+            config_entry: The HSEM config entry.
+            hour_start: Start hour (0-23) of the measurement block.
+            hour_end: End hour (0-23) of the measurement block.
+            async_add_entities: HA callback to register derived child entities.
+        """
         super().__init__(config_entry)
         self._available = False
         self._missing_input_entities = True
@@ -157,7 +158,11 @@ class HSEMHouseConsumptionPowerSensor(RestoreEntity, SensorEntity, HSEMEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the state attributes for the sensor.
 
+        Includes source entity configurations and live power readings.
+        When input entities are missing, returns an error status instead.
+        """
         if self._missing_input_entities:
             return {
                 "status": "error",
@@ -166,7 +171,6 @@ class HSEMHouseConsumptionPowerSensor(RestoreEntity, SensorEntity, HSEMEntity):
                 "unique_id": self._attr_unique_id,
             }
 
-        """Return the state attributes."""
         return {
             "house_consumption_power_entity": self._hsem_house_consumption_power,
             "house_consumption_power_state": round(
@@ -319,6 +323,7 @@ class HSEMHouseConsumptionPowerSensor(RestoreEntity, SensorEntity, HSEMEntity):
             self.async_write_ha_state()
 
     async def _async_track_entities(self) -> None:
+        """Register state-change listeners for source power entities."""
         # Track state changes for the source sensor
         if self._hsem_house_consumption_power:
             if self._hsem_house_consumption_power not in self._tracked_entities:
@@ -345,6 +350,7 @@ class HSEMHouseConsumptionPowerSensor(RestoreEntity, SensorEntity, HSEMEntity):
                 self._tracked_entities.add(self._hsem_ev_charger_power)
 
     async def _async_fetch_sensor_states(self) -> None:
+        """Read live power values from the configured HA source entities."""
         # Update the state of the sensor for house consumption power
 
         self._missing_input_entities = False

--- a/custom_components/hsem/custom_sensors/integration_sensor.py
+++ b/custom_components/hsem/custom_sensors/integration_sensor.py
@@ -1,3 +1,9 @@
+"""Custom HSEM integration sensor that converts power (W) to energy (kWh).
+
+Wraps Home Assistant's built-in :class:`IntegrationSensor` with HSEM device
+metadata so that all derived energy sensors appear on the HSEM device page.
+"""
+
 from __future__ import annotations
 
 from typing import Any
@@ -27,6 +33,15 @@ class HSEMIntegrationSensor(IntegrationSensor, HSEMEntity):
         config_entry: ConfigEntry | None = None,
         **kwargs: Any,
     ) -> None:
+        """Initialize the HSEM integration sensor.
+
+        Args:
+            *args: Positional arguments forwarded to :class:`IntegrationSensor`.
+            id: Unique ID for the HA entity registry.
+            e_id: Entity ID for the sensor.
+            config_entry: The HSEM config entry (required).
+            **kwargs: Keyword arguments forwarded to :class:`IntegrationSensor`.
+        """
         IntegrationSensor.__init__(self, *args, **kwargs)
         assert config_entry is not None, (
             "config_entry is required for HSEMIntegrationSensor"

--- a/custom_components/hsem/custom_sensors/utility_meter_sensor.py
+++ b/custom_components/hsem/custom_sensors/utility_meter_sensor.py
@@ -1,3 +1,9 @@
+"""Custom HSEM utility meter sensor with HSEM device metadata.
+
+Wraps Home Assistant's built-in :class:`UtilityMeterSensor` so that all
+per-hour energy meters appear on the HSEM device page.
+"""
+
 from __future__ import annotations
 
 from typing import Any
@@ -11,7 +17,12 @@ from custom_components.hsem.entity import HSEMEntity
 
 
 class HSEMUtilityMeterSensor(UtilityMeterSensor, HSEMEntity):
-    """Custom Utility Meter Sensor with device_info."""
+    """Custom Utility Meter Sensor with HSEM device_info.
+
+    Tracks daily energy accumulation per hour block with
+    ``state_class=TOTAL`` so the energy dashboard can sum
+    across hours correctly.
+    """
 
     _attr_icon = "mdi:counter"
 
@@ -23,6 +34,15 @@ class HSEMUtilityMeterSensor(UtilityMeterSensor, HSEMEntity):
         config_entry: ConfigEntry | None = None,
         **kwargs: Any,
     ) -> None:
+        """Initialize the HSEM utility meter sensor.
+
+        Args:
+            *args: Positional arguments forwarded to :class:`UtilityMeterSensor`.
+            id: Unique ID for the HA entity registry.
+            e_id: Entity ID for the sensor.
+            config_entry: The HSEM config entry (required).
+            **kwargs: Keyword arguments forwarded to :class:`UtilityMeterSensor`.
+        """
         UtilityMeterSensor.__init__(self, *args, **kwargs)
         assert config_entry is not None, (
             "config_entry is required for HSEMUtilityMeterSensor"


### PR DESCRIPTION
Fixes #491

## Summary

Added Home Assistant convention docstrings to the 4 custom sensor modules that were missing or had incomplete documentation. The other 23 files already had excellent HA-format docstrings.

## Files Changed

- `custom_components/hsem/custom_sensors/integration_sensor.py` — added module docstring + `__init__` docstring
- `custom_components/hsem/custom_sensors/utility_meter_sensor.py` — added module docstring + improved class docstring + `__init__` docstring
- `custom_components/hsem/custom_sensors/avg_sensor.py` — added module docstring + `__init__` docstring + `parse_date` docstring + `_async_track_entities` docstring
- `custom_components/hsem/custom_sensors/house_consumption_power_sensor.py` — replaced listing-style module docstring with HA-format version + improved class docstring + `__init__` docstring + fixed misplaced `extra_state_attributes` docstring + `_async_track_entities` + `_async_fetch_sensor_states` docstrings

## Docstrings Added/Fixed

- **8 new docstrings** added (module, class, `__init__`, methods)
- **2 existing docstrings** reformatted to HA convention
- **1 misplaced docstring** fixed (was after early return in `extra_state_attributes`)

## Quality Gates

| Check | Result |
|---|---|
| `tox -e lint` | ✅ 177 files unchanged, ruff check passed |
| `tox -e typing` | ✅ 0 errors |
| `tox -e quality` | ✅ 0 errors (23 pre-existing warnings in test files) |
| `tox -e py313` | ⚠️ Pre-existing bcrypt ImportError on Windows/Python 3.13 (61 identical errors, unrelated to this change) |

## Checklist

- [x] No logic or code changes — docstrings only
- [x] No type hints touched
- [x] No unrelated refactoring
- [x] All four tox checks run
- [x] Branch naming follows convention: `chore/491-docstrings-sensors`
- [x] Conventional commit format