### PR TITLE
fix(sensornames): prevent entry_id from leaking into entity names

### DIFF
--- a/custom_components/hsem/__init__.py
+++ b/custom_components/hsem/__init__.py
@@ -99,6 +99,26 @@ async def check_huawei_solar_version(hass: HomeAssistant) -> bool:
     return True
 
 
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate old config entries to the current version.
+
+    Home Assistant 2025.x+ calls this function on the component module
+    (__init__.py) instead of the ConfigFlow handler.  We delegate to the
+    existing migration logic in :class:`HSEMConfigFlow`.
+    """
+    from custom_components.hsem.config_flow import HSEMConfigFlow
+
+    flow = HSEMConfigFlow()
+    result = await flow.async_migrate_entry(hass, entry)
+
+    # Ensure the entry's minor_version matches the handler as well.
+    target_minor = getattr(flow, "MINOR_VERSION", 1)
+    if entry.minor_version != target_minor:
+        hass.config_entries.async_update_entry(entry, minor_version=target_minor)
+
+    return result
+
+
 async def async_setup(hass: HomeAssistant, _config: dict[str, Any]) -> bool:
     """Set up the HSEM integration.
 

--- a/custom_components/hsem/custom_selectors/solcast_likelihood.py
+++ b/custom_components/hsem/custom_selectors/solcast_likelihood.py
@@ -20,7 +20,7 @@ from custom_components.hsem.entity import HSEMEntity
 from custom_components.hsem.utils.misc import get_config_value
 from custom_components.hsem.utils.sensornames import (
     get_solcast_likelihood_selector_entity_id,
-    get_solcast_likelihood_selector_key,
+    get_solcast_likelihood_selector_unique_id,
 )
 
 _OPTIONS = ["pv_estimate", "pv_estimate10", "pv_estimate90"]
@@ -59,8 +59,8 @@ class HSEMSolcastLikelihoodSelector(HSEMEntity, SelectEntity):
         self.hass = hass
         self._config_entry = config_entry
         self.entity_description = description
