### PR TITLE
feat(milp): add soft constraints with penalty variables to prevent infeasibility

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -79,16 +79,18 @@ assert result == pytest.approx(expected, rel=1e-6)
 
 ## MILP Variable Vector
 
-The MILP in `milp_optimizer.py` uses **6*n** LP variables (n = number of slots):
+The MILP in `milp_optimizer.py` uses **8*n** LP variables (n = number of future slots):
 
 ```
-Index range    Variable   Meaning
-[0 .. n-1]     ec[t]      Energy charged in slot t (kWh)
-[n .. 2n-1]    ed[t]      Energy discharged in slot t (kWh)
-[2n .. 3n-1]   gi[t]      Grid import in slot t (kWh)
-[3n .. 4n-1]   ge[t]      Grid export in slot t (kWh)
-[4n .. 5n-1]   pv[t]      PV surplus used in slot t (kWh)
-[5n .. 6n-1]   m[t]       max(ec[t], ed[t]) auxiliary variable for cycle cost
+Index range      Variable     Meaning
+[0 .. n-1]       ec[t]        Energy charged in slot t (kWh)
+[n .. 2n-1]      ed[t]        Energy discharged in slot t (kWh)
+[2n .. 3n-1]     gi[t]        Grid import in slot t (kWh)
+[3n .. 4n-1]     ge[t]        Grid export in slot t (kWh)
+[4n .. 5n-1]     pv[t]        PV surplus used in slot t (kWh)
+[5n .. 6n-1]     m[t]         max(ec[t], ed[t]) auxiliary variable for cycle cost
+[6n .. 7n-1]     s_max_pen[t] Penalty: kWh SoC exceeds usable_kwh
+[7n .. 8n-1]     s_min_pen[t] Penalty: kWh SoC drops below 0
 ```
 
 Cycle cost is counted as `α * m[t]` — **not** `α * (ec[t] + ed[t])`.

--- a/custom_components/hsem/planner/candidate_generator.py
+++ b/custom_components/hsem/planner/candidate_generator.py
@@ -147,12 +147,16 @@ class CandidatePlan:
             the SoC simulation runs.
         rejection_reason:
             Human-readable reason when ``is_valid`` is ``False``.
+        diagnostics:
+            Optional diagnostics dict from the candidate generator (e.g., MILP
+            penalty violations).  Set by the generator during candidate creation.
     """
 
     name: str
     slots: list[PlannedSlot]
     is_valid: bool = True
     rejection_reason: str = ""
+    diagnostics: dict | None = field(default=None, repr=False, compare=False)
     _cost: PlanCostBreakdown | None = field(default=None, repr=False, compare=False)
 
 
@@ -279,7 +283,7 @@ def generate_candidates(
         # user-configured extra margin.
         effective_cycle_cost = max(auto_cycle_cost, inp.battery_cycle_cost_per_kwh)
 
-        milp_slots = solve_milp(
+        milp_result = solve_milp(
             baseline_slots,
             now,
             current_kwh=current_kwh,
@@ -299,11 +303,19 @@ def generate_candidates(
                 capacity_loss_pct=inp.battery_capacity_loss_pct,
             ),
         )
-        if milp_slots is not None:
-            candidates.append(CandidatePlan(name=CANDIDATE_MILP, slots=milp_slots))
+        if milp_result is not None:
+            milp_slots, milp_diag = milp_result
+            candidates.append(
+                CandidatePlan(
+                    name=CANDIDATE_MILP, slots=milp_slots, diagnostics=milp_diag
+                )
+            )
             log_planner(
                 "debug",
-                "[gen] MILP candidate added (scipy available and solver succeeded)",
+                "[gen] MILP candidate added (scipy available and solver succeeded)"
+                "  penalty_violations=%s  total_violation=%.4f",
+                milp_diag.get("has_violations", False),
+                milp_diag.get("total_violation_kwh", 0.0),
             )
         else:
             log_planner(

--- a/custom_components/hsem/planner/engine_core.py
+++ b/custom_components/hsem/planner/engine_core.py
@@ -13,7 +13,10 @@ from datetime import datetime
 from custom_components.hsem.models.planner_inputs import PlannerInput
 from custom_components.hsem.models.planner_outputs import DataQuality, PlannerOutput
 from custom_components.hsem.models.time_series import TimeSeriesIndex
-from custom_components.hsem.planner.candidate_generator import generate_candidates
+from custom_components.hsem.planner.candidate_generator import (
+    CANDIDATE_MILP,
+    generate_candidates,
+)
 from custom_components.hsem.planner.candidate_selector import (
     replacement_price_from_next_discharge,
     select_best_candidate,
@@ -696,6 +699,18 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
     candidates, winner, candidate_rejected, hysteresis_result = _select_candidate(
         slots, inp, now, current_kwh, usable_kwh, mcps, mdps, max_soc_kwh, rppk, cw, sdh
     )
+    # Surface MILP penalty violations in warnings if the winner used penalties
+    if (
+        winner.name == CANDIDATE_MILP
+        and winner.diagnostics is not None
+        and winner.diagnostics.get("has_violations", False)
+    ):
+        diag = winner.diagnostics
+        total = diag.get("total_violation_kwh", 0.0)
+        warnings.append(
+            f"MILP: SoC penalty violations detected (total={total:.4f} kWh). "
+            f"The plan may have been forced due to out-of-bounds initial SoC."
+        )
     # Step 5 — finalize plan from winner
     slots = winner.slots
     apply_optimization_strategy(

--- a/custom_components/hsem/planner/milp_optimizer.py
+++ b/custom_components/hsem/planner/milp_optimizer.py
@@ -28,10 +28,10 @@ For each slot ``t ∈ 0…n-1``:
 Objective (minimise)
 --------------------
 ``Σ_t [ p_imp[t]*gi[t] - p_exp[t]*ge[t] + α*m[t]
-       + γ*(ed[t]-ec[t]) + P_soc*s_max_pen[t] + P_soc*s_min_pen[t] ]``
+       + γ*(ed[t]-ec[t]) + p_soc*s_max_pen[t] + p_soc*s_min_pen[t] ]``
 
 where ``α`` = battery cycle cost/kWh, ``γ`` = terminal-SoC replacement
-price, ``P_soc = max(p_imp) * 100`` ensures penalties are only used when
+price, ``p_soc = max(p_imp) * 100`` ensures penalties are only used when
 forced (e.g., initial SoC outside bounds).
 
 Constraints
@@ -370,11 +370,11 @@ def solve_milp(
     # Apply time discount so the MILP objective matches the selector's
     # discounted score (distant savings are worth less).
     #
-    # Penalty cost P_soc ensures penalties are never used unless forced.
+    # Penalty cost p_soc ensures penalties are never used unless forced.
     # It must be much larger than the maximum possible import cost per kWh.
     # ------------------------------------------------------------------
     p_imp_max = float(np.max(p_imp)) if m > 0 else 0.1
-    P_soc = max(p_imp_max, 0.1) * 100.0
+    p_soc = max(p_imp_max, 0.1) * 100.0
 
     use_discount = time_discount_rate < 1.0 - 1e-9
     c_obj = np.zeros(n_vars)
@@ -412,8 +412,8 @@ def solve_milp(
         # Penalty costs: high enough that penalties are zero when SoC is
         # within bounds, but absorb violations when the initial SoC is
         # outside [0, usable_kwh] (e.g., overcharged battery).
-        c_obj[s_max_off + t] = P_soc * discount
-        c_obj[s_min_off + t] = P_soc * discount
+        c_obj[s_max_off + t] = p_soc * discount
+        c_obj[s_min_off + t] = p_soc * discount
 
     # ------------------------------------------------------------------
     # Equality constraints: energy balance per slot

--- a/custom_components/hsem/planner/milp_optimizer.py
+++ b/custom_components/hsem/planner/milp_optimizer.py
@@ -1,97 +1,65 @@
 """MILP-based optimal battery charge/discharge scheduler.
 
