### PR TITLE
fix(milp): cap EV charger power at nameplate rating

### DIFF
--- a/custom_components/hsem/planner/engine_core.py
+++ b/custom_components/hsem/planner/engine_core.py
@@ -349,8 +349,9 @@ def _compute_ev_charger_power(
         # Cap at the charger's rated AC power — the EV planner may allocate
         # a full slot's worth of energy to a slot with only a few minutes
         # remaining.  The charger physically cannot exceed its nameplate.
-        max_ac_power_w = round(ev_plan.charger_power_kw * 1000)
-        ac_power_w = min(ac_power_w, max_ac_power_w)
+        if ev_plan.charger_power_kw > 1e-9:
+            max_ac_power_w = round(ev_plan.charger_power_kw * 1000)
+            ac_power_w = min(ac_power_w, max_ac_power_w)
 
         attr = (
             "ev_second_charger_calculated_power"

--- a/custom_components/hsem/planner/engine_core.py
+++ b/custom_components/hsem/planner/engine_core.py
@@ -346,6 +346,12 @@ def _compute_ev_charger_power(
 
         ac_power_w = round((ev_slot.ac_load_kwh / slot_hours) * 1000)
 
+        # Cap at the charger's rated AC power — the EV planner may allocate
+        # a full slot's worth of energy to a slot with only a few minutes
+        # remaining.  The charger physically cannot exceed its nameplate.
+        max_ac_power_w = round(ev_plan.charger_power_kw * 1000)
+        ac_power_w = min(ac_power_w, max_ac_power_w)
+
         attr = (
             "ev_second_charger_calculated_power"
             if second

--- a/custom_components/hsem/planner/milp_optimizer.py
+++ b/custom_components/hsem/planner/milp_optimizer.py
@@ -744,6 +744,15 @@ def solve_milp(
                 # For the current (partially elapsed) slot, use remaining time
                 # instead of the full slot width so the charger ramps to meet
                 # the MILP's energy target within the available minutes.
+                #
+                # Cap at the charger's rated AC power — the MILP treats all
+                # slots as full-width, so it may allocate max_charge_per_slot
+                # to a slot with only a few minutes remaining.  The charger
+                # physically cannot exceed its nameplate rating.
+                max_ac_power_w = round(
+                    (ev.max_charge_per_slot / ev.charger_efficiency / full_slot_hours)
+                    * 1000
+                )
                 slot_start = out_slots[slot_i].start
                 slot_end = out_slots[slot_i].end
                 if slot_start <= now < slot_end:
@@ -758,6 +767,7 @@ def solve_milp(
                     ac_power_w = round(
                         (ev_dc_kwh / ev.charger_efficiency / full_slot_hours) * 1000
                     )
+                ac_power_w = min(ac_power_w, max_ac_power_w)
 
                 # Write to the correct charger power field (additive across
                 # multiple EVs — max value wins, reflecting the higher demand).

--- a/docs/milp-optimization.md
+++ b/docs/milp-optimization.md
@@ -98,7 +98,7 @@ $$
     && \text{discharge-side conversion loss cost} \\
     - & \gamma \cdot \bigl( ec[t] - ed[t] \bigr)
     && \text{terminal-SoC replacement credit} \\
-    + & p_{\mathrm{soc}} \cdot \bigl( s\_max\_pen[t] + s\_min\_pen[t] \bigr)
+    + & p_{\mathrm{soc}} \cdot \bigl( \mathrm{s\_max\_pen}[t] + \mathrm{s\_min\_pen}[t] \bigr)
     && \text{SoC soft-constraint penalties}
 \bigg] \\
 \end{aligned}
@@ -107,7 +107,7 @@ $$
 Plus EV deadline penalties (undiscounted — deadline is a hard commitment):
 
 $$
-\sum_{v=1}^{E} p_{\mathrm{ev\_pen}}^{(v)} \cdot ev\_pen_v
+\sum_{v=1}^{E} p_{\mathrm{ev\_pen}}^{(v)} \cdot \mathrm{ev\_pen}_v
 $$
 
 Where:
@@ -134,7 +134,7 @@ For each slot $t$:
 
 $$
 gi[t] + pv[t] + ed[t] \cdot \eta_{\mathrm{dis}} =
-\mathrm{base\_load}[t] + \frac{ec[t]}{\eta_{\mathrm{chg}}} + ge[t] + \sum_{v=1}^{E} \frac{ev\_c_v[t]}{\eta_{\mathrm{charger}}^{(v)}}
+\mathrm{base\_load}[t] + \frac{ec[t]}{\eta_{\mathrm{chg}}} + ge[t] + \sum_{v=1}^{E} \frac{\mathrm{ev\_c}_v[t]}{\eta_{\mathrm{charger}}^{(v)}}
 $$
 
 - `base_load[t]` = $\max(\mathrm{net\_load}[t], 0)$ — demand the grid/battery must satisfy (kWh)
@@ -174,13 +174,13 @@ $$
 **EV cumulative SoC upper bound (per EV v):**
 
 $$
-\sum_{k=0}^{t} ev\_c_v[k] \leq \mathrm{capacity}_v - \mathrm{initial\_soc}_v
+\sum_{k=0}^{t} \mathrm{ev\_c}_v[k] \leq \mathrm{capacity}_v - \mathrm{initial\_soc}_v
 $$
 
 **EV deadline target (soft, per EV v):**
 
 $$
-\mathrm{initial\_soc}_v + \sum_{k=0}^{D_v} ev\_c_v[k] + ev\_pen_v \geq \mathrm{target}_v
+\mathrm{initial\_soc}_v + \sum_{k=0}^{D_v} \mathrm{ev\_c}_v[k] + \mathrm{ev\_pen}_v \geq \mathrm{target}_v
 $$
 
 Where $D_v$ is the deadline slot index for EV v.

--- a/tests/planner/test_milp_ev.py
+++ b/tests/planner/test_milp_ev.py
@@ -472,6 +472,49 @@ def test_ev_charger_calculated_power_from_milp():
 
 
 @_pytestmark_scipy
+def test_ev_charger_power_capped_at_max_ac_power():
+    """Charger power never exceeds the charger's rated AC power.
+
+    The MILP treats all slots as full-width, so it may allocate
+    max_charge_per_slot to the current slot even when only a few
+    minutes remain.  The power formula must cap at the charger's
+    nameplate rating.
+
+    With max_charge_per_slot=3.0 kWh DC, charger_eff=0.90, 1 h slots:
+    max AC power = 3.0 / 0.90 / 1.0 * 1000 = 3333 W.
+    """
+    slots = _build_slots(6, start_hour=14, import_price=0.10, consumption_kwh=0.5)
+    ev = EVConfig(
+        enabled=True,
+        initial_soc_kwh=0.0,
+        target_kwh=6.0,
+        capacity_kwh=50.0,
+        max_charge_per_slot=3.0,
+        charger_efficiency=0.90,
+        deadline_slot=5,
+    )
+
+    result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=0.0,
+        usable_kwh=10.0,
+        max_charge_per_slot=5.0,
+        max_discharge_per_slot=None,
+        ev_configs=[ev],
+    )
+
+    assert result is not None
+    out_slots, _diag = result
+
+    max_ac_power = round((3.0 / 0.90 / 1.0) * 1000)
+    for s in out_slots:
+        assert s.ev_charger_calculated_power <= max_ac_power, (
+            f"Power {s.ev_charger_calculated_power} W exceeds max {max_ac_power} W"
+        )
+
+
+@_pytestmark_scipy
 def test_ev_charger_power_zero_when_no_charge():
     """ev_charger_calculated_power is 0 in slots where the MILP decided not to charge."""
     slots = _build_slots(6, start_hour=14, import_price=0.10, consumption_kwh=0.5)


### PR DESCRIPTION
## Summary

PR #557 added EV charger power computation to the MILP, but the power formula `(kWh / remaining_hours * 1000)` had no upper bound. When the MILP allocated `max_charge_per_slot` to the current slot with only a few minutes remaining, it produced physically impossible values (e.g. 40,000 W for a 7.2 kW charger).

### What changed

**`milp_optimizer.py`** — `solve_milp()` EV output section:
- Cap `ac_power_w` at `max_charge_per_slot / charger_eff / full_slot_hours * 1000` (equals charger rated power in W)
- Applies to both `ev_charger_calculated_power` and `ev_second_charger_calculated_power`

**`engine_core.py`** — `_compute_ev_charger_power()`:
- Cap `ac_power_w` at `ev_plan.charger_power_kw * 1000`
- Same cap for both primary and second EV paths

**`tests/planner/test_milp_ev.py`** — 1 new test:
- `test_ev_charger_power_capped_at_max_ac_power` — verifies power never exceeds charger nameplate rating

### Quality Gates

| Gate | Status |
|---|---|
| `py_compile` (all 3 files) | ✅ Passes |
| `tox -e lint` | ⚠️ Env needs rebuild |
| `tox -e py314` | ⚠️ Env needs rebuild |

Fixes #530 (post-merge follow-up to #557)