### PR TITLE
chore(sonar): add sonar-project.properties and fix remaining stragglers

### DIFF
--- a/custom_components/hsem/flows/batteries_excess_export.py
+++ b/custom_components/hsem/flows/batteries_excess_export.py
@@ -17,7 +17,7 @@ from custom_components.hsem.utils.config_validator import merge_errors, validate
 from custom_components.hsem.utils.misc import get_config_value
 
 
-async def get_batteries_excess_export_step_schema(
+async def get_batteries_excess_export_step_schema(  # NOSONAR
     config_entry: ConfigEntry | None,
     _user_input: dict | None = None,
     _hass: HomeAssistant | None = None,
@@ -65,7 +65,7 @@ async def get_batteries_excess_export_step_schema(
 
 async def validate_batteries_excess_export_input(
     user_input: dict,
-) -> dict[str, str]:
+) -> dict[str, str]:  # NOSONAR
     """Validate user input for batteries excess export configuration.
 
     The price threshold is auto-calculated at runtime from battery

--- a/custom_components/hsem/flows/batteries_excess_export.py
+++ b/custom_components/hsem/flows/batteries_excess_export.py
@@ -17,7 +17,7 @@ from custom_components.hsem.utils.config_validator import merge_errors, validate
 from custom_components.hsem.utils.misc import get_config_value
 
 
-async def get_batteries_excess_export_step_schema(  # NOSONAR -- async required by HA config/options flow framework
+async def get_batteries_excess_export_step_schema(
     config_entry: ConfigEntry | None,
     _user_input: dict | None = None,
     _hass: HomeAssistant | None = None,
@@ -65,7 +65,7 @@ async def get_batteries_excess_export_step_schema(  # NOSONAR -- async required 
 
 async def validate_batteries_excess_export_input(
     user_input: dict,
-) -> dict[str, str]:  # NOSONAR -- async required by HA config/options flow framework
+) -> dict[str, str]:
     """Validate user input for batteries excess export configuration.
 
     The price threshold is auto-calculated at runtime from battery

--- a/custom_components/hsem/flows/battery_economics.py
+++ b/custom_components/hsem/flows/battery_economics.py
@@ -16,7 +16,7 @@ from custom_components.hsem.utils.config_validator import merge_errors, validate
 from custom_components.hsem.utils.misc import get_config_value
 
 
-async def get_battery_economics_step_schema(
+async def get_battery_economics_step_schema(  # NOSONAR
     config_entry: ConfigEntry | None,
 ) -> vol.Schema:
     """Return the data schema for the 'battery_economics' step.
@@ -125,7 +125,7 @@ async def get_battery_economics_step_schema(
 
 async def validate_battery_economics_input(
     user_input: dict,
-) -> dict[str, str]:
+) -> dict[str, str]:  # NOSONAR
     """Validate user input for the 'battery_economics' step.
 
     Args:

--- a/custom_components/hsem/flows/battery_economics.py
+++ b/custom_components/hsem/flows/battery_economics.py
@@ -16,7 +16,7 @@ from custom_components.hsem.utils.config_validator import merge_errors, validate
 from custom_components.hsem.utils.misc import get_config_value
 
 
-async def get_battery_economics_step_schema(  # NOSONAR -- async required by HA config/options flow framework
+async def get_battery_economics_step_schema(
     config_entry: ConfigEntry | None,
 ) -> vol.Schema:
     """Return the data schema for the 'battery_economics' step.
@@ -125,7 +125,7 @@ async def get_battery_economics_step_schema(  # NOSONAR -- async required by HA 
 
 async def validate_battery_economics_input(
     user_input: dict,
-) -> dict[str, str]:  # NOSONAR -- async required by HA config/options flow framework
+) -> dict[str, str]:
     """Validate user input for the 'battery_economics' step.
 
     Args:

--- a/custom_components/hsem/flows/ev_helpers.py
+++ b/custom_components/hsem/flows/ev_helpers.py
@@ -50,7 +50,7 @@ _DISCHARGE_POWER_SELECTOR = selector(
 )
 
 
-async def build_ev_charger_schema(  # NOSONAR -- async required by HA config/options flow framework
+async def build_ev_charger_schema(
     config_entry: ConfigEntry | None,
     prefix: str,
     include_primary_fields: bool = False,

--- a/custom_components/hsem/flows/ev_helpers.py
+++ b/custom_components/hsem/flows/ev_helpers.py
@@ -50,7 +50,7 @@ _DISCHARGE_POWER_SELECTOR = selector(
 )
 
 
-async def build_ev_charger_schema(
+async def build_ev_charger_schema(  # NOSONAR
     config_entry: ConfigEntry | None,
     prefix: str,
     include_primary_fields: bool = False,

--- a/custom_components/hsem/flows/ev_planned_load_helpers.py
+++ b/custom_components/hsem/flows/ev_planned_load_helpers.py
@@ -74,7 +74,7 @@ _EFFICIENCY_SELECTOR = selector(
 )
 
 
-async def build_ev_planned_load_schema(
+async def build_ev_planned_load_schema(  # NOSONAR
     config_entry: ConfigEntry | None, prefix: str
 ) -> vol.Schema:
     """Return the data schema for an EV planned load config flow step.

--- a/custom_components/hsem/flows/ev_planned_load_helpers.py
+++ b/custom_components/hsem/flows/ev_planned_load_helpers.py
@@ -74,7 +74,7 @@ _EFFICIENCY_SELECTOR = selector(
 )
 
 
-async def build_ev_planned_load_schema(  # NOSONAR -- async required by HA config/options flow framework
+async def build_ev_planned_load_schema(
     config_entry: ConfigEntry | None, prefix: str
 ) -> vol.Schema:
     """Return the data schema for an EV planned load config flow step.

--- a/custom_components/hsem/flows/huawei_solar.py
+++ b/custom_components/hsem/flows/huawei_solar.py
@@ -21,7 +21,7 @@ from custom_components.hsem.utils.misc import get_config_value
 
 async def get_huawei_solar_step_schema(
     config_entry: ConfigEntry | None,
-) -> vol.Schema:
+) -> vol.Schema:  # NOSONAR
     """Return the data schema for the 'huawei_solar' step."""
     return vol.Schema(
         {

--- a/custom_components/hsem/flows/huawei_solar.py
+++ b/custom_components/hsem/flows/huawei_solar.py
@@ -21,7 +21,7 @@ from custom_components.hsem.utils.misc import get_config_value
 
 async def get_huawei_solar_step_schema(
     config_entry: ConfigEntry | None,
-) -> vol.Schema:  # NOSONAR -- async required by HA config/options flow framework
+) -> vol.Schema:
     """Return the data schema for the 'huawei_solar' step."""
     return vol.Schema(
         {

--- a/custom_components/hsem/flows/init.py
+++ b/custom_components/hsem/flows/init.py
@@ -16,7 +16,7 @@ from custom_components.hsem.utils.misc import get_config_value
 
 async def get_init_step_schema(
     config_entry: ConfigEntry | None,
-) -> vol.Schema:
+) -> vol.Schema:  # NOSONAR
     """Return the data schema for the 'init' step."""
     return vol.Schema(
         {
@@ -101,7 +101,7 @@ async def get_init_step_schema(
 
 async def validate_init_step_input(
     user_input: dict,
-) -> dict[str, str]:
+) -> dict[str, str]:  # NOSONAR
     """Validate user input for the 'init' step."""
     errors = {}
 

--- a/custom_components/hsem/flows/init.py
+++ b/custom_components/hsem/flows/init.py
@@ -16,7 +16,7 @@ from custom_components.hsem.utils.misc import get_config_value
 
 async def get_init_step_schema(
     config_entry: ConfigEntry | None,
-) -> vol.Schema:  # NOSONAR -- async required by HA config/options flow framework
+) -> vol.Schema:
     """Return the data schema for the 'init' step."""
     return vol.Schema(
         {
@@ -101,7 +101,7 @@ async def get_init_step_schema(
 
 async def validate_init_step_input(
     user_input: dict,
-) -> dict[str, str]:  # NOSONAR -- async required by HA config/options flow framework
+) -> dict[str, str]:
     """Validate user input for the 'init' step."""
     errors = {}
 

--- a/custom_components/hsem/flows/months.py
+++ b/custom_components/hsem/flows/months.py
@@ -20,7 +20,7 @@ def _month_options() -> list[str]:
 
 async def get_months_schema(
     config_entry: ConfigEntry | None,
-) -> vol.Schema:  # NOSONAR -- async required by HA config/options flow framework
+) -> vol.Schema:
     """Return the data schema for the 'months' step."""
 
     # Stored months are integers; the multi-select selector requires string
@@ -47,7 +47,7 @@ async def get_months_schema(
     )
 
 
-async def validate_months_input(  # NOSONAR -- async required by HA config/options flow framework
+async def validate_months_input(
     _hass: HomeAssistant, user_input: dict
 ) -> dict[str, str]:
     """Validate user input for the 'months' step."""

--- a/custom_components/hsem/flows/months.py
+++ b/custom_components/hsem/flows/months.py
@@ -20,7 +20,7 @@ def _month_options() -> list[str]:
 
 async def get_months_schema(
     config_entry: ConfigEntry | None,
-) -> vol.Schema:
+) -> vol.Schema:  # NOSONAR
     """Return the data schema for the 'months' step."""
 
     # Stored months are integers; the multi-select selector requires string
@@ -47,7 +47,7 @@ async def get_months_schema(
     )
 
 
-async def validate_months_input(
+async def validate_months_input(  # NOSONAR
     _hass: HomeAssistant, user_input: dict
 ) -> dict[str, str]:
     """Validate user input for the 'months' step."""

--- a/custom_components/hsem/flows/power.py
+++ b/custom_components/hsem/flows/power.py
@@ -16,7 +16,7 @@ from custom_components.hsem.utils.misc import get_config_value
 
 async def get_power_step_schema(
     config_entry: ConfigEntry | None,
-) -> vol.Schema:  # NOSONAR -- async required by HA config/options flow framework
+) -> vol.Schema:
     """Return the data schema for the 'power' step."""
     return vol.Schema(
         {

--- a/custom_components/hsem/flows/power.py
+++ b/custom_components/hsem/flows/power.py
@@ -16,7 +16,7 @@ from custom_components.hsem.utils.misc import get_config_value
 
 async def get_power_step_schema(
     config_entry: ConfigEntry | None,
-) -> vol.Schema:
+) -> vol.Schema:  # NOSONAR
     """Return the data schema for the 'power' step."""
     return vol.Schema(
         {

--- a/custom_components/hsem/flows/prices.py
+++ b/custom_components/hsem/flows/prices.py
@@ -31,7 +31,7 @@ from custom_components.hsem.utils.misc import get_config_value
 
 async def get_prices_step_schema(
     config_entry: ConfigEntry | None,
-) -> vol.Schema:
+) -> vol.Schema:  # NOSONAR
     """Return the data schema for the 'prices' step.
 
     Args:

--- a/custom_components/hsem/flows/prices.py
+++ b/custom_components/hsem/flows/prices.py
@@ -31,7 +31,7 @@ from custom_components.hsem.utils.misc import get_config_value
 
 async def get_prices_step_schema(
     config_entry: ConfigEntry | None,
-) -> vol.Schema:  # NOSONAR -- async required by HA config/options flow framework
+) -> vol.Schema:
     """Return the data schema for the 'prices' step.
 
     Args:

--- a/custom_components/hsem/flows/schedule_helpers.py
+++ b/custom_components/hsem/flows/schedule_helpers.py
@@ -63,7 +63,7 @@ def resolve_usable_capacity_kwh(
     return 10.0
 
 
-async def build_batteries_schedule_step_schema(  # NOSONAR -- async required by HA config/options flow framework
+async def build_batteries_schedule_step_schema(
     schedule_number: int,
     config_entry: ConfigEntry | None,
     _hass: HomeAssistant | None = None,
@@ -105,7 +105,7 @@ async def build_batteries_schedule_step_schema(  # NOSONAR -- async required by 
     )
 
 
-async def validate_batteries_schedule_input(  # NOSONAR -- async required by HA config/options flow framework
+async def validate_batteries_schedule_input(
     schedule_number: int,
     user_input: dict,
 ) -> dict[str, str]:

--- a/custom_components/hsem/flows/schedule_helpers.py
+++ b/custom_components/hsem/flows/schedule_helpers.py
@@ -63,7 +63,7 @@ def resolve_usable_capacity_kwh(
     return 10.0
 
 
-async def build_batteries_schedule_step_schema(
+async def build_batteries_schedule_step_schema(  # NOSONAR
     schedule_number: int,
     config_entry: ConfigEntry | None,
     _hass: HomeAssistant | None = None,
@@ -105,7 +105,7 @@ async def build_batteries_schedule_step_schema(
     )
 
 
-async def validate_batteries_schedule_input(
+async def validate_batteries_schedule_input(  # NOSONAR
     schedule_number: int,
     user_input: dict,
 ) -> dict[str, str]:

--- a/custom_components/hsem/flows/solcast.py
+++ b/custom_components/hsem/flows/solcast.py
@@ -16,7 +16,7 @@ from custom_components.hsem.utils.misc import get_config_value
 
 async def get_solcast_step_schema(
     config_entry: ConfigEntry | None,
-) -> vol.Schema:
+) -> vol.Schema:  # NOSONAR
     """Return the data schema for the 'solcast' step."""
     return vol.Schema(
         {

--- a/custom_components/hsem/flows/solcast.py
+++ b/custom_components/hsem/flows/solcast.py
@@ -16,7 +16,7 @@ from custom_components.hsem.utils.misc import get_config_value
 
 async def get_solcast_step_schema(
     config_entry: ConfigEntry | None,
-) -> vol.Schema:  # NOSONAR -- async required by HA config/options flow framework
+) -> vol.Schema:
     """Return the data schema for the 'solcast' step."""
     return vol.Schema(
         {

--- a/custom_components/hsem/flows/weighted_values.py
+++ b/custom_components/hsem/flows/weighted_values.py
@@ -15,7 +15,7 @@ from custom_components.hsem.utils.config_validator import validate_consumption_w
 from custom_components.hsem.utils.misc import get_config_value
 
 
-async def get_weighted_values_step_schema(  # NOSONAR -- async required by HA config/options flow framework
+async def get_weighted_values_step_schema(
     config_entry: ConfigEntry | None,
 ) -> vol.Schema:
     """Return the data schema for the 'weighted_values' step."""
@@ -91,7 +91,7 @@ async def get_weighted_values_step_schema(  # NOSONAR -- async required by HA co
 
 async def validate_weighted_values_input(
     user_input: dict,
-) -> dict[str, str]:  # NOSONAR -- async required by HA config/options flow framework
+) -> dict[str, str]:
     """Validate user input for the 'weighted_values' step."""
     required_fields = [
         "hsem_house_consumption_energy_weight_1d",

--- a/custom_components/hsem/flows/weighted_values.py
+++ b/custom_components/hsem/flows/weighted_values.py
@@ -15,7 +15,7 @@ from custom_components.hsem.utils.config_validator import validate_consumption_w
 from custom_components.hsem.utils.misc import get_config_value
 
 
-async def get_weighted_values_step_schema(
+async def get_weighted_values_step_schema(  # NOSONAR
     config_entry: ConfigEntry | None,
 ) -> vol.Schema:
     """Return the data schema for the 'weighted_values' step."""
@@ -91,7 +91,7 @@ async def get_weighted_values_step_schema(
 
 async def validate_weighted_values_input(
     user_input: dict,
-) -> dict[str, str]:
+) -> dict[str, str]:  # NOSONAR
     """Validate user input for the 'weighted_values' step."""
     required_fields = [
         "hsem_house_consumption_energy_weight_1d",

--- a/custom_components/hsem/planner/candidate_selector.py
+++ b/custom_components/hsem/planner/candidate_selector.py
@@ -85,7 +85,7 @@ class HysteresisResult:
     new_score: float = 0.0
 
 
-def select_best_candidate(
+def select_best_candidate(  # NOSONAR
     candidates: list[CandidatePlan],
     *,
     now: datetime,

--- a/custom_components/hsem/planner/candidate_selector.py
+++ b/custom_components/hsem/planner/candidate_selector.py
@@ -85,7 +85,7 @@ class HysteresisResult:
     new_score: float = 0.0
 
 
-def select_best_candidate(  # NOSONAR
+def select_best_candidate(
     candidates: list[CandidatePlan],
     *,
     now: datetime,

--- a/custom_components/hsem/planner/engine_core.py
+++ b/custom_components/hsem/planner/engine_core.py
@@ -333,7 +333,7 @@ def _compute_ev_charger_power(
         setattr(slots[idx], attr, ac_power_w)
 
 
-def _build_and_inject_for_ev(  # NOSONAR
+def _build_and_inject_for_ev(
     enabled: bool,
     connected: bool,
     smart: bool,

--- a/custom_components/hsem/planner/milp_optimizer.py
+++ b/custom_components/hsem/planner/milp_optimizer.py
@@ -433,7 +433,7 @@ def solve_milp(
     # ed[t] is the battery-side removed energy (pre discharge loss).  The
     # house receives ed[t]*discharge_eff kWh.
     # ------------------------------------------------------------------
-    A_eq = np.zeros((m, n_vars))
+    A_eq = np.zeros((m, n_vars))  # NOSONAR
     for t in range(m):
         A_eq[t, ec_off + t] = -1.0 / charge_eff  # -ec[t]/charge_eff
         A_eq[t, ed_off + t] = 1.0 * discharge_eff  # +ed[t]*discharge_eff
@@ -460,7 +460,7 @@ def solve_milp(
     # Cycle cost auxiliary rows: m[t] >= ec[t] and m[t] >= ed[t]
     #   → -m[t] + ec[t] <= 0  and  -m[t] + ed[t] <= 0
     cycle_rows = 2 * m
-    A_ub = np.zeros((soc_rows + mutex_rows + cycle_rows, n_vars))
+    A_ub = np.zeros((soc_rows + mutex_rows + cycle_rows, n_vars))  # NOSONAR
     b_ub = np.zeros(soc_rows + mutex_rows + cycle_rows)
 
     for t in range(m):

--- a/custom_components/hsem/planner/milp_optimizer.py
+++ b/custom_components/hsem/planner/milp_optimizer.py
@@ -433,9 +433,7 @@ def solve_milp(
     # ed[t] is the battery-side removed energy (pre discharge loss).  The
     # house receives ed[t]*discharge_eff kWh.
     # ------------------------------------------------------------------
-    A_eq = np.zeros(
-        (m, n_vars)
-    )  # NOSONAR -- MILP notation (equality constraint matrix)
+    A_eq = np.zeros((m, n_vars))
     for t in range(m):
         A_eq[t, ec_off + t] = -1.0 / charge_eff  # -ec[t]/charge_eff
         A_eq[t, ed_off + t] = 1.0 * discharge_eff  # +ed[t]*discharge_eff
@@ -462,9 +460,7 @@ def solve_milp(
     # Cycle cost auxiliary rows: m[t] >= ec[t] and m[t] >= ed[t]
     #   → -m[t] + ec[t] <= 0  and  -m[t] + ed[t] <= 0
     cycle_rows = 2 * m
-    A_ub = np.zeros(
-        (soc_rows + mutex_rows + cycle_rows, n_vars)
-    )  # NOSONAR -- MILP notation (upper-bound constraint matrix)
+    A_ub = np.zeros((soc_rows + mutex_rows + cycle_rows, n_vars))
     b_ub = np.zeros(soc_rows + mutex_rows + cycle_rows)
 
     for t in range(m):

--- a/custom_components/hsem/services.py
+++ b/custom_components/hsem/services.py
@@ -236,7 +236,7 @@ async def async_handle_clear_override(
     _LOGGER.info("HSEM service: clear_override completed")
 
 
-async def async_handle_export_diagnostics(  # NOSONAR -- HA service handler, called with await
+async def async_handle_export_diagnostics(
     hass: HomeAssistant,
     call: ServiceCall,  # noqa: ARG001
 ) -> dict[str, Any]:
@@ -322,7 +322,7 @@ SERVICE_HANDLER_MAP: dict[str, tuple[vol.Schema, Any, SupportsResponse]] = {
 
 async def async_register_services(
     hass: HomeAssistant,
-) -> None:  # NOSONAR -- called with await by __init__.py async_setup_entry
+) -> None:
     """Register all HSEM services with Home Assistant.
 
     Called during :func:`~custom_components.hsem.__init__.async_setup_entry`.
@@ -349,7 +349,7 @@ async def async_register_services(
 
 async def async_unregister_services(
     hass: HomeAssistant,
-) -> None:  # NOSONAR -- called with await by __init__.py async_unload_entry
+) -> None:
     """Remove all HSEM services from Home Assistant.
 
     Called during :func:`~custom_components.hsem.__init__.async_unload_entry`.

--- a/custom_components/hsem/services.py
+++ b/custom_components/hsem/services.py
@@ -236,7 +236,7 @@ async def async_handle_clear_override(
     _LOGGER.info("HSEM service: clear_override completed")
 
 
-async def async_handle_export_diagnostics(
+async def async_handle_export_diagnostics(  # NOSONAR
     hass: HomeAssistant,
     call: ServiceCall,  # noqa: ARG001
 ) -> dict[str, Any]:
@@ -322,7 +322,7 @@ SERVICE_HANDLER_MAP: dict[str, tuple[vol.Schema, Any, SupportsResponse]] = {
 
 async def async_register_services(
     hass: HomeAssistant,
-) -> None:
+) -> None:  # NOSONAR
     """Register all HSEM services with Home Assistant.
 
     Called during :func:`~custom_components.hsem.__init__.async_setup_entry`.
@@ -349,7 +349,7 @@ async def async_register_services(
 
 async def async_unregister_services(
     hass: HomeAssistant,
-) -> None:
+) -> None:  # NOSONAR
     """Remove all HSEM services from Home Assistant.
 
     Called during :func:`~custom_components.hsem.__init__.async_unload_entry`.

--- a/custom_components/hsem/utils/logger.py
+++ b/custom_components/hsem/utils/logger.py
@@ -187,7 +187,7 @@ async def async_close_hsem_logger() -> None:
 # ---------------------------------------------------------------------------
 
 
-async def async_logger(self: Any, msg: str, level: str = "debug") -> None:
+async def async_logger(self: Any, msg: str, level: str = "debug") -> None:  # NOSONAR
     """Emit *msg* through the HSEM file logger if verbose logging is on.
 
     The write is delegated to a ``ThreadPoolExecutor`` so that the

--- a/custom_components/hsem/utils/logger.py
+++ b/custom_components/hsem/utils/logger.py
@@ -153,9 +153,7 @@ def close_hsem_logger_sync() -> None:
 
     Must be called from the executor during teardown.
     """
-    for handler in list(
-        HSEM_LOGGER.handlers
-    ):  # NOSONAR -- list() required for mutation safety during iteration
+    for handler in list(HSEM_LOGGER.handlers):  # NOSONAR -- mutation-safe iteration
         handler.close()
         HSEM_LOGGER.removeHandler(handler)
 
@@ -189,11 +187,7 @@ async def async_close_hsem_logger() -> None:
 # ---------------------------------------------------------------------------
 
 
-async def async_logger(
-    self: Any, msg: str, level: str = "debug"
-) -> (
-    None
-):  # NOSONAR -- called with await by dozens of callers; body delegates to executor
+async def async_logger(self: Any, msg: str, level: str = "debug") -> None:
     """Emit *msg* through the HSEM file logger if verbose logging is on.
 
     The write is delegated to a ``ThreadPoolExecutor`` so that the

--- a/custom_components/hsem/utils/misc.py
+++ b/custom_components/hsem/utils/misc.py
@@ -318,7 +318,7 @@ def clamp_efficiency(pct: float) -> float:
     return max(min(pct, 100.0), 1.0) / 100.0
 
 
-async def async_resolve_entity_id_from_unique_id(
+async def async_resolve_entity_id_from_unique_id(  # NOSONAR
     self: Any, unique_entity_id: str, domain: str = "sensor"
 ) -> str | None:
     """Resolve an entity_id from a unique_id using the entity registry.
@@ -553,7 +553,7 @@ async def async_remove_entity_from_ha(self: Any, entity_unique_id: str) -> bool:
         return False
 
 
-async def async_entity_exists(hass: Any, entity_id: str) -> bool:
+async def async_entity_exists(hass: Any, entity_id: str) -> bool:  # NOSONAR
     """Check whether an entity exists in Home Assistant.
 
     Args:
@@ -566,7 +566,7 @@ async def async_entity_exists(hass: Any, entity_id: str) -> bool:
     return hass.states.get(entity_id) is not None
 
 
-async def async_device_exists(hass: Any, device_id: str) -> bool:
+async def async_device_exists(hass: Any, device_id: str) -> bool:  # NOSONAR
     """Check whether a device exists in Home Assistant.
 
     Args:

--- a/custom_components/hsem/utils/misc.py
+++ b/custom_components/hsem/utils/misc.py
@@ -318,7 +318,7 @@ def clamp_efficiency(pct: float) -> float:
     return max(min(pct, 100.0), 1.0) / 100.0
 
 
-async def async_resolve_entity_id_from_unique_id(  # NOSONAR -- called with await by state_collector, hourly_data_populator, and async_remove_entity_from_ha
+async def async_resolve_entity_id_from_unique_id(
     self: Any, unique_entity_id: str, domain: str = "sensor"
 ) -> str | None:
     """Resolve an entity_id from a unique_id using the entity registry.
@@ -553,11 +553,7 @@ async def async_remove_entity_from_ha(self: Any, entity_unique_id: str) -> bool:
         return False
 
 
-async def async_entity_exists(
-    hass: Any, entity_id: str
-) -> (
-    bool
-):  # NOSONAR -- called with await by async_validate_entity_ids in config_validator
+async def async_entity_exists(hass: Any, entity_id: str) -> bool:
     """Check whether an entity exists in Home Assistant.
 
     Args:
@@ -570,11 +566,7 @@ async def async_entity_exists(
     return hass.states.get(entity_id) is not None
 
 
-async def async_device_exists(
-    hass: Any, device_id: str
-) -> (
-    bool
-):  # NOSONAR -- called with await by async_validate_device_ids in config_validator
+async def async_device_exists(hass: Any, device_id: str) -> bool:
     """Check whether a device exists in Home Assistant.
 
     Args:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,65 @@
+# SonarCloud project configuration for woopstar_hsem
+
+# Exclude Cognitive Complexity — handled in separate refactoring issues
+sonar.issue.ignore.multicriteria=S3776
+
+# S3776: Cognitive Complexity — excluded globally
+sonar.issue.ignore.multicriteria.S3776.ruleKey=python:S3776
+sonar.issue.ignore.multicriteria.S3776.resourceKey=**
+
+# S107: Too many parameters — excluded for known complex functions
+sonar.issue.ignore.multicriteria.S107_engine_core.ruleKey=python:S107
+sonar.issue.ignore.multicriteria.S107_engine_core.resourceKey=custom_components/hsem/planner/engine_core.py
+
+sonar.issue.ignore.multicriteria.S107_candidate_selector.ruleKey=python:S107
+sonar.issue.ignore.multicriteria.S107_candidate_selector.resourceKey=custom_components/hsem/planner/candidate_selector.py
+
+sonar.issue.ignore.multicriteria.S107_test_invariants.ruleKey=python:S107
+sonar.issue.ignore.multicriteria.S107_test_invariants.resourceKey=tests/planner/test_invariants.py
+
+sonar.issue.ignore.multicriteria.S107_test_soc_simulation.ruleKey=python:S107
+sonar.issue.ignore.multicriteria.S107_test_soc_simulation.resourceKey=tests/planner/test_soc_simulation.py
+
+# S117: MILP variable naming (A_eq, A_ub) — standard mathematical notation
+sonar.issue.ignore.multicriteria.S117_milp.ruleKey=python:S117
+sonar.issue.ignore.multicriteria.S117_milp.resourceKey=custom_components/hsem/planner/milp_optimizer.py
+
+# S5655: Intentional type mismatch in tests (testing error handling with wrong types)
+sonar.issue.ignore.multicriteria.S5655_test_recommendation.ruleKey=python:S5655
+sonar.issue.ignore.multicriteria.S5655_test_recommendation.resourceKey=tests/sensors/test_recommendation_resolver.py
+
+sonar.issue.ignore.multicriteria.S5655_test_huawei.ruleKey=python:S5655
+sonar.issue.ignore.multicriteria.S5655_test_huawei.resourceKey=tests/test_huawei_service_calls.py
+
+# S1135: TODO comments — intentional technical debt markers
+sonar.issue.ignore.multicriteria.S1135_applier.ruleKey=python:S1135
+sonar.issue.ignore.multicriteria.S1135_applier.resourceKey=custom_components/hsem/custom_sensors/applier.py
+
+sonar.issue.ignore.multicriteria.S1135_config_reader.ruleKey=python:S1135
+sonar.issue.ignore.multicriteria.S1135_config_reader.resourceKey=custom_components/hsem/custom_sensors/config_reader.py
+
+sonar.issue.ignore.multicriteria.S1135_hourly_data.ruleKey=python:S1135
+sonar.issue.ignore.multicriteria.S1135_hourly_data.resourceKey=custom_components/hsem/custom_sensors/hourly_data_populator.py
+
+sonar.issue.ignore.multicriteria.S1135_state_collector.ruleKey=python:S1135
+sonar.issue.ignore.multicriteria.S1135_state_collector.resourceKey=custom_components/hsem/custom_sensors/state_collector.py
+
+sonar.issue.ignore.multicriteria.S1135_ev_planned_load.ruleKey=python:S1135
+sonar.issue.ignore.multicriteria.S1135_ev_planned_load.resourceKey=custom_components/hsem/flows/ev_planned_load_helpers.py
+
+# S7503: async without await — HA framework requires async on these functions
+sonar.issue.ignore.multicriteria.S7503_flows.ruleKey=python:S7503
+sonar.issue.ignore.multicriteria.S7503_flows.resourceKey=custom_components/hsem/flows/**
+
+sonar.issue.ignore.multicriteria.S7503_services.ruleKey=python:S7503
+sonar.issue.ignore.multicriteria.S7503_services.resourceKey=custom_components/hsem/services.py
+
+sonar.issue.ignore.multicriteria.S7503_misc.ruleKey=python:S7503
+sonar.issue.ignore.multicriteria.S7503_misc.resourceKey=custom_components/hsem/utils/misc.py
+
+sonar.issue.ignore.multicriteria.S7503_logger.ruleKey=python:S7503
+sonar.issue.ignore.multicriteria.S7503_logger.resourceKey=custom_components/hsem/utils/logger.py
+
+# S7503 in tests — pytest async tests don't need await
+sonar.issue.ignore.multicriteria.S7503_tests.ruleKey=python:S7503
+sonar.issue.ignore.multicriteria.S7503_tests.resourceKey=tests/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,6 @@
 # SonarCloud project configuration for woopstar_hsem
 
-# Exclude Cognitive Complexity — handled in separate refactoring issues
-sonar.issue.ignore.multicriteria=S3776
+sonar.issue.ignore.multicriteria=S3776,S107_engine_core,S107_candidate_selector,S107_test_invariants,S107_test_soc_simulation,S117_milp,S5655_test_recommendation,S5655_test_huawei,S1135_applier,S1135_config_reader,S1135_hourly_data,S1135_state_collector,S1135_ev_planned_load,S7503_flows,S7503_services,S7503_misc,S7503_logger,S7503_tests
 
 # S3776: Cognitive Complexity — excluded globally
 sonar.issue.ignore.multicriteria.S3776.ruleKey=python:S3776

--- a/tests/planner/test_invariants.py
+++ b/tests/planner/test_invariants.py
@@ -73,7 +73,7 @@ _TZ = ZoneInfo("Europe/Copenhagen")
 # ---------------------------------------------------------------------------
 
 
-def _make_uniform_input(  # NOSONAR
+def _make_uniform_input(
     *,
     import_price: float = 0.20,
     export_price: float = 0.05,

--- a/tests/planner/test_multi_day_price_preservation.py
+++ b/tests/planner/test_multi_day_price_preservation.py
@@ -191,7 +191,7 @@ class TestTimeSeriesIndexMultiDayAlignment:
         exp = {(0, h): 0.08 for h in range(24)}
         exp.update({(1, h): 0.28 for h in range(24)})
 
-        aligned_imp, aligned_exp = tsi.align_hourly_prices(imp, exp)
+        aligned_imp, _ = tsi.align_hourly_prices(imp, exp)
 
         # First 24 slots (day_offset=0) must carry today's price.
         for i in range(24):
@@ -235,7 +235,7 @@ class TestTimeSeriesIndexMultiDayAlignment:
         imp = dict.fromkeys(range(24), 0.10)
         exp = dict.fromkeys(range(24), 0.08)
 
-        aligned_imp, aligned_exp = tsi.align_hourly_prices(imp, exp)
+        aligned_imp, _ = tsi.align_hourly_prices(imp, exp)
 
         # All 48 slots receive the same cyclical value.
         for i, val in enumerate(aligned_imp):

--- a/tests/planner/test_soc_simulation.py
+++ b/tests/planner/test_soc_simulation.py
@@ -42,7 +42,7 @@ _TZ = ZoneInfo("Europe/Copenhagen")
 # ---------------------------------------------------------------------------
 
 
-def _make_minimal_input(  # NOSONAR
+def _make_minimal_input(
     *,
     battery_soc_pct: float = 50.0,
     battery_rated_capacity_kwh: float = 10.0,

--- a/tests/sensors/test_recommendation_resolver.py
+++ b/tests/sensors/test_recommendation_resolver.py
@@ -164,7 +164,7 @@ class TestBatteryAboveScheduleNeed:
 class TestNoneRec:
     def test_none_rec_does_not_raise(self):
         """resolve_current_recommendation should be a no-op when rec is None."""
-        resolve_current_recommendation(None, _make_live(), 0.0)
+        resolve_current_recommendation(None, _make_live(), 0.0)  # NOSONAR
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sensors/test_recommendation_resolver.py
+++ b/tests/sensors/test_recommendation_resolver.py
@@ -164,9 +164,7 @@ class TestBatteryAboveScheduleNeed:
 class TestNoneRec:
     def test_none_rec_does_not_raise(self):
         """resolve_current_recommendation should be a no-op when rec is None."""
-        resolve_current_recommendation(
-            None, _make_live(), 0.0
-        )  # NOSONAR -- intentional None test
+        resolve_current_recommendation(None, _make_live(), 0.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_huawei_service_calls.py
+++ b/tests/test_huawei_service_calls.py
@@ -245,7 +245,7 @@ class TestSetForcibleDischarge:
                 sensor,
                 "bat_dev",
                 150,
-                3000,  # > 100  # NOSONAR
+                3000,  # > 100
             )
         with pytest.raises(ValueError):
             await async_set_forcible_discharge(sensor, "bat_dev", -1, 3000)  # < 0


### PR DESCRIPTION
## Summary

Fase 7 of #526 - resolves the remaining ~43 SonarCloud stragglers.

### Part A - sonar-project.properties

Created at repo root with exclusions for S3776, S107, S117, S5655, S1135, S7503.
Fixed multicriteria header to list all 18 criteria keys.

### Part B - Code fixes

- B1: test_multi_day_price_preservation.py - replaced unused aligned_exp with _
- B2: logger.py - moved NOSONAR onto same line as list()

### Part C - NOSONAR cleanup

Removed 35 inline NOSONAR comments across 21 files, kept 26 uncovered.

### Quality Gates

- tox -e lint: PASSED
- tox -e typing: PASSED  
- tox -e quality: PASSED (0 errors)
- tox -e py313: Pre-existing bcrypt env issue (unrelated)

Fixes #526