-This module implements a **Mixed Integer Linear Program** that finds the
-globally cost-optimal charge/discharge schedule for the planning horizon.
+Finds the globally cost-optimal charge/discharge schedule via LP.
 It is the PRIMARY planner — heuristic candidates are disabled.
 
 Algorithm overview
 ------------------
-The scheduler is formulated as a **continuous LP** (not MILP) using the
-HiGHS solver via ``scipy.optimize.linprog``.  Binary charge/discharge flags
-are relaxed to continuous values in [0, 1] because the mutual-exclusion
-constraint together with the per-slot energy caps already prevents
-simultaneous charge + discharge in the optimal solution.
+Formulated as a **continuous LP** (not MILP) using the HiGHS solver
+via ``scipy.optimize.linprog``.  Binary charge/discharge flags are
+relaxed to continuous because the mutual-exclusion constraint already
+prevents simultaneous charge + discharge.
 
-Decision variables (flattened into a single vector ``x`` of length 6*n)
------------------------------------------------------------------------
+Decision variables (flattened into ``x`` of length 8*n)
+----------------------------------------------------------
 For each slot ``t ∈ 0…n-1``:
 
-- ``ec[t]``  — energy charged and *stored* in the battery this slot (kWh)
-- ``ed[t]``  — energy discharged *from* the battery this slot (kWh)
-- ``gi[t]``  — total grid import this slot (kWh)
-- ``ge[t]``  — total grid export this slot (kWh)
-- ``pv[t]``  — PV energy available after house consumption (kWh, fixed)
-- ``m[t]``   — auxiliary variable = max(ec[t], ed[t]) for cycle cost (kWh)
+- ``ec[t]`` — energy charged and *stored* in battery this slot (kWh)
+- ``ed[t]`` — energy discharged *from* battery this slot (kWh)
+- ``gi[t]`` — grid import this slot (kWh)
+- ``ge[t]`` — grid export this slot (kWh)
+- ``pv[t]`` — PV surplus after house consumption (kWh, fixed)
+- ``m[t]`` — max(ec[t], ed[t]) for cycle cost (kWh)
+- ``s_max_pen[t]`` — kWh SoC exceeds usable_kwh
+- ``s_min_pen[t]`` — kWh SoC drops below 0
 
-``soc[t]`` is derived from ``ec`` and ``ed`` via the forward recurrence and
-does not need to be an explicit variable.
+``soc[t]`` is derived from ``ec``/``ed`` via forward recurrence.
 
 Objective (minimise)
 --------------------
-``Σ_t [ p_imp[t] * gi[t] - p_exp[t] * ge[t] + α * m[t]
-       + γ * (ed[t] - ec[t]) ]``
+``Σ_t [ p_imp[t]*gi[t] - p_exp[t]*ge[t] + α*m[t]
+       + γ*(ed[t]-ec[t]) + P_soc*s_max_pen[t] + P_soc*s_min_pen[t] ]``
 
-where ``α`` = battery cycle cost per kWh and ``γ`` = terminal-SoC
-replacement price (opportunity cost of ending the horizon with less stored
-energy).  The cycle cost uses the auxiliary variable ``m[t]`` which is
-constrained to satisfy ``m[t] ≥ max(ec[t], ed[t])``, matching
-``cost_function.py``'s ``max(charge, discharge)`` counting.  The
-``cycle_cost_per_kwh`` already includes the 2× throughput factor in its
-denominator (``purchase_price / (2 × usable_kwh × expected_cycles)``),
-so one full round-trip (charge + discharge) correctly costs
-``2 × usable_kwh × cycle_cost_per_kwh = purchase_price / expected_cycles``.
+where ``α`` = battery cycle cost/kWh, ``γ`` = terminal-SoC replacement
+price, ``P_soc = max(p_imp) * 100`` ensures penalties are only used when
+forced (e.g., initial SoC outside bounds).
 
 Constraints
 -----------
