### PR TITLE
docs: use Mermaid diagrams and math equations

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -121,12 +121,19 @@ The `m[t]` constraints are: `m[t] >= ec[t]` and `m[t] >= ed[t]`.
 
 ---
 
+## Documentation Style
+
+- Use Mermaid fenced code blocks for architecture and flow diagrams.
+- Do not use ASCII/Markdown box diagrams for architecture.
+- Use math equations (`$$ ... $$`) for formulas instead of plain text or code-block formulas.
+
+---
+
 ## Cycle Cost Formula
 
-```
-cycle_cost_per_kwh = (purchase_price × capacity_loss_pct / 100)
-                   / (2 × usable_kwh × expected_cycles)
-```
+$$
+cycle\_cost\_per\_kwh = \frac{purchase\_price \times capacity\_loss\_pct / 100}{2 \times usable\_kwh \times expected\_cycles}
+$$
 
 The `2x` denominator accounts for one full round-trip (charge + discharge = 2 × usable_kwh throughput per cycle).
 `capacity_loss_pct` (configurable via `hsem_batteries_capacity_loss_pct`, default 30 %) accounts for the

--- a/docs/adr/adr-001-planner-extraction.md
+++ b/docs/adr/adr-001-planner-extraction.md
@@ -34,16 +34,14 @@ on the Python standard library (plus `scipy` for the optional MILP solver).
 
 ### Architecture boundary
 
-```
-HA integration layer (coordinator, sensors, services, flows)
-    │
-    │  PlannerInput (dataclass) ── pure data, no HA objects
-    ▼
-Pure-Python planner engine (planner/, models/)
-    │
-    │  PlannerOutput (dataclass) ── pure data, no HA objects
-    ▼
-HA integration layer (coordinator → sensors → hardware writes)
+```mermaid
+flowchart TD
+    A[HA integration layer\ncoordinator, sensors, services, flows]
+    B[Pure-Python planner engine\nplanner, models]
+    C[HA integration layer\ncoordinator to sensors to hardware writes]
+
+    A -->|PlannerInput dataclass\npure data, no HA objects| B
+    B -->|PlannerOutput dataclass\npure data, no HA objects| C
 ```
 
 - **`models/planner_inputs.py`** and **`models/planner_outputs.py`** define the

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -20,42 +20,36 @@
 
 ## System context
 
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│                        Home Assistant                                │
-│                                                                      │
-│  ┌──────────────────────────────────────────────────────────────┐   │
-│  │                    HSEM Integration                            │   │
-│  │                                                                │   │
-│  │  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────────┐  │   │
-│  │  │ Sensors  │  │ Select   │  │ Switches │  │ Services     │  │   │
-│  │  │ (20+)    │  │ (1)      │  │ (5+)     │  │ (4)          │  │   │
-│  │  └────┬─────┘  └────┬─────┘  └────┬─────┘  └──────┬───────┘  │   │
-│  │       │              │             │               │          │   │
-│  │  ┌────▼──────────────▼─────────────▼───────────────▼───────┐  │   │
-│  │  │                  Coordinator                             │  │   │
-│  │  │         (HSEMDataUpdateCoordinator)                      │  │   │
-│  │  │   - Config reload  - State collection  - Planner run    │  │   │
-│  │  │   - Forecast tracking  - Recommendation resolution      │  │   │
-│  │  └────────────────────────┬────────────────────────────────┘  │   │
-│  │                           │                                    │   │
-│  │  ┌────────────────────────▼────────────────────────────────┐  │   │
-│  │  │              Pure-Python Planner Engine                   │  │   │
-│  │  │   - Slot population  - Scheduling  - Candidate gen      │  │   │
-│  │  │   - SoC simulation  - Cost scoring  - EV planning       │  │   │
-│  │  │   - MILP optimisation  - Hysteresis                     │  │   │
-│  │  └─────────────────────────────────────────────────────────┘  │   │
-│  └────────────────────────────────────────────────────────────────┘   │
-│                                                                      │
-│  ┌────────────────────────────────────────────────────────────────┐   │
-│  │              External Integrations                              │   │
-│  │  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────────┐  │   │
-│  │  │ Huawei   │  │ Solcast  │  │ Energi   │  │ EV charger   │  │   │
-│  │  │ Solar    │  │ Solar    │  │ Data     │  │ (generic)    │  │   │
-│  │  │ Inverter │  │ Forecast │  │ Service  │  │              │  │   │
-│  │  └──────────┘  └──────────┘  └──────────┘  └──────────────┘  │   │
-│  └────────────────────────────────────────────────────────────────┘   │
-└─────────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    subgraph HA[Home Assistant]
+        subgraph HSEM[HSEM Integration]
+            Sensors[Sensors\n20+]
+            Select[Select\n1]
+            Switches[Switches\n5+]
+            Services[Services\n4]
+            Coordinator[HSEMDataUpdateCoordinator\nConfig reload, state collection, planner run\nForecast tracking, recommendation resolution]
+            Planner[Pure-Python Planner Engine\nSlot population, scheduling, candidate generation\nSoC simulation, cost scoring, EV planning\nMILP optimisation, hysteresis]
+
+            Sensors --> Coordinator
+            Select --> Coordinator
+            Switches --> Coordinator
+            Services --> Coordinator
+            Coordinator --> Planner
+        end
+
+        subgraph External[External Integrations]
+            Huawei[Huawei Solar\nInverter and battery]
+            Solcast[Solcast Solar\nPV forecast]
+            Prices[Electricity Prices\nEnergi Data Service, Nordpool, etc.]
+            EV[EV charger\nGeneric]
+        end
+
+        Huawei --> HSEM
+        Solcast --> HSEM
+        Prices --> HSEM
+        EV --> HSEM
+    end
 ```
 
 ### External dependencies
