### PR TITLE
chore: add @override decorator to all entity override methods

### DIFF
--- a/custom_components/hsem/custom_numbers/battery_efficiency.py
+++ b/custom_components/hsem/custom_numbers/battery_efficiency.py
@@ -11,6 +11,8 @@ HA restarts.
 
 from __future__ import annotations
 
+from typing import override
+
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE, EntityCategory
@@ -81,6 +83,7 @@ class HSEMBatteryEfficiencyNumber(NumberEntity, HSEMEntity):
         stored = convert_to_float(get_config_value(config_entry, config_key))
         self._attr_native_value = stored if stored is not None else default
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Handle the user setting a new value.
 

--- a/custom_components/hsem/custom_numbers/ev_target_soc.py
+++ b/custom_components/hsem/custom_numbers/ev_target_soc.py
@@ -11,6 +11,8 @@ HA restarts.
 
 from __future__ import annotations
 
+from typing import override
+
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE, EntityCategory
@@ -81,6 +83,7 @@ class HSEMEVTargetSocNumber(NumberEntity, HSEMEntity):
         stored = convert_to_float(get_config_value(config_entry, config_key))
         self._attr_native_value = stored if stored is not None else default
 
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Handle the user setting a new value.
 

--- a/custom_components/hsem/custom_selectors/solcast_likelihood.py
+++ b/custom_components/hsem/custom_selectors/solcast_likelihood.py
@@ -9,6 +9,8 @@ The selected value is persisted to the config entry options so it survives
 HA restarts.
 """
 
+from typing import override
+
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
@@ -71,6 +73,7 @@ class HSEMSolcastLikelihoodSelector(SelectEntity, HSEMEntity):
         stored = get_config_value(config_entry, _CONFIG_KEY)
         self._attr_current_option = str(stored) if stored in _OPTIONS else _DEFAULT
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Handle the user selecting a new option.
 

--- a/custom_components/hsem/custom_selectors/working_mode.py
+++ b/custom_components/hsem/custom_selectors/working_mode.py
@@ -5,6 +5,8 @@ This module defines :class:`HSEMWorkingModeSelector`, a standard
 specific working mode or leave it on ``"auto"``.
 """
 
+from typing import override
+
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
@@ -69,6 +71,7 @@ class HSEMWorkingModeSelector(SelectEntity, HSEMEntity):
         # leave _attr_name unset so the translation system can
         # resolve the name via entity_description.translation_key.
 
+    @override
     async def async_select_option(self, option: str) -> None:
         """Handle the user selecting a new option.
 

--- a/custom_components/hsem/custom_sensors/applier_status_sensor.py
+++ b/custom_components/hsem/custom_sensors/applier_status_sensor.py
@@ -29,7 +29,7 @@ working-mode sensor mutates :attr:`CoordinatorData.apply_summary`.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -104,16 +104,19 @@ class HSEMApplierStatusSensor(
     # ------------------------------------------------------------------
 
     @property
+    @override
     def name(self) -> str:
         """Return the display name."""
         return self._name
 
     @property
+    @override
     def unique_id(self) -> str | None:
         """Return the unique ID."""
         return self._attr_unique_id
 
     @property  # type: ignore[misc]  # HA stub declares state as @final
+    @override
     def state(self) -> str:
         """Return the worst-case apply status for the last cycle.
 
