### PR TITLE
chore: pin tox to 4.55.1 and fix bare except in state_collector

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel
-          pip install tox
+          pip install tox==4.55.1
           pip install -r requirements_lint.txt
 
       - name: Pull latest changes

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -30,7 +30,7 @@ jobs:
             tox-lint-
 
       - name: Install tox
-        run: python -m pip install tox
+        run: python -m pip install tox==4.55.1
 
       - name: Format and lint with tox
         run: tox -e lint
@@ -55,7 +55,7 @@ jobs:
             tox-typing-
 
       - name: Install tox
-        run: python -m pip install tox
+        run: python -m pip install tox==4.55.1
 
       - name: Type check with tox
         run: tox -e typing
@@ -80,7 +80,7 @@ jobs:
             tox-quality-
 
       - name: Install tox
-        run: python -m pip install tox
+        run: python -m pip install tox==4.55.1
 
       - name: Run quality checks with tox
         run: tox -e quality
@@ -109,7 +109,7 @@ jobs:
             tox-test-
 
       - name: Install tox
-        run: python -m pip install tox
+        run: python -m pip install tox==4.55.1
 
       - name: Run tests with tox
         run: tox -e py314

--- a/custom_components/hsem/custom_sensors/state_collector.py
+++ b/custom_components/hsem/custom_sensors/state_collector.py
@@ -38,6 +38,7 @@ from custom_components.hsem.utils.conversion import (
     convert_to_float,
 )
 from custom_components.hsem.utils.ha_helpers import (
+    EntityNotFoundError,
     async_resolve_entity_id_from_unique_id,
     ha_get_entity_state_and_convert,
 )
@@ -582,8 +583,12 @@ def _resolve_ev_deadline_from_params(sensor, deadline_entity, deadline_fixed):
                 time_str = raw.state
             elif isinstance(raw, str):
                 time_str = raw
-        except Exception:
-            pass
+        except (EntityNotFoundError, HomeAssistantError) as exc:
+            _LOGGER.warning(
+                "Could not read EV deadline entity '%s': %s. Falling back to default.",
+                deadline_entity,
+                exc,
+            )
 
     if not time_str:
         time_str = deadline_fixed or "07:00"


### PR DESCRIPTION
## Summary

Two fixes:

### 1. Pin tox to 4.55.1
All `pip install tox` calls in `.github/workflows/` are now pinned to `==4.55.1` to ensure reproducible CI builds.

**Files changed:**
- `.github/workflows/format-code.yml`
- `.github/workflows/lint-and-test.yml` (4 jobs: lint, type-check, quality, tests)

### 2. Fix bare `except Exception: pass` (#58)
Replaced the bare except in `_resolve_ev_deadline_from_params()` with specific exception handling for `EntityNotFoundError` and `HomeAssistantError`, and added a warning log when the deadline entity cannot be read.

**File changed:**
- `custom_components/hsem/custom_sensors/state_collector.py`