@@ -164,48 +158,47 @@ HA-dependent sensor entities that consume coordinator data.
 
 The coordinator runs this pipeline every update cycle (default: every 5 minutes):
 
-```
-1. Reload config from ConfigEntry
-       │
-2. Collect live HA entity states (state_collector)
-       │
-3. Build SensorConfig from config entry
-       │
-4. Generate recommendation time-slots
-       │
-5. Build battery-schedule objects
-       │
-6. Populate weighted house-consumption averages
-       │
-7. Populate electricity prices and Solcast PV estimates
-       │
-8. Run pure-Python planner engine:
-   │
-   ├─ 8a. Build time-series index
-   ├─ 8b. Build empty slots
-   ├─ 8c. Populate prices, PV, consumption
-   ├─ 8d. Mark time-passed slots
-   ├─ 8e. Populate battery capacity
-   ├─ 8f. Populate net consumption (pass 1 — without EV)
-   ├─ 8g. Apply discharge schedules
-   ├─ 8h. Apply charge schedules + arbitrage
-   ├─ 8i. Apply excess export
-   ├─ 8j. Apply seasonal optimisation
-   ├─ 8k. Build EV charging plan (from net surplus)
-   ├─ 8l. Populate net consumption (pass 2 — with EV)
-   ├─ 8m. Generate 8+ candidate plans
-   ├─ 8n. Simulate SoC for each candidate
-   ├─ 8o. Score all candidates
-   ├─ 8p. Apply plan-level hysteresis
-   ├─ 8q. Select best candidate
-   ├─ 8r. Apply EV load labelling (layer 2)
-   └─ 8s. Build explanation
-       │
-9. Resolve current slot recommendation (runtime resolver)
-       │
-10. Accumulate forecast vs actual data
-       │
-11. Package CoordinatorData and notify subscribers
+```mermaid
+flowchart TD
+    A[Reload config from ConfigEntry]
+    B[Collect live HA entity states\nstate_collector]
+    C[Build SensorConfig from config entry]
+    D[Generate recommendation time-slots]
+    E[Build battery-schedule objects]
+    F[Populate weighted house-consumption averages]
+    G[Populate electricity prices and Solcast PV estimates]
+
+    subgraph Planner[Run pure-Python planner engine]
+        H1[Build time-series index]
+        H2[Build empty slots]
+        H3[Populate prices, PV, consumption]
+        H4[Mark time-passed slots]
+        H5[Populate battery capacity]
+        H6[Populate net consumption\npass 1 without EV]
+        H7[Apply discharge schedules]
+        H8[Apply charge schedules and arbitrage]
+        H9[Apply excess export]
+        H10[Apply seasonal optimisation]
+        H11[Build EV charging plan\nfrom net surplus]
+        H12[Populate net consumption\npass 2 with EV]
+        H13[Generate 8+ candidate plans]
+        H14[Simulate SoC for each candidate]
+        H15[Score all candidates]
+        H16[Apply plan-level hysteresis]
+        H17[Select best candidate]
+        H18[Apply EV load labelling\nlayer 2]
+        H19[Build explanation]
+
+        H1 --> H2 --> H3 --> H4 --> H5 --> H6 --> H7 --> H8 --> H9 --> H10
+        H10 --> H11 --> H12 --> H13 --> H14 --> H15 --> H16 --> H17 --> H18 --> H19
+    end
+
+    I[Resolve current slot recommendation\nruntime resolver]
+    J[Accumulate forecast vs actual data]
+    K[Package CoordinatorData and notify subscribers]
+
+    A --> B --> C --> D --> E --> F --> G --> H1
+    H19 --> I --> J --> K
 ```
 
 ---
@@ -262,36 +255,76 @@ Plus explicit read-only and dry-run modes that also block hardware writes.
 
 ## Dependency graph
 
-```
-homeassistant/
-  └── __init__.py ─────────────────────────────► config_flow.py, options_flow.py
-      │                                              │
-      ├── coordinator.py ────────────────────────────┤
-      │   │                                          │
-      │   ├── coordinator_builder.py                 │
-      │   ├── custom_sensors/config_reader.py        │
-      │   ├── custom_sensors/state_collector.py      │
-      │   ├── custom_sensors/hourly_data_populator.py│
-      │   ├── custom_sensors/recommendation_resolver.py
-      │   ├── planner/ ├── engine_core.py            │
-      │   │            ├── slot_population.py        │
-      │   │            ├── charge_scheduler.py       │
-      │   │            ├── discharge_scheduler.py    │
-      │   │            ├── candidate_generator.py    │
-      │   │            ├── candidate_selector.py     │
-      │   │            ├── cost_function.py          │
-      │   │            ├── soc_simulation.py         │
-      │   │            ├── milp_optimizer.py         │
-      │   │            ├── ev_planner.py             │
-      │   │            └── engine_explanation.py     │
-      │   ├── utils/ (recommendations, misc, etc.)   │
-      │   └── models/ (planner_inputs, outputs, etc.)│
-      │                                              │
-      ├── sensor.py ─────► custom_sensors/*.py       │
-      ├── select.py                                  │
-      ├── switch.py                                  │
-      └── services.py ───► coordinator.py            │
-                           utils/diagnostics.py      │
+```mermaid
+flowchart TD
+    Init[__init__.py]
+    Config[config_flow.py]
+    Options[options_flow.py]
+    Coordinator[coordinator.py]
+    Builder[coordinator_builder.py]
+    ConfigReader[custom_sensors/config_reader.py]
+    StateCollector[custom_sensors/state_collector.py]
+    HourlyPopulator[custom_sensors/hourly_data_populator.py]
+    Resolver[custom_sensors/recommendation_resolver.py]
+    Sensor[sensor.py]
+    Select[select.py]
+    Switch[switch.py]
+    Services[services.py]
+    Diagnostics[utils/diagnostics.py]
+
+    subgraph Planner[planner]
+        Engine[engine_core.py]
+        SlotPopulation[slot_population.py]
+        Charge[charge_scheduler.py]
+        Discharge[discharge_scheduler.py]
+        Candidates[candidate_generator.py]
+        Selector[candidate_selector.py]
+        Cost[cost_function.py]
+        SoC[soc_simulation.py]
+        MILP[milp_optimizer.py]
+        EVPlanner[ev_planner.py]
+        Explanation[engine_explanation.py]
+    end
+
+    subgraph Shared[shared pure/helper modules]
+        Utils[utils]
+        Models[models]
+    end
+
+    Init --> Config
+    Init --> Options
+    Init --> Coordinator
+    Init --> Sensor
+    Init --> Select
+    Init --> Switch
+    Init --> Services
+
+    Coordinator --> Builder
+    Coordinator --> ConfigReader
+    Coordinator --> StateCollector
+    Coordinator --> HourlyPopulator
+    Coordinator --> Resolver
+    Coordinator --> Engine
+    Coordinator --> Utils
+    Coordinator --> Models
+
+    Sensor --> ConfigReader
+    Sensor --> StateCollector
+    Services --> Coordinator
+    Services --> Diagnostics
+
+    Engine --> SlotPopulation
+    Engine --> Charge
+    Engine --> Discharge
+    Engine --> Candidates
+    Engine --> Selector
+    Engine --> Cost
+    Engine --> SoC
+    Engine --> MILP
+    Engine --> EVPlanner
+    Engine --> Explanation
+    Engine --> Models
+    Engine --> Utils
 ```
 
 All planner modules (`planner/`, `models/`, `utils/recommendations.py`,

--- a/docs/battery-charging-economics.md
+++ b/docs/battery-charging-economics.md
@@ -26,6 +26,7 @@ Measures how much of the battery's total capacity is used during a cycle. A 70% 
 ### Simplified Model
 
 This model calculates depreciation per kWh assuming:
+
 - Full cycles (100% DoD).
 - Uniform capacity loss (degeneration) over the battery's lifetime.
 - No operational inefficiencies (e.g., energy conversion losses).
@@ -34,18 +35,21 @@ This model calculates depreciation per kWh assuming:
 
 ## Formula
 
-```
-Depreciation per kWh = (Purchase Price × Capacity Loss) / (Number of Cycles × Battery Capacity)
-```
+Let:
 
-Where:
+| Symbol | Parameter | Description |
+|---|---|---|
+| $P$ | Purchase price | Total battery system cost (in your currency) |
+| $L$ | Capacity loss | Maximum capacity reduction over lifetime as a fraction, e.g. $0.30$ for 30% |
+| $N$ | Number of cycles | Total expected complete charge/discharge cycles |
+| $C$ | Battery capacity | Total usable energy storage in kWh |
+| $D$ | Depreciation per kWh | Battery wear cost per kWh |
 
-| Parameter | Description |
-|---|---|
-| **Purchase Price** | Total battery system cost (in your currency) |
-| **Capacity Loss** | Maximum capacity reduction over lifetime (percentage, as decimal) |
-| **Number of Cycles** | Total expected complete charge/discharge cycles |
-| **Battery Capacity** | Total usable energy storage (in kWh) |
+The simplified depreciation per kWh is:
+
+$$
+D = \frac{P \times L}{N \times C}
+$$
 
 ---
 
@@ -54,15 +58,17 @@ Where:
 Parameters for a LiFePO4 battery system:
 
 - **Purchase Price**: 48,000 DKK
-- **Capacity Loss**: 30% (0.30)
+- **Capacity Loss**: 30% ($L = 0.30$)
 - **Number of Cycles**: 6,000 full cycles
 - **Battery Capacity**: 10 kWh
 
-```
-Depreciation per kWh = (48,000 × 0.30) / (6,000 × 10)
-                     = 14,400 / 60,000
-                     = 0.24 DKK/kWh
-```
+$$
+\begin{aligned}
+D &= \frac{48{,}000 \times 0.30}{6{,}000 \times 10} \\
+  &= \frac{14{,}400}{60{,}000} \\
+  &= 0.24\ \text{DKK/kWh}
+\end{aligned}
+$$
 
 Each kWh stored and discharged through the battery costs **0.24 DKK** in wear and tear.
 
@@ -70,9 +76,17 @@ Each kWh stored and discharged through the battery costs **0.24 DKK** in wear an
 
 ## Practical Implication
 
-To make charging economically viable, the price difference between charging and discharging must exceed the depreciation cost. For example:
+To make charging economically viable, the price difference between charging and discharging must exceed the depreciation cost:
 
-- If charging electricity costs 1.00 DKK/kWh, the discharge price must be at least **1.24 DKK/kWh** to offset depreciation.
+$$
+\text{Discharge price} - \text{Charge price} \ge D
+$$
+
+For example, if charging electricity costs 1.00 DKK/kWh:
+
+$$
+\text{Minimum discharge price} = 1.00 + 0.24 = 1.24\ \text{DKK/kWh}
+$$
 
 ---
 
@@ -90,14 +104,25 @@ To make charging economically viable, the price difference between charging and 
 
 ## HSEM Integration
 
-HSEM uses this formula in the **Excess Battery Export** feature and battery schedule economics. The recommended threshold is calculated automatically during configuration using the battery purchase price, expected cycles, and usable capacity you provide.
+HSEM uses a round-trip cycle-cost formula in the **Excess Battery Export** feature and battery schedule economics. The recommended threshold is calculated automatically during configuration using the battery purchase price, expected cycles, capacity loss, usable capacity, efficiency, and grid-fee inputs you provide.
 
-**Formula used by HSEM:**
-```
-Depreciation = (Purchase_Price × Capacity_Loss_Pct / 100) / (2 × Expected_Cycles × Usable_Capacity)
-```
+Let:
 
-Note the **2× denominator** — this accounts for both charge and discharge halves of a full cycle, and is the canonical formula used throughout HSEM's planner and cost function.
+| Symbol | Parameter | Description |
+|---|---|---|
+| $P$ | Purchase price | Battery system purchase price |
+| $L_{pct}$ | Capacity loss percent | Lifetime capacity loss percentage |
+| $N$ | Expected cycles | Expected full-cycle lifetime |
+| $C_u$ | Usable capacity | Usable battery capacity in kWh |
+| $\alpha$ | Cycle cost per kWh | HSEM battery wear cost per kWh |
+
+The canonical HSEM cycle-cost formula is:
+
+$$
+\alpha = \frac{P \times \left(\frac{L_{pct}}{100}\right)}{2 \times N \times C_u}
+$$
+
+The **$2 \times$ denominator is mandatory**. It accounts for one full round-trip: a complete charge and discharge moves $2 \times C_u$ kWh of throughput per cycle.
 
 ---
 

--- a/docs/forecast-accuracy-tracking.md
+++ b/docs/forecast-accuracy-tracking.md
@@ -48,32 +48,26 @@ perfect.  The forecast accuracy tracking system:
 
 ## Architecture
 
-```
-┌──────────────────────────────────────────────────────────────────┐
-│                        Coordinator Cycle                         │
-│                                                                  │
-│  1. async_collect_all_states()                                    │
-│     → LiveState with instantaneous power readings                │
-│                                                                  │
-│  2. Planner runs → PlannerOutput with slot forecasts             │
-│                                                                  │
-│  3. _accumulate_forecast_actuals(now, live)                      │
-│     → Reads elapsed time & power from LiveState                  │
-│     → compute_accumulated_energy(power, elapsed) → kWh           │
-│     → Accumulates into current slot's record                     │
-│     → finalise_past_records() for slots whose end time < now     │
-│                                                                  │
-│  4. _register_forecasts_from_planner(planner_output)              │
-│     → Copies solcast_pv_estimate_kwh and                          │
-│       avg_house_consumption_kwh into tracker records              │
-│                                                                  │
-│  5. CoordinatorData packaged and pushed to subscribers            │
-│                                                                  │
-│  6. HSEMForecastAccuracySensor reads tracker from coordinator     │
-│     → native_value = PV MAE (kWh)                                │
-│     → extra_state_attributes = all error metrics + latest slot   │
-│     → _forecast_tracker_data serialised into attributes          │
-└──────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    A[async_collect_all_states]
+    B[LiveState with instantaneous power readings]
+    C[Planner runs]
+    D[PlannerOutput with slot forecasts]
+    E[_accumulate_forecast_actuals now, live]
+    F[Read elapsed time and power from LiveState]
+    G[compute_accumulated_energy power, elapsed]
+    H[Accumulate kWh into current slot record]
+    I[finalise_past_records for slots whose end time is before now]
+    J[_register_forecasts_from_planner planner_output]
+    K[Copy solcast_pv_estimate_kwh and avg_house_consumption_kwh]
+    L[CoordinatorData packaged and pushed to subscribers]
+    M[HSEMForecastAccuracySensor reads tracker]
+    N[native_value is PV MAE in kWh]
+    O[extra_state_attributes include error metrics and latest slot]
+    P[_forecast_tracker_data serialized into attributes]
+
+    A --> B --> C --> D --> E --> F --> G --> H --> I --> J --> K --> L --> M --> N --> O --> P
 ```
 
 ### File layout

--- a/docs/home.md
+++ b/docs/home.md
@@ -148,7 +148,13 @@ Automatically exports excess battery capacity to the grid when profitable:
 2. **Identify excess** — any capacity above requirement is available for export.
 3. **Optimize timing** — export at peak price hours, respecting max discharge rate.
 4. **Differentiate energy source** — solar-charged energy exports at any positive price; grid-charged only exports if profit ≥ threshold.
-5. **Economic threshold** — calculated from battery depreciation: `Depreciation = (Purchase_Price × Capacity_Loss) / (2 × Expected_Cycles × Usable_Capacity)`
+5. **Economic threshold** — calculated from battery charging economics:
+
+$$
+\alpha = \frac{P \times \left(\frac{L_{pct}}{100}\right)}{2 \times N \times C_u}
+$$
+
+See [Battery Charging Economics](battery-charging-economics.md) for the full derivation.
 
 ### Example
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,9 @@
 
 1. **Always read `planner-spec.md`** before modifying planner code
 2. **Always check `huawei_entities.md`** before using a battery/inverter value
-3. Run `tox -e lint` before every commit
-4. Run `tox -e quality` after lint
-5. Run `pytest tests/` before every PR
-6. See `AGENTS.md` and `CLAUDE.md` for full development rules
+3. Use Mermaid for architecture and flow diagrams; do not use ASCII/Markdown box diagrams
+4. Use math equations (`$$ ... $$`) for formulas rather than plain text/code-block formulas
+5. Run `tox -e lint` before every commit
+6. Run `tox -e quality` after lint
+7. Run `pytest tests/` before every PR
+8. See `AGENTS.md` and `CLAUDE.md` for full development rules

--- a/docs/price-scaling.md
+++ b/docs/price-scaling.md
@@ -33,26 +33,18 @@ $$ eds\\_share = \frac{\mathrm{EDS interval}}{\mathrm{Slot width}} $$
 
 ## Scaling pipeline
 
-```
-EDS raw price: P (currency/kWh, full hourly rate)
-        │
-        ▼
-HourlyDataPopulator._async_update_hourly_field
-        │
-        │  Per-slot stored value = P / eds_share
-        │  (each 15-min slot gets 1/4 of the hourly rate)
-        ▼
-Recommendation slot storage
-(HourlyRecommendation objects)
-        │
-        ▼
-coordinator._build_planner_input
-        │
-        │  Planner sees: (P / eds_share) * eds_share = P
-        │  (exact inverse — the planner always receives the original rate)
-        ▼
-Planner engine (PricePoint[])
-    import_price = P (full currency/kWh)
+```mermaid
+flowchart TD
+    A[EDS raw price P\nfull hourly currency per kWh]
+    B[HourlyDataPopulator._async_update_hourly_field]
+    C[Recommendation slot storage\nHourlyRecommendation objects]
+    D[coordinator._build_planner_input]
+    E[Planner engine PricePoint\nimport_price = P]
+
+    A --> B
+    B -->|Per-slot stored value = P / eds_share| C
+    C --> D
+    D -->|Planner input value = stored value × eds_share = P| E
 ```
 
 ### What this is NOT

--- a/docs/safety-modes.md
+++ b/docs/safety-modes.md
@@ -146,39 +146,21 @@ planner output with live sensor readings:
 
 ## Safety gate interactions
 
-```
-                   ┌──────────────┐
-                   │ State        │
-                   │ Collection   │
-                   └──────┬───────┘
-                          │
-                          ▼
-              ┌───────────────────────┐
-              │ Degraded mode         │
-              │ classification        │
-              └──────┬────────────────┘
-                     │
-          ┌──────────┴──────────┐
-          │                     │
-          ▼                     ▼
-    ┌───────────┐        ┌───────────┐
-    │ Error     │        │ OK /      │
-    │ mode      │        │ Degraded  │
-    └─────┬─────┘        └─────┬─────┘
-          │                    │
-          ▼                    ▼
-    ┌───────────┐        ┌───────────┐
-    │ Writes    │        │ Check     │
-    │ BLOCKED  │        │ read-only │
-    └───────────┘        │ & dry-run │
-                         └─────┬─────┘
-                               │
-                    ┌──────────┴──────────┐
-                    │                     │
-                    ▼                     ▼
-              ┌───────────┐        ┌───────────┐
-              │ Read-only │        │ Allowed   │
-              │ BLOCKED   │        │ → Write +│
-              └───────────┘        │   Verify  │
-                                   └───────────┘
+```mermaid
+flowchart TD
+    A[State collection]
+    B[Degraded mode classification]
+    C{Health state}
+    D[Error mode]
+    E[OK or Degraded]
+    F[Writes blocked]
+    G{Read-only or dry-run?}
+    H[Read-only blocked]
+    I[Write and verify allowed]
+
+    A --> B --> C
+    C -->|Error| D --> F
+    C -->|OK or Degraded| E --> G
+    G -->|Yes| H
+    G -->|No| I
 ```


### PR DESCRIPTION
## Summary

Updates documentation formatting so architecture/flow diagrams use Mermaid and formulas use math equations. Also adds a dedicated MILP optimization doc with the full LP formulation.

### Changes

- Convert ASCII/Markdown diagrams to Mermaid in:
  - `docs/architecture-overview.md`
  - `docs/adr/adr-001-planner-extraction.md`
  - `docs/forecast-accuracy-tracking.md`
  - `docs/price-scaling.md`
  - `docs/safety-modes.md`
- Convert battery economics formulas from code blocks/plain text to math equations in:
  - `docs/battery-charging-economics.md`
  - `docs/home.md`
  - `.github/memories.md`
- Add docs-style guidance in:
  - `docs/index.md`
  - `.github/memories.md`
- **New:** `docs/milp-optimization.md` — dedicated MILP doc with:
  - Full pipeline Mermaid diagram
  - Complete 8-variable layout table (base + EV extension)
  - Full objective function with all terms
  - All constraints (equality + inequality) with math equations
  - Post-processing flow diagram
  - Solver configuration and fallback behavior
- Update `docs/candidate-generation.md` to point to new MILP doc instead of outdated 6-variable section

### Validation

- Ran `grep -RIn '┌\|│\|└\|─►\|▼' docs || true` — no ASCII/box-drawing diagrams remain.
- Ran `grep -RIn 'Depreciation per kWh =\|Purchase_Price ×\|cycle_cost_per_kwh = (purchase_price' docs .github/memories.md || true` — no old plain-text battery formulas remain.
- Ran `python3 .github/scripts/generate_wiki_sidebar.py docs/index.md`.
- Ran `git diff --check`.