### PR TITLE
chore: fix remaining HA compliance violations

### DIFF
--- a/custom_components/hsem/custom_selectors/solcast_likelihood.py
+++ b/custom_components/hsem/custom_selectors/solcast_likelihood.py
@@ -59,7 +59,9 @@ class HSEMSolcastLikelihoodSelector(SelectEntity, HSEMEntity):
         self.hass = hass
         self._config_entry = config_entry
         self.entity_description = description
-        self._attr_unique_id = get_solcast_likelihood_selector_key()
+        self._attr_unique_id = (
+            f"{get_solcast_likelihood_selector_key()}_{config_entry.entry_id}"
+        )
         self.entity_id = get_solcast_likelihood_selector_entity_id()
         self._attr_options = list(description.options or _OPTIONS)
         raw_name = description.name

--- a/custom_components/hsem/custom_selectors/working_mode.py
+++ b/custom_components/hsem/custom_selectors/working_mode.py
@@ -58,7 +58,9 @@ class HSEMWorkingModeSelector(SelectEntity, HSEMEntity):
         self.entity_description = description
         # unique_id and entity_id are sourced from sensornames.py to keep
         # all HSEM entity identifiers in one canonical location.
-        self._attr_unique_id = get_force_working_mode_selector_key()
+        self._attr_unique_id = (
+            f"{get_force_working_mode_selector_key()}_{config_entry.entry_id}"
+        )
         self.entity_id = get_force_working_mode_selector_entity_id()
         self._attr_options = list(description.options or [])
         self._attr_current_option = default

--- a/custom_components/hsem/custom_sensors/integration_sensor.py
+++ b/custom_components/hsem/custom_sensors/integration_sensor.py
@@ -6,7 +6,7 @@ metadata so that all derived energy sensors appear on the HSEM device page.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.integration.sensor import IntegrationSensor
 from homeassistant.components.sensor.const import SensorDeviceClass, SensorStateClass
@@ -61,9 +61,11 @@ class HSEMIntegrationSensor(IntegrationSensor, HSEMEntity):
         return SensorDeviceClass.ENERGY
 
     @property
+    @override
     def unique_id(self) -> str | None:
         return self._attr_unique_id
 
     @property
+    @override
     def should_poll(self) -> bool:
         return True