-For each slot ``t``:
-
-1. **SoC forward recurrence** (equality):
-   ``soc[t] = soc[t-1] + ec[t] - ed[t]``
-   (internal SoC in kWh above the discharge floor)
-
-2. **SoC bounds** (inequality):
-   ``soc[t] ≥ 0``  and  ``soc[t] ≤ usable_kwh``
-
-3. **Charge limit** (inequality):
-   ``ec[t] ≤ max_charge_per_slot``
-
-4. **Discharge limit** (inequality):
-   ``ed[t] ≤ max_discharge_per_slot``  (relaxed to usable_kwh when unlimited)
-
-5. **Mutual exclusion** (inequality):
-   ``ec[t] / max_charge_per_slot + ed[t] / max_discharge_per_slot ≤ 1``
-   Prevents simultaneous charge + discharge without binary variables.
-
-6. **Energy balance** (equality):
-   ``gi[t] + pv_avail[t] + ed[t] * discharge_eff
-       = load[t] + ec[t] / charge_eff + ge[t]``
-
-   Where ``pv_avail[t]`` is the PV energy available after house consumption is
-   subtracted.  Because PV first serves the house load, the net residual PV
-   is what the battery or export can absorb.
-
-7. **Non-negativity**: All variables ≥ 0.
-
-Past slots (recommendation == TimePassed) are fixed at zero by using
-zero-capacity bounds and are excluded from the energy balance.
+1. SoC recurrence: ``soc[t] = soc[t-1] + ec[t] - ed[t]``
+2. SoC bounds (soft): ``soc[t] − s_max_pen ≤ usable_kwh``,
+   ``−soc[t] − s_min_pen ≤ 0``
+3. Charge limit: ``ec[t] ≤ max_charge_per_slot``
+4. Discharge limit: ``ed[t] ≤ max_discharge_per_slot``
+5. Mutual exclusion: ``ec[t]/mc + ed[t]/md ≤ 1``
+6. Energy balance:
+   ``gi + pv + ed·η_disch = load + ec/η_chg + ge``
+7. Non-negativity: all ≥ 0. Past slots fixed at zero.
 
 Solving
 -------
-``scipy.optimize.linprog(method='highs')`` is used.  For a 96-slot (48 h ×
-30 min) horizon this solves in well under 50 ms on commodity hardware.
-No extra dependencies beyond ``scipy`` (already a Home Assistant dependency).
+``scipy.optimize.linprog(method='highs')``.  96-slot horizon < 50 ms.
 
 Fallback
 --------
-If the solver fails (infeasible, numerical issue, or timeout), this module
-returns ``None``.  The engine falls back to the rule-based baseline.
+Returns ``None`` if solver crashes/times out; engine falls back to
+rule-based baseline.
 
 Design constraints
 ------------------
-- **Pure Python, no Home Assistant imports** — testable with plain pytest.
-- Only mutates the output ``recommendation`` / ``batteries_charged`` fields
-  on deep-copied slots; never touches the caller's baseline.
-- Respects the same SoC bounds and power limits as :mod:`soc_simulation`.
+- Pure Python, no Home Assistant imports — testable with plain pytest.
+- Only mutates ``recommendation``/``batteries_charged`` on deep-copied
+  slots; never touches the caller's baseline.
 """
 
 from __future__ import annotations
@@ -135,7 +103,7 @@ def solve_milp(
     *,
     export_min_price: float = 0.0,
     recommended_threshold: float = 0.0,
-) -> list[PlannedSlot] | None:
+) -> tuple[list[PlannedSlot], dict] | None:
     """Solve the LP and return a deep-copy slot list with MILP recommendations.
 
     The returned list is independent of *slots* — it is safe to mutate without
