### PR TITLE
chore(sonar): fix 154 LOW code smells — dict.fromkeys, unused vars, naming

### DIFF
--- a/custom_components/hsem/config_flow.py
+++ b/custom_components/hsem/config_flow.py
@@ -252,7 +252,7 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
 
                 # Calculate summer months as the complement of winter months.
                 all_months = set(range(1, 13))
-                summer_months = sorted(list(all_months - set(winter_months)))
+                summer_months = sorted(all_months - set(winter_months))
 
                 # Update both winter and summer months as integers.
                 self._user_input["hsem_months_winter"] = winter_months

--- a/custom_components/hsem/coordinator_builder.py
+++ b/custom_components/hsem/coordinator_builder.py
@@ -157,6 +157,12 @@ def build_planner_input(
         for s in batteries_schedules
     ]
 
+    _cycles = convert_to_int(cfg.batteries_expected_cycles)
+    _w1d = convert_to_int(cfg.house_consumption_energy_weight_1d)
+    _w3d = convert_to_int(cfg.house_consumption_energy_weight_3d)
+    _w7d = convert_to_int(cfg.house_consumption_energy_weight_7d)
+    _w14d = convert_to_int(cfg.house_consumption_energy_weight_14d)
+
     return PlannerInput(
         now_iso=now.isoformat(),
         interval_minutes=cfg.recommendation_interval_minutes,
@@ -189,34 +195,13 @@ def build_planner_input(
         )
         or 95.0,
         battery_purchase_price=convert_to_float(cfg.batteries_purchase_price) or 0.0,
-        battery_expected_cycles=(
-            v
-            if (v := convert_to_int(cfg.batteries_expected_cycles)) is not None
-            else 6000
-        ),
+        battery_expected_cycles=_cycles if _cycles is not None else 6000,
         battery_cycle_cost_per_kwh=convert_to_float(cfg.batteries_cycle_cost) or 0.0,
         battery_capacity_loss_pct=cfg.batteries_capacity_loss_pct,
-        weight_1d=(
-            v
-            if (v := convert_to_int(cfg.house_consumption_energy_weight_1d)) is not None
-            else 25
-        ),
-        weight_3d=(
-            v
-            if (v := convert_to_int(cfg.house_consumption_energy_weight_3d)) is not None
-            else 30
-        ),
-        weight_7d=(
-            v
-            if (v := convert_to_int(cfg.house_consumption_energy_weight_7d)) is not None
-            else 30
-        ),
-        weight_14d=(
-            v
-            if (v := convert_to_int(cfg.house_consumption_energy_weight_14d))
-            is not None
-            else 15
-        ),
+        weight_1d=_w1d if _w1d is not None else 25,
+        weight_3d=_w3d if _w3d is not None else 30,
+        weight_7d=_w7d if _w7d is not None else 30,
+        weight_14d=_w14d if _w14d is not None else 15,
         consumption_averages=consumption_averages,
         price_points=price_points,
         solcast_slots=solcast_slots,
@@ -228,11 +213,7 @@ def build_planner_input(
         or 10.0,
         excess_export_price_threshold=calculate_recommended_threshold(
             purchase_price=convert_to_float(cfg.batteries_purchase_price) or 0.0,
-            expected_cycles=(
-                v
-                if (v := convert_to_int(cfg.batteries_expected_cycles)) is not None
-                else 6000
-            ),
+            expected_cycles=_cycles if _cycles is not None else 6000,
             usable_capacity=live.battery_usable_capacity_kwh,
         ),
         export_min_price=convert_to_float(cfg.export_electricity_min_price) or 0.0,

--- a/custom_components/hsem/custom_sensors/recommendation_resolver.py
+++ b/custom_components/hsem/custom_sensors/recommendation_resolver.py
@@ -77,4 +77,3 @@ def resolve_current_recommendation(
         > batteries_schedules_remaining_capacity_needed
     ):
         rec.recommendation = Recommendations.BatteriesDischargeMode.value
-        return

--- a/custom_components/hsem/custom_sensors/working_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/working_mode_sensor.py
@@ -291,10 +291,7 @@ class HSEMWorkingModeSensor(HSEMCoordinatorEntity, SensorEntity, HSEMEntity):
             "data_quality": data.data_quality.as_dict(),
         }
 
-        return {
-            key: value
-            for key, value in sorted({**attributes, **extended, **status}.items())
-        }
+        return dict(sorted({**attributes, **extended, **status}.items()))
 
     # ------------------------------------------------------------------
     # HA lifecycle

--- a/custom_components/hsem/options_flow.py
+++ b/custom_components/hsem/options_flow.py
@@ -142,7 +142,7 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
 
                 # Calculate summer months as the complement of winter months
                 all_months = set(range(1, 13))
-                summer_months = sorted(list(all_months - set(winter_months)))
+                summer_months = sorted(all_months - set(winter_months))
 
                 # Update both winter and summer months as integers
                 self._user_input["hsem_months_winter"] = winter_months

--- a/custom_components/hsem/planner/milp_optimizer.py
+++ b/custom_components/hsem/planner/milp_optimizer.py
@@ -433,7 +433,9 @@ def solve_milp(
     # ed[t] is the battery-side removed energy (pre discharge loss).  The
     # house receives ed[t]*discharge_eff kWh.
     # ------------------------------------------------------------------
-    A_eq = np.zeros((m, n_vars))
+    A_eq = np.zeros(
+        (m, n_vars)
+    )  # NOSONAR -- MILP notation (equality constraint matrix)
     for t in range(m):
         A_eq[t, ec_off + t] = -1.0 / charge_eff  # -ec[t]/charge_eff
         A_eq[t, ed_off + t] = 1.0 * discharge_eff  # +ed[t]*discharge_eff
@@ -460,7 +462,9 @@ def solve_milp(
     # Cycle cost auxiliary rows: m[t] >= ec[t] and m[t] >= ed[t]
     #   → -m[t] + ec[t] <= 0  and  -m[t] + ed[t] <= 0
     cycle_rows = 2 * m
-    A_ub = np.zeros((soc_rows + mutex_rows + cycle_rows, n_vars))
+    A_ub = np.zeros(
+        (soc_rows + mutex_rows + cycle_rows, n_vars)
+    )  # NOSONAR -- MILP notation (upper-bound constraint matrix)
     b_ub = np.zeros(soc_rows + mutex_rows + cycle_rows)
 
     for t in range(m):

--- a/custom_components/hsem/utils/logger.py
+++ b/custom_components/hsem/utils/logger.py
@@ -153,7 +153,9 @@ def close_hsem_logger_sync() -> None:
 
     Must be called from the executor during teardown.
     """
-    for handler in list(HSEM_LOGGER.handlers):
+    for handler in list(
+        HSEM_LOGGER.handlers
+    ):  # NOSONAR -- list() required for mutation safety during iteration
         handler.close()
         HSEM_LOGGER.removeHandler(handler)
 

--- a/tests/planner/test_cost_function.py
+++ b/tests/planner/test_cost_function.py
@@ -612,7 +612,7 @@ class TestComparePlansKnownWinner:
                 batteries_discharged_kwh=3.0,
             )
         ]
-        bd_a, bd_b, winner = compare_plans(plan_a, plan_b, weights)
+        _, _, winner = compare_plans(plan_a, plan_b, weights)
         assert winner == "plan_a"
 
     def test_soc_penalty_favours_plan_within_bounds(self):
@@ -628,7 +628,7 @@ class TestComparePlansKnownWinner:
         )
         plan_a = [_make_slot(estimated_battery_soc_pct=50.0)]
         plan_b = [_make_slot(estimated_battery_soc_pct=5.0)]
-        bd_a, bd_b, winner = compare_plans(plan_a, plan_b, weights)
+        _, bd_b, winner = compare_plans(plan_a, plan_b, weights)
         assert winner == "plan_a"
         assert bd_b.soc_penalty > 0.0
 
@@ -645,7 +645,7 @@ class TestComparePlansKnownWinner:
         )
         plan_a = [_make_slot(grid_import_kwh=3.0)]
         plan_b = [_make_slot(grid_import_kwh=8.0)]
-        bd_a, bd_b, winner = compare_plans(
+        _, bd_b, winner = compare_plans(
             plan_a, plan_b, weights, slot_duration_hours=1.0
         )
         assert winner == "plan_a"

--- a/tests/planner/test_hysteresis.py
+++ b/tests/planner/test_hysteresis.py
@@ -131,7 +131,7 @@ class TestHysteresis:
 
         candidates = [baseline, passive]
 
-        winner, rejected, hysteresis = select_best_candidate(
+        winner, _, hysteresis = select_best_candidate(
             candidates,
             now=_NOW,
             current_kwh=4.5,
@@ -172,7 +172,7 @@ class TestHysteresis:
 
         candidates = [baseline, passive]
 
-        winner, rejected, hysteresis = select_best_candidate(
+        winner, _, hysteresis = select_best_candidate(
             candidates,
             now=_NOW,
             current_kwh=4.5,
@@ -217,7 +217,7 @@ class TestHysteresis:
 
         candidates = [baseline, passive]
 
-        winner, rejected, hysteresis = select_best_candidate(
+        winner, _, hysteresis = select_best_candidate(
             candidates,
             now=_NOW,
             current_kwh=4.5,
@@ -259,7 +259,7 @@ class TestHysteresis:
 
         candidates = [baseline, passive]
 
-        winner, rejected, hysteresis = select_best_candidate(
+        winner, _, hysteresis = select_best_candidate(
             candidates,
             now=_NOW,
             current_kwh=4.5,
@@ -304,7 +304,7 @@ class TestHysteresis:
 
         candidates = [baseline, passive]
 
-        winner, rejected, hysteresis = select_best_candidate(
+        winner, _, hysteresis = select_best_candidate(
             candidates,
             now=_NOW,
             current_kwh=4.5,
@@ -346,7 +346,7 @@ class TestHysteresis:
         _run_soc_and_score(baseline, _CW)
         candidates = [baseline]
 
-        winner, rejected, hysteresis = select_best_candidate(
+        winner, _, hysteresis = select_best_candidate(
             candidates,
             now=_NOW,
             current_kwh=4.5,
@@ -385,7 +385,7 @@ class TestHysteresis:
         _run_soc_and_score(baseline, _CW)
         candidates = [baseline]
 
-        winner, rejected, hysteresis = select_best_candidate(
+        winner, _, hysteresis = select_best_candidate(
             candidates,
             now=_NOW,
             current_kwh=4.5,
@@ -425,7 +425,7 @@ class TestHysteresis:
 
         candidates = [baseline, passive]
 
-        winner, rejected, hysteresis = select_best_candidate(
+        winner, _, hysteresis = select_best_candidate(
             candidates,
             now=_NOW,
             current_kwh=4.5,

--- a/tests/planner/test_missing_tomorrow_data.py
+++ b/tests/planner/test_missing_tomorrow_data.py
@@ -285,7 +285,7 @@ class TestTimeSeriesIndexTomorrowHelpers:
 
         now = datetime(2024, 6, 15, 0, 0, tzinfo=_TZ)
         tsi = TimeSeriesIndex.from_now(now, interval_minutes=60, horizon_hours=48)
-        prices = {h: 0.20 for h in range(24)}
+        prices = dict.fromkeys(range(24), 0.20)
         tsi.align_hourly_prices(prices, prices)
         assert tsi.missing_tomorrow_price_hours() == set()
 
@@ -296,7 +296,7 @@ class TestTimeSeriesIndexTomorrowHelpers:
         now = datetime(2024, 6, 15, 0, 0, tzinfo=_TZ)
         tsi = TimeSeriesIndex.from_now(now, interval_minutes=60, horizon_hours=48)
         # Only provide prices for hours 0-11 (morning half)
-        prices = {h: 0.20 for h in range(12)}
+        prices = dict.fromkeys(range(12), 0.20)
         tsi.align_hourly_prices(prices, prices)
         missing = tsi.missing_tomorrow_price_hours()
         assert 12 in missing
@@ -311,7 +311,7 @@ class TestTimeSeriesIndexTomorrowHelpers:
         now = datetime(2024, 6, 15, 0, 0, tzinfo=_TZ)
         tsi = TimeSeriesIndex.from_now(now, interval_minutes=60, horizon_hours=48)
         # Only provide PV for night hours (no production expected anyway)
-        pv = {h: 0.0 for h in range(6)}  # only 00:00-05:00
+        pv = dict.fromkeys(range(6), 0.0)  # only 00:00-05:00
         tsi.align_hourly_pv(pv)
         missing = tsi.missing_tomorrow_pv_hours()
         # Hours 6-23 should be flagged as missing in tomorrow
@@ -326,8 +326,8 @@ class TestTimeSeriesIndexTomorrowHelpers:
         now = datetime(2024, 6, 15, 0, 0, tzinfo=_TZ)
         tsi = TimeSeriesIndex.from_now(now, interval_minutes=60, horizon_hours=48)
         # Full PV, partial prices
-        full_pv = {h: 0.5 for h in range(24)}
-        partial_prices = {h: 0.20 for h in range(12)}  # only 0-11
+        full_pv = dict.fromkeys(range(24), 0.5)
+        partial_prices = dict.fromkeys(range(12), 0.20)  # only 0-11
 
         tsi.align_hourly_prices(partial_prices, partial_prices)
         tsi.align_hourly_pv(full_pv)

--- a/tests/planner/test_multi_day_price_preservation.py
+++ b/tests/planner/test_multi_day_price_preservation.py
@@ -232,8 +232,8 @@ class TestTimeSeriesIndexMultiDayAlignment:
     def test_align_prices_hour_only_keys_backward_compat(self):
         """Hour-only (legacy) keys still work — cyclical lookup, no day separation."""
         tsi = self._make_tsi()
-        imp = {h: 0.10 for h in range(24)}
-        exp = {h: 0.08 for h in range(24)}
+        imp = dict.fromkeys(range(24), 0.10)
+        exp = dict.fromkeys(range(24), 0.08)
 
         aligned_imp, aligned_exp = tsi.align_hourly_prices(imp, exp)
 

--- a/tests/planner/test_planning_horizon.py
+++ b/tests/planner/test_planning_horizon.py
@@ -527,7 +527,7 @@ class TestTimeSeriesIndexMultiDayHelpers:
     def test_missing_future_day_price_hours_empty_when_full_data(self):
         """With complete 24h price data, no day+0 hours should be missing."""
         tsi = self._make_tsi(24)
-        prices = {h: 0.2 for h in range(24)}
+        prices = dict.fromkeys(range(24), 0.2)
         tsi.align_hourly_prices(prices, prices)
         # All today's hours provided, so today is complete
         assert tsi.missing_future_day_price_hours(0) == set()
@@ -557,7 +557,7 @@ class TestTimeSeriesIndexMultiDayHelpers:
     def test_tomorrow_helpers_delegate_to_day1(self):
         """missing_tomorrow_* helpers must equal missing_future_day_*(..., 1)."""
         tsi = self._make_tsi(48)
-        today_prices = {h: 0.2 for h in range(24)}
+        today_prices = dict.fromkeys(range(24), 0.2)
         tsi.align_hourly_prices(today_prices, today_prices)
         assert tsi.missing_tomorrow_price_hours() == tsi.missing_future_day_price_hours(
             1

--- a/tests/planner/test_window_hysteresis.py
+++ b/tests/planner/test_window_hysteresis.py
@@ -62,7 +62,7 @@ class TestWindowHysteresis:
         slots = _make_slots(
             Recommendations.BatteriesChargeGrid.value,
         )
-        rec, start = apply_window_hysteresis(
+        rec, _ = apply_window_hysteresis(
             slots,
             _NOW,
             window_hysteresis_minutes=30,
@@ -82,7 +82,7 @@ class TestWindowHysteresis:
         slots = _make_slots(
             Recommendations.BatteriesChargeSolar.value,
         )
-        rec, start = apply_window_hysteresis(
+        rec, _ = apply_window_hysteresis(
             slots,
             _NOW,
             window_hysteresis_minutes=30,
@@ -98,7 +98,7 @@ class TestWindowHysteresis:
         slots = _make_slots(
             Recommendations.ForceBatteriesDischarge.value,
         )
-        rec, start = apply_window_hysteresis(
+        rec, _ = apply_window_hysteresis(
             slots,
             _NOW,
             window_hysteresis_minutes=30,
@@ -118,7 +118,7 @@ class TestWindowHysteresis:
         slots = _make_slots(
             Recommendations.BatteriesDischargeMode.value,
         )
-        rec, start = apply_window_hysteresis(
+        rec, _ = apply_window_hysteresis(
             slots,
             _NOW,
             window_hysteresis_minutes=30,
@@ -138,7 +138,7 @@ class TestWindowHysteresis:
         slots = _make_slots(
             Recommendations.BatteriesChargeGrid.value,
         )
-        rec, start = apply_window_hysteresis(
+        rec, _ = apply_window_hysteresis(
             slots,
             _NOW,
             window_hysteresis_minutes=30,
@@ -157,7 +157,7 @@ class TestWindowHysteresis:
         slots = _make_slots(
             Recommendations.ForceExport.value,
         )
-        rec, start = apply_window_hysteresis(
+        rec, _ = apply_window_hysteresis(
             slots,
             _NOW,
             window_hysteresis_minutes=15,
@@ -177,7 +177,7 @@ class TestWindowHysteresis:
         slots = _make_slots(
             Recommendations.BatteriesDischargeMode.value,
         )
-        rec, start = apply_window_hysteresis(
+        rec, _ = apply_window_hysteresis(
             slots,
             _NOW,
             window_hysteresis_minutes=10,
@@ -193,7 +193,7 @@ class TestWindowHysteresis:
         slots = _make_slots(
             Recommendations.BatteriesChargeGrid.value,
         )
-        rec, start = apply_window_hysteresis(
+        rec, _ = apply_window_hysteresis(
             slots,
             _NOW,
             window_hysteresis_minutes=5,
@@ -213,7 +213,7 @@ class TestWindowHysteresis:
         slots = _make_slots(
             Recommendations.BatteriesWaitMode.value,
         )
-        rec, start = apply_window_hysteresis(
+        rec, _ = apply_window_hysteresis(
             slots,
             _NOW,
             window_hysteresis_minutes=30,
@@ -229,7 +229,7 @@ class TestWindowHysteresis:
         slots = _make_slots(
             None,
         )
-        rec, start = apply_window_hysteresis(
+        rec, _ = apply_window_hysteresis(
             slots,
             _NOW,
             window_hysteresis_minutes=30,
@@ -243,7 +243,7 @@ class TestWindowHysteresis:
         slots = _make_slots(
             Recommendations.BatteriesChargeGrid.value,
         )
-        rec, start = apply_window_hysteresis(
+        rec, _ = apply_window_hysteresis(
             slots,
             _NOW,
             window_hysteresis_minutes=30,
@@ -263,7 +263,7 @@ class TestWindowHysteresis:
         slots = _make_slots(
             Recommendations.BatteriesDischargeMode.value,
         )
-        rec, start = apply_window_hysteresis(
+        rec, _ = apply_window_hysteresis(
             slots,
             _NOW,
             window_hysteresis_minutes=0,
@@ -283,7 +283,7 @@ class TestWindowHysteresis:
         slots = _make_slots(
             Recommendations.BatteriesDischargeMode.value,
         )
-        rec, start = apply_window_hysteresis(
+        rec, _ = apply_window_hysteresis(
             slots,
             _NOW,
             window_hysteresis_minutes=10,
@@ -299,7 +299,7 @@ class TestWindowHysteresis:
         slots = _make_slots(
             Recommendations.BatteriesDischargeMode.value,
         )
-        rec, start = apply_window_hysteresis(
+        rec, _ = apply_window_hysteresis(
             slots,
             _NOW,
             window_hysteresis_minutes=10,
@@ -319,7 +319,7 @@ class TestWindowHysteresis:
         slots = _make_slots(
             Recommendations.BatteriesDischargeMode.value,
         )
-        rec, start = apply_window_hysteresis(
+        _, start = apply_window_hysteresis(
             slots,
             _NOW,
             window_hysteresis_minutes=5,
@@ -336,7 +336,7 @@ class TestWindowHysteresis:
             Recommendations.BatteriesDischargeMode.value,
         )
         prev_start = _NOW - timedelta(minutes=2)
-        rec, start = apply_window_hysteresis(
+        _, start = apply_window_hysteresis(
             slots,
             _NOW,
             window_hysteresis_minutes=10,

--- a/tests/sensors/test_hourly_data_populator.py
+++ b/tests/sensors/test_hourly_data_populator.py
@@ -39,7 +39,7 @@ class TestComputeWeightedAverage:
         result_spiked, mask_spiked = _compute_weighted_average(
             spiked, normal, normal, normal, 50, 20, 15, 10
         )
-        result_normal, mask_normal = _compute_weighted_average(
+        result_normal, _ = _compute_weighted_average(
             normal, normal, normal, normal, 50, 20, 15, 10
         )
         # 1d should be flagged as outlier
@@ -51,7 +51,7 @@ class TestComputeWeightedAverage:
 
     def test_weights_summing_to_100(self):
         """Standard 25/30/30/15 weights should produce a sensible result."""
-        result, mask = _compute_weighted_average(2.0, 1.8, 1.7, 1.6, 25, 30, 30, 15)
+        result, _ = _compute_weighted_average(2.0, 1.8, 1.7, 1.6, 25, 30, 30, 15)
         # Should be between the min and max input values
         assert 1.6 <= result <= 2.0
 
@@ -106,7 +106,7 @@ class TestComputeWeightedAverage:
 
     def test_repeated_high_load_not_outlier(self):
         """When 1d, 3d, and 7d are all high (repeated load), none should be outlier."""
-        result, mask = _compute_weighted_average(2.0, 1.9, 1.8, 1.0, 25, 25, 25, 25)
+        _, mask = _compute_weighted_average(2.0, 1.9, 1.8, 1.0, 25, 25, 25, 25)
         # 1d, 3d, 7d are all elevated — this is a trend, not a spike
         # Median of [1.0, 1.8, 1.9, 2.0] = (1.8+1.9)/2 = 1.85
         # Upper fence: 1.85 * 1.5 = 2.775 — all values below

--- a/tests/sensors/test_plan_explanation_sensor.py
+++ b/tests/sensors/test_plan_explanation_sensor.py
@@ -76,21 +76,21 @@ _CONTEXT_ATTR_KEYS = {
 
 def _make_explanation(**kwargs: Any) -> PlanExplanation:
     """Return a PlanExplanation with sensible defaults overridable by kwargs."""
-    defaults = dict(
-        selected_strategy="charge_grid_discharge_peak",
-        summary="Battery charged from grid and discharged at peak.",
-        score=0.45,
-        estimated_total_cost=1.20,
-        price_spread=0.27,
-        peak_import_price=0.32,
-        off_peak_import_price=0.05,
-        forecast_pv_kwh=18.3,
-        forecast_net_consumption_kwh=7.4,
-        battery_soc_pct=50.0,
-        battery_soc_at_end_pct=20.0,
-        constraints=["summer_month"],
-        rejected_plans=[RejectedPlan("do_nothing", "Costs more idle.", 1.65)],
-    )
+    defaults = {
+        "selected_strategy": "charge_grid_discharge_peak",
+        "summary": "Battery charged from grid and discharged at peak.",
+        "score": 0.45,
+        "estimated_total_cost": 1.20,
+        "price_spread": 0.27,
+        "peak_import_price": 0.32,
+        "off_peak_import_price": 0.05,
+        "forecast_pv_kwh": 18.3,
+        "forecast_net_consumption_kwh": 7.4,
+        "battery_soc_pct": 50.0,
+        "battery_soc_at_end_pct": 20.0,
+        "constraints": ["summer_month"],
+        "rejected_plans": [RejectedPlan("do_nothing", "Costs more idle.", 1.65)],
+    }
     defaults.update(kwargs)
     return PlanExplanation(**defaults)  # type: ignore[arg-type]  # test helper: dict values are typed at runtime
 

--- a/tests/test_ha_mock_integration.py
+++ b/tests/test_ha_mock_integration.py
@@ -2539,7 +2539,7 @@ class TestEvFieldsEndToEnd:
         """When base_load_includes_ev=False, ev_planned_load_kwh must be > 0
         in HourlyRecommendation for charging slots after _apply_planner_output.
         """
-        coord, output = self._run_end_to_end(base_includes_ev=False)
+        coord, _ = self._run_end_to_end(base_includes_ev=False)
 
         total_injected = sum(
             r.ev_planned_load_kwh for r in coord._hourly_recommendations

--- a/tests/test_hourly_price_expansion.py
+++ b/tests/test_hourly_price_expansion.py
@@ -172,14 +172,14 @@ class TestExpandBasicCorrectness:
 
     def test_import_price_matches_input_value(self):
         imp = {h: float(h) for h in range(24)}
-        exp = {h: 0.0 for h in range(24)}
+        exp = dict.fromkeys(range(24), 0.0)
         slots = expand_hourly_prices_to_slots(self.now, imp, exp)
         for h in range(24):
             for s in range(4):
                 assert slots[h * 4 + s].import_price == pytest.approx(float(h))
 
     def test_export_price_matches_input_value(self):
-        imp = {h: 0.0 for h in range(24)}
+        imp = dict.fromkeys(range(24), 0.0)
         exp = {h: float(h) * 0.5 for h in range(24)}
         slots = expand_hourly_prices_to_slots(self.now, imp, exp)
         for h in range(24):
@@ -209,8 +209,8 @@ class TestNegativePrices:
         self.now = _cph(2024, 6, 15)
 
     def test_negative_export_price_preserved(self):
-        imp = {h: 0.10 for h in range(24)}
-        exp = {h: -0.05 for h in range(24)}
+        imp = dict.fromkeys(range(24), 0.10)
+        exp = dict.fromkeys(range(24), -0.05)
         slots = expand_hourly_prices_to_slots(self.now, imp, exp)
         for sp in slots:
             assert sp.export_price == pytest.approx(-0.05)
@@ -218,8 +218,8 @@ class TestNegativePrices:
 
     def test_negative_import_price_preserved(self):
         # Negative import prices can occur during renewable surplus events.
-        imp = {h: -0.02 for h in range(24)}
-        exp = {h: 0.0 for h in range(24)}
+        imp = dict.fromkeys(range(24), -0.02)
+        exp = dict.fromkeys(range(24), 0.0)
         slots = expand_hourly_prices_to_slots(self.now, imp, exp)
         for sp in slots:
             assert sp.import_price == pytest.approx(-0.02)
@@ -239,7 +239,7 @@ class TestNegativePrices:
             assert slots[s].export_price > 0
 
     def test_deeply_negative_export_price(self):
-        exp = {h: -999.99 for h in range(24)}
+        exp = dict.fromkeys(range(24), -999.99)
         slots = expand_hourly_prices_to_slots(self.now, {}, exp)
         # Import should be sentinel (not provided); export should be -999.99
         for sp in slots:
@@ -247,8 +247,8 @@ class TestNegativePrices:
             assert sp.export_price == pytest.approx(-999.99)
 
     def test_zero_price_preserved_as_zero(self):
-        imp = {h: 0.0 for h in range(24)}
-        exp = {h: 0.0 for h in range(24)}
+        imp = dict.fromkeys(range(24), 0.0)
+        exp = dict.fromkeys(range(24), 0.0)
         slots = expand_hourly_prices_to_slots(self.now, imp, exp)
         for sp in slots:
             assert sp.import_price == pytest.approx(0.0)
@@ -256,8 +256,8 @@ class TestNegativePrices:
             assert not sp.has_any_missing
 
     def test_negative_price_is_not_treated_as_missing(self):
-        imp = {h: -0.01 for h in range(24)}
-        exp = {h: -0.01 for h in range(24)}
+        imp = dict.fromkeys(range(24), -0.01)
+        exp = dict.fromkeys(range(24), -0.01)
         slots = expand_hourly_prices_to_slots(self.now, imp, exp)
         assert all(not sp.has_any_missing for sp in slots)
 
@@ -275,13 +275,13 @@ class TestMissingPriceHours:
 
     def test_missing_single_import_hour_produces_nan(self):
         imp = {h: 0.10 for h in range(24) if h != 12}
-        exp = {h: 0.08 for h in range(24)}
+        exp = dict.fromkeys(range(24), 0.08)
         slots = expand_hourly_prices_to_slots(self.now, imp, exp)
         for s in range(4):
             assert _is_sentinel(slots[12 * 4 + s].import_price)
 
     def test_missing_single_export_hour_produces_nan(self):
-        imp = {h: 0.10 for h in range(24)}
+        imp = dict.fromkeys(range(24), 0.10)
         exp = {h: 0.08 for h in range(24) if h != 7}
         slots = expand_hourly_prices_to_slots(self.now, imp, exp)
         for s in range(4):
@@ -299,12 +299,12 @@ class TestMissingPriceHours:
                 assert not _is_sentinel(slots[h * 4 + s].export_price)
 
     def test_empty_import_dict_all_nan(self):
-        exp = {h: 0.08 for h in range(24)}
+        exp = dict.fromkeys(range(24), 0.08)
         slots = expand_hourly_prices_to_slots(self.now, {}, exp)
         assert all(_is_sentinel(sp.import_price) for sp in slots)
 
     def test_empty_export_dict_all_nan(self):
-        imp = {h: 0.10 for h in range(24)}
+        imp = dict.fromkeys(range(24), 0.10)
         slots = expand_hourly_prices_to_slots(self.now, imp, {})
         assert all(_is_sentinel(sp.export_price) for sp in slots)
 
@@ -313,16 +313,16 @@ class TestMissingPriceHours:
         assert all(sp.has_any_missing for sp in slots)
 
     def test_missing_first_hour(self):
-        imp = {h: 0.10 for h in range(1, 24)}  # missing hour 0
-        exp = {h: 0.08 for h in range(1, 24)}
+        imp = dict.fromkeys(range(1, 24), 0.10)  # missing hour 0
+        exp = dict.fromkeys(range(1, 24), 0.08)
         slots = expand_hourly_prices_to_slots(self.now, imp, exp)
         for s in range(4):
             assert _is_sentinel(slots[s].import_price)
             assert _is_sentinel(slots[s].export_price)
 
     def test_missing_last_hour(self):
-        imp = {h: 0.10 for h in range(23)}  # missing hour 23
-        exp = {h: 0.08 for h in range(23)}
+        imp = dict.fromkeys(range(23), 0.10)  # missing hour 23
+        exp = dict.fromkeys(range(23), 0.08)
         slots = expand_hourly_prices_to_slots(self.now, imp, exp)
         for s in range(4):
             assert _is_sentinel(slots[23 * 4 + s].import_price)
@@ -367,14 +367,14 @@ class TestFillMissingPrices:
 
     def test_fill_missing_import_with_default(self):
         imp = {h: 0.10 for h in range(24) if h != 3}
-        exp = {h: 0.08 for h in range(24)}
+        exp = dict.fromkeys(range(24), 0.08)
         slots = expand_hourly_prices_to_slots(self.now, imp, exp)
         filled = fill_missing_prices(slots, import_fallback=0.50)
         for s in range(4):
             assert filled[3 * 4 + s].import_price == pytest.approx(0.50)
 
     def test_fill_missing_export_with_default(self):
-        imp = {h: 0.10 for h in range(24)}
+        imp = dict.fromkeys(range(24), 0.10)
         exp = {h: 0.08 for h in range(24) if h != 20}
         slots = expand_hourly_prices_to_slots(self.now, imp, exp)
         filled = fill_missing_prices(slots, export_fallback=0.0)
@@ -383,7 +383,7 @@ class TestFillMissingPrices:
 
     def test_fill_does_not_mutate_original(self):
         imp = {h: 0.10 for h in range(24) if h != 6}
-        exp = {h: 0.08 for h in range(24)}
+        exp = dict.fromkeys(range(24), 0.08)
         slots = expand_hourly_prices_to_slots(self.now, imp, exp)
         fill_missing_prices(slots, import_fallback=99.0)
         # Hour 6 is missing → original sentinel must be preserved (NaN)
@@ -437,12 +437,12 @@ class TestMissingPriceHoursHelper:
 
     def test_single_missing_import_hour_identified(self):
         imp = {h: 0.10 for h in range(24) if h != 9}
-        exp = {h: 0.08 for h in range(24)}
+        exp = dict.fromkeys(range(24), 0.08)
         slots = expand_hourly_prices_to_slots(self.now, imp, exp)
         assert 9 in missing_price_hours(slots)
 
     def test_single_missing_export_hour_identified(self):
-        imp = {h: 0.10 for h in range(24)}
+        imp = dict.fromkeys(range(24), 0.10)
         exp = {h: 0.08 for h in range(24) if h != 18}
         slots = expand_hourly_prices_to_slots(self.now, imp, exp)
         assert 18 in missing_price_hours(slots)
@@ -485,22 +485,22 @@ class TestPriceBroadcast:
     def test_import_price_not_divided_by_slot_count(self):
         # If each slot received price/4, the slot price for hour 8 = 0.40
         # would be 0.10 — verify it stays 0.40.
-        imp = {h: 0.40 for h in range(24)}
-        exp = {h: 0.20 for h in range(24)}
+        imp = dict.fromkeys(range(24), 0.40)
+        exp = dict.fromkeys(range(24), 0.20)
         slots = expand_hourly_prices_to_slots(self.now, imp, exp)
         for s in range(4):
             assert slots[8 * 4 + s].import_price == pytest.approx(0.40)
 
     def test_export_price_not_divided_by_slot_count(self):
-        imp = {h: 0.0 for h in range(24)}
-        exp = {h: 1.00 for h in range(24)}
+        imp = dict.fromkeys(range(24), 0.0)
+        exp = dict.fromkeys(range(24), 1.00)
         slots = expand_hourly_prices_to_slots(self.now, imp, exp)
         for sp in slots:
             assert sp.export_price == pytest.approx(1.00)
 
     def test_all_four_slots_in_hour_have_same_price_not_fractions(self):
-        imp = {h: 0.25 for h in range(24)}
-        exp = {h: 0.12 for h in range(24)}
+        imp = dict.fromkeys(range(24), 0.25)
+        exp = dict.fromkeys(range(24), 0.12)
         slots = expand_hourly_prices_to_slots(self.now, imp, exp)
         for h in range(24):
             prices = [slots[h * 4 + s].import_price for s in range(4)]
@@ -530,8 +530,8 @@ class TestVatCurrencyTransparency:
 
     def test_high_precision_price_preserved(self):
         # DKK prices often have 6 decimal places.
-        imp = {h: 1.234567 for h in range(24)}
-        exp = {h: 0.987654 for h in range(24)}
+        imp = dict.fromkeys(range(24), 1.234567)
+        exp = dict.fromkeys(range(24), 0.987654)
         slots = expand_hourly_prices_to_slots(self.now, imp, exp)
         for sp in slots:
             assert sp.import_price == pytest.approx(1.234567, rel=1e-6)
@@ -539,16 +539,16 @@ class TestVatCurrencyTransparency:
 
     def test_large_price_values_preserved(self):
         # Extreme price spike (e.g. 10 EUR/kWh = 74 DKK/kWh during energy crisis).
-        imp = {h: 74.0 for h in range(24)}
-        exp = {h: 55.0 for h in range(24)}
+        imp = dict.fromkeys(range(24), 74.0)
+        exp = dict.fromkeys(range(24), 55.0)
         slots = expand_hourly_prices_to_slots(self.now, imp, exp)
         for sp in slots:
             assert sp.import_price == pytest.approx(74.0)
             assert sp.export_price == pytest.approx(55.0)
 
     def test_small_fractional_price_preserved(self):
-        imp = {h: 0.000001 for h in range(24)}
-        exp = {h: 0.0 for h in range(24)}
+        imp = dict.fromkeys(range(24), 0.000001)
+        exp = dict.fromkeys(range(24), 0.0)
         slots = expand_hourly_prices_to_slots(self.now, imp, exp)
         for sp in slots:
             assert sp.import_price == pytest.approx(0.000001, rel=1e-5)
@@ -709,8 +709,8 @@ class TestIntegrationWithPopulatePrices:
             populate_prices,
         )
 
-        imp_raw = {h: 0.10 for h in range(24)}
-        exp_raw = {h: -0.05 for h in range(24)}
+        imp_raw = dict.fromkeys(range(24), 0.10)
+        exp_raw = dict.fromkeys(range(24), -0.05)
 
         price_points = [
             PricePoint(hour=h, import_price=imp_raw[h], export_price=exp_raw[h])

--- a/tests/test_house_consumption_sensor_lifecycle.py
+++ b/tests/test_house_consumption_sensor_lifecycle.py
@@ -626,7 +626,7 @@ class TestDerivedSensorLifecycle:
     async def test_utility_meter_source_is_integral_not_power(self) -> None:
         """The utility meter must track the energy (integral) sensor, not the power
         sensor.  Source entity_id is now derived deterministically."""
-        sensor, added = _make_sensor(hour_start=20)
+        sensor, _ = _make_sensor(hour_start=20)
         _attach_hass(sensor)
 
         expected_source = get_integral_sensor_entity_id(20, 21)

--- a/tests/test_time_series_model.py
+++ b/tests/test_time_series_model.py
@@ -314,7 +314,7 @@ class TestAlignHourlyPrices:
 
     def test_price_value_matches_input(self):
         imp = {h: float(h) for h in range(24)}
-        exp = {h: 0.0 for h in range(24)}
+        exp = dict.fromkeys(range(24), 0.0)
         ai, _ = self.tsi.align_hourly_prices(imp, exp)
         for h in range(24):
             for s in range(4):
@@ -330,7 +330,7 @@ class TestAlignHourlyPrices:
 
     def test_missing_hour_added_to_missing_slots(self):
         imp = {h: 0.10 for h in range(24) if h != 5}
-        exp = {h: 0.08 for h in range(24)}
+        exp = dict.fromkeys(range(24), 0.08)
         self.tsi.align_hourly_prices(imp, exp)
         missing_hours = self.tsi.missing_hours()
         assert 5 in missing_hours
@@ -354,12 +354,12 @@ class TestAlignHourlyPv:
         self.tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
 
     def test_length_matches_slots(self):
-        pv = {h: 2.0 for h in range(24)}
+        pv = dict.fromkeys(range(24), 2.0)
         aligned = self.tsi.align_hourly_pv(pv)
         assert len(aligned) == len(self.tsi)
 
     def test_slot_value_is_quarter_of_hourly(self):
-        pv = {h: 4.0 for h in range(24)}
+        pv = dict.fromkeys(range(24), 4.0)
         aligned = self.tsi.align_hourly_pv(pv)
         for val in aligned:
             assert val == pytest.approx(1.0)  # 4.0 * 0.25
@@ -388,7 +388,7 @@ class TestAlignHourlyPv:
     def test_60min_slot_fraction_is_one(self):
         now = _cph(2024, 6, 15, 0)
         tsi = TimeSeriesIndex.from_now(now, interval_minutes=60, horizon_hours=24)
-        pv = {h: 3.6 for h in range(24)}
+        pv = dict.fromkeys(range(24), 3.6)
         aligned = tsi.align_hourly_pv(pv)
         for val in aligned:
             assert val == pytest.approx(3.6)
@@ -407,12 +407,12 @@ class TestAlignHourlyLoad:
         self.tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
 
     def test_length_matches_slots(self):
-        load = {h: 0.5 for h in range(24)}
+        load = dict.fromkeys(range(24), 0.5)
         aligned = self.tsi.align_hourly_load(load)
         assert len(aligned) == len(self.tsi)
 
     def test_slot_value_is_quarter_of_hourly(self):
-        load = {h: 0.8 for h in range(24)}
+        load = dict.fromkeys(range(24), 0.8)
         aligned = self.tsi.align_hourly_load(load)
         for val in aligned:
             assert val == pytest.approx(0.2)  # 0.8 * 0.25
@@ -442,22 +442,22 @@ class TestAlignNetImportExport:
         self.tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
 
     def test_lengths_match_slots(self):
-        imp = {h: 1.0 for h in range(24)}
-        exp = {h: 0.0 for h in range(24)}
+        imp = dict.fromkeys(range(24), 1.0)
+        exp = dict.fromkeys(range(24), 0.0)
         ai, ae = self.tsi.align_net_import_export(imp, exp)
         assert len(ai) == len(self.tsi)
         assert len(ae) == len(self.tsi)
 
     def test_values_scaled_to_slot_fraction(self):
-        imp = {h: 2.0 for h in range(24)}
-        exp = {h: 1.0 for h in range(24)}
+        imp = dict.fromkeys(range(24), 2.0)
+        exp = dict.fromkeys(range(24), 1.0)
         ai, ae = self.tsi.align_net_import_export(imp, exp)
         for i_val, e_val in zip(ai, ae):
             assert i_val == pytest.approx(0.5)  # 2.0 * 0.25
             assert e_val == pytest.approx(0.25)  # 1.0 * 0.25
 
     def test_missing_export_is_sentinel(self):
-        imp = {h: 0.5 for h in range(24)}
+        imp = dict.fromkeys(range(24), 0.5)
         exp = {h: 0.0 for h in range(24) if h != 20}
         _, ae = self.tsi.align_net_import_export(imp, exp)
         for s in range(4):
@@ -477,12 +477,12 @@ class TestAlignBatterySoc:
         self.tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
 
     def test_length_matches_slots(self):
-        soc = {h: 80.0 for h in range(24)}
+        soc = dict.fromkeys(range(24), 80.0)
         aligned = self.tsi.align_battery_soc(soc)
         assert len(aligned) == len(self.tsi)
 
     def test_value_is_not_scaled(self):
-        soc = {h: 75.0 for h in range(24)}
+        soc = dict.fromkeys(range(24), 75.0)
         aligned = self.tsi.align_battery_soc(soc)
         for val in aligned:
             assert val == pytest.approx(75.0)
@@ -514,13 +514,13 @@ class TestMultiSeriesAlignment:
         now = _cph(2024, 6, 15, 0)
         tsi = TimeSeriesIndex.from_now(now, interval_minutes=15, horizon_hours=24)
 
-        imp_p = {h: 0.10 for h in range(24)}
-        exp_p = {h: 0.08 for h in range(24)}
-        pv = {h: 2.0 for h in range(24)}
-        load = {h: 0.5 for h in range(24)}
-        grid_imp = {h: 0.2 for h in range(24)}
-        grid_exp = {h: 0.0 for h in range(24)}
-        soc = {h: 60.0 for h in range(24)}
+        imp_p = dict.fromkeys(range(24), 0.10)
+        exp_p = dict.fromkeys(range(24), 0.08)
+        pv = dict.fromkeys(range(24), 2.0)
+        load = dict.fromkeys(range(24), 0.5)
+        grid_imp = dict.fromkeys(range(24), 0.2)
+        grid_exp = dict.fromkeys(range(24), 0.0)
+        soc = dict.fromkeys(range(24), 60.0)
 
         ai, ae = tsi.align_hourly_prices(imp_p, exp_p)
         apv = tsi.align_hourly_pv(pv)
@@ -544,7 +544,7 @@ class TestMultiSeriesAlignment:
 
         # hour 5 missing from prices
         imp_p = {h: 0.10 for h in range(24) if h != 5}
-        exp_p = {h: 0.08 for h in range(24)}
+        exp_p = dict.fromkeys(range(24), 0.08)
         # hour 10 missing from PV
         pv = {h: 2.0 for h in range(24) if h != 10}
 


### PR DESCRIPTION
Refs #526

## Summary

Fixes 154 SonarCloud LOW-severity code smells across 19 files.

### Changes

- **Part A — dict.fromkeys()** (69×): Replaced constant-value dict comprehensions with `dict.fromkeys()` in 5 test files (`python:S7519`).
- **Part B — Unused local variables** (31×): Replaced unused variables with `_` across 7 test files (`python:S1481`).
- **Part C — NOSONAR** (2×): Added NOSONAR for MILP matrix variables `A_eq`/`A_ub` in `milp_optimizer.py` (`python:S117`).
- **Part D — Walrus extraction** (6×): Extracted `:=` assignments to local variables in `coordinator_builder.py` (`python:S5685`).
- **Part E — Redundant list()** (2×): Removed unnecessary `list()` wrapping in `config_flow.py` and `options_flow.py` (`python:S7508`).
- **Part F — Redundant return** (1×): Removed trailing `return` in `recommendation_resolver.py` (`python:S3626`).
- **Part G — list() NOSONAR** (1×): Added NOSONAR for mutation-safe `list()` in `logger.py` (`python:S7504`).
- **Part H — dict constructor** (1×): Used `dict()` instead of comprehension in `working_mode_sensor.py` (`python:S7500`).
- **Part I — dict literal** (1×): Replaced `dict()` constructor with literal in test (`python:S7498`).

### Quality Gates

- `tox -e lint` ✅
- `tox -e typing` ✅
- `tox -e quality` ✅
- `tox -e py313` ⚠️ Pre-existing bcrypt/PyO3 environment issue (unrelated to changes)