--- a/custom_components/hsem/custom_sensors/state_collector.py
+++ b/custom_components/hsem/custom_sensors/state_collector.py
@@ -90,7 +90,7 @@ async def async_collect_live_state(
     fwm_entity = force_working_mode_cache
     if fwm_entity is None:
         fwm_entity = await async_resolve_entity_id_from_unique_id(
-            sensor, get_force_working_mode_selector_key(), "select"
+            sensor, f"{get_force_working_mode_selector_key()}_{entry_id}", "select"
         )
     state.force_working_mode = fwm_entity
 

--- a/custom_components/hsem/custom_sensors/utility_meter_sensor.py
+++ b/custom_components/hsem/custom_sensors/utility_meter_sensor.py
@@ -6,7 +6,7 @@ per-hour energy meters appear on the HSEM device page.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, override
 
 from homeassistant.components.sensor.const import SensorDeviceClass, SensorStateClass
 from homeassistant.components.utility_meter.sensor import UtilityMeterSensor
@@ -52,10 +52,12 @@ class HSEMUtilityMeterSensor(UtilityMeterSensor, HSEMEntity):
         self.entity_id = e_id
 
     @property
+    @override
     def unique_id(self) -> str | None:
         return self._attr_unique_id
 
     @property  # type: ignore[misc]  # HA stub declares unit_of_measurement as @final
+    @override
     def unit_of_measurement(self) -> str:
         return UnitOfEnergy.KILO_WATT_HOUR
 
@@ -68,5 +70,6 @@ class HSEMUtilityMeterSensor(UtilityMeterSensor, HSEMEntity):
         return SensorStateClass.TOTAL
 
     @property
+    @override
     def should_poll(self) -> bool:
         return True

--- a/custom_components/hsem/models/time_series.py
+++ b/custom_components/hsem/models/time_series.py
@@ -281,11 +281,11 @@ class TimeSeriesIndex:
         for meta in self.slots:
             if _use_day_key:
                 day_hour_key = (meta.key.day_offset, meta.hour)
-                imp = import_prices.get(day_hour_key)  # type: ignore[call-overload]
-                exp = export_prices.get(day_hour_key)  # type: ignore[call-overload]
+                imp = import_prices.get(day_hour_key)  # type: ignore[call-overload]  # dict key is tuple|int; mypy sees overload ambiguity
+                exp = export_prices.get(day_hour_key)  # type: ignore[call-overload]  # dict key is tuple|int; mypy sees overload ambiguity
             else:
-                imp = import_prices.get(meta.hour)  # type: ignore[call-overload]
-                exp = export_prices.get(meta.hour)  # type: ignore[call-overload]
+                imp = import_prices.get(meta.hour)  # type: ignore[call-overload]  # dict key is tuple|int; mypy sees overload ambiguity
+                exp = export_prices.get(meta.hour)  # type: ignore[call-overload]  # dict key is tuple|int; mypy sees overload ambiguity
 
             if imp is None:
                 self.missing_slots.add(meta.key)
@@ -332,9 +332,9 @@ class TimeSeriesIndex:
         for meta in self.slots:
             if _use_day_key:
                 key = (meta.key.day_offset, meta.hour)
-                hourly_kwh = pv_by_hour.get(key)  # type: ignore[call-overload]
+                hourly_kwh = pv_by_hour.get(key)  # type: ignore[call-overload]  # dict key is tuple|int; mypy sees overload ambiguity
             else:
-                hourly_kwh = pv_by_hour.get(meta.hour)  # type: ignore[call-overload]
+                hourly_kwh = pv_by_hour.get(meta.hour)  # type: ignore[call-overload]  # dict key is tuple|int; mypy sees overload ambiguity
             if hourly_kwh is None:
                 self.missing_slots.add(meta.key)
                 self.missing_pv_slots.add(meta.key)
@@ -374,9 +374,9 @@ class TimeSeriesIndex:
         for meta in self.slots:
             if _use_day_key:
                 key = (meta.key.day_offset, meta.hour)
-                hourly_kwh = load_by_hour.get(key)  # type: ignore[call-overload]
+                hourly_kwh = load_by_hour.get(key)  # type: ignore[call-overload]  # dict key is tuple|int; mypy sees overload ambiguity
             else:
-                hourly_kwh = load_by_hour.get(meta.hour)  # type: ignore[call-overload]
+                hourly_kwh = load_by_hour.get(meta.hour)  # type: ignore[call-overload]  # dict key is tuple|int; mypy sees overload ambiguity
             if hourly_kwh is None:
                 self.missing_slots.add(meta.key)
                 aligned.append(MISSING_SENTINEL)

--- a/custom_components/hsem/utils/forecast_tracker.py
+++ b/custom_components/hsem/utils/forecast_tracker.py
@@ -261,16 +261,16 @@ class ForecastTracker:
 
         mae_pv: float = statistics.mean(
             r.mae_pv for r in finalised if r.mae_pv is not None
-        )  # type: ignore[misc]
+        )  # type: ignore[misc]  # statistics.mean rejects generator of optional float
         mae_load: float = statistics.mean(
             r.mae_load for r in finalised if r.mae_load is not None
-        )  # type: ignore[misc]
+        )  # type: ignore[misc]  # statistics.mean rejects generator of optional float
         bias_pv: float = statistics.mean(
             r.bias_pv for r in finalised if r.bias_pv is not None
-        )  # type: ignore[misc]
+        )  # type: ignore[misc]  # statistics.mean rejects generator of optional float
         bias_load: float = statistics.mean(
             r.bias_load for r in finalised if r.bias_load is not None
-        )  # type: ignore[misc]
+        )  # type: ignore[misc]  # statistics.mean rejects generator of optional float
 
         # RMSE
         rmse_pv = math.sqrt(

--- a/custom_components/hsem/utils/misc.py
+++ b/custom_components/hsem/utils/misc.py
@@ -386,7 +386,7 @@ async def async_set_number_value(self: Any, entity_id: str, value: float | int) 
     entity = self.hass.states.get(entity_id)
 
     if entity is None:
-        _LOGGER.error(f"Entity with id {entity_id} not found.")
+        _LOGGER.error("Entity with id %s not found", entity_id)
         return
 
     try:

--- a/tests/test_diagnostics_dump.py
+++ b/tests/test_diagnostics_dump.py
@@ -16,6 +16,8 @@ import json
 
 import pytest
 
+from homeassistant.const import STATE_UNKNOWN
+
 from custom_components.hsem.models.planner_inputs import PlannerInput
 from custom_components.hsem.planner import run_planner
 from custom_components.hsem.utils.diagnostics import (
@@ -207,7 +209,7 @@ class TestBuildDiagnosticsDump:
         inp = _make_minimal_input()
         out = run_planner(inp)
         dump = build_diagnostics_dump(inp, out)
-        assert dump["hsem_version"] == "unknown"
+        assert dump["hsem_version"] == STATE_UNKNOWN
 
     def test_apply_result_is_none_when_not_provided(self) -> None:
         inp = _make_minimal_input()

--- a/tests/test_platform_entity_refactor.py
+++ b/tests/test_platform_entity_refactor.py
@@ -13,9 +13,8 @@ Verifies that the select, switch, and time platform entities:
 Unique-ID format contract (must never change):
   - Switch:  ``"hsem_<entry_id>_<key>_switch"``   e.g. ``"hsem_<entry_id>_hsem_read_only_switch"``
   - Time:    ``"hsem_<entry_id>_<key>_time"``     e.g. ``"hsem_<entry_id>_hsem_batteries_enable_batteries_schedule_1_start_time"``
-  - Select:  ``"<key>"``               e.g. ``"hsem_force_working_mode"``
-    (The key already carries the ``hsem_`` prefix, keeping it consistent with
-    the switch/time convention and compatible with state-collector lookups.)
+  - Select:  ``"<key>_<entry_id>"``               e.g. ``"hsem_force_working_mode_test_entry_id"``
+    (The key already carries the ``hsem_`` prefix; entry_id is appended for uniqueness.)
 """
 
 from __future__ import annotations
@@ -632,9 +631,9 @@ class TestSelectorUniqueId:
     """Selector unique_id must use the key directly (hsem_ prefix convention)."""
 
     def test_unique_id_is_key(self) -> None:
-        """unique_id must equal the description key exactly."""
+        """unique_id must include the description key and entry_id."""
         entity = _make_selector(key="hsem_force_working_mode")
-        assert entity.unique_id == "hsem_force_working_mode"
+        assert entity.unique_id == "hsem_force_working_mode_test_entry_id"
 
     def test_unique_id_includes_hsem_prefix(self) -> None:
         entity = _make_selector(key="hsem_force_working_mode")
@@ -642,13 +641,14 @@ class TestSelectorUniqueId:
         assert entity.unique_id.startswith("hsem_")
 
     def test_unique_id_equals_canonical_key(self) -> None:
-        """unique_id must equal the canonical key from sensornames, not a caller-supplied key."""
+        """unique_id must start with the canonical key from sensornames."""
         from custom_components.hsem.utils.sensornames import (
             get_force_working_mode_selector_key,
         )
 
         entity = _make_selector(key="hsem_force_working_mode")
-        assert entity.unique_id == get_force_working_mode_selector_key()
+        assert entity.unique_id is not None
+        assert entity.unique_id.startswith(get_force_working_mode_selector_key())
 
     def test_unique_id_is_attr_not_property(self) -> None:
         entity = _make_selector()
@@ -656,9 +656,9 @@ class TestSelectorUniqueId:
         assert entity._attr_unique_id == entity.unique_id
 
     def test_unique_id_format(self) -> None:
-        """unique_id must be the key string (e.g. 'hsem_force_working_mode')."""
+        """unique_id must be '<key>_<entry_id>' (e.g. 'hsem_force_working_mode_test_entry_id')."""
         entity = _make_selector(key="hsem_force_working_mode")
-        assert entity.unique_id == "hsem_force_working_mode"
+        assert entity.unique_id == "hsem_force_working_mode_test_entry_id"
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Fixes the final 19 violations found in the complete HSEM compliance re-audit against `.rules/ha-development-rules.md`.

## Files Changed (10 files)

### Production code (8 files)

| File | Change |
|---|---|
| `utils/misc.py` | Fix f-string + trailing period in `_LOGGER.error` → `%`-formatting |
| `custom_sensors/integration_sensor.py` | Add `@override` to `unique_id`, `should_poll` |
| `custom_sensors/utility_meter_sensor.py` | Add `@override` to `unique_id`, `unit_of_measurement`, `should_poll` |
| `models/time_series.py` | Add justifications to 8 `# type: ignore[call-overload]` comments |
| `utils/forecast_tracker.py` | Add justifications to 4 `# type: ignore[misc]` comments |
| `custom_selectors/working_mode.py` | Include `entry_id` in `unique_id` |
| `custom_selectors/solcast_likelihood.py` | Include `entry_id` in `unique_id` |
| `custom_sensors/state_collector.py` | Update force-working-mode lookup to use entry_id-suffixed unique_id |

### Test code (2 files)

| File | Change |
|---|---|
| `tests/test_diagnostics_dump.py` | Replace hardcoded `"unknown"` with `STATE_UNKNOWN` |
| `tests/test_platform_entity_refactor.py` | Update selector unique_id tests for entry_id inclusion, fix type narrowing |

## What was fixed

1. **Logging f-string + trailing period** — `_LOGGER.error(f"...")` → `_LOGGER.error("... %s", ...)`
2. **Missing `@override`** — 5 methods in `integration_sensor.py` and `utility_meter_sensor.py`
3. **`# type: ignore` without justification** — 12 comments in `time_series.py` and `forecast_tracker.py`
4. **Select unique_id without entry_id** — `HSEMWorkingModeSelector` and `HSEMSolcastLikelihoodSelector` now include `config_entry.entry_id`
5. **Hardcoded `"unknown"` in test** — `test_diagnostics_dump.py` now uses `STATE_UNKNOWN`

## Tests

- `tox -e lint` — ✅ All checks passed
- `tox -e typing` — ✅ 0 errors
- `tox -e quality` — ✅ 0 errors