### PR TITLE
fix(planner): EV charger power uses remaining slot time + docs math fix

### DIFF
--- a/custom_components/hsem/custom_sensors/house_consumption_power_sensor.py
+++ b/custom_components/hsem/custom_sensors/house_consumption_power_sensor.py
@@ -84,6 +84,8 @@ class HSEMHouseConsumptionPowerSensor(RestoreEntity, SensorEntity, HSEMEntity):
             "house_consumption_power_state",
             "ev_charger_power_entity",
             "ev_charger_power_state",
+            "ev_second_charger_power_entity",
+            "ev_second_charger_power_state",
             "house_power_includes_ev_charger_power",
             "hour_start",
             "hour_end",
@@ -112,6 +114,8 @@ class HSEMHouseConsumptionPowerSensor(RestoreEntity, SensorEntity, HSEMEntity):
         self._hsem_house_consumption_power_state = 0.0
         self._hsem_ev_charger_power = None
         self._hsem_ev_charger_power_state = 0.0
+        self._hsem_ev_second_charger_power = None
+        self._hsem_ev_second_charger_power_state = 0.0
         self._hsem_house_power_includes_ev_charger_power = None
         self._hour_start = hour_start
         self._hour_end = hour_end
@@ -184,6 +188,10 @@ class HSEMHouseConsumptionPowerSensor(RestoreEntity, SensorEntity, HSEMEntity):
             ),
             "ev_charger_power_entity": self._hsem_ev_charger_power,
             "ev_charger_power_state": round(self._hsem_ev_charger_power_state, 2),
+            "ev_second_charger_power_entity": self._hsem_ev_second_charger_power,
+            "ev_second_charger_power_state": round(
+                self._hsem_ev_second_charger_power_state, 2
+            ),
             "house_power_includes_ev_charger_power": self._hsem_house_power_includes_ev_charger_power,
             "hour_start": self._hour_start,
             "hour_end": self._hour_end,
@@ -257,6 +265,13 @@ class HSEMHouseConsumptionPowerSensor(RestoreEntity, SensorEntity, HSEMEntity):
         if self._hsem_ev_charger_power == vol.UNDEFINED:
             self._hsem_ev_charger_power = None
 
+        self._hsem_ev_second_charger_power = get_config_value(
+            self._config_entry, "hsem_ev_second_charger_power"
+        )
+
+        if self._hsem_ev_second_charger_power == vol.UNDEFINED:
+            self._hsem_ev_second_charger_power = None
+
         self._hsem_house_power_includes_ev_charger_power = get_config_value(
             self._config_entry, "hsem_house_power_includes_ev_charger_power"
         )
@@ -299,10 +314,14 @@ class HSEMHouseConsumptionPowerSensor(RestoreEntity, SensorEntity, HSEMEntity):
                 and isinstance(self._hsem_house_consumption_power_state, (int, float))
             ):
                 if self._hsem_house_power_includes_ev_charger_power:
+                    # Subtract both EV chargers from house consumption
+                    ev_total_power = (
+                        self._hsem_ev_charger_power_state
+                        + self._hsem_ev_second_charger_power_state
+                    )
                     self._state = round(
                         float(
-                            self._hsem_house_consumption_power_state
-                            - self._hsem_ev_charger_power_state
+                            self._hsem_house_consumption_power_state - ev_total_power
                         ),
                         2,
                     )
@@ -357,6 +376,19 @@ class HSEMHouseConsumptionPowerSensor(RestoreEntity, SensorEntity, HSEMEntity):
                 self._unsub_callbacks.append(unsub)
                 self._tracked_entities.add(self._hsem_ev_charger_power)
 
+        if self._hsem_ev_second_charger_power:
+            if self._hsem_ev_second_charger_power not in self._tracked_entities:
+                _LOGGER.debug(
+                    f"Starting to track state changes for {self._hsem_ev_second_charger_power}"
+                )
+                unsub = async_track_state_change_event(
+                    self.hass,
+                    [self._hsem_ev_second_charger_power],
+                    self._async_handle_update,
+                )
+                self._unsub_callbacks.append(unsub)
+                self._tracked_entities.add(self._hsem_ev_second_charger_power)
+
     async def _async_fetch_sensor_states(self) -> None:
         """Read live power values from the configured HA source entities."""
         # Update the state of the sensor for house consumption power
