### PR TITLE
fix: include config entry ID in all unique_id values

### DIFF
--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -332,6 +332,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                 self._force_working_mode_entity,
                 self._tracked_entities,
                 self._avg_house_consumption_entity_id_cache,
+                entry_id=self._config_entry.entry_id,
             )
             self._listener_unsubs.extend(new_unsubs)
             self._live = self._snapshot.live
@@ -395,6 +396,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                 self._snapshot,
                 cfg,
                 self._avg_house_consumption_entity_id_cache,
+                entry_id=self._config_entry.entry_id,
             )
             await async_logger(
                 self,

--- a/custom_components/hsem/custom_sensors/applier_status_sensor.py
+++ b/custom_components/hsem/custom_sensors/applier_status_sensor.py
@@ -93,7 +93,9 @@ class HSEMApplierStatusSensor(
         HSEMEntity.__init__(self, config_entry)
 
         self._config_entry = config_entry
-        self._attr_unique_id = get_applier_status_sensor_unique_id()
+        self._attr_unique_id = get_applier_status_sensor_unique_id(
+            config_entry.entry_id
+        )
         self.entity_id = get_applier_status_sensor_entity_id()
         self._name = get_applier_status_sensor_name()
 

--- a/custom_components/hsem/custom_sensors/battery_soc_sensor.py
+++ b/custom_components/hsem/custom_sensors/battery_soc_sensor.py
@@ -80,7 +80,7 @@ class HSEMBatterySoCSensor(
 
         self._config_entry = config_entry
 
-        self._attr_unique_id = get_battery_soc_sensor_unique_id()
+        self._attr_unique_id = get_battery_soc_sensor_unique_id(config_entry.entry_id)
         self.entity_id = get_battery_soc_sensor_entity_id()
         self._name = get_battery_soc_sensor_name()
 

--- a/custom_components/hsem/custom_sensors/degraded_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/degraded_mode_sensor.py
@@ -87,7 +87,7 @@ class HSEMDegradedModeSensor(
 
         self._config_entry = config_entry
 
-        self._attr_unique_id = get_degraded_mode_sensor_unique_id()
+        self._attr_unique_id = get_degraded_mode_sensor_unique_id(config_entry.entry_id)
         self.entity_id = get_degraded_mode_sensor_entity_id()
         self._name = get_degraded_mode_sensor_name()
 

--- a/custom_components/hsem/custom_sensors/ev_charging_sensor.py
+++ b/custom_components/hsem/custom_sensors/ev_charging_sensor.py
@@ -73,7 +73,7 @@ class HSEMEVChargingSensor(
 
         self._config_entry = config_entry
 
-        self._attr_unique_id = get_ev_charging_sensor_unique_id()
+        self._attr_unique_id = get_ev_charging_sensor_unique_id(config_entry.entry_id)
         self.entity_id = get_ev_charging_sensor_entity_id()
         self._name = get_ev_charging_sensor_name()
 

--- a/custom_components/hsem/custom_sensors/ev_optimal_charging_plan_sensor.py
+++ b/custom_components/hsem/custom_sensors/ev_optimal_charging_plan_sensor.py
@@ -82,7 +82,9 @@ class HSEMEVOptimalChargingPlanSensor(
         HSEMEntity.__init__(self, config_entry)
 
         self._config_entry = config_entry
-        self._attr_unique_id = get_ev_optimal_charging_plan_sensor_unique_id()
+        self._attr_unique_id = get_ev_optimal_charging_plan_sensor_unique_id(
+            config_entry.entry_id
+        )
         self.entity_id = get_ev_optimal_charging_plan_sensor_entity_id()
         self._name = get_ev_optimal_charging_plan_sensor_name()
 

--- a/custom_components/hsem/custom_sensors/ev_second_optimal_charging_plan_sensor.py
+++ b/custom_components/hsem/custom_sensors/ev_second_optimal_charging_plan_sensor.py
@@ -58,7 +58,9 @@ class HSEMEVSecondOptimalChargingPlanSensor(
         HSEMEntity.__init__(self, config_entry)
 
         self._config_entry = config_entry
-        self._attr_unique_id = get_ev_second_optimal_charging_plan_sensor_unique_id()
+        self._attr_unique_id = get_ev_second_optimal_charging_plan_sensor_unique_id(
+            config_entry.entry_id
+        )
         self.entity_id = get_ev_second_optimal_charging_plan_sensor_entity_id()
         self._name = get_ev_second_optimal_charging_plan_sensor_name()
 

--- a/custom_components/hsem/custom_sensors/force_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/force_mode_sensor.py
@@ -73,7 +73,7 @@ class HSEMForceModeSensor(
 
         self._config_entry = config_entry
 
-        self._attr_unique_id = get_force_mode_sensor_unique_id()
+        self._attr_unique_id = get_force_mode_sensor_unique_id(config_entry.entry_id)
         self.entity_id = get_force_mode_sensor_entity_id()
         self._name = get_force_mode_sensor_name()
 

--- a/custom_components/hsem/custom_sensors/forecast_accuracy_sensor.py
+++ b/custom_components/hsem/custom_sensors/forecast_accuracy_sensor.py
@@ -73,7 +73,9 @@ class HSEMForecastAccuracySensor(
         """
         HSEMCoordinatorEntity.__init__(self, coordinator)
         HSEMEntity.__init__(self, config_entry)
-        self._attr_unique_id = get_forecast_accuracy_sensor_unique_id()
+        self._attr_unique_id = get_forecast_accuracy_sensor_unique_id(
+            config_entry.entry_id
+        )
         self._attr_name = get_forecast_accuracy_sensor_name()
         self.entity_id = get_forecast_accuracy_sensor_entity_id()
 

--- a/custom_components/hsem/custom_sensors/hardware_writes_sensor.py
+++ b/custom_components/hsem/custom_sensors/hardware_writes_sensor.py
@@ -78,7 +78,9 @@ class HSEMHardwareWritesSensor(
 
         self._config_entry = config_entry
 
-        self._attr_unique_id = get_hardware_writes_sensor_unique_id()
+        self._attr_unique_id = get_hardware_writes_sensor_unique_id(
+            config_entry.entry_id
+        )
         self.entity_id = get_hardware_writes_sensor_entity_id()
         self._name = get_hardware_writes_sensor_name()
 

--- a/custom_components/hsem/custom_sensors/hourly_data_populator.py
+++ b/custom_components/hsem/custom_sensors/hourly_data_populator.py
@@ -156,6 +156,7 @@ async def async_populate_avg_house_consumption(
     recommendations: list[HourlyRecommendation],
     cfg: SensorConfig,
     entity_id_cache: dict[str, str],
+    entry_id: str,
 ) -> bool:
     """Populate per-slot weighted average house consumption from the 1/3/7/14-day sensors.
 
@@ -193,10 +194,10 @@ async def async_populate_avg_house_consumption(
     for h in range(24):
         hour_end = (h + 1) % 24
 
-        uid_1d = get_energy_average_sensor_unique_id(h, hour_end, 1)
-        uid_3d = get_energy_average_sensor_unique_id(h, hour_end, 3)
-        uid_7d = get_energy_average_sensor_unique_id(h, hour_end, 7)
-        uid_14d = get_energy_average_sensor_unique_id(h, hour_end, 14)
+        uid_1d = get_energy_average_sensor_unique_id(entry_id, h, hour_end, 1)
+        uid_3d = get_energy_average_sensor_unique_id(entry_id, h, hour_end, 3)
+        uid_7d = get_energy_average_sensor_unique_id(entry_id, h, hour_end, 7)
+        uid_14d = get_energy_average_sensor_unique_id(entry_id, h, hour_end, 14)
 
         # Resolve entity IDs (cached)
         eid_1d = await _resolve_cached(sensor, entity_id_cache, uid_1d)
@@ -566,6 +567,7 @@ def populate_avg_house_consumption_from_snapshot(
     snapshot: StateSnapshot,
     cfg: SensorConfig,
     energy_average_entity_id_cache: dict[str, str],
+    entry_id: str,
 ) -> bool:
     """Populate per-slot house consumption averages from a pre-collected snapshot.
 
@@ -610,10 +612,10 @@ def populate_avg_house_consumption_from_snapshot(
     for h in range(24):
         hour_end = (h + 1) % 24
 
-        uid_1d = get_energy_average_sensor_unique_id(h, hour_end, 1)
-        uid_3d = get_energy_average_sensor_unique_id(h, hour_end, 3)
-        uid_7d = get_energy_average_sensor_unique_id(h, hour_end, 7)
-        uid_14d = get_energy_average_sensor_unique_id(h, hour_end, 14)
+        uid_1d = get_energy_average_sensor_unique_id(entry_id, h, hour_end, 1)
+        uid_3d = get_energy_average_sensor_unique_id(entry_id, h, hour_end, 3)
+        uid_7d = get_energy_average_sensor_unique_id(entry_id, h, hour_end, 7)
+        uid_14d = get_energy_average_sensor_unique_id(entry_id, h, hour_end, 14)
 
         log_planner(
             "debug",

--- a/custom_components/hsem/custom_sensors/house_consumption_power_sensor.py
+++ b/custom_components/hsem/custom_sensors/house_consumption_power_sensor.py
@@ -116,7 +116,7 @@ class HSEMHouseConsumptionPowerSensor(RestoreEntity, SensorEntity, HSEMEntity):
         self._hour_start = hour_start
         self._hour_end = hour_end
         self._attr_unique_id = get_house_consumption_power_sensor_unique_id(
-            hour_start, hour_end
+            config_entry.entry_id, hour_start, hour_end
         )
         self.entity_id = get_house_consumption_power_sensor_entity_id(
             hour_start, hour_end
@@ -399,7 +399,7 @@ class HSEMHouseConsumptionPowerSensor(RestoreEntity, SensorEntity, HSEMEntity):
         ``IntegrationSensor`` to restore its accumulated state.
         """
         integral_sensor_unique_id = get_integral_sensor_unique_id(
-            self._hour_start, self._hour_end
+            self._config_entry.entry_id, self._hour_start, self._hour_end
         )
 
         # Per-runtime guard — skip if already created in this HA session.
@@ -451,7 +451,7 @@ class HSEMHouseConsumptionPowerSensor(RestoreEntity, SensorEntity, HSEMEntity):
         needed.
         """
         utility_meter_unique_id = get_utility_meter_sensor_unique_id(
-            self._hour_start, self._hour_end
+            self._config_entry.entry_id, self._hour_start, self._hour_end
         )
 
         # Per-runtime guard — skip if already created in this HA session.
@@ -517,7 +517,7 @@ class HSEMHouseConsumptionPowerSensor(RestoreEntity, SensorEntity, HSEMEntity):
         entity_id is derived deterministically — no registry lookup needed.
         """
         avg_energy_sensor_unique_id = get_energy_average_sensor_unique_id(
-            self._hour_start, self._hour_end, avg
+            self._config_entry.entry_id, self._hour_start, self._hour_end, avg
         )
 
         # Per-runtime guard — skip if already created in this HA session.

--- a/custom_components/hsem/custom_sensors/last_updated_sensor.py
+++ b/custom_components/hsem/custom_sensors/last_updated_sensor.py
@@ -68,7 +68,7 @@ class HSEMLastUpdatedSensor(
 
         self._config_entry = config_entry
 
-        self._attr_unique_id = get_last_updated_sensor_unique_id()
+        self._attr_unique_id = get_last_updated_sensor_unique_id(config_entry.entry_id)
         self.entity_id = get_last_updated_sensor_entity_id()
         self._name = get_last_updated_sensor_name()
 

--- a/custom_components/hsem/custom_sensors/missing_entities_sensor.py
+++ b/custom_components/hsem/custom_sensors/missing_entities_sensor.py
@@ -73,7 +73,9 @@ class HSEMMissingEntitiesSensor(
 
         self._config_entry = config_entry
 
-        self._attr_unique_id = get_missing_entities_sensor_unique_id()
+        self._attr_unique_id = get_missing_entities_sensor_unique_id(
+            config_entry.entry_id
+        )
         self.entity_id = get_missing_entities_sensor_entity_id()
         self._name = get_missing_entities_sensor_name()
 

--- a/custom_components/hsem/custom_sensors/net_consumption_sensor.py
+++ b/custom_components/hsem/custom_sensors/net_consumption_sensor.py
@@ -81,7 +81,9 @@ class HSEMNetConsumptionSensor(
 
         self._config_entry = config_entry
 
-        self._attr_unique_id = get_net_consumption_sensor_unique_id()
+        self._attr_unique_id = get_net_consumption_sensor_unique_id(
+            config_entry.entry_id
+        )
         self.entity_id = get_net_consumption_sensor_entity_id()
         self._name = get_net_consumption_sensor_name()
 

--- a/custom_components/hsem/custom_sensors/next_update_sensor.py
+++ b/custom_components/hsem/custom_sensors/next_update_sensor.py
@@ -68,7 +68,7 @@ class HSEMNextUpdateSensor(
 
         self._config_entry = config_entry
 
-        self._attr_unique_id = get_next_update_sensor_unique_id()
+        self._attr_unique_id = get_next_update_sensor_unique_id(config_entry.entry_id)
         self.entity_id = get_next_update_sensor_entity_id()
         self._name = get_next_update_sensor_name()
 

--- a/custom_components/hsem/custom_sensors/plan_explanation_sensor.py
+++ b/custom_components/hsem/custom_sensors/plan_explanation_sensor.py
@@ -105,7 +105,9 @@ class HSEMPlanExplanationSensor(
         HSEMEntity.__init__(self, config_entry)
 
         self._config_entry = config_entry
-        self._attr_unique_id = get_plan_explanation_sensor_unique_id()
+        self._attr_unique_id = get_plan_explanation_sensor_unique_id(
+            config_entry.entry_id
+        )
         self.entity_id = get_plan_explanation_sensor_entity_id()
         self._name = get_plan_explanation_sensor_name()
 

--- a/custom_components/hsem/custom_sensors/read_only_sensor.py
+++ b/custom_components/hsem/custom_sensors/read_only_sensor.py
@@ -70,7 +70,7 @@ class HSEMReadOnlySensor(
 
         self._config_entry = config_entry
 
-        self._attr_unique_id = get_read_only_sensor_unique_id()
+        self._attr_unique_id = get_read_only_sensor_unique_id(config_entry.entry_id)
         self.entity_id = get_read_only_sensor_entity_id()
         self._name = get_read_only_sensor_name()
 

--- a/custom_components/hsem/custom_sensors/recommendation_interval_sensor.py
+++ b/custom_components/hsem/custom_sensors/recommendation_interval_sensor.py
@@ -80,7 +80,9 @@ class HSEMRecommendationIntervalSensor(
 
         self._config_entry = config_entry
 
-        self._attr_unique_id = get_recommendation_interval_sensor_unique_id()
+        self._attr_unique_id = get_recommendation_interval_sensor_unique_id(
+            config_entry.entry_id
+        )
         self.entity_id = get_recommendation_interval_sensor_entity_id()
         self._name = get_recommendation_interval_sensor_name()
 

--- a/custom_components/hsem/custom_sensors/state_collector.py
+++ b/custom_components/hsem/custom_sensors/state_collector.py
@@ -62,6 +62,7 @@ async def async_collect_live_state(
     cfg: SensorConfig,
     force_working_mode_cache: str | None,
     tracked_entities: set[str],
+    entry_id: str = "",
 ) -> tuple[LiveState, str | None, list]:
     """Read all HA entity states and return a populated :class:`LiveState`.
 
@@ -378,14 +379,19 @@ async def async_collect_live_state(
 
     # --- EV planned load live state — primary EV ---
     if cfg.ev_planned_load_enabled:
-        _read_ev_planned_load_state(sensor, state, cfg, _read, is_second=False)
+        _read_ev_planned_load_state(
+            sensor, state, cfg, _read, is_second=False, entry_id=entry_id
+        )
 
-    # --- EV planned load live state — second EV ---
     if cfg.ev_second_planned_load_enabled:
-        _read_ev_planned_load_state(sensor, state, cfg, _read, is_second=True)
+        _read_ev_planned_load_state(
+            sensor, state, cfg, _read, is_second=True, entry_id=entry_id
+        )
 
     # --- Register state-change listeners for reactive entities ---
-    new_unsubs = await _register_listeners(sensor, cfg, state, tracked_entities)
+    new_unsubs = await _register_listeners(
+        sensor, cfg, state, tracked_entities, entry_id=entry_id
+    )
 
     return state, fwm_entity, new_unsubs
 
@@ -453,6 +459,7 @@ def _read_ev_planned_load_state(
     cfg: SensorConfig,
     _read: Callable[..., Any],
     is_second: bool,
+    entry_id: str,
 ) -> None:
     """Read EV planned load live state into ``state`` for primary or second EV.
 
@@ -582,6 +589,7 @@ async def _register_listeners(
     cfg: SensorConfig,
     state: LiveState,
     tracked_entities: set[str],
+    entry_id: str,
 ) -> list:
     """Register ``async_track_state_change_event`` for reactive entities.
 
@@ -596,14 +604,14 @@ async def _register_listeners(
     candidates = [
         cfg.ev.status_entity,
         cfg.ev.connected_entity,
-        get_ev_target_soc_number_entity_id(),
-        get_ev_smart_charging_switch_entity_id(),
-        get_ev_deadline_time_entity_id(),
+        get_ev_target_soc_number_entity_id(entry_id),
+        get_ev_smart_charging_switch_entity_id(entry_id),
+        get_ev_deadline_time_entity_id(entry_id),
         cfg.ev_second.status_entity,
         cfg.ev_second.connected_entity,
-        get_ev_second_target_soc_number_entity_id(),
-        get_ev_second_smart_charging_switch_entity_id(),
-        get_ev_second_deadline_time_entity_id(),
+        get_ev_second_target_soc_number_entity_id(entry_id),
+        get_ev_second_smart_charging_switch_entity_id(entry_id),
+        get_ev_second_deadline_time_entity_id(entry_id),
         state.force_working_mode,
     ]
 
@@ -633,6 +641,7 @@ async def async_collect_all_states(
     force_working_mode_cache: str | None,
     tracked_entities: set[str],
     energy_average_entity_id_cache: dict[str, str] | None = None,
+    entry_id: str = "",
 ) -> tuple[StateSnapshot, str | None, list]:
     """Collect **all** HA states once into an immutable :class:`StateSnapshot`.
 
@@ -657,7 +666,7 @@ async def async_collect_all_states(
     """
     # 1. Collect live entity states (battery, power, EV, etc.)
     live, fwm_entity, new_unsubs = await async_collect_live_state(
-        sensor, cfg, force_working_mode_cache, tracked_entities
+        sensor, cfg, force_working_mode_cache, tracked_entities, entry_id=entry_id
     )
 
     # 2. Pre-read energy average sensor values (24 hours × 4 periods)
@@ -673,7 +682,7 @@ async def async_collect_all_states(
     for h in range(24):
         hour_end = (h + 1) % 24
         for days, _uid_key in [(1, "1d"), (3, "3d"), (7, "7d"), (14, "14d")]:
-            uid = get_energy_average_sensor_unique_id(h, hour_end, days)
+            uid = get_energy_average_sensor_unique_id(entry_id, h, hour_end, days)
 
             eid = await _resolve_cached(sensor, avg_cache, uid)
 

--- a/custom_components/hsem/custom_sensors/update_interval_sensor.py
+++ b/custom_components/hsem/custom_sensors/update_interval_sensor.py
@@ -77,7 +77,9 @@ class HSEMUpdateIntervalSensor(
 
         self._config_entry = config_entry
 
-        self._attr_unique_id = get_update_interval_sensor_unique_id()
+        self._attr_unique_id = get_update_interval_sensor_unique_id(
+            config_entry.entry_id
+        )
         self.entity_id = get_update_interval_sensor_entity_id()
         self._name = get_update_interval_sensor_name()
 

--- a/custom_components/hsem/custom_sensors/working_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/working_mode_sensor.py
@@ -83,7 +83,7 @@ class HSEMWorkingModeSensor(HSEMCoordinatorEntity, SensorEntity, HSEMEntity):
 
         self._config_entry = config_entry
 
-        self._attr_unique_id = get_working_mode_sensor_unique_id()
+        self._attr_unique_id = get_working_mode_sensor_unique_id(config_entry.entry_id)
         self.entity_id = get_working_mode_sensor_entity_id()
         self._name = get_working_mode_sensor_name()
 

--- a/custom_components/hsem/custom_switches/description.py
+++ b/custom_components/hsem/custom_switches/description.py
@@ -1,7 +1,7 @@
 """Switch entity description and ID map for the HSEM integration.
 
-Defines :class:`HSEMSwitchEntityDescription` and the module-level
-``_SWITCH_ID_MAP`` dictionary that maps config-entry keys to
+Defines :class:`HSEMSwitchEntityDescription` and the
+``build_switch_id_map()`` function that maps config-entry keys to
 (unique_id, entity_id) tuples.
 """
 
@@ -45,53 +45,62 @@ from custom_components.hsem.utils.sensornames import (
     get_verbose_logging_switch_unique_id,
 )
 
-# Map from config-entry key → (unique_id, entity_id)
-_SWITCH_ID_MAP: dict[str, tuple[str, str]] = {
-    get_read_only_switch_key(): (
-        get_read_only_switch_unique_id(),
-        get_read_only_switch_entity_id(),
-    ),
-    get_extended_attributes_switch_key(): (
-        get_extended_attributes_switch_unique_id(),
-        get_extended_attributes_switch_entity_id(),
-    ),
-    get_verbose_logging_switch_key(): (
-        get_verbose_logging_switch_unique_id(),
-        get_verbose_logging_switch_entity_id(),
-    ),
-    get_batteries_schedule_1_switch_key(): (
-        get_batteries_schedule_1_switch_unique_id(),
-        get_batteries_schedule_1_switch_entity_id(),
-    ),
-    get_batteries_schedule_2_switch_key(): (
-        get_batteries_schedule_2_switch_unique_id(),
-        get_batteries_schedule_2_switch_entity_id(),
-    ),
-    get_batteries_schedule_3_switch_key(): (
-        get_batteries_schedule_3_switch_unique_id(),
-        get_batteries_schedule_3_switch_entity_id(),
-    ),
-    get_ev_force_discharge_switch_key(): (
-        get_ev_force_discharge_switch_unique_id(),
-        get_ev_force_discharge_switch_entity_id(),
-    ),
-    get_ev_smart_charging_switch_key(): (
-        get_ev_smart_charging_switch_unique_id(),
-        get_ev_smart_charging_switch_entity_id(),
-    ),
-    get_ev_force_charge_now_switch_key(): (
-        get_ev_force_charge_now_switch_unique_id(),
-        get_ev_force_charge_now_switch_entity_id(),
-    ),
-    get_ev_second_smart_charging_switch_key(): (
-        get_ev_second_smart_charging_switch_unique_id(),
-        get_ev_second_smart_charging_switch_entity_id(),
-    ),
-    get_ev_second_force_charge_now_switch_key(): (
-        get_ev_second_force_charge_now_switch_unique_id(),
-        get_ev_second_force_charge_now_switch_entity_id(),
-    ),
-}
+
+def build_switch_id_map(entry_id: str) -> dict[str, tuple[str, str]]:
+    """Build the switch ID map for a given config entry.
+
+    Args:
+        entry_id: The config entry ID for uniqueness across entries.
+
+    Returns:
+        A dict mapping config-entry keys to (unique_id, entity_id) tuples.
+    """
+    return {
+        get_read_only_switch_key(): (
+            get_read_only_switch_unique_id(entry_id),
+            get_read_only_switch_entity_id(entry_id),
+        ),
+        get_extended_attributes_switch_key(): (
+            get_extended_attributes_switch_unique_id(entry_id),
+            get_extended_attributes_switch_entity_id(entry_id),
+        ),
+        get_verbose_logging_switch_key(): (
+            get_verbose_logging_switch_unique_id(entry_id),
+            get_verbose_logging_switch_entity_id(entry_id),
+        ),
+        get_batteries_schedule_1_switch_key(): (
+            get_batteries_schedule_1_switch_unique_id(entry_id),
+            get_batteries_schedule_1_switch_entity_id(entry_id),
+        ),
+        get_batteries_schedule_2_switch_key(): (
+            get_batteries_schedule_2_switch_unique_id(entry_id),
+            get_batteries_schedule_2_switch_entity_id(entry_id),
+        ),
+        get_batteries_schedule_3_switch_key(): (
+            get_batteries_schedule_3_switch_unique_id(entry_id),
+            get_batteries_schedule_3_switch_entity_id(entry_id),
+        ),
+        get_ev_force_discharge_switch_key(): (
+            get_ev_force_discharge_switch_unique_id(entry_id),
+            get_ev_force_discharge_switch_entity_id(entry_id),
+        ),
+        get_ev_smart_charging_switch_key(): (
+            get_ev_smart_charging_switch_unique_id(entry_id),
+            get_ev_smart_charging_switch_entity_id(entry_id),
+        ),
+        get_ev_force_charge_now_switch_key(): (
+            get_ev_force_charge_now_switch_unique_id(entry_id),
+            get_ev_force_charge_now_switch_entity_id(entry_id),
+        ),
+        get_ev_second_smart_charging_switch_key(): (
+            get_ev_second_smart_charging_switch_unique_id(entry_id),
+            get_ev_second_smart_charging_switch_entity_id(entry_id),
+        ),
+        get_ev_second_force_charge_now_switch_key(): (
+            get_ev_second_force_charge_now_switch_unique_id(entry_id),
+            get_ev_second_force_charge_now_switch_entity_id(entry_id),
+        ),
+    }
 
 
 @dataclass(frozen=True)

--- a/custom_components/hsem/custom_switches/switch.py
+++ b/custom_components/hsem/custom_switches/switch.py
@@ -14,8 +14,8 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 
 from custom_components.hsem.custom_switches.description import (
-    _SWITCH_ID_MAP,
     HSEMSwitchEntityDescription,
+    build_switch_id_map,
 )
 from custom_components.hsem.entity import HSEMEntity
 from custom_components.hsem.utils.misc import get_config_value
@@ -62,7 +62,8 @@ class HSEMSwitch(SwitchEntity, HSEMEntity):
         if isinstance(raw_name, str):
             self._attr_name = str(raw_name)
         # Resolve unique_id and entity_id from the centralized sensornames map.
-        unique_id, entity_id = _SWITCH_ID_MAP[description.key]
+        switch_id_map = build_switch_id_map(config_entry.entry_id)
+        unique_id, entity_id = switch_id_map[description.key]
         self._attr_unique_id = unique_id
         self.entity_id = entity_id
         self._attr_is_on = bool(get_config_value(self._config_entry, description.key))

--- a/custom_components/hsem/custom_times/description.py
+++ b/custom_components/hsem/custom_times/description.py
@@ -1,7 +1,7 @@
 """Time entity description and ID map for the HSEM integration.
 
-Defines :class:`HSEMTimeEntityDescription` and the module-level
-``_TIME_ID_MAP`` dictionary that maps config-entry keys to
+Defines :class:`HSEMTimeEntityDescription` and the
+``build_time_id_map()`` function that maps config-entry keys to
 (unique_id, entity_id) tuples.
 """
 
@@ -36,41 +36,50 @@ from custom_components.hsem.utils.sensornames import (
     get_schedule_3_start_time_unique_id,
 )
 
-# Map from config-entry key → (unique_id, entity_id)
-_TIME_ID_MAP: dict[str, tuple[str, str]] = {
-    get_schedule_1_start_time_key(): (
-        get_schedule_1_start_time_unique_id(),
-        get_schedule_1_start_time_entity_id(),
-    ),
-    get_schedule_1_end_time_key(): (
-        get_schedule_1_end_time_unique_id(),
-        get_schedule_1_end_time_entity_id(),
-    ),
-    get_schedule_2_start_time_key(): (
-        get_schedule_2_start_time_unique_id(),
-        get_schedule_2_start_time_entity_id(),
-    ),
-    get_schedule_2_end_time_key(): (
-        get_schedule_2_end_time_unique_id(),
-        get_schedule_2_end_time_entity_id(),
-    ),
-    get_schedule_3_start_time_key(): (
-        get_schedule_3_start_time_unique_id(),
-        get_schedule_3_start_time_entity_id(),
-    ),
-    get_schedule_3_end_time_key(): (
-        get_schedule_3_end_time_unique_id(),
-        get_schedule_3_end_time_entity_id(),
-    ),
-    get_ev_deadline_time_key(): (
-        get_ev_deadline_time_unique_id(),
-        get_ev_deadline_time_entity_id(),
-    ),
-    get_ev_second_deadline_time_key(): (
-        get_ev_second_deadline_time_unique_id(),
-        get_ev_second_deadline_time_entity_id(),
-    ),
-}
+
+def build_time_id_map(entry_id: str) -> dict[str, tuple[str, str]]:
+    """Build the time ID map for a given config entry.
+
+    Args:
+        entry_id: The config entry ID for uniqueness across entries.
+
+    Returns:
+        A dict mapping config-entry keys to (unique_id, entity_id) tuples.
+    """
+    return {
+        get_schedule_1_start_time_key(): (
+            get_schedule_1_start_time_unique_id(entry_id),
+            get_schedule_1_start_time_entity_id(entry_id),
+        ),
+        get_schedule_1_end_time_key(): (
+            get_schedule_1_end_time_unique_id(entry_id),
+            get_schedule_1_end_time_entity_id(entry_id),
+        ),
+        get_schedule_2_start_time_key(): (
+            get_schedule_2_start_time_unique_id(entry_id),
+            get_schedule_2_start_time_entity_id(entry_id),
+        ),
+        get_schedule_2_end_time_key(): (
+            get_schedule_2_end_time_unique_id(entry_id),
+            get_schedule_2_end_time_entity_id(entry_id),
+        ),
+        get_schedule_3_start_time_key(): (
+            get_schedule_3_start_time_unique_id(entry_id),
+            get_schedule_3_start_time_entity_id(entry_id),
+        ),
+        get_schedule_3_end_time_key(): (
+            get_schedule_3_end_time_unique_id(entry_id),
+            get_schedule_3_end_time_entity_id(entry_id),
+        ),
+        get_ev_deadline_time_key(): (
+            get_ev_deadline_time_unique_id(entry_id),
+            get_ev_deadline_time_entity_id(entry_id),
+        ),
+        get_ev_second_deadline_time_key(): (
+            get_ev_second_deadline_time_unique_id(entry_id),
+            get_ev_second_deadline_time_entity_id(entry_id),
+        ),
+    }
 
 
 @dataclass(frozen=True)

--- a/custom_components/hsem/custom_times/time.py
+++ b/custom_components/hsem/custom_times/time.py
@@ -15,8 +15,8 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 
 from custom_components.hsem.custom_times.description import (
-    _TIME_ID_MAP,
     HSEMTimeEntityDescription,
+    build_time_id_map,
 )
 from custom_components.hsem.entity import HSEMEntity
 
@@ -63,7 +63,8 @@ class HSEMTimeEntity(TimeEntity, HSEMEntity):
         if isinstance(raw_name, str):
             self._attr_name = str(raw_name)
         # Resolve unique_id and entity_id from the centralized sensornames map.
-        unique_id, entity_id = _TIME_ID_MAP[description.key]
+        time_id_map = build_time_id_map(config_entry.entry_id)
+        unique_id, entity_id = time_id_map[description.key]
         self._attr_unique_id = unique_id
         self.entity_id = entity_id
         self._attr_native_value: time | None = self._parse_time(

--- a/custom_components/hsem/number.py
+++ b/custom_components/hsem/number.py
@@ -73,20 +73,20 @@ async def async_setup_entry(
 
     _id_map = {
         get_charge_efficiency_number_key(): (
-            get_charge_efficiency_number_unique_id(),
+            get_charge_efficiency_number_unique_id(config_entry.entry_id),
             get_charge_efficiency_number_entity_id(),
         ),
         get_discharge_efficiency_number_key(): (
-            get_discharge_efficiency_number_unique_id(),
+            get_discharge_efficiency_number_unique_id(config_entry.entry_id),
             get_discharge_efficiency_number_entity_id(),
         ),
         get_ev_target_soc_number_key(): (
-            get_ev_target_soc_number_unique_id(),
-            get_ev_target_soc_number_entity_id(),
+            get_ev_target_soc_number_unique_id(config_entry.entry_id),
+            get_ev_target_soc_number_entity_id(config_entry.entry_id),
         ),
         get_ev_second_target_soc_number_key(): (
-            get_ev_second_target_soc_number_unique_id(),
-            get_ev_second_target_soc_number_entity_id(),
+            get_ev_second_target_soc_number_unique_id(config_entry.entry_id),
+            get_ev_second_target_soc_number_entity_id(config_entry.entry_id),
         ),
     }
 

--- a/custom_components/hsem/utils/sensornames.py
+++ b/custom_components/hsem/utils/sensornames.py
@@ -25,10 +25,11 @@ def get_integral_sensor_name(hour_start: int, hour_end: int) -> str:
     return f"House Consumption {hour_start:02d}-{hour_end:02d} Energy (Integral)"
 
 
-def get_integral_sensor_unique_id(hour_start: int, hour_end: int) -> str:
+def get_integral_sensor_unique_id(entry_id: str, hour_start: int, hour_end: int) -> str:
     """Generate a unique ID for the integral sensor.
 
     Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
         hour_start (int): Start hour of the time range.
         hour_end (int): End hour of the time range.
 
@@ -36,7 +37,7 @@ def get_integral_sensor_unique_id(hour_start: int, hour_end: int) -> str:
         str: Unique ID of the integral sensor.
 
     """
-    return f"{DOMAIN}_house_consumption_energy_integral_{hour_start:02d}_{hour_end:02d}"
+    return f"{DOMAIN}_{entry_id}_house_consumption_energy_integral_{hour_start:02d}_{hour_end:02d}"
 
 
 def get_integral_sensor_entity_id(hour_start: int, hour_end: int) -> str:
@@ -70,11 +71,12 @@ def get_energy_average_sensor_name(hour_start: int, hour_end: int, avg: int) -> 
 
 
 def get_energy_average_sensor_unique_id(
-    hour_start: int, hour_end: int, avg: int
+    entry_id: str, hour_start: int, hour_end: int, avg: int
 ) -> str:
     """Generate a unique ID for the energy average sensor.
 
     Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
         hour_start (int): Start hour of the time range.
         hour_end (int): End hour of the time range.
         avg (int): Averaging period in days.
@@ -83,9 +85,7 @@ def get_energy_average_sensor_unique_id(
         str: Unique ID of the energy average sensor.
 
     """
-    return (
-        f"{DOMAIN}_house_consumption_energy_avg_{hour_start:02d}_{hour_end:02d}_{avg}d"
-    )
+    return f"{DOMAIN}_{entry_id}_house_consumption_energy_avg_{hour_start:02d}_{hour_end:02d}_{avg}d"
 
 
 def get_energy_average_sensor_entity_id(
@@ -120,10 +120,13 @@ def get_utility_meter_sensor_name(hour_start: int, hour_end: int) -> str:
     return f"House Consumption {hour_start:02d}-{hour_end:02d} Energy (Utility Meter)"
 
 
-def get_utility_meter_sensor_unique_id(hour_start: int, hour_end: int) -> str:
+def get_utility_meter_sensor_unique_id(
+    entry_id: str, hour_start: int, hour_end: int
+) -> str:
     """Generate a unique ID for the utility meter sensor.
 
     Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
         hour_start (int): Start hour of the time range.
         hour_end (int): End hour of the time range.
 
@@ -131,7 +134,7 @@ def get_utility_meter_sensor_unique_id(hour_start: int, hour_end: int) -> str:
         str: Unique ID of the utility meter sensor.
 
     """
-    return f"{DOMAIN}_house_consumption_energy_{hour_start:02d}_{hour_end:02d}_utility_meter"
+    return f"{DOMAIN}_{entry_id}_house_consumption_energy_{hour_start:02d}_{hour_end:02d}_utility_meter"
 
 
 def get_utility_meter_sensor_entity_id(hour_start: int, hour_end: int) -> str:
@@ -163,10 +166,13 @@ def get_house_consumption_power_sensor_name(hour_start: int, hour_end: int) -> s
     return f"House Consumption {hour_start:02d}-{hour_end:02d} Hourly Power"
 
 
-def get_house_consumption_power_sensor_unique_id(hour_start: int, hour_end: int) -> str:
+def get_house_consumption_power_sensor_unique_id(
+    entry_id: str, hour_start: int, hour_end: int
+) -> str:
     """Generate a unique ID for the house consumption power sensor.
 
     Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
         hour_start (int): Start hour of the time range.
         hour_end (int): End hour of the time range.
 
@@ -174,7 +180,9 @@ def get_house_consumption_power_sensor_unique_id(hour_start: int, hour_end: int)
         str: Unique ID of the house consumption power sensor.
 
     """
-    return f"{DOMAIN}_house_consumption_power_{hour_start:02d}_{hour_end:02d}"
+    return (
+        f"{DOMAIN}_{entry_id}_house_consumption_power_{hour_start:02d}_{hour_end:02d}"
+    )
 
 
 def get_house_consumption_power_sensor_entity_id(hour_start: int, hour_end: int) -> str:
@@ -202,14 +210,17 @@ def get_working_mode_sensor_name() -> str:
     return "Working Mode Sensor"
 
 
-def get_working_mode_sensor_unique_id() -> str:
+def get_working_mode_sensor_unique_id(entry_id: str) -> str:
     """Generate a unique ID for the working mode sensor.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
 
     Returns:
         str: Unique ID of the working mode sensor.
 
     """
-    return f"{DOMAIN}_workingmode_sensor"
+    return f"{DOMAIN}_{entry_id}_workingmode_sensor"
 
 
 def get_working_mode_sensor_entity_id() -> str:
@@ -233,14 +244,17 @@ def get_degraded_mode_sensor_name() -> str:
     return "System Health"
 
 
-def get_degraded_mode_sensor_unique_id() -> str:
+def get_degraded_mode_sensor_unique_id(entry_id: str) -> str:
     """Return a unique ID for the degraded-mode sensor.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
 
     Returns:
         str: Unique ID.
 
     """
-    return f"{DOMAIN}_degraded_mode_sensor"
+    return f"{DOMAIN}_{entry_id}_degraded_mode_sensor"
 
 
 def get_degraded_mode_sensor_entity_id() -> str:
@@ -264,14 +278,17 @@ def get_read_only_sensor_name() -> str:
     return "Read-Only Mode"
 
 
-def get_read_only_sensor_unique_id() -> str:
+def get_read_only_sensor_unique_id(entry_id: str) -> str:
     """Return a unique ID for the read-only mode sensor.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
 
     Returns:
         str: Unique ID.
 
     """
-    return f"{DOMAIN}_read_only_sensor"
+    return f"{DOMAIN}_{entry_id}_read_only_sensor"
 
 
 def get_read_only_sensor_entity_id() -> str:
@@ -290,9 +307,13 @@ def get_next_update_sensor_name() -> str:
     return "Next Update"
 
 
-def get_next_update_sensor_unique_id() -> str:
-    """Return a unique ID for the next-update sensor."""
-    return f"{DOMAIN}_next_update_sensor"
+def get_next_update_sensor_unique_id(entry_id: str) -> str:
+    """Return a unique ID for the next-update sensor.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_next_update_sensor"
 
 
 def get_next_update_sensor_entity_id() -> str:
@@ -306,9 +327,13 @@ def get_missing_entities_sensor_name() -> str:
     return "Missing Input Entities"
 
 
-def get_missing_entities_sensor_unique_id() -> str:
-    """Return a unique ID for the missing-entities sensor."""
-    return f"{DOMAIN}_missing_entities_sensor"
+def get_missing_entities_sensor_unique_id(entry_id: str) -> str:
+    """Return a unique ID for the missing-entities sensor.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_missing_entities_sensor"
 
 
 def get_missing_entities_sensor_entity_id() -> str:
@@ -322,9 +347,13 @@ def get_hardware_writes_sensor_name() -> str:
     return "Hardware Writes"
 
 
-def get_hardware_writes_sensor_unique_id() -> str:
-    """Return a unique ID for the hardware-writes-blocked sensor."""
-    return f"{DOMAIN}_hardware_writes_sensor"
+def get_hardware_writes_sensor_unique_id(entry_id: str) -> str:
+    """Return a unique ID for the hardware-writes-blocked sensor.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_hardware_writes_sensor"
 
 
 def get_hardware_writes_sensor_entity_id() -> str:
@@ -338,9 +367,13 @@ def get_net_consumption_sensor_name() -> str:
     return "Net Consumption"
 
 
-def get_net_consumption_sensor_unique_id() -> str:
-    """Return a unique ID for the net-consumption sensor."""
-    return f"{DOMAIN}_net_consumption_sensor"
+def get_net_consumption_sensor_unique_id(entry_id: str) -> str:
+    """Return a unique ID for the net-consumption sensor.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_net_consumption_sensor"
 
 
 def get_net_consumption_sensor_entity_id() -> str:
@@ -354,9 +387,13 @@ def get_force_mode_sensor_name() -> str:
     return "Force Working Mode"
 
 
-def get_force_mode_sensor_unique_id() -> str:
-    """Return a unique ID for the force-working-mode sensor."""
-    return f"{DOMAIN}_force_mode_sensor"
+def get_force_mode_sensor_unique_id(entry_id: str) -> str:
+    """Return a unique ID for the force-working-mode sensor.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_force_mode_sensor"
 
 
 def get_force_mode_sensor_entity_id() -> str:
@@ -370,9 +407,13 @@ def get_update_interval_sensor_name() -> str:
     return "Update Interval"
 
 
-def get_update_interval_sensor_unique_id() -> str:
-    """Return a unique ID for the update-interval sensor."""
-    return f"{DOMAIN}_update_interval_sensor"
+def get_update_interval_sensor_unique_id(entry_id: str) -> str:
+    """Return a unique ID for the update-interval sensor.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_update_interval_sensor"
 
 
 def get_update_interval_sensor_entity_id() -> str:
@@ -386,9 +427,13 @@ def get_last_updated_sensor_name() -> str:
     return "Last Updated"
 
 
-def get_last_updated_sensor_unique_id() -> str:
-    """Return a unique ID for the last-updated sensor."""
-    return f"{DOMAIN}_last_updated_sensor"
+def get_last_updated_sensor_unique_id(entry_id: str) -> str:
+    """Return a unique ID for the last-updated sensor.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_last_updated_sensor"
 
 
 def get_last_updated_sensor_entity_id() -> str:
@@ -402,9 +447,13 @@ def get_battery_soc_sensor_name() -> str:
     return "Battery State of Charge"
 
 
-def get_battery_soc_sensor_unique_id() -> str:
-    """Return a unique ID for the battery-SoC sensor."""
-    return f"{DOMAIN}_battery_soc_sensor"
+def get_battery_soc_sensor_unique_id(entry_id: str) -> str:
+    """Return a unique ID for the battery-SoC sensor.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_battery_soc_sensor"
 
 
 def get_battery_soc_sensor_entity_id() -> str:
@@ -418,9 +467,13 @@ def get_recommendation_interval_sensor_name() -> str:
     return "Recommendation Interval"
 
 
-def get_recommendation_interval_sensor_unique_id() -> str:
-    """Return a unique ID for the recommendation-interval sensor."""
-    return f"{DOMAIN}_recommendation_interval_sensor"
+def get_recommendation_interval_sensor_unique_id(entry_id: str) -> str:
+    """Return a unique ID for the recommendation-interval sensor.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_recommendation_interval_sensor"
 
 
 def get_recommendation_interval_sensor_entity_id() -> str:
@@ -434,9 +487,13 @@ def get_ev_charging_sensor_name() -> str:
     return "EV Charging Active"
 
 
-def get_ev_charging_sensor_unique_id() -> str:
-    """Return a unique ID for the EV-charging sensor."""
-    return f"{DOMAIN}_ev_charging_sensor"
+def get_ev_charging_sensor_unique_id(entry_id: str) -> str:
+    """Return a unique ID for the EV-charging sensor.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_ev_charging_sensor"
 
 
 def get_ev_charging_sensor_entity_id() -> str:
@@ -450,9 +507,13 @@ def get_ev_optimal_charging_plan_sensor_name() -> str:
     return "EV Optimal Charging Plan"
 
 
-def get_ev_optimal_charging_plan_sensor_unique_id() -> str:
-    """Return a unique ID for the EV optimal charging plan sensor."""
-    return f"{DOMAIN}_ev_optimal_charging_plan"
+def get_ev_optimal_charging_plan_sensor_unique_id(entry_id: str) -> str:
+    """Return a unique ID for the EV optimal charging plan sensor.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_ev_optimal_charging_plan"
 
 
 def get_ev_optimal_charging_plan_sensor_entity_id() -> str:
@@ -466,9 +527,13 @@ def get_ev_second_optimal_charging_plan_sensor_name() -> str:
     return "EV 2 Optimal Charging Plan"
 
 
-def get_ev_second_optimal_charging_plan_sensor_unique_id() -> str:
-    """Return a unique ID for the second EV optimal charging plan sensor."""
-    return f"{DOMAIN}_ev_second_optimal_charging_plan"
+def get_ev_second_optimal_charging_plan_sensor_unique_id(entry_id: str) -> str:
+    """Return a unique ID for the second EV optimal charging plan sensor.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_ev_second_optimal_charging_plan"
 
 
 def get_ev_second_optimal_charging_plan_sensor_entity_id() -> str:
@@ -482,9 +547,13 @@ def get_plan_explanation_sensor_name() -> str:
     return "Plan Strategy"
 
 
-def get_plan_explanation_sensor_unique_id() -> str:
-    """Return a unique ID for the plan-explanation sensor."""
-    return f"{DOMAIN}_plan_explanation_sensor"
+def get_plan_explanation_sensor_unique_id(entry_id: str) -> str:
+    """Return a unique ID for the plan-explanation sensor.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_plan_explanation_sensor"
 
 
 def get_plan_explanation_sensor_entity_id() -> str:
@@ -535,9 +604,13 @@ def get_charge_efficiency_number_name() -> str:
     return "Battery Charge Efficiency"
 
 
-def get_charge_efficiency_number_unique_id() -> str:
-    """Return the unique_id for the charge efficiency number entity."""
-    return f"{DOMAIN}_battery_charge_efficiency"
+def get_charge_efficiency_number_unique_id(entry_id: str) -> str:
+    """Return the unique_id for the charge efficiency number entity.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_battery_charge_efficiency"
 
 
 def get_charge_efficiency_number_entity_id() -> str:
@@ -556,9 +629,13 @@ def get_discharge_efficiency_number_name() -> str:
     return "Battery Discharge Efficiency"
 
 
-def get_discharge_efficiency_number_unique_id() -> str:
-    """Return the unique_id for the discharge efficiency number entity."""
-    return f"{DOMAIN}_battery_discharge_efficiency"
+def get_discharge_efficiency_number_unique_id(entry_id: str) -> str:
+    """Return the unique_id for the discharge efficiency number entity.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_battery_discharge_efficiency"
 
 
 def get_discharge_efficiency_number_entity_id() -> str:
@@ -577,14 +654,22 @@ def get_ev_target_soc_number_name() -> str:
     return "EV Target SoC"
 
 
-def get_ev_target_soc_number_unique_id() -> str:
-    """Return the unique_id for the EV target SoC number entity."""
-    return f"{DOMAIN}_{get_ev_target_soc_number_key()}_number"
+def get_ev_target_soc_number_unique_id(entry_id: str) -> str:
+    """Return the unique_id for the EV target SoC number entity.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_{get_ev_target_soc_number_key()}_number"
 
 
-def get_ev_target_soc_number_entity_id() -> str:
-    """Return the entity_id for the EV target SoC number entity."""
-    return f"number.{s(get_ev_target_soc_number_unique_id())}"
+def get_ev_target_soc_number_entity_id(entry_id: str) -> str:
+    """Return the entity_id for the EV target SoC number entity.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"number.{s(get_ev_target_soc_number_unique_id(entry_id))}"
 
 
 # EV 2 Target SoC Number
@@ -598,14 +683,22 @@ def get_ev_second_target_soc_number_name() -> str:
     return "EV 2 Target SoC"
 
 
-def get_ev_second_target_soc_number_unique_id() -> str:
-    """Return the unique_id for the EV 2 target SoC number entity."""
-    return f"{DOMAIN}_{get_ev_second_target_soc_number_key()}_number"
+def get_ev_second_target_soc_number_unique_id(entry_id: str) -> str:
+    """Return the unique_id for the EV 2 target SoC number entity.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_{get_ev_second_target_soc_number_key()}_number"
 
 
-def get_ev_second_target_soc_number_entity_id() -> str:
-    """Return the entity_id for the EV 2 target SoC number entity."""
-    return f"number.{s(get_ev_second_target_soc_number_unique_id())}"
+def get_ev_second_target_soc_number_entity_id(entry_id: str) -> str:
+    """Return the entity_id for the EV 2 target SoC number entity.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"number.{s(get_ev_second_target_soc_number_unique_id(entry_id))}"
 
 
 # Applier Status Sensor
@@ -614,9 +707,13 @@ def get_applier_status_sensor_name() -> str:
     return "Inverter Apply Status"
 
 
-def get_applier_status_sensor_unique_id() -> str:
-    """Return a unique ID for the applier-status sensor."""
-    return f"{DOMAIN}_applier_status_sensor"
+def get_applier_status_sensor_unique_id(entry_id: str) -> str:
+    """Return a unique ID for the applier-status sensor.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_applier_status_sensor"
 
 
 def get_applier_status_sensor_entity_id() -> str:
@@ -630,9 +727,13 @@ def get_forecast_accuracy_sensor_name() -> str:
     return "Forecast Accuracy"
 
 
-def get_forecast_accuracy_sensor_unique_id() -> str:
-    """Return a unique ID for the forecast accuracy sensor."""
-    return f"{DOMAIN}_forecast_accuracy_sensor"
+def get_forecast_accuracy_sensor_unique_id(entry_id: str) -> str:
+    """Return a unique ID for the forecast accuracy sensor.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_forecast_accuracy_sensor"
 
 
 def get_forecast_accuracy_sensor_entity_id() -> str:
@@ -655,14 +756,22 @@ def get_read_only_switch_name() -> str:
     return "Read Only"
 
 
-def get_read_only_switch_unique_id() -> str:
-    """Return the unique_id for the read-only switch."""
-    return f"{DOMAIN}_{get_read_only_switch_key()}_switch"
+def get_read_only_switch_unique_id(entry_id: str) -> str:
+    """Return the unique_id for the read-only switch.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_{get_read_only_switch_key()}_switch"
 
 
-def get_read_only_switch_entity_id() -> str:
-    """Return the entity_id for the read-only switch."""
-    return f"switch.{s(get_read_only_switch_unique_id())}"
+def get_read_only_switch_entity_id(entry_id: str) -> str:
+    """Return the entity_id for the read-only switch.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"switch.{s(get_read_only_switch_unique_id(entry_id))}"
 
 
 def get_extended_attributes_switch_key() -> str:
@@ -675,14 +784,22 @@ def get_extended_attributes_switch_name() -> str:
     return "Extended Attributes"
 
 
-def get_extended_attributes_switch_unique_id() -> str:
-    """Return the unique_id for the extended-attributes switch."""
-    return f"{DOMAIN}_{get_extended_attributes_switch_key()}_switch"
+def get_extended_attributes_switch_unique_id(entry_id: str) -> str:
+    """Return the unique_id for the extended-attributes switch.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_{get_extended_attributes_switch_key()}_switch"
 
 
-def get_extended_attributes_switch_entity_id() -> str:
-    """Return the entity_id for the extended-attributes switch."""
-    return f"switch.{s(get_extended_attributes_switch_unique_id())}"
+def get_extended_attributes_switch_entity_id(entry_id: str) -> str:
+    """Return the entity_id for the extended-attributes switch.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"switch.{s(get_extended_attributes_switch_unique_id(entry_id))}"
 
 
 def get_verbose_logging_switch_key() -> str:
@@ -695,14 +812,22 @@ def get_verbose_logging_switch_name() -> str:
     return "Verbose Logging"
 
 
-def get_verbose_logging_switch_unique_id() -> str:
-    """Return the unique_id for the verbose-logging switch."""
-    return f"{DOMAIN}_{get_verbose_logging_switch_key()}_switch"
+def get_verbose_logging_switch_unique_id(entry_id: str) -> str:
+    """Return the unique_id for the verbose-logging switch.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_{get_verbose_logging_switch_key()}_switch"
 
 
-def get_verbose_logging_switch_entity_id() -> str:
-    """Return the entity_id for the verbose-logging switch."""
-    return f"switch.{s(get_verbose_logging_switch_unique_id())}"
+def get_verbose_logging_switch_entity_id(entry_id: str) -> str:
+    """Return the entity_id for the verbose-logging switch.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"switch.{s(get_verbose_logging_switch_unique_id(entry_id))}"
 
 
 def get_batteries_schedule_1_switch_key() -> str:
@@ -715,14 +840,22 @@ def get_batteries_schedule_1_switch_name() -> str:
     return "Batteries Discharge Schedule 1"
 
 
-def get_batteries_schedule_1_switch_unique_id() -> str:
-    """Return the unique_id for the batteries-schedule-1 switch."""
-    return f"{DOMAIN}_{get_batteries_schedule_1_switch_key()}_switch"
+def get_batteries_schedule_1_switch_unique_id(entry_id: str) -> str:
+    """Return the unique_id for the batteries-schedule-1 switch.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_{get_batteries_schedule_1_switch_key()}_switch"
 
 
-def get_batteries_schedule_1_switch_entity_id() -> str:
-    """Return the entity_id for the batteries-schedule-1 switch."""
-    return f"switch.{s(get_batteries_schedule_1_switch_unique_id())}"
+def get_batteries_schedule_1_switch_entity_id(entry_id: str) -> str:
+    """Return the entity_id for the batteries-schedule-1 switch.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"switch.{s(get_batteries_schedule_1_switch_unique_id(entry_id))}"
 
 
 def get_batteries_schedule_2_switch_key() -> str:
@@ -735,14 +868,22 @@ def get_batteries_schedule_2_switch_name() -> str:
     return "Batteries Discharge Schedule 2"
 
 
-def get_batteries_schedule_2_switch_unique_id() -> str:
-    """Return the unique_id for the batteries-schedule-2 switch."""
-    return f"{DOMAIN}_{get_batteries_schedule_2_switch_key()}_switch"
+def get_batteries_schedule_2_switch_unique_id(entry_id: str) -> str:
+    """Return the unique_id for the batteries-schedule-2 switch.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_{get_batteries_schedule_2_switch_key()}_switch"
 
 
-def get_batteries_schedule_2_switch_entity_id() -> str:
-    """Return the entity_id for the batteries-schedule-2 switch."""
-    return f"switch.{s(get_batteries_schedule_2_switch_unique_id())}"
+def get_batteries_schedule_2_switch_entity_id(entry_id: str) -> str:
+    """Return the entity_id for the batteries-schedule-2 switch.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"switch.{s(get_batteries_schedule_2_switch_unique_id(entry_id))}"
 
 
 def get_batteries_schedule_3_switch_key() -> str:
@@ -755,14 +896,22 @@ def get_batteries_schedule_3_switch_name() -> str:
     return "Batteries Discharge Schedule 3"
 
 
-def get_batteries_schedule_3_switch_unique_id() -> str:
-    """Return the unique_id for the batteries-schedule-3 switch."""
-    return f"{DOMAIN}_{get_batteries_schedule_3_switch_key()}_switch"
+def get_batteries_schedule_3_switch_unique_id(entry_id: str) -> str:
+    """Return the unique_id for the batteries-schedule-3 switch.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_{get_batteries_schedule_3_switch_key()}_switch"
 
 
-def get_batteries_schedule_3_switch_entity_id() -> str:
-    """Return the entity_id for the batteries-schedule-3 switch."""
-    return f"switch.{s(get_batteries_schedule_3_switch_unique_id())}"
+def get_batteries_schedule_3_switch_entity_id(entry_id: str) -> str:
+    """Return the entity_id for the batteries-schedule-3 switch.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"switch.{s(get_batteries_schedule_3_switch_unique_id(entry_id))}"
 
 
 def get_ev_force_discharge_switch_key() -> str:
@@ -775,14 +924,22 @@ def get_ev_force_discharge_switch_name() -> str:
     return "EV Charger Force Max Discharge Power"
 
 
-def get_ev_force_discharge_switch_unique_id() -> str:
-    """Return the unique_id for the EV-force-discharge switch."""
-    return f"{DOMAIN}_{get_ev_force_discharge_switch_key()}_switch"
+def get_ev_force_discharge_switch_unique_id(entry_id: str) -> str:
+    """Return the unique_id for the EV-force-discharge switch.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_{get_ev_force_discharge_switch_key()}_switch"
 
 
-def get_ev_force_discharge_switch_entity_id() -> str:
-    """Return the entity_id for the EV-force-discharge switch."""
-    return f"switch.{s(get_ev_force_discharge_switch_unique_id())}"
+def get_ev_force_discharge_switch_entity_id(entry_id: str) -> str:
+    """Return the entity_id for the EV-force-discharge switch.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"switch.{s(get_ev_force_discharge_switch_unique_id(entry_id))}"
 
 
 # ---------------------------------------------------------------------------
@@ -800,14 +957,22 @@ def get_ev_smart_charging_switch_name() -> str:
     return "EV Smart Charging"
 
 
-def get_ev_smart_charging_switch_unique_id() -> str:
-    """Return the unique_id for the primary EV smart charging switch."""
-    return f"{DOMAIN}_{get_ev_smart_charging_switch_key()}_switch"
+def get_ev_smart_charging_switch_unique_id(entry_id: str) -> str:
+    """Return the unique_id for the primary EV smart charging switch.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_{get_ev_smart_charging_switch_key()}_switch"
 
 
-def get_ev_smart_charging_switch_entity_id() -> str:
-    """Return the entity_id for the primary EV smart charging switch."""
-    return f"switch.{s(get_ev_smart_charging_switch_unique_id())}"
+def get_ev_smart_charging_switch_entity_id(entry_id: str) -> str:
+    """Return the entity_id for the primary EV smart charging switch.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"switch.{s(get_ev_smart_charging_switch_unique_id(entry_id))}"
 
 
 def get_ev_force_charge_now_switch_key() -> str:
@@ -820,14 +985,22 @@ def get_ev_force_charge_now_switch_name() -> str:
     return "EV Force Charge Now"
 
 
-def get_ev_force_charge_now_switch_unique_id() -> str:
-    """Return the unique_id for the primary EV force-charge-now switch."""
-    return f"{DOMAIN}_{get_ev_force_charge_now_switch_key()}_switch"
+def get_ev_force_charge_now_switch_unique_id(entry_id: str) -> str:
+    """Return the unique_id for the primary EV force-charge-now switch.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_{get_ev_force_charge_now_switch_key()}_switch"
 
 
-def get_ev_force_charge_now_switch_entity_id() -> str:
-    """Return the entity_id for the primary EV force-charge-now switch."""
-    return f"switch.{s(get_ev_force_charge_now_switch_unique_id())}"
+def get_ev_force_charge_now_switch_entity_id(entry_id: str) -> str:
+    """Return the entity_id for the primary EV force-charge-now switch.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"switch.{s(get_ev_force_charge_now_switch_unique_id(entry_id))}"
 
 
 def get_ev_second_smart_charging_switch_key() -> str:
@@ -840,14 +1013,22 @@ def get_ev_second_smart_charging_switch_name() -> str:
     return "EV 2 Smart Charging"
 
 
-def get_ev_second_smart_charging_switch_unique_id() -> str:
-    """Return the unique_id for the second EV smart charging switch."""
-    return f"{DOMAIN}_{get_ev_second_smart_charging_switch_key()}_switch"
+def get_ev_second_smart_charging_switch_unique_id(entry_id: str) -> str:
+    """Return the unique_id for the second EV smart charging switch.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_{get_ev_second_smart_charging_switch_key()}_switch"
 
 
-def get_ev_second_smart_charging_switch_entity_id() -> str:
-    """Return the entity_id for the second EV smart charging switch."""
-    return f"switch.{s(get_ev_second_smart_charging_switch_unique_id())}"
+def get_ev_second_smart_charging_switch_entity_id(entry_id: str) -> str:
+    """Return the entity_id for the second EV smart charging switch.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"switch.{s(get_ev_second_smart_charging_switch_unique_id(entry_id))}"
 
 
 def get_ev_second_force_charge_now_switch_key() -> str:
@@ -860,14 +1041,22 @@ def get_ev_second_force_charge_now_switch_name() -> str:
     return "EV 2 Force Charge Now"
 
 
-def get_ev_second_force_charge_now_switch_unique_id() -> str:
-    """Return the unique_id for the second EV force-charge-now switch."""
-    return f"{DOMAIN}_{get_ev_second_force_charge_now_switch_key()}_switch"
+def get_ev_second_force_charge_now_switch_unique_id(entry_id: str) -> str:
+    """Return the unique_id for the second EV force-charge-now switch.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_{get_ev_second_force_charge_now_switch_key()}_switch"
 
 
-def get_ev_second_force_charge_now_switch_entity_id() -> str:
-    """Return the entity_id for the second EV force-charge-now switch."""
-    return f"switch.{s(get_ev_second_force_charge_now_switch_unique_id())}"
+def get_ev_second_force_charge_now_switch_entity_id(entry_id: str) -> str:
+    """Return the entity_id for the second EV force-charge-now switch.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"switch.{s(get_ev_second_force_charge_now_switch_unique_id(entry_id))}"
 
 
 # ---------------------------------------------------------------------------
@@ -885,14 +1074,22 @@ def get_ev_deadline_time_name() -> str:
     return "EV Charge Deadline"
 
 
-def get_ev_deadline_time_unique_id() -> str:
-    """Return the unique ID for the EV charge deadline time entity."""
-    return f"{DOMAIN}_{get_ev_deadline_time_key()}_time"
+def get_ev_deadline_time_unique_id(entry_id: str) -> str:
+    """Return the unique ID for the EV charge deadline time entity.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_{get_ev_deadline_time_key()}_time"
 
 
-def get_ev_deadline_time_entity_id() -> str:
-    """Return the Home Assistant entity ID for the EV charge deadline time entity."""
-    return f"time.{s(get_ev_deadline_time_unique_id())}"
+def get_ev_deadline_time_entity_id(entry_id: str) -> str:
+    """Return the Home Assistant entity ID for the EV charge deadline time entity.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"time.{s(get_ev_deadline_time_unique_id(entry_id))}"
 
 
 def get_ev_second_deadline_time_key() -> str:
@@ -905,14 +1102,22 @@ def get_ev_second_deadline_time_name() -> str:
     return "EV 2 Charge Deadline"
 
 
-def get_ev_second_deadline_time_unique_id() -> str:
-    """Return the unique ID for the second EV charge deadline time entity."""
-    return f"{DOMAIN}_{get_ev_second_deadline_time_key()}_time"
+def get_ev_second_deadline_time_unique_id(entry_id: str) -> str:
+    """Return the unique ID for the second EV charge deadline time entity.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_{get_ev_second_deadline_time_key()}_time"
 
 
-def get_ev_second_deadline_time_entity_id() -> str:
-    """Return the Home Assistant entity ID for the second EV charge deadline time entity."""
-    return f"time.{s(get_ev_second_deadline_time_unique_id())}"
+def get_ev_second_deadline_time_entity_id(entry_id: str) -> str:
+    """Return the Home Assistant entity ID for the second EV charge deadline time entity.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"time.{s(get_ev_second_deadline_time_unique_id(entry_id))}"
 
 
 # ---------------------------------------------------------------------------
@@ -930,14 +1135,22 @@ def get_schedule_1_start_time_name() -> str:
     return "Batteries Discharge Schedule 1 Start"
 
 
-def get_schedule_1_start_time_unique_id() -> str:
-    """Return the unique_id for the schedule-1-start time entity."""
-    return f"{DOMAIN}_{get_schedule_1_start_time_key()}_time"
+def get_schedule_1_start_time_unique_id(entry_id: str) -> str:
+    """Return the unique_id for the schedule-1-start time entity.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_{get_schedule_1_start_time_key()}_time"
 
 
-def get_schedule_1_start_time_entity_id() -> str:
-    """Return the entity_id for the schedule-1-start time entity."""
-    return f"time.{s(get_schedule_1_start_time_unique_id())}"
+def get_schedule_1_start_time_entity_id(entry_id: str) -> str:
+    """Return the entity_id for the schedule-1-start time entity.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"time.{s(get_schedule_1_start_time_unique_id(entry_id))}"
 
 
 def get_schedule_1_end_time_key() -> str:
@@ -950,14 +1163,22 @@ def get_schedule_1_end_time_name() -> str:
     return "Batteries Discharge Schedule 1 End"
 
 
-def get_schedule_1_end_time_unique_id() -> str:
-    """Return the unique_id for the schedule-1-end time entity."""
-    return f"{DOMAIN}_{get_schedule_1_end_time_key()}_time"
+def get_schedule_1_end_time_unique_id(entry_id: str) -> str:
+    """Return the unique_id for the schedule-1-end time entity.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_{get_schedule_1_end_time_key()}_time"
 
 
-def get_schedule_1_end_time_entity_id() -> str:
-    """Return the entity_id for the schedule-1-end time entity."""
-    return f"time.{s(get_schedule_1_end_time_unique_id())}"
+def get_schedule_1_end_time_entity_id(entry_id: str) -> str:
+    """Return the entity_id for the schedule-1-end time entity.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"time.{s(get_schedule_1_end_time_unique_id(entry_id))}"
 
 
 def get_schedule_2_start_time_key() -> str:
@@ -970,14 +1191,22 @@ def get_schedule_2_start_time_name() -> str:
     return "Batteries Discharge Schedule 2 Start"
 
 
-def get_schedule_2_start_time_unique_id() -> str:
-    """Return the unique_id for the schedule-2-start time entity."""
-    return f"{DOMAIN}_{get_schedule_2_start_time_key()}_time"
+def get_schedule_2_start_time_unique_id(entry_id: str) -> str:
+    """Return the unique_id for the schedule-2-start time entity.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_{get_schedule_2_start_time_key()}_time"
 
 
-def get_schedule_2_start_time_entity_id() -> str:
-    """Return the entity_id for the schedule-2-start time entity."""
-    return f"time.{s(get_schedule_2_start_time_unique_id())}"
+def get_schedule_2_start_time_entity_id(entry_id: str) -> str:
+    """Return the entity_id for the schedule-2-start time entity.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"time.{s(get_schedule_2_start_time_unique_id(entry_id))}"
 
 
 def get_schedule_2_end_time_key() -> str:
@@ -990,14 +1219,22 @@ def get_schedule_2_end_time_name() -> str:
     return "Batteries Discharge Schedule 2 End"
 
 
-def get_schedule_2_end_time_unique_id() -> str:
-    """Return the unique_id for the schedule-2-end time entity."""
-    return f"{DOMAIN}_{get_schedule_2_end_time_key()}_time"
+def get_schedule_2_end_time_unique_id(entry_id: str) -> str:
+    """Return the unique_id for the schedule-2-end time entity.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_{get_schedule_2_end_time_key()}_time"
 
 
-def get_schedule_2_end_time_entity_id() -> str:
-    """Return the entity_id for the schedule-2-end time entity."""
-    return f"time.{s(get_schedule_2_end_time_unique_id())}"
+def get_schedule_2_end_time_entity_id(entry_id: str) -> str:
+    """Return the entity_id for the schedule-2-end time entity.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"time.{s(get_schedule_2_end_time_unique_id(entry_id))}"
 
 
 def get_schedule_3_start_time_key() -> str:
@@ -1010,14 +1247,22 @@ def get_schedule_3_start_time_name() -> str:
     return "Batteries Discharge Schedule 3 Start"
 
 
-def get_schedule_3_start_time_unique_id() -> str:
-    """Return the unique_id for the schedule-3-start time entity."""
-    return f"{DOMAIN}_{get_schedule_3_start_time_key()}_time"
+def get_schedule_3_start_time_unique_id(entry_id: str) -> str:
+    """Return the unique_id for the schedule-3-start time entity.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_{get_schedule_3_start_time_key()}_time"
 
 
-def get_schedule_3_start_time_entity_id() -> str:
-    """Return the entity_id for the schedule-3-start time entity."""
-    return f"time.{s(get_schedule_3_start_time_unique_id())}"
+def get_schedule_3_start_time_entity_id(entry_id: str) -> str:
+    """Return the entity_id for the schedule-3-start time entity.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"time.{s(get_schedule_3_start_time_unique_id(entry_id))}"
 
 
 def get_schedule_3_end_time_key() -> str:
@@ -1030,11 +1275,19 @@ def get_schedule_3_end_time_name() -> str:
     return "Batteries Discharge Schedule 3 End"
 
 
-def get_schedule_3_end_time_unique_id() -> str:
-    """Return the unique_id for the schedule-3-end time entity."""
-    return f"{DOMAIN}_{get_schedule_3_end_time_key()}_time"
+def get_schedule_3_end_time_unique_id(entry_id: str) -> str:
+    """Return the unique_id for the schedule-3-end time entity.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_{get_schedule_3_end_time_key()}_time"
 
 
-def get_schedule_3_end_time_entity_id() -> str:
-    """Return the entity_id for the schedule-3-end time entity."""
-    return f"time.{s(get_schedule_3_end_time_unique_id())}"
+def get_schedule_3_end_time_entity_id(entry_id: str) -> str:
+    """Return the entity_id for the schedule-3-end time entity.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"time.{s(get_schedule_3_end_time_unique_id(entry_id))}"

--- a/tests/sensors/test_hourly_data_populator.py
+++ b/tests/sensors/test_hourly_data_populator.py
@@ -162,7 +162,9 @@ class TestSnapshotPopulation:
         for h in range(24):
             hour_end = (h + 1) % 24
             for days, val in [(1, 1.0), (3, 1.0), (7, 1.0), (14, 1.0)]:
-                uid = get_energy_average_sensor_unique_id(h, hour_end, days)
+                uid = get_energy_average_sensor_unique_id(
+                    "test_entry_id", h, hour_end, days
+                )
                 eid = f"sensor.energy_avg_{h:02d}_{days}d"
                 eid_cache[uid] = eid
                 energy_average_values[eid] = float(val)
@@ -203,7 +205,7 @@ class TestSnapshotPopulation:
         ]
 
         result = populate_avg_house_consumption_from_snapshot(
-            recs, snapshot, cfg, eid_cache
+            recs, snapshot, cfg, eid_cache, entry_id="test_entry_id"
         )
 
         assert result is True
@@ -236,7 +238,9 @@ class TestSnapshotPopulation:
             )
             for h in range(24)
         ]
-        populate_avg_house_consumption_from_snapshot(recs2, snapshot, cfg, eid_cache)
+        populate_avg_house_consumption_from_snapshot(
+            recs2, snapshot, cfg, eid_cache, entry_id="test_entry_id"
+        )
         for r1, r2 in zip(recs, recs2, strict=False):
             assert r1.avg_house_consumption_kwh == pytest.approx(
                 r2.avg_house_consumption_kwh
@@ -294,7 +298,9 @@ class TestSnapshotPopulation:
                 (7, base_val * 1.10),
                 (14, base_val * 1.15),
             ]:
-                uid = get_energy_average_sensor_unique_id(h, hour_end, days)
+                uid = get_energy_average_sensor_unique_id(
+                    "test_entry_id", h, hour_end, days
+                )
                 eid = f"sensor.energy_avg_{h:02d}_{days}d"
                 eid_cache[uid] = eid
                 energy_average_values[eid] = float(val)
@@ -365,14 +371,18 @@ class TestSnapshotPopulation:
         ]
 
         tz = UTC
-        populate_avg_house_consumption_from_snapshot(recs1, snapshot, cfg, eid_cache)
+        populate_avg_house_consumption_from_snapshot(
+            recs1, snapshot, cfg, eid_cache, entry_id="test_entry_id"
+        )
         populate_price_and_solcast_from_snapshot(recs1, snapshot, cfg, tz)
 
         # Second population with identical data
         recs2 = [
             _make_rec(base + td(hours=h), base + td(hours=h + 1)) for h in range(24)
         ]
-        populate_avg_house_consumption_from_snapshot(recs2, snapshot, cfg, eid_cache)
+        populate_avg_house_consumption_from_snapshot(
+            recs2, snapshot, cfg, eid_cache, entry_id="test_entry_id"
+        )
         populate_price_and_solcast_from_snapshot(recs2, snapshot, cfg, tz)
 
         # Assert determinism

--- a/tests/test_house_consumption_sensor_lifecycle.py
+++ b/tests/test_house_consumption_sensor_lifecycle.py
@@ -132,7 +132,7 @@ class TestPowerSensorMetadata:
 
     def test_unique_id_format(self) -> None:
         sensor, _ = _make_sensor(hour_start=7)
-        expected = get_house_consumption_power_sensor_unique_id(7, 8)
+        expected = get_house_consumption_power_sensor_unique_id("test_entry_id", 7, 8)
         assert sensor.unique_id == expected
 
 
@@ -496,7 +496,7 @@ class TestDerivedSensorLifecycle:
         fake_now = MagicMock()
         fake_now.hour = 6
         fake_now.isoformat.return_value = "2026-05-12T06:00:00"
-        integral_uid = get_integral_sensor_unique_id(6, 7)
+        integral_uid = get_integral_sensor_unique_id("test_entry_id", 6, 7)
 
         async def fake_fetch():
             sensor._hsem_house_consumption_power_state = 500.0
@@ -534,7 +534,7 @@ class TestDerivedSensorLifecycle:
         # _derived_sensors_created is empty — simulates fresh HA restart.
         assert len(sensor._derived_sensors_created) == 0
 
-        integral_uid = get_integral_sensor_unique_id(9, 10)
+        integral_uid = get_integral_sensor_unique_id("test_entry_id", 9, 10)
 
         fake_now = MagicMock()
         fake_now.hour = 5  # Outside active window — just tests derived sensor path

--- a/tests/test_platform_entity_refactor.py
+++ b/tests/test_platform_entity_refactor.py
@@ -11,8 +11,8 @@ Verifies that the select, switch, and time platform entities:
 - preserve user-facing entity IDs
 
 Unique-ID format contract (must never change):
-  - Switch:  ``"hsem_<key>_switch"``   e.g. ``"hsem_hsem_read_only_switch"``
-  - Time:    ``"hsem_<key>_time"``     e.g. ``"hsem_hsem_batteries_enable_batteries_schedule_1_start_time"``
+  - Switch:  ``"hsem_<entry_id>_<key>_switch"``   e.g. ``"hsem_<entry_id>_hsem_read_only_switch"``
+  - Time:    ``"hsem_<entry_id>_<key>_time"``     e.g. ``"hsem_<entry_id>_hsem_batteries_enable_batteries_schedule_1_start_time"``
   - Select:  ``"<key>"``               e.g. ``"hsem_force_working_mode"``
     (The key already carries the ``hsem_`` prefix, keeping it consistent with
     the switch/time convention and compatible with state-collector lookups.)
@@ -426,18 +426,18 @@ class TestTimeUniqueId:
     """Time unique_id must preserve the existing format to avoid breaking registries."""
 
     def test_unique_id_format(self) -> None:
-        """unique_id must be 'hsem_<key>_time'."""
+        """unique_id must be 'hsem_<entry_id>_<key>_time'."""
         key = "hsem_batteries_enable_batteries_schedule_1_start"
         entity = _make_time(key=key)
-        assert entity.unique_id == f"{DOMAIN}_{key}_time"
+        assert entity.unique_id == f"{DOMAIN}_test_entry_id_{key}_time"
 
     def test_unique_id_all_times(self) -> None:
-        """Every time key produces the expected 'hsem_<key>_time' id."""
+        """Every time key produces the expected 'hsem_<entry_id>_<key>_time' id."""
         from custom_components.hsem.time import TIME_DESCRIPTIONS
 
         for desc in TIME_DESCRIPTIONS:
             entity = _make_time(key=desc.key, name=str(desc.name))
-            assert entity.unique_id == f"{DOMAIN}_{desc.key}_time"
+            assert entity.unique_id == f"{DOMAIN}_test_entry_id_{desc.key}_time"
 
     def test_unique_id_is_attr_not_property(self) -> None:
         entity = _make_time()

--- a/tests/test_platform_entity_refactor.py
+++ b/tests/test_platform_entity_refactor.py
@@ -202,16 +202,19 @@ class TestSwitchUniqueId:
         )
 
         entity = _make_switch(key=get_read_only_switch_key())
-        assert entity.unique_id == get_read_only_switch_unique_id()
+        assert entity.unique_id == get_read_only_switch_unique_id("test_entry_id")
 
     def test_unique_id_all_switches(self) -> None:
         """Every switch key produces the unique_id from the sensornames getter."""
-        from custom_components.hsem.custom_switches.description import _SWITCH_ID_MAP
+        from custom_components.hsem.custom_switches.description import (
+            build_switch_id_map,
+        )
         from custom_components.hsem.switch import SWITCH_DESCRIPTIONS
 
+        switch_id_map = build_switch_id_map("test_entry_id")
         for desc in SWITCH_DESCRIPTIONS:
             entity = _make_switch(key=desc.key, name=str(desc.name))
-            expected_uid, _ = _SWITCH_ID_MAP[desc.key]
+            expected_uid, _ = switch_id_map[desc.key]
             assert entity.unique_id == expected_uid
 
     def test_unique_id_is_attr_not_property(self) -> None:


### PR DESCRIPTION
## Summary

Adds config entry ID to every `unique_id` value across the HSEM integration. This was the final remaining item from the HA compliance audit (punkt 2 — unique_id must be stable and include config entry ID).

## Files Changed (31 files)

### Core: `utils/sensornames.py`
- Added `entry_id: str` as the first parameter to all ~35 `get_*_unique_id()` functions
- Updated docstrings to document the new parameter
- Updated 6 `get_*_entity_id()` functions that internally call `*_unique_id()` to pass `entry_id` through

### Sensors (18 files)
- Updated all `_attr_unique_id = get_*_sensor_unique_id()` assignments to pass `config_entry.entry_id`

### State collection pipeline (3 files)
- `custom_sensors/state_collector.py` — Added `entry_id` param to `async_collect_all_states`, `async_collect_live_state`, `_read_ev_planned_load_state`, `_register_listeners`
- `custom_sensors/hourly_data_populator.py` — Added `entry_id` param to populator functions
- `coordinator.py` — Passes `entry_id=self._config_entry.entry_id` to collection and population calls

### Switches, times, numbers (5 files)
- `custom_switches/description.py` — Replaced module-level `_SWITCH_ID_MAP` with `build_switch_id_map(entry_id)` factory function
- `custom_switches/switch.py` — Uses `build_switch_id_map(config_entry.entry_id)`
- `custom_times/description.py` — Replaced module-level `_TIME_ID_MAP` with `build_time_id_map(entry_id)` factory function
- `custom_times/time.py` — Uses `build_time_id_map(config_entry.entry_id)`
- `number.py` — Passes `config_entry.entry_id` to all id-getter calls

### Tests (3 files)
- Updated test call sites with `"test_entry_id"` test value
- Fixed `test_platform_entity_refactor.py` time unique_id assertions for new format

### Pattern

```python
# Before:
def get_battery_soc_sensor_unique_id() -> str:
    return f"{DOMAIN}_battery_soc_sensor"

# After:
def get_battery_soc_sensor_unique_id(entry_id: str) -> str:
    return f"{DOMAIN}_{entry_id}_battery_soc_sensor"
```

## Tests

- `tox -e lint` — ✅ All checks passed
- `tox -e typing` — ✅ 0 errors
- `tox -e quality` — ✅ 0 errors

Fixes #491