### PR TITLE
chore(sonar): fix 11 HIGH code smells — duplicate literals, type suppressions, empty function

### DIFF
--- a/custom_components/hsem/switch.py
+++ b/custom_components/hsem/switch.py
@@ -27,63 +27,66 @@ from custom_components.hsem.utils.sensornames import (
     get_verbose_logging_switch_key,
 )
 
+_ICON_TOGGLE = "mdi:toggle-switch"
+_ICON_EV = "mdi:ev-station"
+
 # One description per switch.  Keys are sourced from sensornames.py so that
 # unique_ids and entity_ids are defined in one place.  Display names come
 # from translations via translation_key.
 SWITCH_DESCRIPTIONS: tuple[HSEMSwitchEntityDescription, ...] = (
     HSEMSwitchEntityDescription(
         key=get_read_only_switch_key(),
-        icon="mdi:toggle-switch",
+        icon=_ICON_TOGGLE,
         translation_key="read_only",
     ),
     HSEMSwitchEntityDescription(
         key=get_extended_attributes_switch_key(),
-        icon="mdi:toggle-switch",
+        icon=_ICON_TOGGLE,
         translation_key="extended_attributes",
     ),
     HSEMSwitchEntityDescription(
         key=get_verbose_logging_switch_key(),
-        icon="mdi:toggle-switch",
+        icon=_ICON_TOGGLE,
         translation_key="verbose_logging",
     ),
     HSEMSwitchEntityDescription(
         key=get_batteries_schedule_1_switch_key(),
-        icon="mdi:toggle-switch",
+        icon=_ICON_TOGGLE,
         translation_key="batteries_schedule_1",
     ),
     HSEMSwitchEntityDescription(
         key=get_batteries_schedule_2_switch_key(),
-        icon="mdi:toggle-switch",
+        icon=_ICON_TOGGLE,
         translation_key="batteries_schedule_2",
     ),
     HSEMSwitchEntityDescription(
         key=get_batteries_schedule_3_switch_key(),
-        icon="mdi:toggle-switch",
+        icon=_ICON_TOGGLE,
         translation_key="batteries_schedule_3",
     ),
     HSEMSwitchEntityDescription(
         key=get_ev_force_discharge_switch_key(),
-        icon="mdi:toggle-switch",
+        icon=_ICON_TOGGLE,
         translation_key="ev_force_discharge",
     ),
     HSEMSwitchEntityDescription(
         key=get_ev_smart_charging_switch_key(),
-        icon="mdi:ev-station",
+        icon=_ICON_EV,
         translation_key="ev_smart_charging",
     ),
     HSEMSwitchEntityDescription(
         key=get_ev_force_charge_now_switch_key(),
-        icon="mdi:ev-station",
+        icon=_ICON_EV,
         translation_key="ev_force_charge_now",
     ),
     HSEMSwitchEntityDescription(
         key=get_ev_second_smart_charging_switch_key(),
-        icon="mdi:ev-station",
+        icon=_ICON_EV,
         translation_key="ev_second_smart_charging",
     ),
     HSEMSwitchEntityDescription(
         key=get_ev_second_force_charge_now_switch_key(),
-        icon="mdi:ev-station",
+        icon=_ICON_EV,
         translation_key="ev_second_force_charge_now",
     ),
 )

--- a/custom_components/hsem/time.py
+++ b/custom_components/hsem/time.py
@@ -22,48 +22,50 @@ from custom_components.hsem.utils.sensornames import (
     get_schedule_3_start_time_key,
 )
 
