### PR TITLE
chore(audit): verify unload handling and services lifecycle

### DIFF
--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -267,6 +267,12 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
 
         Called from :func:`~custom_components.hsem.__init__.async_unload_entry`.
         """
+        # Cancel the base DataUpdateCoordinator's internal refresh timer
+        # (set to 24 h as a fallback).  Without this the timer holds a
+        # reference to the coordinator and prevents garbage collection.
+        unsub_refresh = getattr(self, "_unsub_refresh", None)
+        if unsub_refresh is not None:
+            unsub_refresh()
         if self._hourly_timer_unsub is not None:
             self._hourly_timer_unsub()
             self._hourly_timer_unsub = None


### PR DESCRIPTION
## Summary

This PR audits and fixes HSEM's compliance with two Home Assistant development guideline checklist items:

- **Unload handling** — verifies all resources created during `async_setup_entry` are properly cleaned up in `async_unload_entry`
- **Services lifecycle** — verifies services are registered/unregistered at the correct lifecycle points

## Part E — Unload Handling

### Resources created during setup

| Resource | Created in | Cleaned up in |
|---|---|---|
| `async_track_time_change` (hourly) | `coordinator.async_setup()` | `coordinator.async_teardown()` |
| `async_track_time_interval` (configurable) | `coordinator._register_interval_timer()` | `coordinator.async_teardown()` |
| `async_track_state_change_event` listeners | `state_collector._register_listeners()` | `coordinator.async_teardown()` via `_listener_unsubs` |
| `async_track_time_interval` (avg sensor) | `HSEMAvgSensor.async_added_to_hass()` | `HSEMAvgSensor.async_will_remove_from_hass()` |
| `async_track_state_change_event` (avg sensor) | `HSEMAvgSensor._async_track_entities()` | `HSEMAvgSensor.async_will_remove_from_hass()` |
| `async_track_state_change_event` (house consumption) | `HSEMHouseConsumptionPowerSensor._async_track_entities()` | `HSEMHouseConsumptionPowerSensor.async_will_remove_from_hass()` |
| `hass.async_create_task` (working mode) | `HSEMWorkingModeSensor._handle_coordinator_update()` | `HSEMWorkingModeSensor.async_will_remove_from_hass()` |
| `hass.data[DOMAIN][entry.entry_id]` | `async_setup_entry()` | `async_unload_entry()` via `hass.data[DOMAIN].pop()` |
| `hass.config_entries.async_forward_entry_setups()` | `async_setup_entry()` | `async_unload_entry()` via `async_unload_platforms()` |
| `entry.add_update_listener()` | `async_setup_entry()` | Auto-cleaned by `entry.async_on_unload()` |
| HSEM log file handler | `async_init_hsem_logger()` | `async_close_hsem_logger()` |
| `DataUpdateCoordinator._unsub_refresh` (base class) | `super().__init__()` | **FIXED** — now cancelled in `async_teardown()` |

### Gap found and fixed

- **`DataUpdateCoordinator._unsub_refresh`** — The base class creates an internal refresh timer (set to 24 h as fallback). This timer was never explicitly cancelled, holding a reference to the coordinator and preventing garbage collection. Fixed by adding cancellation in `async_teardown()`.

## Part F — Services Lifecycle

### Services registered

| Service | Schema | Handler |
|---|---|---|
| `hsem.force_recalculation` | `vol.Schema({})` | `async_handle_force_recalculation` |
| `hsem.set_temporary_override` | `vol.Schema({...})` | `async_handle_set_temporary_override` |
| `hsem.clear_override` | `vol.Schema({})` | `async_handle_clear_override` |
| `hsem.export_diagnostics` | `vol.Schema({})` | `async_handle_export_diagnostics` |

### Lifecycle verification

- **Register**: Services registered in `async_setup_entry` via `async_register_services()` — correct
- **Unregister**: Services removed in `async_unload_entry` via `async_unregister_services()` — correct
- **Handlers**: All handlers are async, handle errors gracefully with `HomeAssistantError` — correct
- **Schema**: All services have `voluptuous` schemas for input validation — correct

### No gaps found

## Files changed

- `custom_components/hsem/coordinator.py` — Added `_unsub_refresh` cancellation in `async_teardown()`

## Quality gates

- `tox -e lint` — PASS
- `tox -e typing` — PASS
- `tox -e quality` — PASS (23 pre-existing warnings, 0 new)
- `tox -e py313` — FAIL (pre-existing `bcrypt` PyO3 incompatibility with Python 3.13 on Windows; confirmed on main)