@@ -200,8 +168,13 @@ def solve_milp(
             and ``BatteriesDischargeMode`` (house-load only).  Defaults to 0.0.
 
     Returns:
-        A list of :class:`PlannedSlot` copies with MILP-derived recommendations,
-        or ``None`` if the solver fails or the problem is infeasible.
+        A tuple ``(slots, diagnostics)`` where:
+        - ``slots`` is a list of :class:`PlannedSlot` copies with MILP-derived
+          recommendations.
+        - ``diagnostics`` is a dict with keys ``"s_max_pen"``, ``"s_min_pen"``,
+          ``"has_violations"``, ``"total_violation_kwh"``.
+        Returns ``None`` if the solver fails (unrelated to constraint
+        violations — e.g., solver crash or numerical issue).
     """
     import copy
 
@@ -352,16 +325,23 @@ def solve_milp(
 
     # ------------------------------------------------------------------
     # Variable layout: x = [ec(0..m-1), ed(0..m-1), gi(0..m-1), ge(0..m-1),
-    #                       pv(0..m-1), m(0..m-1)]
-    # Offsets: ec_off=0, ed_off=m, gi_off=2m, ge_off=3m, pv_off=4m, m_off=5m
+    #                       pv(0..m-1), m(0..m-1),
+    #                       s_max_pen(0..m-1), s_min_pen(0..m-1)]
+    # Offsets: ec_off=0, ed_off=m, gi_off=2m, ge_off=3m, pv_off=4m, m_off=5m,
+    #          s_max_off=6m, s_min_off=7m
     # pv[t] is a FIXED variable bounded to [pv_avail[t], pv_avail[t]] — the
     # solar energy available after house consumption.  Making it explicit in
     # the LP (rather than netting it into b_eq) prevents infeasibility when
     # net_load is strongly negative and SoC constraints limit charge/export.
     # m[t] is the auxiliary variable for cycle cost: m[t] = max(ec[t], ed[t]).
+    # s_max_pen[t] and s_min_pen[t] are penalty variables that absorb SoC
+    # bound violations at a very high cost, ensuring the LP is never infeasible
+    # due to initial SoC being outside bounds.
     # ------------------------------------------------------------------
     ec_off, ed_off, gi_off, ge_off, pv_off, m_off = 0, m, 2 * m, 3 * m, 4 * m, 5 * m
-    n_vars = 6 * m
+    s_max_off = 6 * m
+    s_min_off = 7 * m
+    n_vars = 8 * m
 
     # Resolve charge/discharge efficiencies for the energy balance equation.
     # The MILP must account for real-world conversion losses so its solution
@@ -389,7 +369,13 @@ def solve_milp(
     #
     # Apply time discount so the MILP objective matches the selector's
     # discounted score (distant savings are worth less).
+    #
+    # Penalty cost P_soc ensures penalties are never used unless forced.
+    # It must be much larger than the maximum possible import cost per kWh.
     # ------------------------------------------------------------------
+    p_imp_max = float(np.max(p_imp)) if m > 0 else 0.1
+    P_soc = max(p_imp_max, 0.1) * 100.0
+
     use_discount = time_discount_rate < 1.0 - 1e-9
     c_obj = np.zeros(n_vars)
 
@@ -423,6 +409,12 @@ def solve_milp(
             c_obj[ec_off + t] -= replacement_price_per_kwh
             c_obj[ed_off + t] += replacement_price_per_kwh
 
+        # Penalty costs: high enough that penalties are zero when SoC is
+        # within bounds, but absorb violations when the initial SoC is
+        # outside [0, usable_kwh] (e.g., overcharged battery).
+        c_obj[s_max_off + t] = P_soc * discount
+        c_obj[s_min_off + t] = P_soc * discount
+
     # ------------------------------------------------------------------
     # Equality constraints: energy balance per slot
     # gi[t] + pv[t] + ed[t]*discharge_eff = base_load[t] + ec[t]/charge_eff + ge[t]
@@ -444,16 +436,18 @@ def solve_milp(
 
     # ------------------------------------------------------------------
     # Inequality constraints:
-    #   1. SoC recurrence: soc[t] = soc[0] + Σ_{k≤t} (t) (ec[k] − ed[k])
-    #      We need: soc[t] ≤ usable_kwh  →  Σ_{k≤t}(ec[k]−ed[k]) ≤ usable−soc0
-    #      And:    soc[t] ≥ 0          → -Σ_{k≤t}(ec[k]−ed[k]) ≤ soc0
+    #   1. SoC recurrence: soc[t] = soc[0] + Σ_{k≤t} (ec[k] − ed[k])
+    #      Upper (soft): Σ_{k≤t}(ec[k]−ed[k]) − s_max_pen[t] ≤ usable−soc0
+    #      Lower (soft): −Σ_{k≤t}(ec[k]−ed[k]) − s_min_pen[t] ≤ soc0
+    #      Penalty variables s_max_pen[t] and s_min_pen[t] absorb violations
+    #      at high cost, preventing infeasibility from out-of-bounds initial SoC.
     #   2. Mutual exclusion: ec[t]/max_charge + ed[t]/max_dis ≤ 1
     #   3. ec[t] ≤ max_charge_per_slot  (via bounds)
     #   4. ed[t] ≤ max_dis              (via bounds)
     # ------------------------------------------------------------------
     # We encode SoC bounds as inequality rows:
-    #   upper: cumsum(ec−ed)[t] ≤ (usable_kwh − current_kwh)
-    #   lower: −cumsum(ec−ed)[t] ≤ current_kwh
+    #   upper: cumsum(ec−ed)[t] − s_max_pen[t] ≤ (usable_kwh − current_kwh)
+    #   lower: −cumsum(ec−ed)[t] − s_min_pen[t] ≤ current_kwh
     soc_rows = 2 * m
     # Mutual exclusion rows: ec[t]/max_charge + ed[t]/max_dis <= 1
     mutex_rows = m
@@ -465,12 +459,16 @@ def solve_milp(
 
     for t in range(m):
         for k in range(t + 1):
-            # Upper SoC bound row
+            # Upper SoC bound row (soft)
             A_ub[t, ec_off + k] = 1.0
             A_ub[t, ed_off + k] = -1.0
-            # Lower SoC bound row
+            # Lower SoC bound row (soft)
             A_ub[m + t, ec_off + k] = -1.0
             A_ub[m + t, ed_off + k] = 1.0
+        # Penalty variable absorbs violation in upper bound
+        A_ub[t, s_max_off + t] = -1.0
+        # Penalty variable absorbs violation in lower bound
+        A_ub[m + t, s_min_off + t] = -1.0
         b_ub[t] = usable_kwh - current_kwh  # upper SoC headroom
         b_ub[m + t] = current_kwh  # lower SoC headroom
 
@@ -491,7 +489,9 @@ def solve_milp(
         b_ub[cycle_row_start + m + t] = 0.0
 
     # ------------------------------------------------------------------
-    # Variable bounds: all ≥ 0, charge/discharge capped by power limits
+    # Variable bounds: all ≥ 0, charge/discharge capped by power limits.
+    # Penalty variables are unbounded above (can absorb arbitrary
+    # violations) and non-negative (violations cannot be negative).
     # ------------------------------------------------------------------
     bounds = (
         [(0.0, max_charge_per_slot)] * m  # ec[t]
@@ -502,6 +502,8 @@ def solve_milp(
             (pv_avail[t], pv_avail[t]) for t in range(m)
         ]  # pv[t] fixed to actual surplus
         + [(0.0, None)] * m  # m[t] (auxiliary, unbounded above, ≥ 0)
+        + [(0.0, None)] * m  # s_max_pen[t] (penalty, ≥ 0)
+        + [(0.0, None)] * m  # s_min_pen[t] (penalty, ≥ 0)
     )
 
     # ------------------------------------------------------------------
@@ -595,10 +597,60 @@ def solve_milp(
                     slot_i
                 ].recommendation = Recommendations.BatteriesDischargeMode.value
 
+    # ------------------------------------------------------------------
+    # Extract penalty variable values and compute violation diagnostics
+    # ------------------------------------------------------------------
+    s_max_pen_sol = result.x[s_max_off : s_max_off + m]
+    s_min_pen_sol = result.x[s_min_off : s_min_off + m]
+
+    s_max_pen_list = [float(v) for v in s_max_pen_sol]
+    s_min_pen_list = [float(v) for v in s_min_pen_sol]
+    total_violation = sum(s_max_pen_list) + sum(s_min_pen_list)
+    has_violations = total_violation > 1e-6
+
+    if has_violations:
+        violating_slots: list[dict] = []
+        for t in range(m):
+            slot_i = future_idx[t]
+            s_start = slots[slot_i].start.isoformat()
+            if s_max_pen_list[t] > 1e-6:
+                violating_slots.append(
+                    {
+                        "slot": t,
+                        "time": s_start,
+                        "type": "s_max_pen",
+                        "kwh": round(s_max_pen_list[t], 4),
+                    }
+                )
+            if s_min_pen_list[t] > 1e-6:
+                violating_slots.append(
+                    {
+                        "slot": t,
+                        "time": s_start,
+                        "type": "s_min_pen",
+                        "kwh": round(s_min_pen_list[t], 4),
+                    }
+                )
+        log_planner(
+            "warning",
+            "[milp] SoC penalty violations detected: total=%.4f kWh, %d violating slots",
+            total_violation,
+            len(violating_slots),
+        )
+        for v in violating_slots:
+            log_planner(
+                "warning",
+                "[milp] Penalty slot %d (%s) %s: %.4f kWh",
+                v["slot"],
+                v["time"],
+                v["type"],
+                v["kwh"],
+            )
+
     log_planner(
         "debug",
         "[milp] LP solved: objective=%.4f  charge_slots=%d  discharge_slots=%d"
-        "  replacement_price=%s",
+        "  replacement_price=%s  penalty_total=%.4f  has_violations=%s",
         float(result.fun),
         sum(
             1
@@ -620,9 +672,18 @@ def solve_milp(
             if replacement_price_per_kwh is not None
             else "(none)"
         ),
+        total_violation,
+        has_violations,
     )
 
-    return out_slots
+    diagnostics: dict = {
+        "s_max_pen": s_max_pen_list,
+        "s_min_pen": s_min_pen_list,
+        "has_violations": has_violations,
+        "total_violation_kwh": round(total_violation, 4),
+    }
+
+    return out_slots, diagnostics
 
 
 def is_scipy_available() -> bool:

--- a/docs/hsem-planner-spec.md
+++ b/docs/hsem-planner-spec.md
@@ -290,6 +290,44 @@ If a slot recommends forced discharge, force export, or discharge-only behavior,
 
 No recommendation may be energetically invisible.
 
+## MILP soft constraints (penalty approach)
+
+The MILP optimizer (`milp_optimizer.py`) uses **soft constraints** with penalty
+variables to prevent infeasibility when the initial SoC is outside bounds
+(e.g., overcharged battery).
+
+### Penalty variables
+
+- `s_max_pen[t]` — kWh by which SoC exceeds `usable_kwh` in slot `t`
+- `s_min_pen[t]` — kWh by which SoC drops below 0 in slot `t`
+
+### Soft SOC bounds
+
+```text
+Upper: soc[t] - s_max_pen[t] <= usable_kwh
+Lower: -soc[t] - s_min_pen[t] <= 0
+```
+
+### Penalty cost
+
+```text
+P_soc = max(p_imp) * 100
+```
+
+The penalty cost is added to the objective:
+`P_soc * (s_max_pen[t] + s_min_pen[t])`.  It is high enough that the solver
+never uses penalties unless forced by an out-of-bounds initial SoC.
+
+### Invariants
+
+- The MILP is **never** infeasible due to initial SoC boundary violations.
+- When `current_kwh` is within `[0, usable_kwh]`, all penalty values are zero.
+- When `current_kwh > usable_kwh`, `s_max_pen[0]` absorbs the excess and
+  decreases over time as the solver discharges.
+- Violations are logged at WARNING level.
+- The diagnostics dict (returned alongside the slot list) captures penalty
+  values for the engine to surface.
+
 ## Cost function
 
 The cost function returns **two distinct aggregates** for every plan

--- a/docs/hsem-planner-spec.md
+++ b/docs/hsem-planner-spec.md
@@ -311,11 +311,11 @@ Lower: -soc[t] - s_min_pen[t] <= 0
 ### Penalty cost
 
 ```text
-P_soc = max(p_imp) * 100
+p_soc = max(p_imp) * 100
 ```
 
 The penalty cost is added to the objective:
-`P_soc * (s_max_pen[t] + s_min_pen[t])`.  It is high enough that the solver
+`p_soc * (s_max_pen[t] + s_min_pen[t])`.  It is high enough that the solver
 never uses penalties unless forced by an out-of-bounds initial SoC.
 
 ### Invariants

--- a/tests/planner/test_milp_optimizer.py
+++ b/tests/planner/test_milp_optimizer.py
@@ -150,7 +150,7 @@ def test_milp_charges_in_cheap_slots_and_discharges_in_expensive():
         cheap, expensive, cheap_price=0.05, expensive_price=3.0
     )
 
-    result = solve_milp(
+    milp_result = solve_milp(
         slots,
         _NOW,
         current_kwh=0.0,
@@ -159,7 +159,10 @@ def test_milp_charges_in_cheap_slots_and_discharges_in_expensive():
         max_discharge_per_slot=5.0,
     )
 
-    assert result is not None, "MILP must return a solution on a clear arbitrage case"
+    assert milp_result is not None, (
+        "MILP must return a solution on a clear arbitrage case"
+    )
+    result, _diag = milp_result
 
     # At least some cheap-hour slots should be BatteriesChargeGrid
     charge_hours = {
@@ -193,7 +196,7 @@ def test_milp_cheaper_than_no_action_on_arbitrage_case():
         cheap, expensive, cheap_price=0.05, expensive_price=3.0
     )
 
-    milp_slots = solve_milp(
+    milp_result = solve_milp(
         slots,
         _NOW,
         current_kwh=0.0,
@@ -201,7 +204,8 @@ def test_milp_cheaper_than_no_action_on_arbitrage_case():
         max_charge_per_slot=5.0,
         max_discharge_per_slot=5.0,
     )
-    assert milp_slots is not None
+    assert milp_result is not None
+    milp_slots, _diag = milp_result
 
     # No-action baseline: clear all charge/discharge on a copy of the slots
     baseline_slots = _copy_slots(slots)
@@ -223,7 +227,7 @@ def test_milp_respects_soc_upper_bound():
     slots = _make_arbitrage_slots([0, 1, 2, 3, 4, 5], [], cheap_price=0.01)
     usable_kwh = 5.0
 
-    result = solve_milp(
+    milp_result = solve_milp(
         slots,
         _NOW,
         current_kwh=0.0,
@@ -231,7 +235,8 @@ def test_milp_respects_soc_upper_bound():
         max_charge_per_slot=3.0,
         max_discharge_per_slot=None,
     )
-    assert result is not None
+    assert milp_result is not None
+    result, _diag = milp_result
 
     # Run SoC simulation to get actual capacity values
     simulate_soc(
@@ -345,7 +350,7 @@ def test_milp_cycle_cost_matches_score_plan():
         ),
     ]
 
-    result = solve_milp(
+    milp_result = solve_milp(
         slots,
         _NOW,
         current_kwh=0.0,
@@ -354,7 +359,8 @@ def test_milp_cycle_cost_matches_score_plan():
         max_discharge_per_slot=max_discharge,
         cycle_cost_per_kwh=cycle_cost,
     )
-    assert result is not None, "MILP must return a solution"
+    assert milp_result is not None, "MILP must return a solution"
+    result, _diag = milp_result
 
     # Run SoC simulation to populate batteries_discharged_kwh
     simulate_soc(
@@ -434,7 +440,7 @@ def test_milp_solves_96_slot_horizon_under_100ms():
         slots_96.append(s)
 
     t_start = time_module.perf_counter()
-    result = solve_milp(
+    milp_result = solve_milp(
         slots_96,
         _NOW,
         current_kwh=5.0,
@@ -444,7 +450,8 @@ def test_milp_solves_96_slot_horizon_under_100ms():
     )
     elapsed = time_module.perf_counter() - t_start
 
-    assert result is not None, "MILP must solve the 96-slot horizon"
+    assert milp_result is not None, "MILP must solve the 96-slot horizon"
+    result, _diag = milp_result
     assert elapsed < 0.10, (
         f"MILP took {elapsed * 1000:.1f} ms on 96 slots — must be under 100 ms"
     )
@@ -785,7 +792,7 @@ def test_cycle_cost_obj_coefficients_sum_to_one_cycle_cost():
         cheap, expensive, cheap_price=0.05, expensive_price=2.00
     )
 
-    milp_slots = solve_milp(
+    milp_result = solve_milp(
         slots,
         _NOW,
         current_kwh=1.0,
@@ -796,7 +803,8 @@ def test_cycle_cost_obj_coefficients_sum_to_one_cycle_cost():
         charge_efficiency_pct=100.0,
         discharge_efficiency_pct=100.0,
     )
-    assert milp_slots is not None, "MILP must return a solution"
+    assert milp_result is not None, "MILP must return a solution"
+    milp_slots, _diag = milp_result
 
     # Score the MILP plan with the same cycle cost
     simulate_soc(
@@ -866,7 +874,7 @@ def test_milp_holds_energy_for_expensive_slot_via_terminal_soc():
         )
         slots.append(s)
 
-    milp_slots = solve_milp(
+    milp_result = solve_milp(
         slots,
         _NOW,
         current_kwh=5.0,
@@ -877,7 +885,8 @@ def test_milp_holds_energy_for_expensive_slot_via_terminal_soc():
         charge_efficiency_pct=100.0,
         discharge_efficiency_pct=100.0,
     )
-    assert milp_slots is not None
+    assert milp_result is not None
+    milp_slots, _diag = milp_result
 
     simulate_soc(
         milp_slots,
@@ -904,10 +913,10 @@ def test_milp_holds_energy_for_expensive_slot_via_terminal_soc():
 
 
 @_scipy_skip()
-def test_milp_n_vars_is_6m():
-    """n_vars should be 6*m (ec, ed, gi, ge, pv, m auxiliary for cycle cost)."""
+def test_milp_n_vars_is_8m():
+    """n_vars should be 8*m (ec, ed, gi, ge, pv, m, s_max_pen, s_min_pen)."""
     slots = _make_arbitrage_slots([0], [23])
-    result = solve_milp(
+    milp_result = solve_milp(
         slots,
         _NOW,
         current_kwh=1.0,
@@ -915,7 +924,8 @@ def test_milp_n_vars_is_6m():
         max_charge_per_slot=5.0,
         max_discharge_per_slot=5.0,
     )
-    assert result is not None, "MILP must return a solution"
+    assert milp_result is not None, "MILP must return a solution"
+    result, _diag = milp_result
     assert len(result) == 24, "Expected 24 slots output"
 
 
@@ -948,7 +958,7 @@ def test_milp_no_simultaneous_charge_discharge_at_negative_prices():
             s.avg_house_consumption_kwh - s.solcast_pv_estimate_kwh
         )
 
-    milp_slots = solve_milp(
+    milp_result = solve_milp(
         slots,
         _NOW,
         current_kwh=3.0,
@@ -961,8 +971,9 @@ def test_milp_no_simultaneous_charge_discharge_at_negative_prices():
     )
     # The LP may be infeasible with the clamped export prices (0.01)
     # and negative import prices (-0.05).  Skip the check in that case.
-    if milp_slots is None:
+    if milp_result is None:
         return
+    milp_slots, _diag = milp_result
 
     # Verify no slot has both charge and discharge above the minimum threshold.
     for s in milp_slots:
@@ -1000,7 +1011,7 @@ def test_milp_mutex_post_hoc_always_trivially_true():
             )
             slots.append(s)
 
-        milp_slots = solve_milp(
+        milp_result = solve_milp(
             slots,
             _NOW,
             current_kwh=3.0,
@@ -1011,8 +1022,9 @@ def test_milp_mutex_post_hoc_always_trivially_true():
             charge_efficiency_pct=100.0,
             discharge_efficiency_pct=100.0,
         )
-        if milp_slots is None:
+        if milp_result is None:
             continue  # skip infeasible random patterns
+        milp_slots, _diag = milp_result
 
         for s in milp_slots:
             is_charge = s.recommendation == Recommendations.BatteriesChargeGrid.value
@@ -1054,7 +1066,7 @@ def test_milp_soc_rises_after_cheap_charge_slot():
     initial_kwh = 0.0
     max_charge = 5.0
 
-    milp_slots = solve_milp(
+    milp_result = solve_milp(
         slots,
         _NOW,
         current_kwh=initial_kwh,
@@ -1065,7 +1077,8 @@ def test_milp_soc_rises_after_cheap_charge_slot():
         charge_efficiency_pct=100.0,
         discharge_efficiency_pct=100.0,
     )
-    assert milp_slots is not None, "MILP must solve the 4-slot problem"
+    assert milp_result is not None, "MILP must solve the 4-slot problem"
+    milp_slots, _diag = milp_result
 
     simulate_soc(
         milp_slots,
@@ -1088,3 +1101,144 @@ def test_milp_soc_rises_after_cheap_charge_slot():
         f"expected > {initial_kwh} — MILP charge may not be propagated "
         "through soc_simulation"
     )
+
+
+# ---------------------------------------------------------------------------
+# Penalty / soft constraint tests (issue #531)
+# ---------------------------------------------------------------------------
+
+
+@_scipy_skip()
+def test_milp_overcharged_start_discharges_with_penalty():
+    """Overcharged battery (current_kwh > usable_kwh) should cause the MILP
+    to discharge aggressively with penalty variables absorbing the excess.
+
+    With current_kwh=12 and usable_kwh=9, the battery starts 3 kWh above max.
+    The MILP must:
+    - Return a valid solution (not None)
+    - Discharge aggressively in early slots to bring SoC within bounds
+    - Have s_max_pen violations in early slots that decrease over time
+    """
+    slots = _make_arbitrage_slots([0, 1, 2, 3], [20, 21, 22, 23])
+
+    milp_result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=12.0,  # 3 kWh above usable_kwh=9.0
+        usable_kwh=9.0,
+        max_charge_per_slot=5.0,
+        max_discharge_per_slot=5.0,
+        cycle_cost_per_kwh=0.01,
+    )
+
+    assert milp_result is not None, (
+        "MILP must return a solution even with overcharged battery"
+    )
+    milp_slots, diag = milp_result
+
+    # Check diagnostics
+    assert diag is not None
+    assert diag.get("has_violations", False), (
+        "Overcharged start must trigger s_max_pen violations"
+    )
+    total = diag.get("total_violation_kwh", 0.0)
+    assert total > 1e-6, f"Expected penalty > 0 for overcharged start, got {total}"
+
+    # Verify discharge happens in early slots
+    early_discharge_slots = [
+        s
+        for s in milp_slots[:4]
+        if s.recommendation
+        in (
+            Recommendations.BatteriesDischargeMode.value,
+            Recommendations.ForceBatteriesDischarge.value,
+        )
+    ]
+    assert len(early_discharge_slots) > 0, (
+        "Overcharged battery must discharge in early slots"
+    )
+
+
+@_scipy_skip()
+def test_milp_normal_start_zero_penalty():
+    """Normal battery (current_kwh within bounds) must produce zero penalty.
+
+    When the initial SoC is within [0, usable_kwh], the MILP must never use
+    penalty variables because P_soc >> max(p_imp).  The diagnostics must show
+    has_violations=False and total_violation_kwh=0.
+    """
+    slots = _make_arbitrage_slots([0, 1, 2, 3], [20, 21, 22, 23])
+
+    milp_result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=5.0,  # safely within bounds (0, 9)
+        usable_kwh=9.0,
+        max_charge_per_slot=5.0,
+        max_discharge_per_slot=5.0,
+        cycle_cost_per_kwh=0.01,
+    )
+
+    assert milp_result is not None, "MILP must return a solution"
+    _milp_slots, diag = milp_result
+
+    assert not diag.get("has_violations", True), (
+        "Normal start must have no penalty violations"
+    )
+    total = diag.get("total_violation_kwh", 1.0)
+    assert total < 1e-6, f"Expected zero penalty, got {total}"
+
+    # Also verify the s_max_pen and s_min_pen lists are all ~0
+    s_max = diag.get("s_max_pen", [1.0])
+    s_min = diag.get("s_min_pen", [1.0])
+    assert all(abs(v) < 1e-6 for v in s_max), f"s_max_pen should be zero: {s_max}"
+    assert all(abs(v) < 1e-6 for v in s_min), f"s_min_pen should be zero: {s_min}"
+
+
+@_scipy_skip()
+def test_milp_extreme_overcharge_returns_plan_with_violations():
+    """Extremely overcharged battery (current_kwh >> usable_kwh) must still
+    return a valid plan with violations.
+
+    With current_kwh=18 and usable_kwh=9, the battery is 9 kWh above max.
+    The MILP must:
+    - Return a solution (not None)
+    - Have large penalties
+    - Discharge every slot until SoC is within bounds
+    """
+    slots = _make_arbitrage_slots([0, 1, 2, 3], [20, 21, 22, 23])
+
+    milp_result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=18.0,  # 9 kWh above usable_kwh=9.0
+        usable_kwh=9.0,
+        max_charge_per_slot=5.0,
+        max_discharge_per_slot=5.0,
+        cycle_cost_per_kwh=0.01,
+    )
+
+    assert milp_result is not None, (
+        "MILP must return a solution even with extremely overcharged battery "
+        "(2x usable_kwh)"
+    )
+    milp_slots, diag = milp_result
+
+    # Must have violations
+    assert diag.get("has_violations", False), (
+        "Extreme overcharge must trigger violations"
+    )
+    total = diag.get("total_violation_kwh", 0.0)
+    assert total > 1e-6, f"Expected penalty > 0, got {total}"
+
+    # Must have discharge actions (to bring SoC down)
+    discharge_slots = [
+        s
+        for s in milp_slots
+        if s.recommendation
+        in (
+            Recommendations.BatteriesDischargeMode.value,
+            Recommendations.ForceBatteriesDischarge.value,
+        )
+    ]
+    assert len(discharge_slots) > 0, "Extremely overcharged battery must discharge"

--- a/tests/planner/test_milp_optimizer.py
+++ b/tests/planner/test_milp_optimizer.py
@@ -451,7 +451,7 @@ def test_milp_solves_96_slot_horizon_under_100ms():
     elapsed = time_module.perf_counter() - t_start
 
     assert milp_result is not None, "MILP must solve the 96-slot horizon"
-    result, _diag = milp_result
+    _, _diag = milp_result
     assert elapsed < 0.10, (
         f"MILP took {elapsed * 1000:.1f} ms on 96 slots — must be under 100 ms"
     )
@@ -1164,7 +1164,7 @@ def test_milp_normal_start_zero_penalty():
     """Normal battery (current_kwh within bounds) must produce zero penalty.
 
     When the initial SoC is within [0, usable_kwh], the MILP must never use
-    penalty variables because P_soc >> max(p_imp).  The diagnostics must show
+    penalty variables because p_soc >> max(p_imp).  The diagnostics must show
     has_violations=False and total_violation_kwh=0.
     """
     slots = _make_arbitrage_slots([0, 1, 2, 3], [20, 21, 22, 23])


### PR DESCRIPTION
## Summary

The MILP optimizer now uses **soft constraints** with penalty variables to prevent infeasibility when the initial battery SoC is outside bounds (e.g., overcharged).

Previously, if `current_kwh > usable_kwh`, the LP was infeasible and returned `None`, forcing the engine to fall back to the much worse rule-based heuristic. Now the MILP always finds a solution — violations are penalized heavily but never cause infeasibility.

## Changes

### `milp_optimizer.py`
- Variable vector extended from **6×n** to **8×n** with `s_max_pen[t]` and `s_min_pen[t]`
- SOC bounds changed from hard to soft:
  - Upper: `Σ(ec−ed) − s_max_pen[t] ≤ usable_kwh − current_kwh`
  - Lower: `−Σ(ec−ed) − s_min_pen[t] ≤ current_kwh`
- Penalty cost `P_soc = max(p_imp) × 100` added to objective
- Violations logged at WARNING level when any penalty > 1e-6
- Return type changed to `tuple[list[PlannedSlot], dict] | None` with diagnostics dict

### `candidate_generator.py`
- `CandidatePlan` now carries optional `diagnostics` dict
- MILP diagnostics stored when candidate is created

### `engine_core.py`
- When the MILP candidate wins and has violations, surfaces a warning message in the planner output

### `memories.md`
- Updated MILP variable vector from 6×n to 8×n

### `docs/hsem-planner-spec.md`
- Added "MILP soft constraints (penalty approach)" section documenting invariants

### `tests/planner/test_milp_optimizer.py`
- Updated all existing tests to handle tuple return from `solve_milp()`
- Renamed `test_milp_n_vars_is_6m` → `test_milp_n_vars_is_8m`
- **3 new tests:**
  - `test_milp_overcharged_start_discharges_with_penalty` — overcharged battery triggers penalty + discharge
  - `test_milp_normal_start_zero_penalty` — normal SoC → zero penalty
  - `test_milp_extreme_overcharge_returns_plan_with_violations` — 2× overcharge still returns valid plan

## Checks

- ✅ `tox -e lint` — passes
- ✅ `tox -e typing` — passes
- ✅ `tox -e quality` — passes (0 errors, pre-existing warnings only)
- ⚠️ `tox -e py313` — cannot run locally (bcrypt Windows environment issue, pre-existing)
- ✅ File sizes: `milp_optimizer.py` at 29.5 KB (< 30 KB limit)

Fixes #531