+_ICON_CLOCK = "mdi:clock"
+
 # One description per time entity.  Keys are sourced from sensornames.py so
 # that unique_ids and entity_ids are defined in one place.  Display names
 # come from translations via translation_key.
 TIME_DESCRIPTIONS: tuple[HSEMTimeEntityDescription, ...] = (
     HSEMTimeEntityDescription(
         key=get_schedule_1_start_time_key(),
-        icon="mdi:clock",
+        icon=_ICON_CLOCK,
         translation_key="schedule_1_start",
     ),
     HSEMTimeEntityDescription(
         key=get_schedule_1_end_time_key(),
-        icon="mdi:clock",
+        icon=_ICON_CLOCK,
         translation_key="schedule_1_end",
     ),
     HSEMTimeEntityDescription(
         key=get_schedule_2_start_time_key(),
-        icon="mdi:clock",
+        icon=_ICON_CLOCK,
         translation_key="schedule_2_start",
     ),
     HSEMTimeEntityDescription(
         key=get_schedule_2_end_time_key(),
-        icon="mdi:clock",
+        icon=_ICON_CLOCK,
         translation_key="schedule_2_end",
     ),
     HSEMTimeEntityDescription(
         key=get_schedule_3_start_time_key(),
-        icon="mdi:clock",
+        icon=_ICON_CLOCK,
         translation_key="schedule_3_start",
     ),
     HSEMTimeEntityDescription(
         key=get_schedule_3_end_time_key(),
-        icon="mdi:clock",
+        icon=_ICON_CLOCK,
         translation_key="schedule_3_end",
     ),
     HSEMTimeEntityDescription(
         key=get_ev_deadline_time_key(),
-        icon="mdi:clock",
+        icon=_ICON_CLOCK,
         translation_key="ev_deadline",
     ),
     HSEMTimeEntityDescription(
         key=get_ev_second_deadline_time_key(),
-        icon="mdi:clock",
+        icon=_ICON_CLOCK,
         translation_key="ev_second_deadline",
     ),
 )

--- a/custom_components/hsem/utils/inverter_verify.py
+++ b/custom_components/hsem/utils/inverter_verify.py
@@ -32,6 +32,8 @@ from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
 # Public constants
 # ---------------------------------------------------------------------------
 
+_LOG_FMT = "%s — %s"
+
 #: Default seconds to wait between write and read-back.
 #: The inverter is polled every 5-10 s by HA, so the settle time must be
 #: long enough for at least one full poll cycle to complete.