@@ -377,11 +409,22 @@ class HSEMHouseConsumptionPowerSensor(RestoreEntity, SensorEntity, HSEMEntity):
                 )
                 self._hsem_ev_charger_power_state = convert_to_float(raw_ev) or 0.0
 
+            # Update the state of the sensor for second EV charger power
+            if self._hsem_ev_second_charger_power:
+                raw_ev2 = ha_get_entity_state_and_convert(
+                    self, self._hsem_ev_second_charger_power, "float"
+                )
+                self._hsem_ev_second_charger_power_state = (
+                    convert_to_float(raw_ev2) or 0.0
+                )
+
         except (HomeAssistantError, ValueError, TypeError) as exc:
             _LOGGER.warning(
                 "Sensor read failed for entity_id=%s (operation=_async_fetch_sensor_states): "
                 "%s: %s",
-                self._hsem_house_consumption_power or self._hsem_ev_charger_power,
+                self._hsem_house_consumption_power
+                or self._hsem_ev_charger_power
+                or self._hsem_ev_second_charger_power,
                 type(exc).__name__,
                 repr(exc),
             )

--- a/custom_components/hsem/planner/engine_core.py
+++ b/custom_components/hsem/planner/engine_core.py
@@ -288,6 +288,7 @@ def _compute_ev_charger_power(
     slot_starts: list[datetime],
     ev_plan: EVChargingPlan | None,
     interval_minutes: int,
+    now: datetime,
     *,
     second: bool = False,
 ) -> None:
@@ -298,6 +299,11 @@ def _compute_ev_charger_power(
 
         AC power (W) = (ac_load_kwh / slot_hours) × 1000
 
+    For the **current** (partially elapsed) slot the divisor is the
+    remaining slot duration, not the full slot width, because the EV
+    planner already scales ``ac_load_kwh`` to the remaining minutes.
+    Using the full slot width would understate the required charge power.
+
     When the plan is ``None`` or empty the field stays at the default 0.0.
 
     Args:
@@ -305,6 +311,7 @@ def _compute_ev_charger_power(
         slot_starts: Slot start datetimes (same length as *slots*).
         ev_plan: EV charging plan (may be ``None``).
         interval_minutes: Slot width in minutes.
+        now: Current time (timezone-aware), used to detect the current slot.
         second: If ``True``, write to ``ev_second_charger_calculated_power``;
             otherwise write to ``ev_charger_calculated_power``.
     """
@@ -315,7 +322,7 @@ def _compute_ev_charger_power(
     from custom_components.hsem.utils.datetime_utils import utc_key
 
     slot_map = {utc_key(s): i for i, s in enumerate(slot_starts)}
-    hours_per_slot = interval_minutes / 60.0
+    full_hours = interval_minutes / 60.0
 
     for ev_slot in ev_plan.charging_slots:
         idx = slot_map.get(utc_key(ev_slot.start))
@@ -324,9 +331,18 @@ def _compute_ev_charger_power(
         if ev_slot.ac_load_kwh < 1e-9:
             continue
 
-        # AC-side power: ac_load_kwh (already includes charger efficiency)
-        # divided by slot duration in hours.
-        ac_power_w = round((ev_slot.ac_load_kwh / hours_per_slot) * 1000)
+        # For the current (partially elapsed) slot, the EV planner has
+        # already scaled ``ac_load_kwh`` to the *remaining* minutes.
+        # Divide by remaining hours to get the correct target power.
+        # For future slots the full slot width is used.
+        slot_end = slots[idx].end
+        if slots[idx].start <= now < slot_end:
+            remaining_min = max((slot_end - now).total_seconds() / 60.0, 0.0167)
+            slot_hours = remaining_min / 60.0
+        else:
+            slot_hours = full_hours
+
+        ac_power_w = round((ev_slot.ac_load_kwh / slot_hours) * 1000)
 
         attr = (
             "ev_second_charger_calculated_power"
@@ -631,8 +647,8 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
     # per-slot energy targets.  The EVChargingSlot.estimated_charged_kwh is
     # battery-side (DC) kWh delivered to the EV.  The AC power the charger
     # must draw is larger by 1/eff to account for charger/cable losses.
-    _compute_ev_charger_power(slots, ss, ev_cp, inp.interval_minutes)
-    _compute_ev_charger_power(slots, ss, ev2_cp, inp.interval_minutes, second=True)
+    _compute_ev_charger_power(slots, ss, ev_cp, inp.interval_minutes, now)
+    _compute_ev_charger_power(slots, ss, ev2_cp, inp.interval_minutes, now, second=True)
     populate_net_consumption(slots)
     populate_estimated_cost(slots, export_min_price=inp.export_min_price)
     rt = calculate_recommended_threshold(

--- a/docs/hsem-consumption-prediction.md
+++ b/docs/hsem-consumption-prediction.md
@@ -11,7 +11,7 @@ suppression, and reliability weighting.
 HSEM predicts house load using a **multi-window weighted average** of historical
 consumption data. The prediction feeds the planner's net consumption calculation:
 
-$$ \text{net\_consumption}[t] = \text{load\_forecast}[t] + \text{ev\_load}[t] - \text{pv\_forecast}[t] $$
+$$ \text{net_consumption}[t] = \text{load_forecast}[t] + \text{ev_load}[t] - \text{pv_forecast}[t] $$
 
 Accurate load prediction is critical: over-prediction leads to unnecessary grid
 imports; under-prediction leads to insufficient battery charging for peak hours.
@@ -110,7 +110,7 @@ flagged as a spike:
 **Severity scaling:** The fraction of weight actually removed interpolates
 between 0 at the `_MIN` ratio and the maximum at the `_MAX` ratio:
 
-$$ \text{reduced\_fraction} = \frac{\text{ratio} - \text{ratio\_min}}{\text{ratio\_max} - \text{ratio\_min}} \cdot \text{max\_reduction} $$
+$$ \text{reduced_fraction} = \frac{\text{ratio} - \text{ratio_min}}{\text{ratio_max} - \text{ratio_min}} \cdot \text{max_reduction} $$
 
 ### Baseline capping
 
@@ -118,7 +118,7 @@ Short windows (1-day, 3-day) are also capped against a blended baseline:
 
 $$ \text{baseline} = 0.70 \cdot avg_7 + 0.30 \cdot avg_{14} $$
 
-$$ \text{capped\_value} = \text{clamp}(value, 0.80 \cdot \text{baseline}, 1.20 \cdot \text{baseline}) $$
+$$ \text{capped_value} = \text{clamp}(value, 0.80 \cdot \text{baseline}, 1.20 \cdot \text{baseline}) $$
 
 The 3-day uses slightly looser bounds (0.85 – 1.15) to avoid removing legitimate
 multi-day trends.

--- a/docs/hsem-energy-accounting.md
+++ b/docs/hsem-energy-accounting.md
@@ -10,12 +10,12 @@ the cost function, and the MILP solver.
 
 For every planning slot, energy balance must hold:
 
-$$ \text{net\_load}[t] = \text{house\_load}[t] + \text{ev\_planned\_load}[t] - \text{pv}[t] $$
+$$ \text{net_load}[t] = \text{house_load}[t] + \text{ev_planned_load}[t] - \text{pv}[t] $$
 
-When EV integration is disabled, $\text{ev\_planned\_load}[t] = 0$.
+When EV integration is disabled, $\text{ev_planned_load}[t] = 0$.
 
-Positive $\text{net\_load}[t]$ means the house needs energy (import or battery discharge).
-Negative $\text{net\_load}[t]$ means there is surplus energy (export or battery charge).
+Positive $\text{net_load}[t]$ means the house needs energy (import or battery discharge).
+Negative $\text{net_load}[t]$ means there is surplus energy (export or battery charge).
 
 ---
 
@@ -25,37 +25,37 @@ Negative $\text{net\_load}[t]$ means there is surplus energy (export or battery 
 
 The battery and grid flows must satisfy:
 
-$$ \text{house\_load}[t] = \text{pv\_to\_house}[t] + \text{battery\_to\_house}[t] + \text{grid\_to\_house}[t] $$
+$$ \text{house_load}[t] = \text{pv_to_house}[t] + \text{battery_to_house}[t] + \text{grid_to_house}[t] $$
 
-$$ \text{grid\_import}[t] = \text{grid\_to\_house}[t] + \text{grid\_to\_battery}[t] + \text{ev\_grid\_import}[t] $$
+$$ \text{grid_import}[t] = \text{grid_to_house}[t] + \text{grid_to_battery}[t] + \text{ev_grid_import}[t] $$
 
 ### PV production split
 
-$$ \text{pv}[t] = \text{pv\_to\_house}[t] + \text{pv\_to\_ev}[t] + \text{pv\_to\_battery}[t] + \text{pv\_exported}[t] + \text{pv\_curtailed}[t] $$
+$$ \text{pv}[t] = \text{pv_to_house}[t] + \text{pv_to_ev}[t] + \text{pv_to_battery}[t] + \text{pv_exported}[t] + \text{pv_curtailed}[t] $$
 
 ### Battery charge
 
-$$ \text{battery\_charge\_stored}[t] = (\text{pv\_to\_battery}[t] + \text{grid\_to\_battery}[t]) \cdot \eta_{chg} $$
+$$ \text{battery_charge_stored}[t] = (\text{pv_to_battery}[t] + \text{grid_to_battery}[t]) \cdot \eta_{chg} $$
 
-Where $\eta_{chg} = \text{charge\_efficiency\_pct} / 100$.
+Where $\eta_{chg} = \text{charge_efficiency_pct} / 100$.
 
 ### Grid import for charging
 
-$$ \text{grid\_to\_battery}[t] = \text{battery\_charge\_stored}[t] / \eta_{chg} $$
+$$ \text{grid_to_battery}[t] = \text{battery_charge_stored}[t] / \eta_{chg} $$
 
-> **Key invariant:** The cost function prices $\text{grid\_to\_battery}[t]$, not
-> $\text{battery\_charge\_stored}[t]$. This ensures conversion losses are included
+> **Key invariant:** The cost function prices $\text{grid_to_battery}[t]$, not
+> $\text{battery_charge_stored}[t]$. This ensures conversion losses are included
 > in the import cost.
 
 ### Battery discharge
 
-$$ \text{usable\_discharge}[t] = \text{battery\_removed}[t] \cdot \eta_{dis} $$
+$$ \text{usable_discharge}[t] = \text{battery_removed}[t] \cdot \eta_{dis} $$
 
-Where $\eta_{dis} = \text{discharge\_efficiency\_pct} / 100$.
+Where $\eta_{dis} = \text{discharge_efficiency_pct} / 100$.
 
 The battery energy removed to supply a target house load:
 
-$$ \text{battery\_removed}[t] = \text{house\_load\_from\_battery}[t] / \eta_{dis} $$
+$$ \text{battery_removed}[t] = \text{house_load_from_battery}[t] / \eta_{dis} $$
 
 ---
 
@@ -63,28 +63,28 @@ $$ \text{battery\_removed}[t] = \text{house\_load\_from\_battery}[t] / \eta_{dis
 
 For each slot:
 
-$$ \text{soc\_after\_kwh}[t] = \text{soc\_before\_kwh}[t] + \text{charge\_stored}[t] - \text{battery\_removed}[t] $$
+$$ \text{soc_after_kwh}[t] = \text{soc_before_kwh}[t] + \text{charge_stored}[t] - \text{battery_removed}[t] $$
 
 ### SoC bounds
 
-$$ \text{soc\_after\_kwh}[t] \in [\text{min\_soc\_kwh}, \text{max\_soc\_kwh}] $$
+$$ \text{soc_after_kwh}[t] \in [\text{min_soc_kwh}, \text{max_soc_kwh}] $$
 
 Where:
 
-$$ \text{min\_soc\_kwh} = \text{rated\_kwh} \cdot \frac{\text{end\_of\_discharge\_soc\_pct}}{100} $$
+$$ \text{min_soc_kwh} = \text{rated_kwh} \cdot \frac{\text{end_of_discharge_soc_pct}}{100} $$
 
-$$ \text{max\_soc\_kwh} = \text{rated\_kwh} \cdot \frac{\text{battery\_max\_soc\_pct}}{100} $$
+$$ \text{max_soc_kwh} = \text{rated_kwh} \cdot \frac{\text{battery_max_soc_pct}}{100} $$
 
-$$ \text{usable\_kwh} = \text{max\_soc\_kwh} - \text{min\_soc\_kwh} $$
+$$ \text{usable_kwh} = \text{max_soc_kwh} - \text{min_soc_kwh} $$
 
 ### Power limits (per-slot energy caps)
 
-$$ \text{charge\_stored}[t] \leq \text{max\_charge\_per\_slot} = \frac{\text{max\_charge\_power\_w}}{1000} \cdot \frac{\text{interval\_minutes}}{60} $$
+$$ \text{charge_stored}[t] \leq \text{max_charge_per_slot} = \frac{\text{max_charge_power_w}}{1000} \cdot \frac{\text{interval_minutes}}{60} $$
 
-$$ \text{battery\_removed}[t] \leq \text{max\_discharge\_per\_slot} = \frac{\text{max\_discharge\_power\_w}}{1000} \cdot \frac{\text{interval\_minutes}}{60} $$
+$$ \text{battery_removed}[t] \leq \text{max_discharge_per_slot} = \frac{\text{max_discharge_power_w}}{1000} \cdot \frac{\text{interval_minutes}}{60} $$
 
-When $\text{max\_discharge\_power\_w}$ is `None` (unlimited), the per-slot cap is
-relaxed to $\text{usable\_kwh}$.
+When $\text{max_discharge_power_w}$ is `None` (unlimited), the per-slot cap is
+relaxed to $\text{usable_kwh}$.
 
 ---
 
@@ -94,9 +94,9 @@ relaxed to $\text{usable\_kwh}$.
 
 The EV charger draws from the **AC bus** — it never draws from the house battery:
 
-$$ \text{ev\_ac\_load}[t] = \frac{\text{ev\_battery\_charged}[t]}{\text{charger\_efficiency}} $$
+$$ \text{ev_ac_load}[t] = \frac{\text{ev_battery_charged}[t]}{\text{charger_efficiency}} $$
 
-Where $\text{charger\_efficiency} = \text{charger\_efficiency\_pct} / 100$.
+Where $\text{charger_efficiency} = \text{charger_efficiency_pct} / 100$.
 
 ### Three-field EV load model
 
@@ -110,9 +110,9 @@ Where $\text{charger\_efficiency} = \text{charger\_efficiency\_pct} / 100$.
 
 The EV planner selects slots using net consumption **after house load**:
 
-$$ \text{slot\_net\_surplus}[t] = \max(-\text{estimated\_net\_consumption}[t], 0) $$
+$$ \text{slot_net_surplus}[t] = \max(-\text{estimated_net_consumption}[t], 0) $$
 
-Where $\text{estimated\_net\_consumption}[t] = \text{house\_load}[t] - \text{pv}[t]$.
+Where $\text{estimated_net_consumption}[t] = \text{house_load}[t] - \text{pv}[t]$.
 
 #### Historical note (PR #397, #406)
 
@@ -131,7 +131,7 @@ before EV planning so that PV confidence decay is automatically applied.
 
 $$ \eta_{roundtrip} = \eta_{chg} \cdot \eta_{dis} $$
 
-$$ \text{roundtrip\_loss} = 1 - \eta_{roundtrip} $$
+$$ \text{roundtrip_loss} = 1 - \eta_{roundtrip} $$
 
 ### Example
 
@@ -160,7 +160,7 @@ For multi-day horizons, PV estimates are discounted:
 | 1 (tomorrow) | 0.90 |
 | 2 (day after) | 0.80 |
 
-$$ \text{pv\_decayed}[t] = \text{pv\_raw}[t] \cdot \text{decay\_factor}[day\_offset] $$
+$$ \text{pv_decayed}[t] = \text{pv_raw}[t] \cdot \text{decay_factor}[day\_offset] $$
 
 Prices are **not** decayed because spot-market prices are typically firm by mid-day.
 
@@ -173,7 +173,7 @@ Prices are **not** decayed because spot-market prices are typically firm by mid-
 | W → kW | $\text{kW} = \text{W} / 1000$ |
 | Wh → kWh | $\text{kWh} = \text{Wh} / 1000$ |
 | Power → energy | $\text{kWh} = \text{kW} \times \text{hours}$ |
-| Accumulated energy | $\text{kWh} = \text{power\_W} \times \frac{\text{elapsed\_seconds}}{3600} / 1000$ |
+| Accumulated energy | $\text{kWh} = \text{power_W} \times \frac{\text{elapsed_seconds}}{3600} / 1000$ |
 
 All internal planner calculations use **kWh** for energy and **kW** for power.
 Power limits from Huawei Solar are received in **Watts** and converted at the

--- a/docs/hsem-planner-spec.md
+++ b/docs/hsem-planner-spec.md
@@ -857,7 +857,7 @@ Three per-slot fields capture EV load intent precisely:
 | `ev_planned_load_kwh` | Extra EV AC load **added to net consumption** — only the portion not already in `avg_house_consumption`. Zero when `base_load_includes_ev = True`. |
 | `ev_accounted_load_kwh` | EV AC load **already included** in the house consumption sensor. Non-zero when `base_load_includes_ev = True`. Must not be added to net consumption again. |
 | `ev_total_planned_load_kwh` | Total planned EV AC load regardless of accounting mode: `ev_planned_load_kwh + ev_accounted_load_kwh`. Always non-zero when any EV charging is planned. |
-| `ev_charger_calculated_power` | Target AC power (W) for the primary EV charger during this slot. Computed from the EV planner's per-slot energy target: `round((ac_load_kwh / slot_hours) × 1000)`. Zero when no charging is planned. |
+| `ev_charger_calculated_power` | Target AC power (W) for the primary EV charger during this slot. Computed from the EV planner's per-slot energy target: `round((ac_load_kwh / slot_duration_hours) × 1000)`. For the **current** (partially elapsed) slot, `slot_duration_hours` is the remaining time (minimum 1 s), because the EV planner already scales `ac_load_kwh` to the remaining minutes. For future slots the full slot width is used. Zero when no charging is planned. |
 | `ev_second_charger_calculated_power` | Same as above, for the second EV. |
 
 When `base_load_includes_ev = False`:
@@ -978,11 +978,14 @@ The EV planner (`planner/ev_planner.py`) MUST satisfy these invariants:
     draws from the grid; all energy is solar-surplus with zero cost.
 
 12. **EV charger power field**: `ev_charger_calculated_power` is computed
-    from the EV planner's `ac_load_kwh` (AC-side energy) divided by slot
-    duration.  The field is zero when no EV charging is planned in that
-    slot.  It is purely a planner output — the applier must read this
-    value to throttle the go-e charger; the planner does not control
-    hardware directly.
+    from the EV planner's `ac_load_kwh` (AC-side energy) divided by the
+    slot duration in hours.  For the **current** (partially elapsed)
+    slot the divisor is the remaining slot time (minimum 1 s), because
+    the EV planner already scales `ac_load_kwh` to the remaining minutes.
+    Using the full slot width would understate the required charge power.
+    The field is zero when no EV charging is planned in that slot.  It is
+    purely a planner output — the applier must read this value to throttle
+    the go-e charger; the planner does not control hardware directly.
 
 ### Invariants for tests
 

--- a/docs/hsem-price-interval-semantics.md
+++ b/docs/hsem-price-interval-semantics.md
@@ -21,7 +21,7 @@ be correctly scaled so the planner always sees the full currency/kWh rate.
 
 ## The `eds_share` conversion factor
 
-$$ \text{eds\_share} = \frac{\text{EDS interval}}{\text{Slot width}} $$
+$$ \text{eds_share} = \frac{\text{EDS interval}}{\text{Slot width}} $$
 
 | EDS interval | Slot width | `eds_share` | Effect |
 |---|---|---|---|

--- a/tests/planner/test_ev_planned_load.py
+++ b/tests/planner/test_ev_planned_load.py
@@ -2857,6 +2857,130 @@ class TestEvChargerCalculatedPower:
         """Trickle-charge 15-min slot: (0.5 / 0.25) * 1000 = 2000 W."""
         assert round((0.5 / 0.25) * 1000) == 2000
 
+    def test_current_slot_uses_remaining_time(self):
+        """Mid-slot: power uses remaining time, not full slot width.
+
+        At 07:10 (5 min left in a 15-min slot), if ac_load_kwh = 0.78,
+        the power should be 0.78 / (5/60) * 1000 ≈ 9360 W, not
+        0.78 / 0.25 * 1000 = 3120 W.
+        """
+        from custom_components.hsem.models.planner_outputs import PlannedSlot
+        from custom_components.hsem.planner.engine_core import (
+            _compute_ev_charger_power,
+        )
+        from custom_components.hsem.planner.ev_planner import EVChargingSlot
+
+        tz = _UTC
+        slot_start = datetime(2024, 6, 15, 7, 0, tzinfo=tz)
+        slot_end = datetime(2024, 6, 15, 7, 15, tzinfo=tz)
+        now = datetime(2024, 6, 15, 7, 10, tzinfo=tz)  # 5 min left
+
+        slots = [PlannedSlot(start=slot_start, end=slot_end)]
+        slot_starts = [slot_start]
+
+        ev_slot = EVChargingSlot(
+            start=slot_start,
+            end=slot_end,
+            estimated_charged_kwh=0.75,
+            ac_load_kwh=0.78,  # scaled to 5 min by EV planner
+            solar_surplus_kwh=0.0,
+            import_needed_kwh=0.78,
+            import_price=1.0,
+            estimated_cost=0.78,
+        )
+        ev_plan = EVChargingPlan(
+            ev_connected=True,
+            state="charging",
+            charging_slots=[ev_slot],
+        )
+
+        _compute_ev_charger_power(slots, slot_starts, ev_plan, 15, now)
+
+        # Expected: 0.78 kWh / (5/60) h * 1000 = 9360 W
+        # Wrong (old behaviour): 0.78 / 0.25 * 1000 = 3120 W
+        expected = round((0.78 / (5 / 60)) * 1000)
+        assert slots[0].ev_charger_calculated_power == expected, (
+            f"Expected {expected} W (using 5 min remaining), "
+            f"got {slots[0].ev_charger_calculated_power} W"
+        )
+        assert slots[0].ev_charger_calculated_power > 5000, (
+            "Power should be >> 3120 W (old wrong value)"
+        )
+
+    def test_future_slot_uses_full_width(self):
+        """Future slot: power uses full slot width."""
+        from custom_components.hsem.models.planner_outputs import PlannedSlot
+        from custom_components.hsem.planner.engine_core import (
+            _compute_ev_charger_power,
+        )
+        from custom_components.hsem.planner.ev_planner import EVChargingSlot
+
+        tz = _UTC
+        slot_start = datetime(2024, 6, 15, 8, 0, tzinfo=tz)
+        slot_end = datetime(2024, 6, 15, 8, 15, tzinfo=tz)
+        now = datetime(2024, 6, 15, 7, 10, tzinfo=tz)  # before the slot
+
+        slots = [PlannedSlot(start=slot_start, end=slot_end)]
+        slot_starts = [slot_start]
+
+        ev_slot = EVChargingSlot(
+            start=slot_start,
+            end=slot_end,
+            estimated_charged_kwh=2.6,
+            ac_load_kwh=2.75,
+            solar_surplus_kwh=0.0,
+            import_needed_kwh=2.75,
+            import_price=1.0,
+            estimated_cost=2.75,
+        )
+        ev_plan = EVChargingPlan(
+            ev_connected=True,
+            state="charging",
+            charging_slots=[ev_slot],
+        )
+
+        _compute_ev_charger_power(slots, slot_starts, ev_plan, 15, now)
+
+        # Full-width: 2.75 / 0.25 * 1000 = 11000 W
+        expected = round((2.75 / 0.25) * 1000)
+        assert slots[0].ev_charger_calculated_power == expected
+
+    def test_remaining_time_minimum_guard(self):
+        """Minimum 1 s remaining-time guard prevents division by zero."""
+        from custom_components.hsem.models.planner_outputs import PlannedSlot
+        from custom_components.hsem.planner.engine_core import (
+            _compute_ev_charger_power,
+        )
+        from custom_components.hsem.planner.ev_planner import EVChargingSlot
+
+        tz = _UTC
+        slot_start = datetime(2024, 6, 15, 7, 0, tzinfo=tz)
+        slot_end = datetime(2024, 6, 15, 7, 15, tzinfo=tz)
+        now = datetime(2024, 6, 15, 7, 14, 59, 999999, tzinfo=tz)
+
+        slots = [PlannedSlot(start=slot_start, end=slot_end)]
+        slot_starts = [slot_start]
+
+        ev_slot = EVChargingSlot(
+            start=slot_start,
+            end=slot_end,
+            estimated_charged_kwh=0.03,
+            ac_load_kwh=0.03,
+            solar_surplus_kwh=0.0,
+            import_needed_kwh=0.03,
+            import_price=1.0,
+            estimated_cost=0.03,
+        )
+        ev_plan = EVChargingPlan(
+            ev_connected=True,
+            state="charging",
+            charging_slots=[ev_slot],
+        )
+
+        # Should not raise ZeroDivisionError.
+        _compute_ev_charger_power(slots, slot_starts, ev_plan, 15, now)
+        assert slots[0].ev_charger_calculated_power > 0
+
     def test_pass_3_skips_when_battery_not_full(self):
         """Pass 3 adds no slots when battery is below usable_kwh."""
         now = _dt(0)

--- a/tests/test_exception_handling.py
+++ b/tests/test_exception_handling.py
@@ -549,6 +549,7 @@ class TestHouseConsumptionSensorReadFailure:
         sensor.hass = MagicMock()
         sensor._hsem_house_consumption_power = "sensor.house_power"
         sensor._hsem_ev_charger_power = None
+        sensor._hsem_ev_second_charger_power = None
         sensor._missing_input_entities = False
 
         # Patch ha_get_entity_state_and_convert to raise EntityNotFoundError
@@ -573,6 +574,7 @@ class TestHouseConsumptionSensorReadFailure:
         sensor.hass = MagicMock()
         sensor._hsem_house_consumption_power = "sensor.house_power"
         sensor._hsem_ev_charger_power = None
+        sensor._hsem_ev_second_charger_power = None
         sensor._missing_input_entities = False
 
         with patch(
@@ -595,6 +597,7 @@ class TestHouseConsumptionSensorReadFailure:
         sensor.hass = MagicMock()
         sensor._hsem_house_consumption_power = "sensor.house_power"
         sensor._hsem_ev_charger_power = None
+        sensor._hsem_ev_second_charger_power = None
         sensor._missing_input_entities = True  # start dirty
 
         with (


### PR DESCRIPTION
The `HSEMHouseConsumptionPowerSensor` only subtracted EV #1 charger power from house consumption when `house_power_includes_ev_charger_power` was enabled. EV #2 (configured via `hsem_ev_second_charger_power`) was never read, tracked, or included in the calculation — causing the house baseline and its derived energy averages (1d/3d/7d/14d) to be inflated whenever the second EV was charging.

## Changes

### EV #2 house consumption fix

Threaded full EV #2 support through the entire sensor pipeline:

- `__init__` — added `_hsem_ev_second_charger_power` and `_hsem_ev_second_charger_power_state`
- `_update_settings` — reads `hsem_ev_second_charger_power` from config
- `extra_state_attributes` — exposes second EV entity + state
- `_async_track_entities` — registers state-change listener for EV #2
- `_async_fetch_sensor_states` — fetches live power from EV #2
- `_async_handle_update` — sums both EV powers before subtracting from house consumption
- `_unrecorded_attributes` — added new attribute keys

Also fixed three `MagicMock(spec=...)` tests in `test_exception_handling.py` that broke because the spec mock didn't have the new `_hsem_ev_second_charger_power` attribute set.

The coordinator (`state_collector.py`) and planner (`coordinator_builder.py`) already handled both EVs correctly; this was the last gap in the EV load separation pipeline.

### EV charger calculated power fix

`ev_charger_calculated_power` was computed by dividing per-slot AC energy by the full slot width. For the current (partially elapsed) slot the EV planner already scales `ac_load_kwh` to remaining minutes, so using the full slot width understated the required charge power — causing the value to decline steadily within each slot (e.g. from ~11 kW at slot start to ~0.2 kW at slot end).

The fix uses remaining slot time for the current slot and full slot width for future slots. A minimum 1 s guard prevents division by zero.

### Docs math rendering fix

Three documentation files used `\text{foo\_bar}` with escaped underscores. GitHub's Markdown processor strips the backslash escape, leaving MathJax unable to parse the expressions — causing `'_' allowed only in math mode` errors on the rendered page. Removed unnecessary backslashes inside `\text{}` blocks (text mode already treats `_` as a regular character).

Fixes #323