@@ -126,11 +129,13 @@ class HSEMApplierStatusSensor(
         return data.apply_summary.overall_status.value
 
     @property
+    @override
     def should_poll(self) -> bool:
         """No polling — driven by the coordinator."""
         return False
 
     @property
+    @override
     def available(self) -> bool:
         """True once the coordinator has completed at least one successful cycle."""
         return (
@@ -138,6 +143,7 @@ class HSEMApplierStatusSensor(
         ) or self._restored_state is not None
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return per-entity write results and aggregated failure lists."""
         data: CoordinatorData | None = self.coordinator.data
@@ -172,6 +178,7 @@ class HSEMApplierStatusSensor(
     # HA lifecycle
     # ------------------------------------------------------------------
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore previous state and register coordinator listener."""
         await super().async_added_to_hass()

--- a/custom_components/hsem/custom_sensors/avg_sensor.py
+++ b/custom_components/hsem/custom_sensors/avg_sensor.py
@@ -11,7 +11,7 @@ hour block and average period (1, 3, 7, or 14 days).
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Any, override
 
 import homeassistant.util.dt as dt_util
 from homeassistant.components.sensor import SensorEntity
@@ -81,6 +81,7 @@ class HSEMAvgSensor(RestoreEntity, SensorEntity, HSEMEntity):
         self._unsub_callbacks: list = []
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes."""
         return {
@@ -94,30 +95,37 @@ class HSEMAvgSensor(RestoreEntity, SensorEntity, HSEMEntity):
         }
 
     @property  # type: ignore[misc]  # HA stub declares state as @final
+    @override
     def state(self) -> float | None:
         return self._state
 
     @property  # type: ignore[misc]  # HA stub declares unit_of_measurement as @final
+    @override
     def unit_of_measurement(self) -> str:
         return UnitOfEnergy.KILO_WATT_HOUR
 
     @property
+    @override
     def state_class(self) -> SensorStateClass:
         return SensorStateClass.MEASUREMENT
 
     @property
+    @override
     def device_class(self) -> SensorDeviceClass:
         return SensorDeviceClass.ENERGY
 
     @property
+    @override
     def unique_id(self) -> str | None:
         return self._attr_unique_id
 
     @property
+    @override
     def name(self) -> str:
         return self._name
 
     @property
+    @override
     def should_poll(self) -> bool:
         return True
 
@@ -138,6 +146,7 @@ class HSEMAvgSensor(RestoreEntity, SensorEntity, HSEMEntity):
         date_part = date_str.split("T")[0] if "T" in date_str else date_str
         return datetime.strptime(date_part, "%Y-%m-%d").date().isoformat()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Handle when sensor is added to Home Assistant."""
 
@@ -169,6 +178,7 @@ class HSEMAvgSensor(RestoreEntity, SensorEntity, HSEMEntity):
 
         await super().async_added_to_hass()
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Cancel all tracked listeners when the entity is removed."""
         for unsub in self._unsub_callbacks:

--- a/custom_components/hsem/custom_sensors/battery_soc_sensor.py
+++ b/custom_components/hsem/custom_sensors/battery_soc_sensor.py
@@ -17,7 +17,7 @@ and updates automatically after every coordinator cycle.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.sensor.const import SensorDeviceClass
@@ -91,16 +91,19 @@ class HSEMBatterySoCSensor(
     # ------------------------------------------------------------------
 
     @property
+    @override
     def name(self) -> str:
         """Return the display name."""
         return self._name
 
     @property
+    @override
     def unique_id(self) -> str | None:
         """Return the unique ID."""
         return self._attr_unique_id
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return the battery SoC percentage from the last cycle."""
         data: CoordinatorData | None = self.coordinator.data
@@ -114,11 +117,13 @@ class HSEMBatterySoCSensor(
         return data.live.huawei_batteries_soc_pct
 
     @property
+    @override
     def should_poll(self) -> bool:
         """No polling — driven by the coordinator."""
         return False
 
     @property
+    @override
     def available(self) -> bool:
         """True once the coordinator has completed at least one successful cycle."""
         return (
@@ -126,6 +131,7 @@ class HSEMBatterySoCSensor(
         ) or self._restored_state is not None
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return battery capacity context."""
         data: CoordinatorData | None = self.coordinator.data
@@ -148,6 +154,7 @@ class HSEMBatterySoCSensor(
     # HA lifecycle
     # ------------------------------------------------------------------
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore previous state and register coordinator listener."""
         await super().async_added_to_hass()

--- a/custom_components/hsem/custom_sensors/degraded_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/degraded_mode_sensor.py
@@ -28,7 +28,7 @@ polling or push from the working-mode sensor.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -99,16 +99,19 @@ class HSEMDegradedModeSensor(
     # ------------------------------------------------------------------
 
     @property
+    @override
     def name(self) -> str:
         """Return the display name."""
         return self._name
 
     @property
+    @override
     def unique_id(self) -> str | None:
         """Return the unique ID."""
         return self._attr_unique_id
 
     @property  # type: ignore[misc]  # HA stub declares state as @final
+    @override
     def state(self) -> str:
         """Return the current health state string."""
         data: CoordinatorData | None = self.coordinator.data
@@ -118,11 +121,13 @@ class HSEMDegradedModeSensor(
         return data.live.degraded_mode.value
 
     @property
+    @override
     def should_poll(self) -> bool:
         """No polling — driven by the coordinator."""
         return False
 
     @property
+    @override
     def available(self) -> bool:
         """True once the coordinator has completed at least one successful cycle."""
         return (
@@ -130,6 +135,7 @@ class HSEMDegradedModeSensor(
         ) or self._restored_state is not None
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return diagnostic attributes visible on the entity detail page.
 
@@ -185,6 +191,7 @@ class HSEMDegradedModeSensor(
     # HA lifecycle
     # ------------------------------------------------------------------
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore previous state and register coordinator listener."""
         await super().async_added_to_hass()

--- a/custom_components/hsem/custom_sensors/ev_charging_sensor.py
+++ b/custom_components/hsem/custom_sensors/ev_charging_sensor.py
@@ -17,7 +17,7 @@ and updates automatically after every coordinator cycle.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -84,16 +84,19 @@ class HSEMEVChargingSensor(
     # ------------------------------------------------------------------
 
     @property
+    @override
     def name(self) -> str:
         """Return the display name."""
         return self._name
 
     @property
+    @override
     def unique_id(self) -> str | None:
         """Return the unique ID."""
         return self._attr_unique_id
 
     @property  # type: ignore[misc]  # HA stub declares state as @final
+    @override
     def state(self) -> str:
         """Return ``'on'`` when any EV charger is active, ``'off'`` otherwise."""
         data: CoordinatorData | None = self.coordinator.data
@@ -102,11 +105,13 @@ class HSEMEVChargingSensor(
         return STATE_ON if data.live.any_ev_charging else STATE_OFF
 
     @property
+    @override
     def should_poll(self) -> bool:
         """No polling — driven by the coordinator."""
         return False
 
     @property
+    @override
     def available(self) -> bool:
         """True once the coordinator has completed at least one successful cycle."""
         return (
@@ -114,6 +119,7 @@ class HSEMEVChargingSensor(
         ) or self._restored_state is not None
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return individual charger states."""
         data: CoordinatorData | None = self.coordinator.data
@@ -145,6 +151,7 @@ class HSEMEVChargingSensor(
     # HA lifecycle
     # ------------------------------------------------------------------
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore previous state and register coordinator listener."""
         await super().async_added_to_hass()

--- a/custom_components/hsem/custom_sensors/ev_optimal_charging_plan_sensor.py
+++ b/custom_components/hsem/custom_sensors/ev_optimal_charging_plan_sensor.py
@@ -23,7 +23,7 @@ appears in the *Diagnostic* section of the device page.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -93,16 +93,19 @@ class HSEMEVOptimalChargingPlanSensor(
     # ------------------------------------------------------------------
 
     @property
+    @override
     def name(self) -> str:
         """Return the display name."""
         return self._name
 
     @property
+    @override
     def unique_id(self) -> str | None:
         """Return the unique ID."""
         return self._attr_unique_id
 
     @property  # type: ignore[misc]  # HA stub declares state as @final
+    @override
     def state(self) -> str:
         """Return the current EV charging plan state."""
         data: CoordinatorData | None = self.coordinator.data
@@ -115,6 +118,7 @@ class HSEMEVOptimalChargingPlanSensor(
         return state if state in _VALID_STATES else STATE_UNAVAILABLE
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return EV charging plan attributes."""
         data: CoordinatorData | None = self.coordinator.data
@@ -123,6 +127,7 @@ class HSEMEVOptimalChargingPlanSensor(
         return data.ev_charging_plan.as_attributes()
 
     @property
+    @override
     def available(self) -> bool:
         """Return True when the coordinator has data."""
         return self.coordinator.data is not None
@@ -131,6 +136,7 @@ class HSEMEVOptimalChargingPlanSensor(
     # State restore
     # ------------------------------------------------------------------
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore previous state on startup."""
         await super().async_added_to_hass()

--- a/custom_components/hsem/custom_sensors/ev_second_optimal_charging_plan_sensor.py
+++ b/custom_components/hsem/custom_sensors/ev_second_optimal_charging_plan_sensor.py
@@ -8,7 +8,7 @@ See :mod:`ev_optimal_charging_plan_sensor` for full documentation.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -65,16 +65,19 @@ class HSEMEVSecondOptimalChargingPlanSensor(
         self._restored_state: str | None = None
 
     @property
+    @override
     def name(self) -> str:
         """Return the display name."""
         return self._name
 
     @property
+    @override
     def unique_id(self) -> str | None:
         """Return the unique ID."""
         return self._attr_unique_id
 
     @property  # type: ignore[misc]  # HA stub declares state as @final
+    @override
     def state(self) -> str:
         """Return the current second EV charging plan state."""
         data: CoordinatorData | None = self.coordinator.data
@@ -87,6 +90,7 @@ class HSEMEVSecondOptimalChargingPlanSensor(
         return state if state in _VALID_STATES else STATE_UNAVAILABLE
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return second EV charging plan attributes."""
         data: CoordinatorData | None = self.coordinator.data
@@ -95,10 +99,12 @@ class HSEMEVSecondOptimalChargingPlanSensor(
         return data.ev_second_charging_plan.as_attributes()
 
     @property
+    @override
     def available(self) -> bool:
         """Return True when the coordinator has data."""
         return self.coordinator.data is not None
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore previous state on startup."""
         await super().async_added_to_hass()

--- a/custom_components/hsem/custom_sensors/force_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/force_mode_sensor.py
@@ -19,7 +19,7 @@ and updates automatically after every coordinator cycle.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -84,16 +84,19 @@ class HSEMForceModeSensor(
     # ------------------------------------------------------------------
 
     @property
+    @override
     def name(self) -> str:
         """Return the display name."""
         return self._name
 
     @property
+    @override
     def unique_id(self) -> str | None:
         """Return the unique ID."""
         return self._attr_unique_id
 
     @property  # type: ignore[misc]  # HA stub declares state as @final
+    @override
     def state(self) -> str:
         """Return the force-mode select value (``'auto'`` when not overriding)."""
         data: CoordinatorData | None = self.coordinator.data
@@ -102,11 +105,13 @@ class HSEMForceModeSensor(
         return data.live.force_working_mode_state
 
     @property
+    @override
     def should_poll(self) -> bool:
         """No polling — driven by the coordinator."""
         return False
 
     @property
+    @override
     def available(self) -> bool:
         """True once the coordinator has completed at least one successful cycle."""
         return (
@@ -114,6 +119,7 @@ class HSEMForceModeSensor(
         ) or self._restored_state is not None
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the override state, expiry, and resolved entity ID."""
         data: CoordinatorData | None = self.coordinator.data
@@ -134,6 +140,7 @@ class HSEMForceModeSensor(
     # HA lifecycle
     # ------------------------------------------------------------------
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore previous state and register coordinator listener."""
         await super().async_added_to_hass()

--- a/custom_components/hsem/custom_sensors/forecast_accuracy_sensor.py
+++ b/custom_components/hsem/custom_sensors/forecast_accuracy_sensor.py
@@ -24,7 +24,7 @@ The sensor is a *diagnostic* entity (``EntityCategory.DIAGNOSTIC``).
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any, cast, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -78,6 +78,7 @@ class HSEMForecastAccuracySensor(
         self.entity_id = get_forecast_accuracy_sensor_entity_id()
 
     @property
+    @override
     def native_value(self) -> str | float | None:
         """Return the sensor state.
 
@@ -96,6 +97,7 @@ class HSEMForecastAccuracySensor(
         return cast(float, round(summary.mae_pv_kwh, 3))
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return diagnostic attributes for the sensor.
 
@@ -138,6 +140,7 @@ class HSEMForecastAccuracySensor(
         return cast(dict[str, Any], attrs)
 
     @property
+    @override
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit of measurement."""
         return UnitOfEnergy.KILO_WATT_HOUR
@@ -146,6 +149,7 @@ class HSEMForecastAccuracySensor(
     # HA lifecycle — reboot persistence
     # ------------------------------------------------------------------
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore forecast tracker data from the previous HA session."""
         await super().async_added_to_hass()

--- a/custom_components/hsem/custom_sensors/hardware_writes_sensor.py
+++ b/custom_components/hsem/custom_sensors/hardware_writes_sensor.py
@@ -19,7 +19,7 @@ and updates automatically after every coordinator cycle.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -89,16 +89,19 @@ class HSEMHardwareWritesSensor(
     # ------------------------------------------------------------------
 
     @property
+    @override
     def name(self) -> str:
         """Return the display name."""
         return self._name
 
     @property
+    @override
     def unique_id(self) -> str | None:
         """Return the unique ID."""
         return self._attr_unique_id
 
     @property  # type: ignore[misc]  # HA stub declares state as @final
+    @override
     def state(self) -> str:
         """Return ``'allowed'`` or ``'blocked'`` based on degraded-mode state."""
         data: CoordinatorData | None = self.coordinator.data
@@ -109,11 +112,13 @@ class HSEMHardwareWritesSensor(
         )
 
     @property
+    @override
     def should_poll(self) -> bool:
         """No polling — driven by the coordinator."""
         return False
 
     @property
+    @override
     def available(self) -> bool:
         """True once the coordinator has completed at least one successful cycle."""
         return (
@@ -121,6 +126,7 @@ class HSEMHardwareWritesSensor(
         ) or self._restored_state is not None
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return details about why writes are blocked (if applicable).
 
@@ -152,6 +158,7 @@ class HSEMHardwareWritesSensor(
     # HA lifecycle
     # ------------------------------------------------------------------
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore previous state and register coordinator listener."""
         await super().async_added_to_hass()

--- a/custom_components/hsem/custom_sensors/house_consumption_power_sensor.py
+++ b/custom_components/hsem/custom_sensors/house_consumption_power_sensor.py
@@ -14,7 +14,7 @@ These derived sensors feed the planner's house-consumption estimates.
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -137,26 +137,32 @@ class HSEMHouseConsumptionPowerSensor(RestoreEntity, SensorEntity, HSEMEntity):
         self._update_settings()
 
     @property
+    @override
     def name(self) -> str:
         return self._name
 
     @property
+    @override
     def unique_id(self) -> str | None:
         return self._attr_unique_id
 
     @property  # type: ignore[misc]  # HA stub declares state as @final
+    @override
     def state(self) -> float | None:
         return self._state
 
     @property
+    @override
     def should_poll(self) -> bool:
         return True
 
     @property
+    @override
     def available(self) -> bool:
         return self._available
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes for the sensor.
 
@@ -196,6 +202,7 @@ class HSEMHouseConsumptionPowerSensor(RestoreEntity, SensorEntity, HSEMEntity):
 
         await self._async_handle_update(None)
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Handle when sensor is added to Home Assistant.
 
@@ -229,6 +236,7 @@ class HSEMHouseConsumptionPowerSensor(RestoreEntity, SensorEntity, HSEMEntity):
 
         await super().async_added_to_hass()
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Cancel all tracked listeners when the entity is removed."""
         for unsub in self._unsub_callbacks:

--- a/custom_components/hsem/custom_sensors/last_updated_sensor.py
+++ b/custom_components/hsem/custom_sensors/last_updated_sensor.py
@@ -14,7 +14,7 @@ and updates automatically after every coordinator cycle.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -79,16 +79,19 @@ class HSEMLastUpdatedSensor(
     # ------------------------------------------------------------------
 
     @property
+    @override
     def name(self) -> str:
         """Return the display name."""
         return self._name
 
     @property
+    @override
     def unique_id(self) -> str | None:
         """Return the unique ID."""
         return self._attr_unique_id
 
     @property  # type: ignore[misc]  # HA stub declares state as @final
+    @override
     def state(self) -> str | None:
         """Return the last-updated ISO timestamp."""
         data: CoordinatorData | None = self.coordinator.data
@@ -97,11 +100,13 @@ class HSEMLastUpdatedSensor(
         return data.last_updated
 
     @property
+    @override
     def should_poll(self) -> bool:
         """No polling — driven by the coordinator."""
         return False
 
     @property
+    @override
     def available(self) -> bool:
         """True once the coordinator has completed at least one successful cycle."""
         return (
@@ -109,6 +114,7 @@ class HSEMLastUpdatedSensor(
         ) or self._restored_state is not None
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the next-update timestamp as context."""
         data: CoordinatorData | None = self.coordinator.data
@@ -120,6 +126,7 @@ class HSEMLastUpdatedSensor(
     # HA lifecycle
     # ------------------------------------------------------------------
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore previous state and register coordinator listener."""
         await super().async_added_to_hass()

--- a/custom_components/hsem/custom_sensors/missing_entities_sensor.py
+++ b/custom_components/hsem/custom_sensors/missing_entities_sensor.py
@@ -18,7 +18,7 @@ and updates automatically after every coordinator cycle.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -84,16 +84,19 @@ class HSEMMissingEntitiesSensor(
     # ------------------------------------------------------------------
 
     @property
+    @override
     def name(self) -> str:
         """Return the display name."""
         return self._name
 
     @property
+    @override
     def unique_id(self) -> str | None:
         """Return the unique ID."""
         return self._attr_unique_id
 
     @property  # type: ignore[misc]  # HA stub declares state as @final
+    @override
     def state(self) -> int:
         """Return the number of missing input entities."""
         data: CoordinatorData | None = self.coordinator.data
@@ -107,11 +110,13 @@ class HSEMMissingEntitiesSensor(
         return len(data.live.missing_entities_list)
 
     @property
+    @override
     def should_poll(self) -> bool:
         """No polling — driven by the coordinator."""
         return False
 
     @property
+    @override
     def available(self) -> bool:
         """True once the coordinator has completed at least one successful cycle."""
         return (
@@ -119,6 +124,7 @@ class HSEMMissingEntitiesSensor(
         ) or self._restored_state is not None
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the full list of missing entity labels as an attribute."""
         data: CoordinatorData | None = self.coordinator.data
@@ -132,6 +138,7 @@ class HSEMMissingEntitiesSensor(
     # HA lifecycle
     # ------------------------------------------------------------------
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore previous state and register coordinator listener."""
         await super().async_added_to_hass()

--- a/custom_components/hsem/custom_sensors/net_consumption_sensor.py
+++ b/custom_components/hsem/custom_sensors/net_consumption_sensor.py
@@ -17,7 +17,7 @@ and updates automatically after every coordinator cycle.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.sensor.const import SensorDeviceClass
@@ -92,16 +92,19 @@ class HSEMNetConsumptionSensor(
     # ------------------------------------------------------------------
 
     @property
+    @override
     def name(self) -> str:
         """Return the display name."""
         return self._name
 
     @property
+    @override
     def unique_id(self) -> str | None:
         """Return the unique ID."""
         return self._attr_unique_id
 
     @property
+    @override
     def native_value(self) -> float | None:
         """Return net consumption in Watts."""
         data: CoordinatorData | None = self.coordinator.data
@@ -115,11 +118,13 @@ class HSEMNetConsumptionSensor(
         return data.live.net_consumption_w
 
     @property
+    @override
     def should_poll(self) -> bool:
         """No polling — driven by the coordinator."""
         return False
 
     @property
+    @override
     def available(self) -> bool:
         """True once the coordinator has completed at least one successful cycle."""
         return (
@@ -127,6 +132,7 @@ class HSEMNetConsumptionSensor(
         ) or self._restored_state is not None
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return breakdown of the net consumption components."""
         data: CoordinatorData | None = self.coordinator.data
@@ -149,6 +155,7 @@ class HSEMNetConsumptionSensor(
     # HA lifecycle
     # ------------------------------------------------------------------
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore previous state and register coordinator listener."""
         await super().async_added_to_hass()

--- a/custom_components/hsem/custom_sensors/next_update_sensor.py
+++ b/custom_components/hsem/custom_sensors/next_update_sensor.py
@@ -14,7 +14,7 @@ and updates automatically after every coordinator cycle.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -79,16 +79,19 @@ class HSEMNextUpdateSensor(
     # ------------------------------------------------------------------
 
     @property
+    @override
     def name(self) -> str:
         """Return the display name."""
         return self._name
 
     @property
+    @override
     def unique_id(self) -> str | None:
         """Return the unique ID."""
         return self._attr_unique_id
 
     @property  # type: ignore[misc]  # HA stub declares state as @final
+    @override
     def state(self) -> str | None:
         """Return the next-update ISO timestamp."""
         data: CoordinatorData | None = self.coordinator.data
@@ -97,11 +100,13 @@ class HSEMNextUpdateSensor(
         return data.next_update
 
     @property
+    @override
     def should_poll(self) -> bool:
         """No polling — driven by the coordinator."""
         return False
 
     @property
+    @override
     def available(self) -> bool:
         """True once the coordinator has completed at least one successful cycle."""
         return (
@@ -109,6 +114,7 @@ class HSEMNextUpdateSensor(
         ) or self._restored_state is not None
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return diagnostic attributes."""
         data: CoordinatorData | None = self.coordinator.data
@@ -125,6 +131,7 @@ class HSEMNextUpdateSensor(
     # HA lifecycle
     # ------------------------------------------------------------------
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore previous state and register coordinator listener."""
         await super().async_added_to_hass()

--- a/custom_components/hsem/custom_sensors/plan_explanation_sensor.py
+++ b/custom_components/hsem/custom_sensors/plan_explanation_sensor.py
@@ -36,7 +36,7 @@ the default Lovelace dashboard.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -117,16 +117,19 @@ class HSEMPlanExplanationSensor(
     # ------------------------------------------------------------------
 
     @property
+    @override
     def name(self) -> str:
         """Return the display name."""
         return self._name
 
     @property
+    @override
     def unique_id(self) -> str | None:
         """Return the unique ID."""
         return self._attr_unique_id
 
     @property  # type: ignore[misc]  # HA stub declares state as @final
+    @override
     def state(self) -> str:
         """Return the currently active plan strategy.
 
@@ -139,11 +142,13 @@ class HSEMPlanExplanationSensor(
         return data.plan_explanation.selected_strategy or _UNKNOWN_STRATEGY
 
     @property
+    @override
     def should_poll(self) -> bool:
         """No polling — driven by the coordinator."""
         return False
 
     @property
+    @override
     def available(self) -> bool:
         """True once the coordinator has completed at least one successful cycle."""
         return (
@@ -151,6 +156,7 @@ class HSEMPlanExplanationSensor(
         ) or self._restored_state is not None
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the full plan explanation merged with diagnostic context.
 
@@ -210,6 +216,7 @@ class HSEMPlanExplanationSensor(
     # HA lifecycle
     # ------------------------------------------------------------------
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore previous state and register coordinator listener."""
         await super().async_added_to_hass()

--- a/custom_components/hsem/custom_sensors/read_only_sensor.py
+++ b/custom_components/hsem/custom_sensors/read_only_sensor.py
@@ -16,7 +16,7 @@ polling.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -82,16 +82,19 @@ class HSEMReadOnlySensor(
     # ------------------------------------------------------------------
 
     @property
+    @override
     def name(self) -> str:
         """Return the display name."""
         return self._name
 
     @property
+    @override
     def unique_id(self) -> str | None:
         """Return the unique ID."""
         return self._attr_unique_id
 
     @property  # type: ignore[misc]  # HA stub declares state as @final
+    @override
     def state(self) -> str:
         """Return ``'on'`` when read-only mode is active, ``'off'`` otherwise."""
         data: CoordinatorData | None = self.coordinator.data
@@ -100,11 +103,13 @@ class HSEMReadOnlySensor(
         return STATE_ON if bool(data.cfg.read_only) else STATE_OFF
 
     @property
+    @override
     def should_poll(self) -> bool:
         """No polling — driven by the coordinator."""
         return False
 
     @property
+    @override
     def available(self) -> bool:
         """True once the coordinator has completed at least one successful cycle."""
         return (
@@ -112,6 +117,7 @@ class HSEMReadOnlySensor(
         ) or self._restored_state is not None
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return diagnostic attributes visible on the entity detail page."""
         data: CoordinatorData | None = self.coordinator.data
@@ -130,6 +136,7 @@ class HSEMReadOnlySensor(
     # HA lifecycle
     # ------------------------------------------------------------------
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore previous state and register coordinator listener."""
         await super().async_added_to_hass()

--- a/custom_components/hsem/custom_sensors/recommendation_interval_sensor.py
+++ b/custom_components/hsem/custom_sensors/recommendation_interval_sensor.py
@@ -19,7 +19,7 @@ and updates automatically after every coordinator cycle.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -91,16 +91,19 @@ class HSEMRecommendationIntervalSensor(
     # ------------------------------------------------------------------
 
     @property
+    @override
     def name(self) -> str:
         """Return the display name."""
         return self._name
 
     @property
+    @override
     def unique_id(self) -> str | None:
         """Return the unique ID."""
         return self._attr_unique_id
 
     @property
+    @override
     def native_value(self) -> int | None:
         """Return the recommendation slot width in minutes."""
         data: CoordinatorData | None = self.coordinator.data
@@ -114,11 +117,13 @@ class HSEMRecommendationIntervalSensor(
         return data.cfg.recommendation_interval_minutes
 
     @property
+    @override
     def should_poll(self) -> bool:
         """No polling — driven by the coordinator."""
         return False
 
     @property
+    @override
     def available(self) -> bool:
         """True once the coordinator has completed at least one successful cycle."""
         return (
@@ -126,6 +131,7 @@ class HSEMRecommendationIntervalSensor(
         ) or self._restored_state is not None
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the planning horizon (hours) as an attribute."""
         data: CoordinatorData | None = self.coordinator.data
@@ -147,6 +153,7 @@ class HSEMRecommendationIntervalSensor(
     # HA lifecycle
     # ------------------------------------------------------------------
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore previous state and register coordinator listener."""
         await super().async_added_to_hass()

--- a/custom_components/hsem/custom_sensors/update_interval_sensor.py
+++ b/custom_components/hsem/custom_sensors/update_interval_sensor.py
@@ -15,7 +15,7 @@ and updates automatically after every coordinator cycle.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -88,16 +88,19 @@ class HSEMUpdateIntervalSensor(
     # ------------------------------------------------------------------
 
     @property
+    @override
     def name(self) -> str:
         """Return the display name."""
         return self._name
 
     @property
+    @override
     def unique_id(self) -> str | None:
         """Return the unique ID."""
         return self._attr_unique_id
 
     @property
+    @override
     def native_value(self) -> int | None:
         """Return the update interval in minutes."""
         data: CoordinatorData | None = self.coordinator.data
@@ -111,11 +114,13 @@ class HSEMUpdateIntervalSensor(
         return data.cfg.update_interval
 
     @property
+    @override
     def should_poll(self) -> bool:
         """No polling — driven by the coordinator."""
         return False
 
     @property
+    @override
     def available(self) -> bool:
         """True once the coordinator has completed at least one successful cycle."""
         return (
@@ -123,6 +128,7 @@ class HSEMUpdateIntervalSensor(
         ) or self._restored_state is not None
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional configuration context."""
         data: CoordinatorData | None = self.coordinator.data
@@ -140,6 +146,7 @@ class HSEMUpdateIntervalSensor(
     # HA lifecycle
     # ------------------------------------------------------------------
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Restore previous state and register coordinator listener."""
         await super().async_added_to_hass()

--- a/custom_components/hsem/custom_sensors/working_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/working_mode_sensor.py
@@ -16,7 +16,7 @@ coordinator.  This entity only reacts to coordinator pushes.
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
@@ -97,16 +97,19 @@ class HSEMWorkingModeSensor(HSEMCoordinatorEntity, SensorEntity, HSEMEntity):
     # ------------------------------------------------------------------
 
     @property
+    @override
     def name(self) -> str:
         """Return the display name."""
         return self._name
 
     @property
+    @override
     def unique_id(self) -> str | None:
         """Return the unique ID."""
         return self._attr_unique_id
 
     @property  # type: ignore[misc]  # HA stub declares state as @final
+    @override
     def state(self) -> str | None:
         """Return the working-mode recommendation for the current slot."""
         if self.coordinator.data is None:
@@ -114,11 +117,13 @@ class HSEMWorkingModeSensor(HSEMCoordinatorEntity, SensorEntity, HSEMEntity):
         return self.coordinator.data.state
 
     @property
+    @override
     def should_poll(self) -> bool:
         """No polling — driven by the coordinator."""
         return False
 
     @property
+    @override
     def available(self) -> bool:
         """True once the coordinator has completed at least one successful cycle."""
         return (
@@ -126,6 +131,7 @@ class HSEMWorkingModeSensor(HSEMCoordinatorEntity, SensorEntity, HSEMEntity):
         )
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return entity state attributes."""
         data: CoordinatorData | None = self.coordinator.data
@@ -294,6 +300,7 @@ class HSEMWorkingModeSensor(HSEMCoordinatorEntity, SensorEntity, HSEMEntity):
     # HA lifecycle
     # ------------------------------------------------------------------
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register coordinator listener and run an initial hardware-write pass."""
         await super().async_added_to_hass()
@@ -302,6 +309,7 @@ class HSEMWorkingModeSensor(HSEMCoordinatorEntity, SensorEntity, HSEMEntity):
         if self.coordinator.data is not None:
             await self._async_apply_hardware_writes(self.coordinator.data)
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Cancel any pending background update task before unloading.
 
@@ -325,6 +333,7 @@ class HSEMWorkingModeSensor(HSEMCoordinatorEntity, SensorEntity, HSEMEntity):
     # Coordinator callback
     # ------------------------------------------------------------------
 
+    @override
     def _handle_coordinator_update(self) -> None:
         """Receive a coordinator push and schedule hardware writes + state flush.
 

--- a/custom_components/hsem/custom_switches/switch.py
+++ b/custom_components/hsem/custom_switches/switch.py
@@ -6,7 +6,7 @@ Defines :class:`HSEMSwitch`.
 on/off state to the config entry options so it survives HA restarts.
 """
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
@@ -68,16 +68,19 @@ class HSEMSwitch(SwitchEntity, HSEMEntity):
         self._attr_is_on = bool(get_config_value(self._config_entry, description.key))
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional state attributes."""
         return {"description": self.entity_description.description}
 
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on and persist to config entry."""
         self._attr_is_on = True
         await self._persist_state()
         self.async_write_ha_state()
 
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off and persist to config entry."""
         self._attr_is_on = False

--- a/custom_components/hsem/custom_times/time.py
+++ b/custom_components/hsem/custom_times/time.py
@@ -7,7 +7,7 @@ value to the config entry options so it survives HA restarts.
 """
 
 from datetime import datetime, time
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.time import TimeEntity
 from homeassistant.config_entries import ConfigEntry
@@ -102,6 +102,7 @@ class HSEMTimeEntity(TimeEntity, HSEMEntity):
     # ------------------------------------------------------------------
 
     @property
+    @override
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional state attributes."""
         return {"description": self.entity_description.description}
@@ -110,6 +111,7 @@ class HSEMTimeEntity(TimeEntity, HSEMEntity):
     # TimeEntity interface
     # ------------------------------------------------------------------
 
+    @override
     async def async_set_value(self, value: time) -> None:
         """Handle a user-requested time change.
 

--- a/custom_components/hsem/entity.py
+++ b/custom_components/hsem/entity.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, override
 
 import homeassistant.helpers.device_registry as dr
 import homeassistant.helpers.entity_registry as er
@@ -34,6 +34,7 @@ class HSEMEntity(Entity):
         self._config = config_entry
 
     @property
+    @override
     def device_info(self) -> DeviceInfo:
         """Return the device information."""
         return DeviceInfo(
@@ -43,10 +44,12 @@ class HSEMEntity(Entity):
             model="Custom Integration",
         )
 
+    @override
     async def async_will_remove_from_hass(self) -> None:
         """Entity being removed from hass."""
         await super().async_will_remove_from_hass()
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Attach the entity to same device as the source entity."""
 


### PR DESCRIPTION
## Summary

Adds `@override` from `typing` to every method that overrides a parent class method across all HSEM entity files. This was the largest remaining item from the HA compliance audit (punkt 1).

## Files Changed (27 files)

### Base entity
- `custom_components/hsem/entity.py` — `device_info`, `async_will_remove_from_hass`, `async_added_to_hass`

### Sensor files (18 files)
- `applier_status_sensor.py` — 7 methods
- `avg_sensor.py` — 11 methods (largest file)
- `battery_soc_sensor.py` — 7 methods
- `degraded_mode_sensor.py` — 7 methods
- `ev_charging_sensor.py` — 7 methods
- `ev_optimal_charging_plan_sensor.py` — 6 methods
- `ev_second_optimal_charging_plan_sensor.py` — 6 methods
- `force_mode_sensor.py` — 7 methods
- `forecast_accuracy_sensor.py` — 4 methods
- `hardware_writes_sensor.py` — 7 methods
- `house_consumption_power_sensor.py` — 8 methods
- `last_updated_sensor.py` — 7 methods
- `missing_entities_sensor.py` — 7 methods
- `net_consumption_sensor.py` — 7 methods
- `next_update_sensor.py` — 7 methods
- `plan_explanation_sensor.py` — 7 methods
- `read_only_sensor.py` — 7 methods
- `recommendation_interval_sensor.py` — 7 methods
- `update_interval_sensor.py` — 7 methods
- `working_mode_sensor.py` — 9 methods

### Switch, time, number, select (6 files)
- `custom_switches/switch.py` — 3 methods
- `custom_times/time.py` — 2 methods
- `custom_numbers/battery_efficiency.py` — 1 method
- `custom_numbers/ev_target_soc.py` — 1 method
- `custom_selectors/solcast_likelihood.py` — 1 method
- `custom_selectors/working_mode.py` — 1 method

### What was NOT decorated
- `__init__` methods (constructors are not overrides)
- `async_update`, `async_options_updated` in non-RestoreEntity classes (mypy does not recognize them as overrides since HA stubs don't declare them on the base)
- Methods set via `_attr_*` class attributes (no method body to decorate)

## Tests

- `tox -e lint` — ✅ All checks passed
- `tox -e typing` — ✅ 0 errors
- `tox -e quality` — ✅ 0 errors