-        self._attr_unique_id = (
-            f"{get_solcast_likelihood_selector_key()}_{config_entry.entry_id}"
+        self._attr_unique_id = get_solcast_likelihood_selector_unique_id(
+            config_entry.entry_id
         )
         self.entity_id = get_solcast_likelihood_selector_entity_id()
         self._attr_options = list(description.options or _OPTIONS)

--- a/custom_components/hsem/custom_selectors/working_mode.py
+++ b/custom_components/hsem/custom_selectors/working_mode.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant
 from custom_components.hsem.entity import HSEMEntity
 from custom_components.hsem.utils.sensornames import (
     get_force_working_mode_selector_entity_id,
-    get_force_working_mode_selector_key,
+    get_force_working_mode_selector_unique_id,
 )
 
 
@@ -58,8 +58,8 @@ class HSEMWorkingModeSelector(HSEMEntity, SelectEntity):
         self.entity_description = description
         # unique_id and entity_id are sourced from sensornames.py to keep
         # all HSEM entity identifiers in one canonical location.
-        self._attr_unique_id = (
-            f"{get_force_working_mode_selector_key()}_{config_entry.entry_id}"
+        self._attr_unique_id = get_force_working_mode_selector_unique_id(
+            config_entry.entry_id
         )
         self.entity_id = get_force_working_mode_selector_entity_id()
         self._attr_options = list(description.options or [])

--- a/custom_components/hsem/custom_sensors/state_collector.py
+++ b/custom_components/hsem/custom_sensors/state_collector.py
@@ -385,9 +385,7 @@ async def async_collect_live_state(
         _read_ev_planned_load_state(sensor, state, cfg, _read, is_second=True)
 
     # --- Register state-change listeners for reactive entities ---
-    new_unsubs = await _register_listeners(
-        sensor, cfg, state, tracked_entities, entry_id=entry_id
-    )
+    new_unsubs = await _register_listeners(sensor, cfg, state, tracked_entities)
 
     return state, fwm_entity, new_unsubs
 
@@ -584,7 +582,6 @@ async def _register_listeners(
     cfg: SensorConfig,
     state: LiveState,
     tracked_entities: set[str],
-    entry_id: str,
 ) -> list:
     """Register ``async_track_state_change_event`` for reactive entities.
 
@@ -599,14 +596,14 @@ async def _register_listeners(
     candidates = [
         cfg.ev.status_entity,
         cfg.ev.connected_entity,
-        get_ev_target_soc_number_entity_id(entry_id),
-        get_ev_smart_charging_switch_entity_id(entry_id),
-        get_ev_deadline_time_entity_id(entry_id),
+        get_ev_target_soc_number_entity_id(),
+        get_ev_smart_charging_switch_entity_id(),
+        get_ev_deadline_time_entity_id(),
         cfg.ev_second.status_entity,
         cfg.ev_second.connected_entity,
-        get_ev_second_target_soc_number_entity_id(entry_id),
-        get_ev_second_smart_charging_switch_entity_id(entry_id),
-        get_ev_second_deadline_time_entity_id(entry_id),
+        get_ev_second_target_soc_number_entity_id(),
+        get_ev_second_smart_charging_switch_entity_id(),
+        get_ev_second_deadline_time_entity_id(),
         state.force_working_mode,
     ]
 

--- a/custom_components/hsem/custom_switches/description.py
+++ b/custom_components/hsem/custom_switches/description.py
@@ -58,47 +58,47 @@ def build_switch_id_map(entry_id: str) -> dict[str, tuple[str, str]]:
     return {
         get_read_only_switch_key(): (
             get_read_only_switch_unique_id(entry_id),
-            get_read_only_switch_entity_id(entry_id),
+            get_read_only_switch_entity_id(),
         ),
         get_extended_attributes_switch_key(): (
             get_extended_attributes_switch_unique_id(entry_id),
-            get_extended_attributes_switch_entity_id(entry_id),
+            get_extended_attributes_switch_entity_id(),
         ),
         get_verbose_logging_switch_key(): (
             get_verbose_logging_switch_unique_id(entry_id),
-            get_verbose_logging_switch_entity_id(entry_id),
+            get_verbose_logging_switch_entity_id(),
         ),
         get_batteries_schedule_1_switch_key(): (
             get_batteries_schedule_1_switch_unique_id(entry_id),
-            get_batteries_schedule_1_switch_entity_id(entry_id),
+            get_batteries_schedule_1_switch_entity_id(),
         ),
         get_batteries_schedule_2_switch_key(): (
             get_batteries_schedule_2_switch_unique_id(entry_id),
-            get_batteries_schedule_2_switch_entity_id(entry_id),
+            get_batteries_schedule_2_switch_entity_id(),
         ),
         get_batteries_schedule_3_switch_key(): (
             get_batteries_schedule_3_switch_unique_id(entry_id),
-            get_batteries_schedule_3_switch_entity_id(entry_id),
+            get_batteries_schedule_3_switch_entity_id(),
         ),
         get_ev_force_discharge_switch_key(): (
             get_ev_force_discharge_switch_unique_id(entry_id),
-            get_ev_force_discharge_switch_entity_id(entry_id),
+            get_ev_force_discharge_switch_entity_id(),
         ),
         get_ev_smart_charging_switch_key(): (
             get_ev_smart_charging_switch_unique_id(entry_id),
-            get_ev_smart_charging_switch_entity_id(entry_id),
+            get_ev_smart_charging_switch_entity_id(),
         ),
         get_ev_force_charge_now_switch_key(): (
             get_ev_force_charge_now_switch_unique_id(entry_id),
-            get_ev_force_charge_now_switch_entity_id(entry_id),
+            get_ev_force_charge_now_switch_entity_id(),
         ),
         get_ev_second_smart_charging_switch_key(): (
             get_ev_second_smart_charging_switch_unique_id(entry_id),
-            get_ev_second_smart_charging_switch_entity_id(entry_id),
+            get_ev_second_smart_charging_switch_entity_id(),
         ),
         get_ev_second_force_charge_now_switch_key(): (
             get_ev_second_force_charge_now_switch_unique_id(entry_id),
-            get_ev_second_force_charge_now_switch_entity_id(entry_id),
+            get_ev_second_force_charge_now_switch_entity_id(),
         ),
     }
 

--- a/custom_components/hsem/custom_times/description.py
+++ b/custom_components/hsem/custom_times/description.py
@@ -49,35 +49,35 @@ def build_time_id_map(entry_id: str) -> dict[str, tuple[str, str]]:
     return {
         get_schedule_1_start_time_key(): (
             get_schedule_1_start_time_unique_id(entry_id),
-            get_schedule_1_start_time_entity_id(entry_id),
+            get_schedule_1_start_time_entity_id(),
         ),
         get_schedule_1_end_time_key(): (
             get_schedule_1_end_time_unique_id(entry_id),
-            get_schedule_1_end_time_entity_id(entry_id),
+            get_schedule_1_end_time_entity_id(),
         ),
         get_schedule_2_start_time_key(): (
             get_schedule_2_start_time_unique_id(entry_id),
-            get_schedule_2_start_time_entity_id(entry_id),
+            get_schedule_2_start_time_entity_id(),
         ),
         get_schedule_2_end_time_key(): (
             get_schedule_2_end_time_unique_id(entry_id),
-            get_schedule_2_end_time_entity_id(entry_id),
+            get_schedule_2_end_time_entity_id(),
         ),
         get_schedule_3_start_time_key(): (
             get_schedule_3_start_time_unique_id(entry_id),
-            get_schedule_3_start_time_entity_id(entry_id),
+            get_schedule_3_start_time_entity_id(),
         ),
         get_schedule_3_end_time_key(): (
             get_schedule_3_end_time_unique_id(entry_id),
-            get_schedule_3_end_time_entity_id(entry_id),
+            get_schedule_3_end_time_entity_id(),
         ),
         get_ev_deadline_time_key(): (
             get_ev_deadline_time_unique_id(entry_id),
-            get_ev_deadline_time_entity_id(entry_id),
+            get_ev_deadline_time_entity_id(),
         ),
         get_ev_second_deadline_time_key(): (
             get_ev_second_deadline_time_unique_id(entry_id),
-            get_ev_second_deadline_time_entity_id(entry_id),
+            get_ev_second_deadline_time_entity_id(),
         ),
     }
 

--- a/custom_components/hsem/number.py
+++ b/custom_components/hsem/number.py
@@ -82,11 +82,11 @@ async def async_setup_entry(  # NOSONAR -- HA platform callback, must be async
         ),
         get_ev_target_soc_number_key(): (
             get_ev_target_soc_number_unique_id(config_entry.entry_id),
-            get_ev_target_soc_number_entity_id(config_entry.entry_id),
+            get_ev_target_soc_number_entity_id(),
         ),
         get_ev_second_target_soc_number_key(): (
             get_ev_second_target_soc_number_unique_id(config_entry.entry_id),
-            get_ev_second_target_soc_number_entity_id(config_entry.entry_id),
+            get_ev_second_target_soc_number_entity_id(),
         ),
     }
 

--- a/custom_components/hsem/utils/sensornames.py
+++ b/custom_components/hsem/utils/sensornames.py
@@ -572,9 +572,18 @@ def get_force_working_mode_selector_name() -> str:
     return "Force Working Mode"
 
 
+def get_force_working_mode_selector_unique_id(entry_id: str) -> str:
+    """Return the unique_id for the force-working-mode select entity.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{get_force_working_mode_selector_key()}_{entry_id}"
+
+
 def get_force_working_mode_selector_entity_id() -> str:
     """Return the entity_id for the force-working-mode select entity."""
-    return f"select.{s(f'{DOMAIN}_force_working_mode')}"
+    return f"select.{s(get_force_working_mode_selector_key())}"
 
 
 # Solcast PV Forecast Likelihood Selector
@@ -588,9 +597,18 @@ def get_solcast_likelihood_selector_name() -> str:
     return "Solcast PV Forecast Likelihood"
 
 
+def get_solcast_likelihood_selector_unique_id(entry_id: str) -> str:
+    """Return the unique_id for the solcast likelihood select entity.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{get_solcast_likelihood_selector_key()}_{entry_id}"
+
+
 def get_solcast_likelihood_selector_entity_id() -> str:
     """Return the entity_id for the solcast likelihood select entity."""
-    return f"select.{s(f'{DOMAIN}_solcast_likelihood')}"
+    return f"select.{s(get_solcast_likelihood_selector_key())}"
 
 
 # Battery Charge Efficiency Number
@@ -663,13 +681,9 @@ def get_ev_target_soc_number_unique_id(entry_id: str) -> str:
     return f"{DOMAIN}_{entry_id}_{get_ev_target_soc_number_key()}_number"
 
 
-def get_ev_target_soc_number_entity_id(entry_id: str) -> str:
-    """Return the entity_id for the EV target SoC number entity.
-
-    Args:
-        entry_id (str): The config entry ID for uniqueness across entries.
-    """
-    return f"number.{s(get_ev_target_soc_number_unique_id(entry_id))}"
+def get_ev_target_soc_number_entity_id() -> str:
+    """Return the entity_id for the EV target SoC number entity."""
+    return f"number.{s(get_ev_target_soc_number_key())}"
 
 
 # EV 2 Target SoC Number
@@ -692,13 +706,9 @@ def get_ev_second_target_soc_number_unique_id(entry_id: str) -> str:
     return f"{DOMAIN}_{entry_id}_{get_ev_second_target_soc_number_key()}_number"
 
 
-def get_ev_second_target_soc_number_entity_id(entry_id: str) -> str:
-    """Return the entity_id for the EV 2 target SoC number entity.
-
-    Args:
-        entry_id (str): The config entry ID for uniqueness across entries.
-    """
-    return f"number.{s(get_ev_second_target_soc_number_unique_id(entry_id))}"
+def get_ev_second_target_soc_number_entity_id() -> str:
+    """Return the entity_id for the EV 2 target SoC number entity."""
+    return f"number.{s(get_ev_second_target_soc_number_key())}"
 
 
 # Applier Status Sensor
@@ -765,13 +775,9 @@ def get_read_only_switch_unique_id(entry_id: str) -> str:
     return f"{DOMAIN}_{entry_id}_{get_read_only_switch_key()}_switch"
 
 
-def get_read_only_switch_entity_id(entry_id: str) -> str:
-    """Return the entity_id for the read-only switch.
-
-    Args:
-        entry_id (str): The config entry ID for uniqueness across entries.
-    """
-    return f"switch.{s(get_read_only_switch_unique_id(entry_id))}"
+def get_read_only_switch_entity_id() -> str:
+    """Return the entity_id for the read-only switch."""
+    return f"switch.{s(get_read_only_switch_key())}"
 
 
 def get_extended_attributes_switch_key() -> str:
@@ -793,13 +799,9 @@ def get_extended_attributes_switch_unique_id(entry_id: str) -> str:
     return f"{DOMAIN}_{entry_id}_{get_extended_attributes_switch_key()}_switch"
 
 
-def get_extended_attributes_switch_entity_id(entry_id: str) -> str:
-    """Return the entity_id for the extended-attributes switch.
-
-    Args:
-        entry_id (str): The config entry ID for uniqueness across entries.
-    """
-    return f"switch.{s(get_extended_attributes_switch_unique_id(entry_id))}"
+def get_extended_attributes_switch_entity_id() -> str:
+    """Return the entity_id for the extended-attributes switch."""
+    return f"switch.{s(get_extended_attributes_switch_key())}"
 
 
 def get_verbose_logging_switch_key() -> str:
@@ -821,13 +823,9 @@ def get_verbose_logging_switch_unique_id(entry_id: str) -> str:
     return f"{DOMAIN}_{entry_id}_{get_verbose_logging_switch_key()}_switch"
 
 
-def get_verbose_logging_switch_entity_id(entry_id: str) -> str:
-    """Return the entity_id for the verbose-logging switch.
-
-    Args:
-        entry_id (str): The config entry ID for uniqueness across entries.
-    """
-    return f"switch.{s(get_verbose_logging_switch_unique_id(entry_id))}"
+def get_verbose_logging_switch_entity_id() -> str:
+    """Return the entity_id for the verbose-logging switch."""
+    return f"switch.{s(get_verbose_logging_switch_key())}"
 
 
 def get_batteries_schedule_1_switch_key() -> str:
@@ -849,13 +847,9 @@ def get_batteries_schedule_1_switch_unique_id(entry_id: str) -> str:
     return f"{DOMAIN}_{entry_id}_{get_batteries_schedule_1_switch_key()}_switch"
 
 
-def get_batteries_schedule_1_switch_entity_id(entry_id: str) -> str:
-    """Return the entity_id for the batteries-schedule-1 switch.
-
-    Args:
-        entry_id (str): The config entry ID for uniqueness across entries.
-    """
-    return f"switch.{s(get_batteries_schedule_1_switch_unique_id(entry_id))}"
+def get_batteries_schedule_1_switch_entity_id() -> str:
+    """Return the entity_id for the batteries-schedule-1 switch."""
+    return f"switch.{s(get_batteries_schedule_1_switch_key())}"
 
 
 def get_batteries_schedule_2_switch_key() -> str:
@@ -877,13 +871,9 @@ def get_batteries_schedule_2_switch_unique_id(entry_id: str) -> str:
     return f"{DOMAIN}_{entry_id}_{get_batteries_schedule_2_switch_key()}_switch"
 
 
-def get_batteries_schedule_2_switch_entity_id(entry_id: str) -> str:
-    """Return the entity_id for the batteries-schedule-2 switch.
-
-    Args:
-        entry_id (str): The config entry ID for uniqueness across entries.
-    """
-    return f"switch.{s(get_batteries_schedule_2_switch_unique_id(entry_id))}"
+def get_batteries_schedule_2_switch_entity_id() -> str:
+    """Return the entity_id for the batteries-schedule-2 switch."""
+    return f"switch.{s(get_batteries_schedule_2_switch_key())}"
 
 
 def get_batteries_schedule_3_switch_key() -> str:
@@ -905,13 +895,9 @@ def get_batteries_schedule_3_switch_unique_id(entry_id: str) -> str:
     return f"{DOMAIN}_{entry_id}_{get_batteries_schedule_3_switch_key()}_switch"
 
 
-def get_batteries_schedule_3_switch_entity_id(entry_id: str) -> str:
-    """Return the entity_id for the batteries-schedule-3 switch.
-
-    Args:
-        entry_id (str): The config entry ID for uniqueness across entries.
-    """
-    return f"switch.{s(get_batteries_schedule_3_switch_unique_id(entry_id))}"
+def get_batteries_schedule_3_switch_entity_id() -> str:
+    """Return the entity_id for the batteries-schedule-3 switch."""
+    return f"switch.{s(get_batteries_schedule_3_switch_key())}"
 
 
 def get_ev_force_discharge_switch_key() -> str:
@@ -933,13 +919,9 @@ def get_ev_force_discharge_switch_unique_id(entry_id: str) -> str:
     return f"{DOMAIN}_{entry_id}_{get_ev_force_discharge_switch_key()}_switch"
 
 
-def get_ev_force_discharge_switch_entity_id(entry_id: str) -> str:
-    """Return the entity_id for the EV-force-discharge switch.
-
-    Args:
-        entry_id (str): The config entry ID for uniqueness across entries.
-    """
-    return f"switch.{s(get_ev_force_discharge_switch_unique_id(entry_id))}"
+def get_ev_force_discharge_switch_entity_id() -> str:
+    """Return the entity_id for the EV-force-discharge switch."""
+    return f"switch.{s(get_ev_force_discharge_switch_key())}"
 
 
 # ---------------------------------------------------------------------------
@@ -966,13 +948,9 @@ def get_ev_smart_charging_switch_unique_id(entry_id: str) -> str:
     return f"{DOMAIN}_{entry_id}_{get_ev_smart_charging_switch_key()}_switch"
 
 
-def get_ev_smart_charging_switch_entity_id(entry_id: str) -> str:
-    """Return the entity_id for the primary EV smart charging switch.
-
-    Args:
-        entry_id (str): The config entry ID for uniqueness across entries.
-    """
-    return f"switch.{s(get_ev_smart_charging_switch_unique_id(entry_id))}"
+def get_ev_smart_charging_switch_entity_id() -> str:
+    """Return the entity_id for the primary EV smart charging switch."""
+    return f"switch.{s(get_ev_smart_charging_switch_key())}"
 
 
 def get_ev_force_charge_now_switch_key() -> str:
@@ -994,13 +972,9 @@ def get_ev_force_charge_now_switch_unique_id(entry_id: str) -> str:
     return f"{DOMAIN}_{entry_id}_{get_ev_force_charge_now_switch_key()}_switch"
 
 
-def get_ev_force_charge_now_switch_entity_id(entry_id: str) -> str:
-    """Return the entity_id for the primary EV force-charge-now switch.
-
-    Args:
-        entry_id (str): The config entry ID for uniqueness across entries.
-    """
-    return f"switch.{s(get_ev_force_charge_now_switch_unique_id(entry_id))}"
+def get_ev_force_charge_now_switch_entity_id() -> str:
+    """Return the entity_id for the primary EV force-charge-now switch."""
+    return f"switch.{s(get_ev_force_charge_now_switch_key())}"
 
 
 def get_ev_second_smart_charging_switch_key() -> str:
@@ -1022,13 +996,9 @@ def get_ev_second_smart_charging_switch_unique_id(entry_id: str) -> str:
     return f"{DOMAIN}_{entry_id}_{get_ev_second_smart_charging_switch_key()}_switch"
 
 
-def get_ev_second_smart_charging_switch_entity_id(entry_id: str) -> str:
-    """Return the entity_id for the second EV smart charging switch.
-
-    Args:
-        entry_id (str): The config entry ID for uniqueness across entries.
-    """
-    return f"switch.{s(get_ev_second_smart_charging_switch_unique_id(entry_id))}"
+def get_ev_second_smart_charging_switch_entity_id() -> str:
+    """Return the entity_id for the second EV smart charging switch."""
+    return f"switch.{s(get_ev_second_smart_charging_switch_key())}"
 
 
 def get_ev_second_force_charge_now_switch_key() -> str:
@@ -1050,13 +1020,9 @@ def get_ev_second_force_charge_now_switch_unique_id(entry_id: str) -> str:
     return f"{DOMAIN}_{entry_id}_{get_ev_second_force_charge_now_switch_key()}_switch"
 
 
-def get_ev_second_force_charge_now_switch_entity_id(entry_id: str) -> str:
-    """Return the entity_id for the second EV force-charge-now switch.
-
-    Args:
-        entry_id (str): The config entry ID for uniqueness across entries.
-    """
-    return f"switch.{s(get_ev_second_force_charge_now_switch_unique_id(entry_id))}"
+def get_ev_second_force_charge_now_switch_entity_id() -> str:
+    """Return the entity_id for the second EV force-charge-now switch."""
+    return f"switch.{s(get_ev_second_force_charge_now_switch_key())}"
 
 
 # ---------------------------------------------------------------------------
@@ -1083,13 +1049,9 @@ def get_ev_deadline_time_unique_id(entry_id: str) -> str:
     return f"{DOMAIN}_{entry_id}_{get_ev_deadline_time_key()}_time"
 
 
-def get_ev_deadline_time_entity_id(entry_id: str) -> str:
-    """Return the Home Assistant entity ID for the EV charge deadline time entity.
-
-    Args:
-        entry_id (str): The config entry ID for uniqueness across entries.
-    """
-    return f"time.{s(get_ev_deadline_time_unique_id(entry_id))}"
+def get_ev_deadline_time_entity_id() -> str:
+    """Return the Home Assistant entity ID for the EV charge deadline time entity."""
+    return f"time.{s(get_ev_deadline_time_key())}"
 
 
 def get_ev_second_deadline_time_key() -> str:
@@ -1111,13 +1073,9 @@ def get_ev_second_deadline_time_unique_id(entry_id: str) -> str:
     return f"{DOMAIN}_{entry_id}_{get_ev_second_deadline_time_key()}_time"
 
 
-def get_ev_second_deadline_time_entity_id(entry_id: str) -> str:
-    """Return the Home Assistant entity ID for the second EV charge deadline time entity.
-
-    Args:
-        entry_id (str): The config entry ID for uniqueness across entries.
-    """
-    return f"time.{s(get_ev_second_deadline_time_unique_id(entry_id))}"
+def get_ev_second_deadline_time_entity_id() -> str:
+    """Return the Home Assistant entity ID for the second EV charge deadline time entity."""
+    return f"time.{s(get_ev_second_deadline_time_key())}"
 
 
 # ---------------------------------------------------------------------------
@@ -1144,13 +1102,9 @@ def get_schedule_1_start_time_unique_id(entry_id: str) -> str:
     return f"{DOMAIN}_{entry_id}_{get_schedule_1_start_time_key()}_time"
 
 
-def get_schedule_1_start_time_entity_id(entry_id: str) -> str:
-    """Return the entity_id for the schedule-1-start time entity.
-
-    Args:
-        entry_id (str): The config entry ID for uniqueness across entries.
-    """
-    return f"time.{s(get_schedule_1_start_time_unique_id(entry_id))}"
+def get_schedule_1_start_time_entity_id() -> str:
+    """Return the entity_id for the schedule-1-start time entity."""
+    return f"time.{s(get_schedule_1_start_time_key())}"
 
 
 def get_schedule_1_end_time_key() -> str:
@@ -1172,13 +1126,9 @@ def get_schedule_1_end_time_unique_id(entry_id: str) -> str:
     return f"{DOMAIN}_{entry_id}_{get_schedule_1_end_time_key()}_time"
 
 
-def get_schedule_1_end_time_entity_id(entry_id: str) -> str:
-    """Return the entity_id for the schedule-1-end time entity.
-
-    Args:
-        entry_id (str): The config entry ID for uniqueness across entries.
-    """
-    return f"time.{s(get_schedule_1_end_time_unique_id(entry_id))}"
+def get_schedule_1_end_time_entity_id() -> str:
+    """Return the entity_id for the schedule-1-end time entity."""
+    return f"time.{s(get_schedule_1_end_time_key())}"
 
 
 def get_schedule_2_start_time_key() -> str:
@@ -1200,13 +1150,9 @@ def get_schedule_2_start_time_unique_id(entry_id: str) -> str:
     return f"{DOMAIN}_{entry_id}_{get_schedule_2_start_time_key()}_time"
 
 
-def get_schedule_2_start_time_entity_id(entry_id: str) -> str:
-    """Return the entity_id for the schedule-2-start time entity.
-
-    Args:
-        entry_id (str): The config entry ID for uniqueness across entries.
-    """
-    return f"time.{s(get_schedule_2_start_time_unique_id(entry_id))}"
+def get_schedule_2_start_time_entity_id() -> str:
+    """Return the entity_id for the schedule-2-start time entity."""
+    return f"time.{s(get_schedule_2_start_time_key())}"
 
 
 def get_schedule_2_end_time_key() -> str:
@@ -1228,13 +1174,9 @@ def get_schedule_2_end_time_unique_id(entry_id: str) -> str:
     return f"{DOMAIN}_{entry_id}_{get_schedule_2_end_time_key()}_time"
 
 
-def get_schedule_2_end_time_entity_id(entry_id: str) -> str:
-    """Return the entity_id for the schedule-2-end time entity.
-
-    Args:
-        entry_id (str): The config entry ID for uniqueness across entries.
-    """
-    return f"time.{s(get_schedule_2_end_time_unique_id(entry_id))}"
+def get_schedule_2_end_time_entity_id() -> str:
+    """Return the entity_id for the schedule-2-end time entity."""
+    return f"time.{s(get_schedule_2_end_time_key())}"
 
 
 def get_schedule_3_start_time_key() -> str:
@@ -1256,13 +1198,9 @@ def get_schedule_3_start_time_unique_id(entry_id: str) -> str:
     return f"{DOMAIN}_{entry_id}_{get_schedule_3_start_time_key()}_time"
 
 
-def get_schedule_3_start_time_entity_id(entry_id: str) -> str:
-    """Return the entity_id for the schedule-3-start time entity.
-
-    Args:
-        entry_id (str): The config entry ID for uniqueness across entries.
-    """
-    return f"time.{s(get_schedule_3_start_time_unique_id(entry_id))}"
+def get_schedule_3_start_time_entity_id() -> str:
+    """Return the entity_id for the schedule-3-start time entity."""
+    return f"time.{s(get_schedule_3_start_time_key())}"
 
 
 def get_schedule_3_end_time_key() -> str:
@@ -1284,10 +1222,6 @@ def get_schedule_3_end_time_unique_id(entry_id: str) -> str:
     return f"{DOMAIN}_{entry_id}_{get_schedule_3_end_time_key()}_time"
 
 
-def get_schedule_3_end_time_entity_id(entry_id: str) -> str:
-    """Return the entity_id for the schedule-3-end time entity.
-
-    Args:
-        entry_id (str): The config entry ID for uniqueness across entries.
-    """
-    return f"time.{s(get_schedule_3_end_time_unique_id(entry_id))}"
+def get_schedule_3_end_time_entity_id() -> str:
+    """Return the entity_id for the schedule-3-end time entity."""
+    return f"time.{s(get_schedule_3_end_time_key())}"


### PR DESCRIPTION
## Summary

Two fixes in one PR:

### 1. Migration handler not found (`__init__.py`)
HA 2025.x+ calls `async_migrate_entry` on the **component module** instead of the ConfigFlow handler. Added the missing function to `__init__.py` so config entries at version 1 can migrate to version 2 without logging `"Migration handler not found"`.

### 2. ULID-leak in entity IDs (`sensornames.py` + call sites)
21 `_entity_id` functions for switches, numbers, and times were building user-facing entity IDs by slugifying the `_unique_id()` — which embeds the config entry's ULID. This produced unreadable names like:

```
switch.hsem_01jh7vf4zsp6xg6vez3van9dsx_hsem_ev_force_charge_now_switch
```

Fixed to produce clean names like sensors already did:

```
switch.hsem_ev_force_charge_now
```

The `entry_id` **stays in `unique_id`** per PR #523's contract for HA-internal deduplication — only the user-facing `entity_id` was fixed.

### 3. Selector consistency
Added missing `_unique_id()` helpers for selectors (`force_working_mode`, `solcast_likelihood`) so every entity type follows the same canonical pattern: `_key()`, `_name()`, `_unique_id(entry_id)`, `_entity_id()`.

### 4. Dead parameter removal
Removed unused `entry_id` parameter from `_register_listeners()` in `state_collector.py` — it became dead after the entity_id calls were fixed to no longer accept it.

## Files changed

| File | Change |
|---|---|
| `__init__.py` | Added `async_migrate_entry()` |
| `utils/sensornames.py` | Fixed 21 `_entity_id` functions + added 2 `_unique_id` helpers |
| `custom_switches/description.py` | Removed `entry_id` arg from 11 calls |
| `custom_times/description.py` | Removed `entry_id` arg from 8 calls |
| `number.py` | Removed `entry_id` arg from 2 calls |
| `custom_sensors/state_collector.py` | Removed `entry_id` arg from 6 calls + dead parameter |
| `custom_selectors/working_mode.py` | Uses `_unique_id()` helper instead of inline construction |
| `custom_selectors/solcast_likelihood.py` | Uses `_unique_id()` helper instead of inline construction |

## Validation

- ✅ `tox -e lint` — passes
- ✅ `tox -e typing` — passes