### PR TITLE
fix(daily-tracker): offload file I/O to thread pool to avoid blocking event loop

### DIFF
--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -636,7 +636,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                 # Daily plan-vs-actual accumulation from planner output.
                 # -----------------------------------------------------------------------
                 try:
-                    self._accumulate_daily_plan_actuals(now, live, planner_output)
+                    await self._accumulate_daily_plan_actuals(now, live, planner_output)
                 except Exception:
                     _LOGGER.exception(
                         "Daily plan-vs-actual accumulation failed — "
@@ -896,7 +896,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
     # Daily plan-vs-actual accumulation (issue #540)
     # ------------------------------------------------------------------
 
-    def _accumulate_daily_plan_actuals(
+    async def _accumulate_daily_plan_actuals(
         self,
         now: datetime,
         live: LiveState,
@@ -915,11 +915,11 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             live: Live HA entity state snapshot.
             output: Planner output with slot-level decisions.
         """
-        self._init_daily_tracker()
+        await self._init_daily_tracker()
         tracker = self._daily_tracker
 
         # Check and handle day rollover first.
-        tracker.check_day_rollover(now)
+        await tracker.check_day_rollover(now)
 
         # ---- Plan accumulation ----
         # Accumulate plan values for the current in-progress slot (and any
@@ -948,7 +948,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             export_price=live.export_electricity_price,
         )
 
-    def _init_daily_tracker(self) -> None:
+    async def _init_daily_tracker(self) -> None:
         """Lazily initialise the daily plan-vs-actual tracker.
 
         Called once on the first access.  Registers the midnight timer
@@ -964,7 +964,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             self._daily_tracker.history_file = str(
                 Path(config_dir) / "hsem_daily_history.json"
             )
-            self._daily_tracker.load_history()
+            await self._daily_tracker.load_history()
 
             self._midnight_unsub = async_track_time_change(
                 self.hass,
@@ -994,7 +994,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         tracker = self._daily_tracker
         if tracker.history_file:
             today_record = tracker._build_today_record()
-            saved = tracker._save_record_to_history(today_record)
+            saved = await tracker._save_record_to_history(today_record)
             if saved:
                 _LOGGER.info(
                     "Daily plan-vs-actual record saved for %s",

--- a/custom_components/hsem/models/daily_plan_vs_actual.py
+++ b/custom_components/hsem/models/daily_plan_vs_actual.py
@@ -9,6 +9,7 @@ All fields are plain Python types; no Home Assistant imports are used.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import tempfile
@@ -194,17 +195,19 @@ class DailyPlanVsActualTracker:
     _last_pv_energy_kwh: float | None = field(default=None, repr=False)
 
     def __post_init__(self) -> None:
-        """Set today's date if not already set and load existing history."""
+        """Set today's date if not already set.
+
+        History loading is deferred — call :meth:`load_history` explicitly
+        to avoid blocking I/O during dataclass construction.
+        """
         if not self.today:
             self.today = date.today().isoformat()
-        if self.history_file:
-            self.load_history()
 
     # ------------------------------------------------------------------
     # Midday counter reset
     # ------------------------------------------------------------------
 
-    def check_day_rollover(self, now: datetime) -> DayRolloverResult | None:
+    async def check_day_rollover(self, now: datetime) -> DayRolloverResult | None:
         """Check if the calendar day has changed and handle rollover.
 
         When the day changes, the current day's record is finalised and saved,
@@ -223,7 +226,7 @@ class DailyPlanVsActualTracker:
 
         # Day has changed — finalise and save yesterday's record.
         today_record = self._build_today_record()
-        saved = self._save_record_to_history(today_record)
+        saved = await self._save_record_to_history(today_record)
 
         # Reset counters for the new day.
         self.today = today_str
@@ -364,7 +367,7 @@ class DailyPlanVsActualTracker:
     # JSON persistence
     # ------------------------------------------------------------------
 
-    def load_history(self) -> None:
+    async def load_history(self) -> None:
         """Load history from the JSON file, if it exists.
 
         Handles corrupted files gracefully by starting with an empty history.
@@ -373,12 +376,8 @@ class DailyPlanVsActualTracker:
         if not path.exists():
             return
 
-        try:
-            with open(path, encoding="utf-8") as f:
-                data = json.load(f)
-        except (json.JSONDecodeError, OSError):
-            # Corrupted file — start fresh.
-            self.history = []
+        data = await asyncio.to_thread(self._read_history_file, path)
+        if data is None:
             return
 
         days = data.get("days", [])
@@ -386,7 +385,16 @@ class DailyPlanVsActualTracker:
             self.history = [DailyRecord.from_dict(d) for d in days]
             self._prune_history()
 
-    def _save_record_to_history(self, record: DailyRecord) -> bool:
+    @staticmethod
+    def _read_history_file(path: Path) -> dict[str, Any] | None:
+        """Read and parse the history JSON file (sync, offloaded to thread)."""
+        try:
+            with open(path, encoding="utf-8") as f:
+                return json.load(f)  # type: ignore[no-any-return]
+        except (json.JSONDecodeError, OSError):
+            return None
+
+    async def _save_record_to_history(self, record: DailyRecord) -> bool:
         """Append a record to the in-memory history, prune, and persist to disk.
 
         Uses atomic write (write to temp file, then rename) to protect against
@@ -401,14 +409,14 @@ class DailyPlanVsActualTracker:
         self.history.append(record)
         self._prune_history()
 
-        return self._write_history_file()
+        return await self._write_history_file()
 
     def _prune_history(self) -> None:
         """Keep only the most recent ``max_history_days`` records."""
         if len(self.history) > self.max_history_days:
             self.history = self.history[-self.max_history_days :]
 
-    def _write_history_file(self) -> bool:
+    async def _write_history_file(self) -> bool:
         """Write the history list to disk atomically.
 
         Returns:
@@ -425,6 +433,11 @@ class DailyPlanVsActualTracker:
         path = Path(self.history_file)
         path.parent.mkdir(parents=True, exist_ok=True)
 
+        return await asyncio.to_thread(self._write_history_file_sync, data, path)
+
+    @staticmethod
+    def _write_history_file_sync(data: dict[str, Any], path: Path) -> bool:
+        """Write the history list to disk atomically (sync, offloaded to thread)."""
         try:
             # Write to a temp file in the same directory, then atomically rename.
             fd, tmp_path = tempfile.mkstemp(

--- a/tests/test_daily_plan_vs_actual.py
+++ b/tests/test_daily_plan_vs_actual.py
@@ -18,6 +18,8 @@ from custom_components.hsem.models.daily_plan_vs_actual import (
     DayRolloverResult,
 )
 
+pytestmark = pytest.mark.asyncio
+
 
 class TestDailyMetrics:
     """Tests for :class:`DailyMetrics`."""
@@ -239,19 +241,19 @@ class TestDailyPlanVsActualTracker:
         # Delta = |45 - 50| = 5 pct-points → 0.5 kWh
         assert tracker.actual.battery_cycled_kwh == pytest.approx(0.5)
 
-    def test_check_day_rollover_no_change(self) -> None:
+    async def test_check_day_rollover_no_change(self) -> None:
         """No rollover when day hasn't changed."""
         tracker = DailyPlanVsActualTracker(today="2026-06-01")
-        result = tracker.check_day_rollover(datetime(2026, 6, 1, 12, 0, 0))
+        result = await tracker.check_day_rollover(datetime(2026, 6, 1, 12, 0, 0))
         assert result is None
 
-    def test_check_day_rollover_changes(self) -> None:
+    async def test_check_day_rollover_changes(self) -> None:
         """Day rollover returns a result and resets counters."""
         tracker = DailyPlanVsActualTracker(today="2026-06-01")
         tracker.accumulate_plan(grid_import_kwh=5.0, import_price=1.0)
         tracker.accumulate_actual(soc_pct=50.0)
 
-        result = tracker.check_day_rollover(datetime(2026, 6, 2, 0, 5, 0))
+        result = await tracker.check_day_rollover(datetime(2026, 6, 2, 0, 5, 0))
         assert result is not None
         assert isinstance(result, DayRolloverResult)
         assert result.record.date == "2026-06-01"
@@ -303,11 +305,13 @@ class TestDailyPlanVsActualTracker:
         record = tracker.get_yesterday_record()
         assert record is None
 
-    def test_history_pruning(self) -> None:
+    async def test_history_pruning(self) -> None:
         """History is pruned to max_history_days."""
         tracker = DailyPlanVsActualTracker(max_history_days=3)
         for i in range(5):
-            tracker._save_record_to_history(DailyRecord(date=f"2026-06-{i + 1:02d}"))
+            await tracker._save_record_to_history(
+                DailyRecord(date=f"2026-06-{i + 1:02d}")
+            )
         assert len(tracker.history) == 3
         # Should keep the 3 most recent (June 3, 4, 5).
         assert tracker.history[-1].date == "2026-06-05"
@@ -327,7 +331,7 @@ class TestDailyPlanVsActualTracker:
         assert attrs["history_days"] == 90
         assert attrs["history_total_days"] == 0
 
-    def test_json_persistence_roundtrip(self) -> None:
+    async def test_json_persistence_roundtrip(self) -> None:
         """Save and load history through a temp JSON file."""
         with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tmp:
             tmp_path = tmp.name
@@ -347,12 +351,13 @@ class TestDailyPlanVsActualTracker:
 
             # Simulate day rollover to save.
             tracker.today = "2026-06-01"
-            tracker.check_day_rollover(datetime(2026, 6, 2, 0, 5, 0))
+            await tracker.check_day_rollover(datetime(2026, 6, 2, 0, 5, 0))
 
             # Load from the file with a new tracker.
             tracker2 = DailyPlanVsActualTracker(
                 history_file=tmp_path, max_history_days=90
             )
+            await tracker2.load_history()
             assert len(tracker2.history) == 1
             assert tracker2.history[0].date == "2026-06-01"
             assert tracker2.history[0].plan.grid_import_kwh == pytest.approx(5.0)
@@ -369,7 +374,7 @@ class TestDailyPlanVsActualTracker:
         finally:
             os.unlink(tmp_path)
 
-    def test_corrupted_file_handling(self) -> None:
+    async def test_corrupted_file_handling(self) -> None:
         """Tracker loads gracefully from a corrupted file."""
         with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as tmp:
             tmp.write("this is not valid json")
@@ -379,12 +384,13 @@ class TestDailyPlanVsActualTracker:
             tracker = DailyPlanVsActualTracker(
                 history_file=tmp_path, max_history_days=90
             )
+            await tracker.load_history()
             # Should have loaded empty history despite corruption.
             assert tracker.history == []
         finally:
             os.unlink(tmp_path)
 
-    def test_load_missing_file(self) -> None:
+    async def test_load_missing_file(self) -> None:
         """Tracker handles missing history file gracefully."""
         import tempfile as tf
 
@@ -393,4 +399,5 @@ class TestDailyPlanVsActualTracker:
             history_file=nonexistent,
             max_history_days=90,
         )
+        await tracker.load_history()
         assert tracker.history == []


### PR DESCRIPTION
## Summary

Fixes #549

`DailyPlanVsActualTracker` was using synchronous `open()`, `os.fdopen()`, and `os.replace()` for JSON file I/O inside the event loop via three call paths:

1. Update cycle → `_init_daily_tracker()` → `load_history()`
2. Update cycle → `check_day_rollover()` → `_save_record_to_history()` → `_write_history_file()`
3. Midnight handler → `_save_record_to_history()` → `_write_history_file()`

## What changed

- Offloaded all file I/O to `asyncio.to_thread()` — no new dependencies
- Made `load_history`, `_write_history_file`, `_save_record_to_history`, and `check_day_rollover` async
- Removed `load_history()` call from `__post_init__` (can't be async); coordinator calls it explicitly via `await`
- Updated coordinator callers to `await` all four now-async methods
- Updated tests: converted sync tests to async, added explicit `await tracker.load_history()` calls (since history is no longer auto-loaded on construction)

## Files changed

| File | Change |
|---|---|
| `custom_components/hsem/models/daily_plan_vs_actual.py` | Async I/O via `asyncio.to_thread`, new `_read_history_file` and `_write_history_file_sync` static methods |
| `custom_components/hsem/coordinator.py` | `await` on all tracker I/O methods; `_init_daily_tracker` and `_accumulate_daily_plan_actuals` now async |
| `tests/test_daily_plan_vs_actual.py` | I/O tests converted to async; explicit `load_history()` calls added |

## Quality gates

- [ ] `tox -e lint` passes
- [ ] `tox -e typing` passes
- [ ] `tox -e quality` passes
- [ ] `tox -e py313` passes