### PR TITLE
docs: add HA-convention docstrings to all remaining modules

### DIFF
--- a/custom_components/hsem/__init__.py
+++ b/custom_components/hsem/__init__.py
@@ -117,6 +117,12 @@ async def async_setup(hass: HomeAssistant, _config: dict) -> bool:
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up the HSEM integration from a config entry.
+
+    Creates the shared :class:`HSEMDataUpdateCoordinator`, runs the first
+    update cycle, forwards platform setups, registers services, and adds
+    an options update listener.
+    """
     if not await check_huawei_solar_version(hass):
         return False
 

--- a/custom_components/hsem/config_flow.py
+++ b/custom_components/hsem/config_flow.py
@@ -178,6 +178,10 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the user config flow step.
+
+        Validates user input and advances to the next step in the config flow.
+        """
         errors = {}
 
         # Set a stable, deterministic unique id so that the guard below
@@ -207,6 +211,10 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
     async def async_step_prices(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the prices config flow step.
+
+        Validates user input and advances to the next step in the config flow.
+        """
         errors = {}
 
         if user_input is not None:
@@ -227,6 +235,10 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
     async def async_step_months(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the months config flow step.
+
+        Validates user input and advances to the next step in the config flow.
+        """
         errors = {}
 
         if user_input is not None:
@@ -260,6 +272,10 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
     async def async_step_solcast(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the solcast config flow step.
+
+        Validates user input and advances to the next step in the config flow.
+        """
         errors = {}
 
         if user_input is not None:
@@ -280,6 +296,10 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
     async def async_step_huawei_solar(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the huawei_solar config flow step.
+
+        Validates user input and advances to the next step in the config flow.
+        """
         errors = {}
 
         if user_input is not None:
@@ -314,6 +334,10 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
     async def async_step_battery_economics(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the battery_economics config flow step.
+
+        Validates user input and advances to the next step in the config flow.
+        """
         errors = {}
 
         if user_input is not None:
@@ -334,6 +358,10 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
     async def async_step_power(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the power config flow step.
+
+        Validates user input and advances to the next step in the config flow.
+        """
         errors = {}
 
         if user_input is not None:
@@ -354,6 +382,10 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
     async def async_step_ev(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the ev config flow step.
+
+        Validates user input and advances to the next step in the config flow.
+        """
         errors = {}
 
         if user_input is not None:
@@ -378,6 +410,10 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
     async def async_step_ev_second(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the ev_second config flow step.
+
+        Validates user input and advances to the next step in the config flow.
+        """
         errors = {}
 
         if user_input is not None:
@@ -398,6 +434,10 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
     async def async_step_ev_planned_load(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the ev_planned_load config flow step.
+
+        Validates user input and advances to the next step in the config flow.
+        """
         errors = {}
 
         if user_input is not None:
@@ -420,6 +460,10 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
     async def async_step_ev_second_planned_load(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the ev_second_planned_load config flow step.
+
+        Validates user input and advances to the next step in the config flow.
+        """
         errors = {}
 
         if user_input is not None:
@@ -440,6 +484,10 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
     async def async_step_batteries_schedules(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the batteries_schedules config flow step.
+
+        Validates user input and advances to the next step in the config flow.
+        """
         errors = {}
 
         if user_input is not None:
@@ -462,6 +510,10 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
     async def async_step_batteries_excess_export(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the batteries_excess_export config flow step.
+
+        Validates user input and advances to the next step in the config flow.
+        """
         errors = {}
 
         if user_input is not None:
@@ -484,6 +536,10 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
     async def async_step_weighted_values(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the weighted_values config flow step.
+
+        Validates user input and advances to the next step in the config flow.
+        """
         errors = {}
 
         if user_input is not None:

--- a/custom_components/hsem/flows/batteries_excess_export.py
+++ b/custom_components/hsem/flows/batteries_excess_export.py
@@ -1,4 +1,10 @@
-"""Flow configuration for battery excess energy export optimization."""
+"""Config flow step for battery excess energy export optimization.
+
+Allows the user to enable or disable excess energy export from
+batteries and configure the discharge buffer percentage. The price
+threshold is auto-calculated at runtime from battery depreciation
+parameters.
+"""
 
 import voluptuous as vol
 

--- a/custom_components/hsem/flows/init.py
+++ b/custom_components/hsem/flows/init.py
@@ -1,3 +1,10 @@
+"""Config flow step for initial HSEM device setup.
+
+Handles the first step of the config flow where the user configures
+the device name, update interval, logging verbosity, extended
+attributes, and recommendation interval settings.
+"""
+
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/hsem/flows/months.py
+++ b/custom_components/hsem/flows/months.py
@@ -1,3 +1,9 @@
+"""Config flow step for selecting winter months.
+
+Allows the user to select which months are considered winter months
+for the purpose of seasonal adjustments in the planner.
+"""
+
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
@@ -13,7 +19,7 @@ def _month_options() -> list[str]:
 
 
 async def get_months_schema(config_entry: ConfigEntry | None) -> vol.Schema:
-    """Return the data schema for the 'power' step."""
+    """Return the data schema for the 'months' step."""
 
     # Stored months are integers; the multi-select selector requires string
     # option values.  Convert here so the form pre-selects the saved months.

--- a/custom_components/hsem/flows/power.py
+++ b/custom_components/hsem/flows/power.py
@@ -1,3 +1,9 @@
+"""Config flow step for power sensor selection.
+
+Allows the user to select the Home Assistant entities for house
+consumption power and solar production power.
+"""
+
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/hsem/flows/solcast.py
+++ b/custom_components/hsem/flows/solcast.py
@@ -1,3 +1,9 @@
+"""Config flow step for Solcast solar forecast configuration.
+
+Allows the user to select the Solcast forecast entities for today
+and tomorrow, as well as the PV estimate likelihood level.
+"""
+
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/hsem/flows/weighted_values.py
+++ b/custom_components/hsem/flows/weighted_values.py
@@ -1,3 +1,10 @@
+"""Config flow step for weighted consumption values.
+
+Allows the user to configure the weighting percentages for house
+consumption energy estimates over 1-day, 3-day, 7-day, and 14-day
+lookback periods.
+"""
+
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/hsem/models/battery_schedule.py
+++ b/custom_components/hsem/models/battery_schedule.py
@@ -1,9 +1,23 @@
+"""Dataclass representing a battery charge/discharge schedule window.
+
+A battery schedule defines a time window during which the battery should
+charge or discharge, along with the economic parameters that drive the
+decision (average import price and required capacity).
+"""
+
 from dataclasses import dataclass
 from datetime import time
 
 
 @dataclass
 class BatterySchedule:
+    """A single battery charge/discharge schedule window.
+
+    Holds the enabled state, time boundaries, and economic parameters
+    (average import price, needed capacity, and associated cost) for one
+    battery schedule window.
+    """
+
     enabled: bool
     start: time
     end: time

--- a/custom_components/hsem/models/hourly_recommendation.py
+++ b/custom_components/hsem/models/hourly_recommendation.py
@@ -1,4 +1,9 @@
-"""Dataclass representing a single planning slot recommendation."""
+"""Dataclass representing a single planning slot recommendation.
+
+Each :class:`HourlyRecommendation` captures the planner's decision for one
+time slot: the recommended working mode, all energy flows (consumption,
+production, battery, EV, grid), and the resulting cost estimate.
+"""
 
 from dataclasses import dataclass
 from datetime import datetime

--- a/custom_components/hsem/models/live_state.py
+++ b/custom_components/hsem/models/live_state.py
@@ -21,7 +21,12 @@ from custom_components.hsem.utils.degraded_mode import (
 
 @dataclass
 class EVLiveState:
-    """Live state snapshot for a single EV charger."""
+    """Live state snapshot for a single EV charger.
+
+    Captures the charger's current operating state (charging status, power,
+    SoC, connection state) and user-configured limits such as target SoC
+    and maximum discharge power.
+    """
 
     is_charging: bool = False
     """True when the charger reports an active charging session."""
@@ -47,7 +52,11 @@ class EVLiveState:
 
 @dataclass
 class TouPeriodsState:
-    """Live state of the Huawei TOU charging/discharging periods entity."""
+    """Live state of the Huawei TOU charging/discharging periods entity.
+
+    Captures the raw TOU period string from the inverter and the parsed
+    list of period entries used by the planner.
+    """
 
     raw_state: str | None = None
     """String state of the TOU entity (e.g. ``"active"``)."""

--- a/custom_components/hsem/models/sensor_config.py
+++ b/custom_components/hsem/models/sensor_config.py
@@ -21,7 +21,12 @@ from custom_components.hsem.const import DEFAULT_CONFIG_VALUES
 
 @dataclass
 class EVChargerConfig:
-    """Configuration for a single EV charger."""
+    """Configuration for a single EV charger.
+
+    Holds the entity IDs for the charger's status, power, SoC, and
+    connection sensors, along with behavioural flags such as whether to
+    allow charging past the target SoC and force maximum discharge power.
+    """
 
     status_entity: str | None = None
     power_entity: str | None = None
@@ -34,7 +39,12 @@ class EVChargerConfig:
 
 @dataclass
 class BatteryScheduleConfig:
-    """Configuration for one charge/discharge battery schedule window."""
+    """Configuration for one charge/discharge battery schedule window.
+
+    Defines whether the schedule window is enabled and its start/end times.
+    Used as a nested config block within :class:`SensorConfig` for up to
+    three independent battery schedule windows.
+    """
 
     enabled: bool = False
     start: time | None = None

--- a/custom_components/hsem/options_flow.py
+++ b/custom_components/hsem/options_flow.py
@@ -1,4 +1,4 @@
-"""This module defines the configuration flow for the HSEM integration in Home Assistant."""
+"""This module defines the options flow for the HSEM integration in Home Assistant."""
 
 from typing import Any
 
@@ -63,6 +63,7 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
     """Options flow for HSEM."""
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize the options flow with a reference to the config entry."""
         self._config_entry = config_entry
         self._user_input: dict[str, Any] = {}
 
@@ -76,6 +77,10 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the init options step.
+
+        Validates user input and advances to the next step in the options flow.
+        """
         errors = {}
 
         if user_input is not None:
@@ -96,6 +101,10 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
     async def async_step_prices(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the prices options step.
+
+        Validates user input and advances to the next step in the options flow.
+        """
         errors = {}
 
         if user_input is not None:
@@ -116,6 +125,10 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
     async def async_step_months(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the months options step.
+
+        Validates user input and advances to the next step in the options flow.
+        """
         errors = {}
 
         if user_input is not None:
@@ -149,6 +162,10 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
     async def async_step_solcast(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the solcast options step.
+
+        Validates user input and advances to the next step in the options flow.
+        """
         errors = {}
 
         if user_input is not None:
@@ -169,6 +186,10 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
     async def async_step_huawei_solar(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the huawei_solar options step.
+
+        Validates user input and advances to the next step in the options flow.
+        """
         errors = {}
 
         if user_input is not None:
@@ -189,6 +210,10 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
     async def async_step_battery_economics(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the battery_economics options step.
+
+        Validates user input and advances to the next step in the options flow.
+        """
         errors = {}
 
         if user_input is not None:
@@ -209,6 +234,10 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
     async def async_step_power(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the power options step.
+
+        Validates user input and advances to the next step in the options flow.
+        """
         errors = {}
 
         if user_input is not None:
@@ -229,6 +258,10 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
     async def async_step_ev(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the ev options step.
+
+        Validates user input and advances to the next step in the options flow.
+        """
         errors = {}
 
         if user_input is not None:
@@ -253,6 +286,10 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
     async def async_step_ev_second(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the ev_second options step.
+
+        Validates user input and advances to the next step in the options flow.
+        """
         errors = {}
 
         if user_input is not None:
@@ -273,6 +310,10 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
     async def async_step_ev_planned_load(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the ev_planned_load options step.
+
+        Validates user input and advances to the next step in the options flow.
+        """
         errors = {}
 
         if user_input is not None:
@@ -295,6 +336,10 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
     async def async_step_ev_second_planned_load(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the ev_second_planned_load options step.
+
+        Validates user input and advances to the next step in the options flow.
+        """
         errors = {}
 
         if user_input is not None:
@@ -315,6 +360,10 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
     async def async_step_batteries_schedules(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the batteries_schedules options step.
+
+        Validates user input and advances to the next step in the options flow.
+        """
         errors = {}
 
         if user_input is not None:
@@ -337,6 +386,10 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
     async def async_step_batteries_excess_export(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the batteries_excess_export options step.
+
+        Validates user input and advances to the next step in the options flow.
+        """
         errors = {}
 
         if user_input is not None:
@@ -359,6 +412,10 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
     async def async_step_weighted_values(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
+        """Handle the weighted_values options step.
+
+        Validates user input and advances to the next step in the options flow.
+        """
         errors = {}
 
         if user_input is not None:

--- a/custom_components/hsem/sensor.py
+++ b/custom_components/hsem/sensor.py
@@ -1,3 +1,11 @@
+"""Sensor platform for the HSEM integration.
+
+Sets up all HSEM sensor entities from a config entry, including
+diagnostic sensors, forecast accuracy, working mode, and EV charging
+sensors.  All sensors subscribe to the shared
+:class:`HSEMDataUpdateCoordinator` for periodic updates.
+"""
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback

--- a/custom_components/hsem/utils/huawei.py
+++ b/custom_components/hsem/utils/huawei.py
@@ -1,27 +1,7 @@
-"""This module provides utility functions for interacting with Huawei solar inverters
-via Home Assistant services. It includes functions to set the maximum grid export
-power percentage and to configure Time-of-Use (TOU) periods for batteries.
+"""Utility functions for interacting with Huawei solar inverters via Home Assistant services.
 
-Functions:
-    async_set_grid_export_power_pct(self, device_id, power_percentage):
-        Asynchronously sets the maximum grid export power percentage for a specified device.
-
-    async_set_grid_export_power_watt(self, device_id, power_watt):
-        Asynchronously sets the maximum grid export power in watts for a specified device.
-
-    async_set_tou_periods(self, batteries_id, tou_modes):
-        Asynchronously sets the Time-of-Use (TOU) periods for specified batteries.
-
-Dependencies:
-    - logging: For logging error and success messages.
-    - voluptuous as vol: For input validation.
-    - homeassistant.core: For Home Assistant core functionalities.
-    - homeassistant.exceptions: For Home Assistant specific exceptions.
-
-Usage:
-    These functions are designed to be used within a Home Assistant custom component
-    to interact with Huawei solar inverters. They handle service calls to the
-    "huawei_solar" integration and manage errors appropriately.
+Includes functions to set the maximum grid export power percentage and
+to configure Time-of-Use (TOU) periods for batteries.
 """
 
 from typing import Any
@@ -40,7 +20,12 @@ from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
 async def async_set_grid_export_power_pct(
     self: Any, device_id: str, power_percentage: int
 ) -> None:
-    """Set the maximum grid export power percentage and handle errors.
+    """Set the maximum grid export power percentage for a Huawei inverter.
+
+    Args:
+        self: The calling coordinator or component instance.
+        device_id: The device ID of the inverter.
+        power_percentage: The export power limit as a percentage (0-100).
 
     Raises:
         ServiceNotFound: When the huawei_solar service is not registered in HA.
@@ -160,7 +145,12 @@ async def async_set_grid_export_power_watt(
 async def async_set_tou_periods(
     self: Any, batteries_id: str, tou_modes: list[str]
 ) -> None:
-    """Set the TOU modes for the specified batteries.
+    """Set the Time-of-Use periods for the specified batteries.
+
+    Args:
+        self: The calling coordinator or component instance.
+        batteries_id: The device ID of the batteries.
+        tou_modes: A list of TOU mode strings to apply.
 
     Raises:
         ServiceNotFound: When the huawei_solar service is not registered in HA.
@@ -218,9 +208,15 @@ async def async_set_forcible_discharge(
     """Set forcible discharge for the battery at specified power and target SOC.
 
     Args:
-        device_id (str): The device ID of the battery (e.g. sensor.luna2000_xxx).
-        target_soc (int): The target SOC level to discharge to (0-100).
-        power (int): The maximum discharge power in watts.
+        self: The calling coordinator or component instance.
+        device_id: The device ID of the battery (e.g. ``sensor.luna2000_xxx``).
+        target_soc: The target SOC level to discharge to (0-100).
+        power: The maximum discharge power in watts.
+
+    Raises:
+        ValueError: If target_soc or power are out of valid range.
+        ServiceNotFound: When the huawei_solar service is not registered in HA.
+        HomeAssistantError: On any other HA-level write failure.
     """
 
     # Validate input parameters
@@ -286,7 +282,12 @@ async def async_stop_forcible_discharge(self: Any, device_id: str) -> None:
     """Stop any active forcible charge or discharge on the battery.
 
     Args:
-        device_id (str): The device ID of the battery.
+        self: The calling coordinator or component instance.
+        device_id: The device ID of the battery.
+
+    Raises:
+        ServiceNotFound: When the huawei_solar service is not registered in HA.
+        HomeAssistantError: On any other HA-level write failure.
     """
     if not self.hass.services.has_service("huawei_solar", "stop_forcible_charge"):
         raise ServiceNotFound("huawei_solar", "stop_forcible_charge")

--- a/custom_components/hsem/utils/misc.py
+++ b/custom_components/hsem/utils/misc.py
@@ -1,4 +1,8 @@
-"""This module provides utility functions for the Home Assistant custom integration."""
+"""General-purpose utility functions for the HSEM custom integration.
+
+Includes helpers for config value retrieval, type conversion, entity
+resolution, service calls, and battery power calculations.
+"""
 
 import hashlib
 from datetime import datetime, time, timedelta
@@ -31,7 +35,21 @@ def generate_hash(input_sensor: str) -> str:
 
 
 def get_config_value(config_entry: Any | None, key: str) -> Any:
-    """Get the configuration value from options or fall back to the initial data."""
+    """Get a configuration value from options, data, or defaults.
+
+    Looks up the key in the config entry's ``options`` first, then
+    ``data``, and finally falls back to ``DEFAULT_CONFIG_VALUES``.
+
+    Args:
+        config_entry: The Home Assistant config entry, or None.
+        key: The configuration key to look up.
+
+    Returns:
+        The resolved configuration value.
+
+    Raises:
+        KeyError: If the key is not present in DEFAULT_CONFIG_VALUES.
+    """
     if key not in DEFAULT_CONFIG_VALUES:
         raise KeyError(f"Key '{key}' not found in DEFAULT_VALUES")
 
@@ -52,7 +70,14 @@ def get_config_value(config_entry: Any | None, key: str) -> Any:
 
 
 def convert_to_time(time_value: str | time) -> time:
-    """Convert a time value (str or datetime.time) to a datetime.time object."""
+    """Convert a string or ``datetime.time`` to a ``datetime.time`` object.
+
+    Args:
+        time_value: A time string in ``HH:MM:SS`` format or a ``datetime.time``.
+
+    Returns:
+        The converted ``datetime.time`` object.
+    """
     if isinstance(time_value, time):
         return time_value
 
@@ -218,7 +243,17 @@ def convert_months_to_int(months: list) -> list[int]:
 
 
 def convert_to_boolean(state: Any) -> bool:
-    """Resolve the input sensor state and cast it to a boolean."""
+    """Resolve an input sensor state and cast it to a boolean.
+
+    Handles booleans, integers, and a wide range of string values
+    (``"on"``, ``"off"``, ``"charging"``, ``"connected"``, etc.).
+
+    Args:
+        state: The raw sensor state value.
+
+    Returns:
+        The resolved boolean value.  Returns False for unrecognised inputs.
+    """
 
     if state is None:
         return False
@@ -286,11 +321,18 @@ def clamp_efficiency(pct: float) -> float:
 async def async_resolve_entity_id_from_unique_id(
     self: Any, unique_entity_id: str, domain: str = "sensor"
 ) -> str | None:
-    """Resolve the entity_id from the unique_id using the entity registry.
+    """Resolve an entity_id from a unique_id using the entity registry.
 
-    :param unique_entity_id: Unique ID of the entity to resolve.
-    :param domain: The domain of the entity (e.g., 'sensor').
-    :return: The resolved entity_id or None if not found.
+    Results are cached per (domain, unique_id) pair to avoid repeated
+    registry lookups.
+
+    Args:
+        self: The calling coordinator or component instance.
+        unique_entity_id: The unique ID of the entity to resolve.
+        domain: The Home Assistant domain (e.g. ``"sensor"``).
+
+    Returns:
+        The resolved entity_id, or None if not found.
     """
 
     global _entity_id_from_unique_id_cache
@@ -328,12 +370,16 @@ async def async_resolve_entity_id_from_unique_id(
 
 
 async def async_set_number_value(self: Any, entity_id: str, value: float | int) -> None:
-    """Set the value for a number entity.
+    """Set the value of a Home Assistant number entity.
 
-    Parameters:
-    - entity_id (str): The entity_id of the number entity.
-    - value (float|int): The value to set.
+    Args:
+        self: The calling coordinator or component instance.
+        entity_id: The entity_id of the number entity.
+        value: The numeric value to set.
 
+    Raises:
+        ServiceNotFound: If the ``number.set_value`` service is not registered.
+        HomeAssistantError: On any other HA-level write failure.
     """
     entity = self.hass.states.get(entity_id)
 
@@ -362,7 +408,17 @@ async def async_set_number_value(self: Any, entity_id: str, value: float | int) 
 
 
 async def async_set_select_option(self: Any, entity_id: str, option: str) -> None:
-    """Set the selected option for an entity."""
+    """Set the selected option of a Home Assistant select entity.
+
+    Args:
+        self: The calling coordinator or component instance.
+        entity_id: The entity_id of the select entity.
+        option: The option value to select.
+
+    Raises:
+        ServiceNotFound: If the ``select.select_option`` service is not registered.
+        HomeAssistantError: On any other HA-level write failure.
+    """
 
     # Check if entity_id exists
     entity = self.hass.states.get(entity_id)
@@ -398,7 +454,22 @@ def ha_get_entity_state_and_convert(
     output_type: str | None = None,
     float_precision: int = 2,
 ) -> float | int | bool | str | None:
-    """Get the state of an entity."""
+    """Get an entity's state and convert it to the requested type.
+
+    Args:
+        self: The calling coordinator or component instance.
+        entity_id: The entity_id to query, or None.
+        output_type: The desired output type (``"float"``, ``"int"``,
+            ``"boolean"``, ``"string"``, or None for the raw state object).
+        float_precision: Number of decimal places when output_type is ``"float"``.
+
+    Returns:
+        The converted state value, or None if the entity is unavailable.
+
+    Raises:
+        EntityNotFoundError: If the entity is not found or state is unknown.
+        HomeAssistantError: If conversion fails.
+    """
 
     if entity_id is None:
         return None
@@ -449,9 +520,14 @@ def ha_get_entity_state_and_convert(
 
 
 async def async_remove_entity_from_ha(self: Any, entity_unique_id: str) -> bool:
-    """Remove an existing entity in Home Assistant based on its unique ID.
+    """Remove an entity from Home Assistant by its unique ID.
 
-    :param entity_unique_id: The unique ID of the entity to be removed.
+    Args:
+        self: The calling coordinator or component instance.
+        entity_unique_id: The unique ID of the entity to remove.
+
+    Returns:
+        True if the entity was found and removed, False otherwise.
     """
     # Check if the entity exists
     entity_exists = await async_resolve_entity_id_from_unique_id(self, entity_unique_id)
@@ -476,19 +552,43 @@ async def async_remove_entity_from_ha(self: Any, entity_unique_id: str) -> bool:
 
 
 async def async_entity_exists(hass: Any, entity_id: str) -> bool:
-    """Check if an entity exists in Home Assistant."""
+    """Check whether an entity exists in Home Assistant.
+
+    Args:
+        hass: The Home Assistant core instance.
+        entity_id: The entity_id to check.
+
+    Returns:
+        True if the entity exists, False otherwise.
+    """
     return hass.states.get(entity_id) is not None
 
 
 async def async_device_exists(hass: Any, device_id: str) -> bool:
-    """Check if a device exists in Home Assistant."""
+    """Check whether a device exists in Home Assistant.
+
+    Args:
+        hass: The Home Assistant core instance.
+        device_id: The device ID to check.
+
+    Returns:
+        True if the device exists, False otherwise.
+    """
     device_registry = dr.async_get(hass)
     return device_registry.async_get(device_id) is not None
 
 
 def get_max_discharge_power(usable_capacity: int) -> int:
-    """Return max discharge power in WATT based on Huawei batteries max rated capacity.
+    """Return the maximum discharge power in watts for a Huawei battery.
+
     Supports both old (S0: 5/10/15 kWh) and new (S1: 7/14/21 kWh) series.
+
+    Args:
+        usable_capacity: The usable battery capacity in watt-hours.
+
+    Returns:
+        The maximum discharge power in watts.  Defaults to 2500 W for
+        unknown capacities.
     """
     mapping = {
         # Old batteries (S0)

--- a/custom_components/hsem/utils/sensornames.py
+++ b/custom_components/hsem/utils/sensornames.py
@@ -1,3 +1,10 @@
+"""Sensor name, unique ID, and entity ID generators for HSEM entities.
+
+Each entity type has a family of getter functions that return the
+configuration key, display name, unique ID, and Home Assistant entity ID
+for use in config flow, entity registration, and state collection.
+"""
+
 from homeassistant.components import number, select, sensor, switch, time
 from homeassistant.util import slugify as s
 
@@ -896,34 +903,42 @@ def get_ev_second_force_charge_now_switch_entity_id() -> str:
 
 
 def get_ev_deadline_time_key() -> str:
+    """Return the config key for the EV charge deadline time entity."""
     return f"{DOMAIN}_ev_deadline_time"
 
 
 def get_ev_deadline_time_name() -> str:
+    """Return the display name for the EV charge deadline time entity."""
     return "EV Charge Deadline"
 
 
 def get_ev_deadline_time_unique_id() -> str:
+    """Return the unique ID for the EV charge deadline time entity."""
     return f"{DOMAIN}_{get_ev_deadline_time_key()}_time"
 
 
 def get_ev_deadline_time_entity_id() -> str:
+    """Return the Home Assistant entity ID for the EV charge deadline time entity."""
     return time.ENTITY_ID_FORMAT.format(s(get_ev_deadline_time_unique_id()))
 
 
 def get_ev_second_deadline_time_key() -> str:
+    """Return the config key for the second EV charge deadline time entity."""
     return f"{DOMAIN}_ev_second_deadline_time"
 
 
 def get_ev_second_deadline_time_name() -> str:
+    """Return the display name for the second EV charge deadline time entity."""
     return "EV 2 Charge Deadline"
 
 
 def get_ev_second_deadline_time_unique_id() -> str:
+    """Return the unique ID for the second EV charge deadline time entity."""
     return f"{DOMAIN}_{get_ev_second_deadline_time_key()}_time"
 
 
 def get_ev_second_deadline_time_entity_id() -> str:
+    """Return the Home Assistant entity ID for the second EV charge deadline time entity."""
     return time.ENTITY_ID_FORMAT.format(s(get_ev_second_deadline_time_unique_id()))
 
 

--- a/custom_components/hsem/utils/workingmodes.py
+++ b/custom_components/hsem/utils/workingmodes.py
@@ -1,14 +1,19 @@
-"""This module defines the `WorkingModes` enumeration for different working modes.
+"""Working mode enumeration for Huawei Luna2000 inverters.
 
-Classes:
-    WorkingModes (Enum): An enumeration representing various working modes.
-
+Defines the three inverter operating modes that HSEM can switch between.
 """
 
 from enum import Enum
 
 
 class WorkingModes(Enum):
+    """Huawei Luna2000 inverter working modes."""
+
     TimeOfUse = "time_of_use_luna2000"
+    """Time-of-Use mode: battery charges/discharges according to a TOU schedule."""
+
     MaximizeSelfConsumption = "maximise_self_consumption"
+    """Maximise self-consumption: battery prioritises powering the home over export."""
+
     FullyFedToGrid = "fully_fed_to_grid"
+    """Fully fed to grid: all solar production is exported to the grid."""


### PR DESCRIPTION
## Summary

Completes the last remaining item in Section 2 (Style Guidelines) of issue #491: adding Home Assistant convention docstrings to all remaining modules.

## What Changed

### Module docstrings added (6 files)
- `flows/init.py`, `flows/months.py`, `flows/power.py`, `flows/solcast.py`, `flows/weighted_values.py`, `sensor.py`

### Module docstrings upgraded to HA format (3 files)
- `utils/huawei.py` — replaced verbose multi-section docstring with concise summary
- `flows/batteries_excess_export.py` — expanded single-line to multi-line
- `models/hourly_recommendation.py` — expanded single-line to multi-line

### Class docstrings added/upgraded (8 files)
- `models/battery_schedule.py` — `BatterySchedule` class and field docstrings
- `models/live_state.py` — `TouPeriodsState` expanded
- `models/sensor_config.py` — `EVChargerConfig`, `BatteryScheduleConfig` expanded
- `utils/misc.py` — 9 public functions upgraded from bare one-liners to Args/Returns format
- `utils/sensornames.py` — 8 EV deadline time functions
- `utils/workingmodes.py` — `WorkingModes` class docstring

### Method docstrings added (30 methods)
- `config_flow.py` — 14 `async_step_*` methods
- `options_flow.py` — 14 `async_step_*` methods + `__init__`
- `__init__.py` — `async_setup_entry`

### Bug fixes
- `options_flow.py` module docstring said "configuration flow" → corrected to "options flow"
- `flows/months.py` `get_months_schema` docstring said "'power' step" → corrected to "'months' step"

## Files Changed

18 files, 385 insertions, 61 deletions — **docstring-only, zero logic changes**

## Quality Gates

| Gate | Result |
|------|--------|
| `tox -e lint` (isort + black + ruff) | ✅ PASS |
| `tox -e typing` (mypy) | ✅ PASS — 0 issues |
| `tox -e quality` (pyright + vulture) | ✅ PASS — 0 errors |
| `tox -e py313` (pytest) | ⚠️ Pre-existing `bcrypt` PyO3 import error on Windows; unrelated to docstrings |

Fixes #491