@@ -205,7 +207,7 @@ async def async_write_and_verify(
             await writer()
         except Exception as exc:  # noqa: BLE001
             last_error = f"Write error on attempt {attempt}: {exc}"
-            _LOGGER.warning("%s — %s", entity_id, last_error)
+            _LOGGER.warning(_LOG_FMT, entity_id, last_error)
             # Wait before retrying even after a write error (device may recover).
             if attempt < max_retries:
                 await asyncio.sleep(settle_seconds)
@@ -220,7 +222,7 @@ async def async_write_and_verify(
             )
         except Exception as exc:  # noqa: BLE001
             last_error = f"Read-back error on attempt {attempt}: {exc}"
-            _LOGGER.warning("%s — %s", entity_id, last_error)
+            _LOGGER.warning(_LOG_FMT, entity_id, last_error)
             last_actual = None
             continue
 
@@ -250,7 +252,7 @@ async def async_write_and_verify(
         last_error = (
             f"Mismatch on attempt {attempt}: desired={desired}, actual={readback}"
         )
-        _LOGGER.warning("%s — %s", entity_id, last_error)
+        _LOGGER.warning(_LOG_FMT, entity_id, last_error)
 
     # ------------------------------------------------------------------
     # All retries exhausted

--- a/tests/planner/fixtures.py
+++ b/tests/planner/fixtures.py
@@ -26,6 +26,8 @@ from custom_components.hsem.models.planner_inputs import (
     SolcastSlot,
 )
 
+_DEFAULT_SUMMER_ISO = "2024-06-15T00:00:00+02:00"
+
 # ---------------------------------------------------------------------------
 # Base 24-hour time-series helpers
 # ---------------------------------------------------------------------------
@@ -250,7 +252,7 @@ def _default_schedules() -> list[BatteryScheduleInput]:
 
 def make_summer_day_input(
     *,
-    now_iso: str = "2024-06-15T00:00:00+02:00",
+    now_iso: str = _DEFAULT_SUMMER_ISO,
     battery_soc_pct: float = 50.0,
     battery_rated_capacity_kwh: float = 10.0,
     battery_end_of_discharge_soc_pct: float = 10.0,
@@ -386,7 +388,7 @@ def make_winter_day_input(
 
 def make_flat_price_input(
     *,
-    now_iso: str = "2024-06-15T00:00:00+02:00",
+    now_iso: str = _DEFAULT_SUMMER_ISO,
     import_price: float = 0.20,
     export_price: float = 0.05,
     battery_soc_pct: float = 0.0,
@@ -443,7 +445,7 @@ def make_flat_price_input(
 
 def make_negative_price_input(
     *,
-    now_iso: str = "2024-06-15T00:00:00+02:00",
+    now_iso: str = _DEFAULT_SUMMER_ISO,
     negative_hours: list[int] | None = None,
     interval_minutes: int = 60,
 ) -> PlannerInput:

--- a/tests/sensors/test_recommendation_resolver.py
+++ b/tests/sensors/test_recommendation_resolver.py
@@ -164,7 +164,9 @@ class TestBatteryAboveScheduleNeed:
 class TestNoneRec:
     def test_none_rec_does_not_raise(self):
         """resolve_current_recommendation should be a no-op when rec is None."""
-        resolve_current_recommendation(None, _make_live(), 0.0)
+        resolve_current_recommendation(
+            None, _make_live(), 0.0
+        )  # NOSONAR -- intentional None test
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -78,7 +78,7 @@ class TestValidateEntityIdFormat:
         assert validate_entity_id_format("") is False
 
     def test_none(self):
-        assert validate_entity_id_format(None) is False  # type: ignore[arg-type]  # test passes mock where real type expected
+        assert validate_entity_id_format(None) is False  # type: ignore[arg-type]  # NOSONAR -- intentional None test
 
     def test_special_chars(self):
         assert validate_entity_id_format("sensor.my-sensor!") is False

--- a/tests/test_huawei_service_calls.py
+++ b/tests/test_huawei_service_calls.py
@@ -241,7 +241,12 @@ class TestSetForcibleDischarge:
         """Passing a non-integer or out-of-range target_soc must raise ValueError."""
         sensor = _make_sensor(has_service=True)
         with pytest.raises(ValueError):
-            await async_set_forcible_discharge(sensor, "bat_dev", 150, 3000)  # > 100
+            await async_set_forcible_discharge(
+                sensor,
+                "bat_dev",
+                150,
+                3000,  # > 100  # NOSONAR
+            )
         with pytest.raises(ValueError):
             await async_set_forcible_discharge(sensor, "bat_dev", -1, 3000)  # < 0
         with pytest.raises(ValueError):

--- a/tests/test_listener_cleanup.py
+++ b/tests/test_listener_cleanup.py
@@ -76,7 +76,7 @@ class TestAvgSensorListenerCleanup:
         state_unsub = MagicMock()
 
         async def _fake_handle_update(_event=None):
-            pass
+            """No-op stub replacing the real async handler during listener cleanup tests."""
 
         sensor._async_handle_update = _fake_handle_update
 


### PR DESCRIPTION
## What

Fixes 11 SonarCloud HIGH-severity code smells across 8 files.

### Part A — Duplicate String Literals → Constants (5 issues, `python:S1192`)

| File | Constant | Occurrences |
|---|---|---|
| `custom_components/hsem/switch.py` | `_ICON_TOGGLE`, `_ICON_EV` | 7 + 4 |
| `custom_components/hsem/time.py` | `_ICON_CLOCK` | 8 |
| `custom_components/hsem/utils/inverter_verify.py` | `_LOG_FMT` | 4 |
| `tests/planner/fixtures.py` | `_DEFAULT_SUMMER_ISO` | 3 |

### Part B — Type Mismatch Suppressions (3 issues, `python:S5655`)

Added `# NOSONAR` comments to intentional test cases that pass invalid types to verify error handling:
- `tests/test_config_validation.py` — `None` passed to `validate_entity_id_format(str)`
- `tests/test_huawei_service_calls.py` — `150` (out-of-range) passed to `async_set_forcible_discharge`
- `tests/sensors/test_recommendation_resolver.py` — `None` passed to `resolve_current_recommendation(HourlyRecommendation)`

### Part C — Empty Function (1 issue, `python:S1186`)

Added docstring to `_fake_handle_update` stub in `tests/test_listener_cleanup.py`.

## Quality Gates

- ✅ `tox -e lint` — ruff format + ruff check
- ✅ `tox -e typing` — mypy (no issues in 178 files)
- ✅ `tox -e quality` — pyright (0 errors) + vulture
- ⚠️ `tox -e py313` — pre-existing `bcrypt` PyO3/CPython 3.13 incompatibility on Windows (unrelated to these changes)

Refs #526