### PR TITLE
ci(workflows): add SonarCloud CI-based analysis workflow

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,27 @@
+name: SonarCloud
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
+jobs:
+  sonarqube:
+    name: SonarQube
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io


### PR DESCRIPTION
Add `.github/workflows/sonarcloud.yml` to run SonarCloud scans via CI-based analysis on pushes to `main` and pull requests.

**Why:** The project was using automatic analysis, which ignores `sonar-project.properties` and its `sonar.issue.ignore.multicriteria` exclusion rules (e.g. S7637 for SHA-pinned GitHub Actions, S107 for complex functions, etc.). CI-based analysis respects these exclusions.

**Changes:**
- Added `.github/workflows/sonarcloud.yml` with `SonarSource/sonarqube-scan-action`
- Sets `SONAR_HOST_URL: https://sonarcloud.io` to target SonarCloud (not SonarQube Server)
- Permissions: `contents: read`, `checks: write`, `pull-requests: write`

**Manual steps required after merge:**
1. Add `SONAR_TOKEN` secret to the repository
2. Disable automatic analysis in SonarCloud UI: **Administration > Analysis Method**