### PR TITLE
fix(entity): sync entity state when config flow updates options

### DIFF
--- a/custom_components/hsem/custom_numbers/battery_efficiency.py
+++ b/custom_components/hsem/custom_numbers/battery_efficiency.py
@@ -85,6 +85,27 @@ class HSEMBatteryEfficiencyNumber(HSEMEntity, NumberEntity):
         self._attr_native_value = stored if stored is not None else default
 
     @override
+    async def async_added_to_hass(self) -> None:
+        """Register a config-entry update listener.
+
+        When the user changes a setting via the config/options flow, the
+        entity re-reads its value from the config entry so the UI stays
+        in sync.
+        """
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self._config_entry.add_update_listener(self._async_handle_config_update)
+        )
+
+    async def _async_handle_config_update(
+        self, hass: HomeAssistant, entry: ConfigEntry
+    ) -> None:
+        """Re-read the current value from the updated config entry."""
+        stored = convert_to_float(get_config_value(entry, self._config_key))
+        self._attr_native_value = stored if stored is not None else self._default
+        self.async_write_ha_state()
+
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Handle the user setting a new value.
 

--- a/custom_components/hsem/custom_numbers/ev_target_soc.py
+++ b/custom_components/hsem/custom_numbers/ev_target_soc.py
@@ -85,6 +85,27 @@ class HSEMEVTargetSocNumber(HSEMEntity, NumberEntity):
         self._attr_native_value = stored if stored is not None else default
 
     @override
+    async def async_added_to_hass(self) -> None:
+        """Register a config-entry update listener.
+
+        When the user changes a setting via the config/options flow, the
+        entity re-reads its value from the config entry so the UI stays
+        in sync.
+        """
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self._config_entry.add_update_listener(self._async_handle_config_update)
+        )
+
+    async def _async_handle_config_update(
+        self, hass: HomeAssistant, entry: ConfigEntry
+    ) -> None:
+        """Re-read the current value from the updated config entry."""
+        stored = convert_to_float(get_config_value(entry, self._config_key))
+        self._attr_native_value = stored if stored is not None else self._default
+        self.async_write_ha_state()
+
+    @override
     async def async_set_native_value(self, value: float) -> None:
         """Handle the user setting a new value.
 

--- a/custom_components/hsem/custom_selectors/solcast_likelihood.py
+++ b/custom_components/hsem/custom_selectors/solcast_likelihood.py
@@ -76,6 +76,27 @@ class HSEMSolcastLikelihoodSelector(HSEMEntity, SelectEntity):
         self._attr_current_option = str(stored) if stored in _OPTIONS else _DEFAULT
 
     @override
+    async def async_added_to_hass(self) -> None:
+        """Register a config-entry update listener.
+
+        When the user changes a setting via the config/options flow, the
+        entity re-reads its value from the config entry so the UI stays
+        in sync.
+        """
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self._config_entry.add_update_listener(self._async_handle_config_update)
+        )
+
+    async def _async_handle_config_update(
+        self, hass: HomeAssistant, entry: ConfigEntry
+    ) -> None:
+        """Re-read the current option from the updated config entry."""
+        stored = get_config_value(entry, _CONFIG_KEY)
+        self._attr_current_option = str(stored) if stored in _OPTIONS else _DEFAULT
+        self.async_write_ha_state()
+
+    @override
     async def async_select_option(self, option: str) -> None:
         """Handle the user selecting a new option.
 

--- a/custom_components/hsem/custom_switches/switch.py
+++ b/custom_components/hsem/custom_switches/switch.py
@@ -68,6 +68,26 @@ class HSEMSwitch(HSEMEntity, SwitchEntity):
         self.entity_id = entity_id
         self._attr_is_on = bool(get_config_value(self._config_entry, description.key))
 
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Register a config-entry update listener.
+
+        When the user changes a setting via the config/options flow, the
+        entity re-reads its value from the config entry so the UI stays
+        in sync.
+        """
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self._config_entry.add_update_listener(self._async_handle_config_update)
+        )
+
+    async def _async_handle_config_update(
+        self, hass: HomeAssistant, entry: ConfigEntry
+    ) -> None:
+        """Re-read the current on/off state from the updated config entry."""
+        self._attr_is_on = bool(get_config_value(entry, self.entity_description.key))
+        self.async_write_ha_state()
+
     @property
     @override
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/custom_components/hsem/custom_times/time.py
+++ b/custom_components/hsem/custom_times/time.py
@@ -19,6 +19,7 @@ from custom_components.hsem.custom_times.description import (
     build_time_id_map,
 )
 from custom_components.hsem.entity import HSEMEntity
+from custom_components.hsem.utils.misc import get_config_value
 
 
 class HSEMTimeEntity(HSEMEntity, TimeEntity):
@@ -70,6 +71,27 @@ class HSEMTimeEntity(HSEMEntity, TimeEntity):
         self._attr_native_value: time | None = self._parse_time(
             description.default_value
         )
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Register a config-entry update listener.
+
+        When the user changes a setting via the config/options flow, the
+        entity re-reads its value from the config entry so the UI stays
+        in sync.
+        """
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self._config_entry.add_update_listener(self._async_handle_config_update)
+        )
+
+    async def _async_handle_config_update(
+        self, hass: HomeAssistant, entry: ConfigEntry
+    ) -> None:
+        """Re-read the current time value from the updated config entry."""
+        stored = str(get_config_value(entry, self.entity_description.key))
+        self._attr_native_value = self._parse_time(stored)
+        self.async_write_ha_state()
 
     # ------------------------------------------------------------------
     # Helpers


### PR DESCRIPTION
## Problem

When a user changes a setting via the config/options flow (e.g., `hsem_solcast_pv_forecast_forecast_likelihood`, battery efficiency, EV target SoC, schedule times, or any switch toggle), the corresponding entity state in the UI does **not** update. The entity only reads its value from `config_entry.options` once during `__init__` and never refreshes it.

## Root Cause

None of the config-backed entity classes registered a `config_entry.add_update_listener` in `async_added_to_hass`. The coordinator's `async_options_updated` callback re-runs the pipeline, but the entity classes themselves never re-read their state from the updated config entry.

## Fix

Added `async_added_to_hass` with a `config_entry.add_update_listener` to all five affected entity classes:

| File | Class | Platform |
|------|-------|----------|
| `custom_selectors/solcast_likelihood.py` | `HSEMSolcastLikelihoodSelector` | select |
| `custom_switches/switch.py` | `HSEMSwitch` | switch |
| `custom_numbers/battery_efficiency.py` | `HSEMBatteryEfficiencyNumber` | number |
| `custom_numbers/ev_target_soc.py` | `HSEMEVTargetSocNumber` | number |
| `custom_times/time.py` | `HSEMTimeEntity` | time |

Each listener re-reads the value from the updated config entry and calls `async_write_ha_state()` so the UI reflects the change immediately.

The `HSEMWorkingModeSelector` is intentionally excluded — it always starts at `"auto"` and gets reset by the coordinator, so it doesn't need to track config entry changes.

## Testing

- All five files compile without syntax errors.
- The test suite cannot run locally due to a `bcrypt` / Python 3.14 incompatibility in the HA dev environment (unrelated to this change).