### PR TITLE
chore(audit): verify async patterns and config flow lifecycle

### DIFF
--- a/custom_components/hsem/custom_sensors/working_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/working_mode_sensor.py
@@ -345,7 +345,8 @@ class HSEMWorkingModeSensor(HSEMCoordinatorEntity, SensorEntity, HSEMEntity):
         This method runs asynchronously after every coordinator refresh.
         A ``CancelledError`` is re-raised immediately so that asyncio can
         clean up the task correctly; no hardware write can occur after
-        cancellation.
+        cancellation.  Other exceptions are logged so that hardware-write
+        failures are visible in the HA log.
         """
         try:
             data = self.coordinator.data
@@ -357,6 +358,12 @@ class HSEMWorkingModeSensor(HSEMCoordinatorEntity, SensorEntity, HSEMEntity):
         except asyncio.CancelledError:
             # Task was cancelled (entity unloaded) — propagate cleanly.
             raise
+        except Exception:
+            await async_logger(
+                self,
+                "Hardware-write task failed during coordinator update",
+                level="error",
+            )
 
     async def _async_apply_hardware_writes(self, data: CoordinatorData) -> None:
         """Perform inverter and battery hardware writes for the current slot.


### PR DESCRIPTION
## Summary

Audit of HSEM against Home Assistant development guidelines Section 1 checklist items:

- **All HA event loop calls use correct async patterns**
- **Config flow uses ConfigFlow/OptionsFlow pattern correctly and respects HA's lifecycle**

---

### Part G — Async Patterns

**`async_create_task` calls found:** 1 (`working_mode_sensor.py:337`)

| Check | Status |
|---|---|
| Error handling | ✅ Fixed — added `except Exception` with `async_logger` to prevent silent failures |
| Cancellation | ✅ Task stored in `_update_task`, cancelled in `async_will_remove_from_hass` |
| Not fire-and-forget | ✅ Task reference stored for lifecycle management |
| No bare except | ✅ `CancelledError` re-raised; other exceptions now logged |

**Blocking calls in async context:** 0 found. All `logger.py` I/O uses `run_in_executor` correctly.

**Missing await:** 0 found.

**Manual event loop access:** Only in `logger.py` for `run_in_executor` offloading — correct pattern.

**Async method naming:** All public async methods use `async_` prefix. Private methods (`_set_update_interval`, `_register_interval_timer`, `_resolve_cached`, `_register_listeners`, `_persist_state`, `_persist_value`) are internal helpers — no change needed.

### Part H — ConfigFlow/OptionsFlow Lifecycle

| Check | Status |
|---|---|
| Inherits from `ConfigFlow` with `domain=DOMAIN` | ✅ |
| `VERSION = 2` set | ✅ |
| `async_step_user` entry point | ✅ |
| `async_migrate_entry` present | ✅ |
| Unique ID handling with `_abort_if_unique_id_configured` | ✅ |
| No state leaks — fresh `_user_input` per instance | ✅ |
| Every step returns proper dict | ✅ |
| Steps route via `return await self.async_step_xxx()` | ✅ |
| Input validated before saving | ✅ |
| OptionsFlow inherits from `OptionsFlow` | ✅ |
| OptionsFlow pre-fills defaults from config entry | ✅ |
| `async_step_init` entry point | ✅ |

### Files Changed

- `custom_components/hsem/custom_sensors/working_mode_sensor.py` — Added exception logging to `_async_on_coordinator_update` to prevent silent hardware-write failures

### Quality Gates

| Check | Result |
|---|---|
| `tox -e lint` | ✅ Passed |
| `tox -e typing` | ✅ Passed |
| `tox -e quality` | ✅ Passed (0 errors, 23 pre-existing warnings) |
| `tox -e py313` | ❌ Pre-existing `bcrypt` PyO3/CPython 3.13 incompatibility (unrelated to this change) |
