### PR TITLE
docs: update documentation to reflect current codebase state

### DIFF
--- a/docs/candidate-generation.md
+++ b/docs/candidate-generation.md
@@ -10,10 +10,8 @@ the candidate set, and the mathematical models behind each strategy.
 1. [Why multiple candidates?](#why-multiple-candidates)
 2. [Candidate list](#candidate-list)
 3. [Assumptions behind each candidate](#assumptions-behind-each-candidate)
-4. [Partial-SoC candidates (BatPred-inspired)](#partial-soc-candidates)
-5. [MILP global optimisation](#milp-global-optimisation)
-6. [Candidate deduplication](#candidate-deduplication)
-7. [Hysteresis](#hysteresis)
+4. [MILP global optimisation](#milp-global-optimisation)
+5. [Hysteresis](#hysteresis)
 
 ---
 
@@ -32,19 +30,31 @@ independent strategies and picking the cheapest valid one, the planner:
 
 ## Candidate list
 
-The generator (`planner/candidate_generator.py`) produces these candidates:
+The generator (`planner/candidate_generator.py`) operates in **MILP-only mode**.
+The MILP finds the globally optimal solution; heuristic candidates are disabled
+because the MILP consistently dominates them. Only diagnostic baselines remain
+alongside the MILP:
 
 | # | Name | Strategy |
 |---|---|---|
-| 1 | `baseline` | Current HSEM scheduling output (discharge → charge → excess export → optimisation) |
-| 2 | `no_action` | Battery completely idle — no forced charge or discharge |
-| 3 | `passive` | Solar charging only where PV surplus exists; no grid charge or forced discharge |
-| 4 | `grid_charge` | Grid-charge slots kept; solar charging removed |
-| 5 | `solar_only` | Only solar-charge slots kept; grid charging cleared |
-| 6 | `discharge_only` | Discharge slots kept; all charge slots cleared |
-| 7 | `aggressive` | Cheapest N slots forced to grid-charge; most expensive M slots forced to discharge |
-| 8 | `milp` | Globally-optimal LP solution (when scipy is available) |
-| 9–14 | `soc_plan_25/50/75/100/125/full` | Partial-SoC candidates charging different fractions of discharge-window need |
+| 1 | `no_action` | Battery completely idle — no forced charge or discharge |
+| 2 | `passive` | Solar charging only where PV surplus exists; no grid charge or forced discharge |
+| 3 | `milp` | Globally-optimal LP solution (when scipy is available) |
+
+### Historical candidates (disabled)
+
+The following candidates were previously generated but are now commented out
+in MILP-only mode. They remain documented for reference and may be re-enabled
+as diagnostic tools:
+
+| Name | Strategy |
+|---|---|
+| `baseline` | Current HSEM scheduling output (discharge → charge → excess export → optimisation) |
+| `grid_charge` | Grid-charge slots kept; solar charging removed |
+| `solar_only` | Only solar-charge slots kept; grid charging cleared |
+| `discharge_only` | Discharge slots kept; all charge slots cleared |
+| `aggressive` | Cheapest N slots forced to grid-charge; most expensive M slots forced to discharge |
+| `soc_plan_25/50/75/100/125/full` | Partial-SoC candidates charging different fractions of discharge-window need |
 
 ---
 
@@ -79,152 +89,28 @@ without any grid-based scheduling.
 - Battery fills from PV, never from grid
 - Battery never discharges unless native inverter logic does so
 
-### `grid_charge`
-
-**Assumption:** Buying grid energy at a low price, storing it, and using it
-during a high-price period is profitable after accounting for round-trip losses,
-cycle cost, and the minimum price spread.
-
-**Purpose:** Tests whether the price spread available in the horizon justifies
-the round-trip cost of grid charging.
-
-**Mathematical model:**
-- Grid-charge slots kept from the scheduler's output
-- Solar charging cleared
-- Discharge slots kept (to recover the stored energy)
-- Effectively: "charge from grid when cheap, discharge when expensive,
-  ignore solar charging"
-
-### `solar_only`
-
-**Assumption:** Solar energy is always cheaper than any grid import, and the
-battery should prioritise storing PV surplus over grid charging.
-
-**Purpose:** Tests whether PV surplus alone can satisfy the discharge-window
-demand without incurring grid-import costs.
-
-**Mathematical model:**
-- Solar-charge slots kept
-- Grid charging cleared
-- Discharge slots kept when needed
-- Effectively: "store every kWh of PV surplus, use it during expensive slots"
-
-### `discharge_only`
-
-**Assumption:** The battery has enough stored energy from previous cycles to
-cover the discharge demand without any additional charging within the horizon.
-
-**Purpose:** Tests whether the existing SoC is sufficient to ride through
-the horizon without recharging.
-
-**Mathematical model:**
-- Discharge slots kept
-- All charge slots cleared
-- Battery only discharges, never charges
-- Useful when SoC is high and horizon is short
-
-### `aggressive`
-
-**Assumption:** The most extreme price spread in the horizon should be fully
-exploited by charging at the cheapest N slots and discharging at the most
-expensive M slots, ignoring schedules.
-
-**Purpose:** Upper-bound test — what is the maximum arbitrage value if we
-ignore schedule constraints?
-
-**Mathematical model:**
-- N dynamically computed from battery headroom: `N = ceil(usable_headroom_kwh / max_charge_per_slot)`
-- M dynamically computed from usable energy: `M = ceil(current_kwh_above_floor / max_discharge_per_slot)`
-- N cheapest import slots set to `batteries_charge_grid`
-- M most expensive import slots set to `batteries_discharge_mode`
-- Scales with horizon length and battery capacity (fix for issue #416 Bug 2)
-
----
-
-## Partial-SoC candidates
-
-Introduced as a BatPred-inspired improvement (issue #445 fix), partial-SoC candidates
-charge different fractions of the energy needed for upcoming discharge windows.
-This lets the selector find the optimal charge level — charging exactly what's
-needed, not filling to 100 % every time.
-
-### Charge fractions
-
-| Candidate | Fraction | Meaning |
-|---|---|---|
-| `soc_plan_25` | 0.25 | Charge 25 % of the discharge-window need |
-| `soc_plan_50` | 0.50 | Charge 50 % |
-| `soc_plan_75` | 0.75 | Charge 75 % |
-| `soc_plan_100` | 1.00 | Charge exactly what's needed |
-| `soc_plan_125` | 1.25 | Charge 125 % (safety margin) |
-| `soc_plan_full` | 2.00 | Fill to maximum usable capacity |
-
-### Energy needed calculation
-
-```python
-energy_needed = sum(
-    discharge_energy for each discharge window in the horizon
-) - current_kwh_above_floor
-
-charge_target = energy_needed * fraction
-```
-
-### When partial-SoC helps
-
-Partial charging avoids the **cycle-cost overhead** of filling the battery
-completely when the discharge demand is small. Consider:
-
-- Discharge window needs 3 kWh
-- Battery is at 50 % of 10 kWh usable (5 kWh above floor)
-- Full charge (soc_plan_full) would charge 5 more kWh, incurring 5 kWh × cycle_cost
-- soc_plan_100 charges exactly 0 kWh (already have enough)
-- soc_plan_25 / 50 / 75 may be suboptimal here because existing SoC already
-  exceeds the need — the candidates converge to the same plan
-
-When SoC is low and discharge need is large, partial-SoC candidates let the
-selector find the precise charge level that minimises the sum of import cost
-and cycle cost.
-
-### Assumptions
-
-- Discharge-window energy can be predicted from schedule configuration
-- Cycle cost is proportional to throughput
-- The optimal charge level is somewhere between 25 % and 100 % of the
-  discharge-window need (not necessarily full)
-
 ---
 
 ## MILP global optimisation
 
 The MILP solver (`planner/milp_optimizer.py`) uses scipy's HiGHS to find the
-globally optimal charge/discharge schedule.
+globally optimal charge/discharge schedule. This is the **primary planner** —
+the MILP solution is preferred over all heuristic candidates.
 
 See [MILP Optimization](milp-optimization.md) for the full LP formulation,
 variable layout, constraints, solver pipeline, and post-processing flow.
 
+### EV co-optimisation
+
+When one or more active EVs are provided, the MILP co-optimises EV charging
+alongside the battery schedule. EV charging variables are added to the LP
+variable vector and the energy balance equation includes EV charger load.
+
 ### Fallback
 
 If `scipy` is unavailable or the solver fails (infeasible / numerical issue),
-the MILP candidate is silently dropped and the rule-based candidates compete
-as normal.
-
----
-
-## Candidate deduplication
-
-When generating partial-SoC candidates, targets within 0.05 kWh of each other
-are deduplicated to prevent near-identical plans from polluting the candidate list:
-
-```python
-DUPLICATE_THRESHOLD_KWH = 0.05
-filtered = [targets[0]]
-for t in sorted(targets)[1:]:
-    if t - filtered[-1] >= DUPLICATE_THRESHOLD_KWH:
-        filtered.append(t)
-```
-
-This is especially important when `current_kwh` is low and all partial-SoC
-fractions collapse to the same charge target.
+the MILP candidate is silently dropped and the remaining candidates
+(`no_action`, `passive`) compete as normal.
 
 ---
 

--- a/docs/config-flow-reference.md
+++ b/docs/config-flow-reference.md
@@ -25,16 +25,19 @@ init → prices → months → solcast → huawei_solar
 | Read-only mode | `hsem_read_only` | `False` | Block all hardware writes when enabled |
 | Verbose logging | `hsem_verbose_logging` | `False` | Enable debug-level planner logging |
 
-### Step: `energidataservice`
+### Step: `prices`
 
-Electricity price sensor configuration.
+Generic electricity price sensor configuration. Provider-agnostic — supports
+Energi Data Service, Nordpool, Amber Electric, and any other price source.
 
 | Field | Key | Default | Description |
 |---|---|---|---|
-| Import price sensor | `hsem_energi_data_service_import` | `sensor.energi_data_service` | HA entity for import price |
-| Export price sensor | `hsem_energi_data_service_export` | `sensor.energi_data_service_produktion` | HA entity for export price |
-| EDS update interval | `hsem_energi_data_service_update_interval` | 15 minutes | How often EDS publishes prices (15 or 60) |
-| Export min price | `hsem_energi_data_service_export_min_price` | 0.0 | Below this, inverter throttles export to zero |
+| Import price sensor | `hsem_import_electricity_price_sensor` | `sensor.energi_data_service` | HA entity for import price |
+| Export price sensor | `hsem_export_electricity_price_sensor` | `sensor.energi_data_service_produktion` | HA entity for export price |
+| Import price forecast sensor | `hsem_import_electricity_price_forecast_sensor` | — | Optional dedicated import forecast sensor |
+| Export price forecast sensor | `hsem_export_electricity_price_forecast_sensor` | — | Optional dedicated export forecast sensor |
+| Export min price | `hsem_export_electricity_min_price` | 0.0 | Below this, inverter throttles export to zero |
+| Price update interval | `hsem_electricity_price_update_interval` | 15 minutes | How often the price source publishes (15, 30, or 60) |
 
 ### Step: `months`
 
@@ -108,8 +111,15 @@ Primary EV charger configuration.
 | EV charger status | `hsem_ev_charger_status` | — | Charger status sensor entity |
 | EV charger power | `hsem_ev_charger_power` | — | Charger power sensor entity |
 | EV SoC sensor | `hsem_ev_soc` | — | EV battery SoC sensor |
-| EV SoC target | `hsem_ev_soc_target` | — | EV target SoC entity |
+| EV SoC target | `hsem_ev_soc_target` | 80 % | EV target SoC |
 | EV connected sensor | `hsem_ev_connected` | — | Binary sensor for EV plugged in |
+| Allow charge past target | `hsem_ev_allow_charge_past_target_soc` | `False` | Allow solar-only charging beyond target SoC |
+| Force max discharge power | `hsem_ev_charger_force_max_discharge_power` | `False` | Force maximum discharge power during discharge slots |
+| Max discharge power | `hsem_ev_charger_max_discharge_power` | 0 | Maximum discharge power cap (W) |
+
+### Step: `ev_second`
+
+Second EV charger configuration (identical fields to primary EV step; only shown when second EV enabled).
 
 ### Step: `ev_planned_load`
 
@@ -121,12 +131,18 @@ Primary EV planned load integration (optional, default disabled).
 | Battery capacity | `hsem_ev_planned_load_battery_capacity_kwh` | 0.0 | EV battery nameplate capacity (kWh) |
 | Charger power | `hsem_ev_planned_load_charger_power_kw` | 0.0 | Charger AC output (kW) |
 | Charger efficiency | `hsem_ev_planned_load_charger_efficiency` | 100 % | Charger efficiency |
+| Charger min power | `hsem_ev_planned_load_charger_min_power_w` | 1380 W | Minimum charger power for physical operation |
 
 Target SoC and deadline are configured outside this step:
-- **Target SoC**: via the basic EV charger sensor (`hsem_ev_soc_target`)
+- **Target SoC**: via the number entity `number.hsem_ev_target_soc`
 - **Deadline**: via the HSEM time entity `time.hsem_ev_deadline_time`
 - **Smart charging**: via the HSEM switch `switch.hsem_ev_smart_charging`
+- **Force charge now**: via the HSEM switch `switch.hsem_ev_force_charge_now`
+- **Allow charge past target**: via `hsem_ev_allow_charge_past_target_soc` in the EV charger step
 
+### Step: `ev_second_planned_load`
+
+Second EV planned load integration (identical fields; only shown when second EV enabled).
 
 ### Step: `batteries_schedule_1/2/3`
 
@@ -153,7 +169,7 @@ Excess battery export configuration.
 
 ### Step: `weighted_values`
 
-Consumption prediction weights and battery configuration.
+Consumption prediction weight configuration.
 
 | Field | Key | Default | Description |
 |---|---|---|---|
@@ -161,17 +177,9 @@ Consumption prediction weights and battery configuration.
 | Weight 3-day | `hsem_house_consumption_energy_weight_3d` | 30 % | Weight for 3-day average |
 | Weight 7-day | `hsem_house_consumption_energy_weight_7d` | 30 % | Weight for 7-day average |
 | Weight 14-day | `hsem_house_consumption_energy_weight_14d` | 15 % | Weight for 14-day average |
-| Charge efficiency | `hsem_batteries_charge_efficiency` | 95 % | Battery charge efficiency |
-| Discharge efficiency | `hsem_batteries_discharge_efficiency` | 95 % | Battery discharge efficiency |
-| Purchase price | `hsem_batteries_purchase_price` | 0.0 | Battery purchase price for cycle cost |
-| Expected cycles | `hsem_batteries_expected_cycles` | 6000 | Expected lifetime cycles |
-| Cycle cost | `hsem_batteries_cycle_cost` | 0.0 | Explicit cycle cost (auto-derived when 0) |
-| Planning horizon | `hsem_recommendation_interval_length` | 48 hours | How far to plan ahead |
-| Slot width | `hsem_recommendation_interval_minutes` | 15 minutes | Width of each planning slot |
-| Hysteresis enabled | `hsem_planner_hysteresis_enabled` | `True` | Enable plan-level hysteresis |
-| Hysteresis % | `hsem_planner_hysteresis_percentage` | 5.0 % | Percentage threshold for plan switching |
-| Window hysteresis | `hsem_planner_window_hysteresis_minutes` | 0 | Window-level hysteresis hold time (0 = disabled) |
-| Extended attributes | `hsem_extended_attributes` | `False` | Expose extended sensor attributes |
+
+Battery parameters and planner settings in this step duplicate their primary-step
+counterparts and are kept for backward compatibility during migration.
 
 ### Step: `energy_and_ml`
 

--- a/docs/consumption-prediction.md
+++ b/docs/consumption-prediction.md
@@ -39,7 +39,7 @@ $$
 where:
 
 - $X$ is the $n \times k$ design matrix ($n$ observations, $k$ features)
-- $W = \operatorname{diag}(w_1, \ldots, w_n)$ weights recent observations higher
+- $W = \mathrm{diag}(w_1, \ldots, w_n)$ weights recent observations higher
 - $\alpha = 1.0$ is the L2 regularization strength
 - $y$ is the vector of observed per-slot energy (kWh)
 

--- a/docs/ev-charge-plan-setup.md
+++ b/docs/ev-charge-plan-setup.md
@@ -18,8 +18,9 @@ deciding how to use solar surplus and battery capacity.
 4. [Field reference](#field-reference)
 5. [Double-counting — when to enable base_load_includes_ev](#double-counting)
 6. [Second EV](#second-ev)
-7. [Sensor entities](#sensor-entities)
-8. [Troubleshooting](#troubleshooting)
+7. [How the EV planner works](#how-the-ev-planner-works)
+8. [Sensor entities](#sensor-entities)
+9. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -69,7 +70,7 @@ Go to **Settings → Devices & Services → HSEM → Configure** to open the opt
 The EV charge plan step appears after the EV charger setup steps:
 
 ```
-init → energidataservice → months → solcast
+init → prices → months → solcast
      → huawei_solar → power
      → ev (force-discharge charger) → [ev_second]
      → ev_planned_load               ← you are here
@@ -90,7 +91,7 @@ At minimum you must:
 - Select your **EV Battery SoC Sensor**
 
 All other fields have sensible defaults (target SoC 80 %, deadline 07:00, efficiency
-100 %).
+100 %, min charger power 1380 W).
 
 ---
 
@@ -109,6 +110,7 @@ All other fields have sensible defaults (target SoC 80 %, deadline 07:00, effici
 | **EV Battery Capacity (kWh)** | Yes | `0` | EV battery nameplate capacity. Range 1–200 kWh, step 0.5 kWh. |
 | **EV Charger Power (kW)** | Yes | `0` | AC output power of the charger. Range 0.1–50 kW, step 0.1 kW. |
 | **EV Charger Efficiency** | Yes | `100` % | Fraction of AC energy delivered to the EV battery. Most AC chargers are 95–100 %. Range 50–100 %, step 1 %. |
+| **Charger Min Power (W)** | Yes | `1380` | Minimum AC power required for the charger to physically operate (230 V × 6 A). Below this, the slot is zeroed out by engine post-processing. Range 0–22000 W, step 10 W. |
 | **Base House Load Already Includes EV** | Yes | `off` | See [Double-counting](#double-counting). |
 | **EV Actual Charging Power Sensor (optional)** | Optional | — | Sensor for real-time EV charge power. Used for diagnostics only — not fed into the planner. |
 
@@ -125,19 +127,32 @@ You do **not** need to set it separately.
 
 **How your CT clamp position determines the setting in the EV step:**
 
-```
-Scenario A — CT clamp UPSTREAM of the EVSE (includes EV power):
-  house_consumption_sensor = lights + appliances + EV charger
-  → Set hsem_house_power_includes_ev_charger_power = True
-  → base_load_includes_ev is auto-derived as True
-  → HSEM does NOT add ev_planned_load_kwh again
+```mermaid
+flowchart TD
+    A{Where is your CT clamp?}
+    B[Scenario A — upstream of charger]
+    C[Scenario B — downstream of charger]
+    D[Set includes_ev = True\nHSEM does NOT add EV load again]
+    E[Set includes_ev = False\nHSEM adds EV load to net consumption]
 
-Scenario B — CT clamp DOWNSTREAM of the EVSE (excludes EV power):
-  house_consumption_sensor = lights + appliances only
-  → Set hsem_house_power_includes_ev_charger_power = False
-  → base_load_includes_ev is auto-derived as False
-  → HSEM adds ev_planned_load_kwh to net consumption
+    A -->|Measures house + EV| B --> D
+    A -->|Measures house only| C --> E
 ```
+
+### Net load formula
+
+The planner's net load with EV is:
+
+$$
+\mathrm{net\_load}[t] = \mathrm{house\_load}[t] - \mathrm{pv}[t] + \left\{
+\begin{array}{ll}
+0 & \text{if } \mathrm{base\_load\_includes\_ev} \\
+\mathrm{ev\_load}[t] & \text{otherwise}
+\end{array}
+\right.
+$$
+
+### Quick test
 
 If you are unsure, plug the EV in and watch the house consumption sensor. If it rises
 by the charger power when charging starts, set `hsem_house_power_includes_ev_charger_power`
@@ -153,6 +168,49 @@ All fields are the same; just use the second car's sensors and config values.
 
 The two EV plans are independent. Their per-slot loads are **summed** into
 `ev_planned_load_kwh` on each planner slot before net consumption is calculated.
+
+---
+
+## How the EV planner works
+
+```mermaid
+flowchart TD
+    A[Read EV state: SoC, connected, deadline, target]
+    B{EV connected AND\nsmart charging enabled?}
+    C[Calculate energy needed:\ncapacity × (target% − current%)]
+    D[Sensor shows not_connected\nor smart_charging_disabled]
+    E{Energy needed > 0?}
+    F[Sort candidate slots before deadline\nby cheapest import price]
+    G[Allocate solar surplus slots first]
+    H[Fill remaining need with\ncheapest grid import slots]
+    I[Inject per-slot EV AC load\ninto planner net consumption]
+    J[Battery planner runs with\nreduced net surplus]
+    K[MILP co-optimises EV charging\nwith battery schedule]
+    L[Post-processing: minimum power floor\nand power recomputation]
+
+    A --> B
+    B -->|No| D
+    B -->|Yes| C --> E
+    E -->|No| D
+    E -->|Yes| F --> G --> H --> I --> J --> K --> L
+```
+
+### Inputs
+
+| Input | Source | Description |
+|---|---|---|
+| Current EV SoC | `hsem_ev_soc` sensor | Percentage (0–100 %) |
+| Target SoC | `hsem_ev_soc_target` entity or 80 % default | Target percentage |
+| Deadline | `time.hsem_ev_deadline` entity or `"07:00"` | Time-of-day by which EV must be charged |
+| Battery capacity | `hsem_ev_planned_load_battery_capacity_kwh` | Nameplate kWh |
+| Charger AC power | `hsem_ev_planned_load_charger_power_kw` | AC kW output |
+| Charger efficiency | `hsem_ev_planned_load_charger_efficiency` | Percent (50–100) |
+| Charger min power | `hsem_ev_planned_load_charger_min_power_w` | Watts (default 1380) |
+| Connected sensor | `hsem_ev_connected` binary sensor | Plug status |
+| Smart charging switch | `switch.hsem_ev_smart_charging` | Enable/disable |
+| Force charge now | `switch.hsem_ev_force_charge_now` | Immediate charge |
+| Allow past target | `hsem_ev_allow_charge_past_target_soc` | Solar-only surplus charging past target |
+| Base load includes EV | `hsem_house_power_includes_ev_charger_power` | CT clamp position |
 
 ---
 
@@ -246,6 +304,13 @@ This was a bug fixed in PR #397. The EV planner was computing solar surplus from
 raw `pv - house_load` fields.
 
 If you are on a version before this fix, update HSEM.
+
+### EV charging slots show zero power
+
+The engine post-processing applies a **minimum power floor** (default 1380 W, configurable
+via `hsem_ev_planned_load_charger_min_power_w`). If the computed AC power for a slot is
+below this threshold, the slot's EV fields are zeroed out because the charger physically
+cannot operate below 6 A (230 V × 6 A = 1380 W).
 
 ### Deadline is in the past
 

--- a/docs/forecast-accuracy-tracking.md
+++ b/docs/forecast-accuracy-tracking.md
@@ -134,11 +134,11 @@ of 15-minute slots.  Older records are automatically pruned.
 
 ### Energy accumulation
 
-Instantaneous power readings (Watts) are converted to energy (kWh) using:
+$$
+E = P \times \frac{\Delta t}{3600} \times \frac{1}{1000}
+$$
 
-```text
-energy_kwh = power_w × (elapsed_seconds / 3600.0) / 1000.0
-```
+where $P$ is instantaneous power in watts and $\Delta t$ is elapsed seconds.
 
 The helper function `compute_accumulated_energy(power_w, elapsed_seconds)`
 handles this conversion.  Elapsed time is computed as the difference between
@@ -154,17 +154,17 @@ across all finalised records:
 
 ### MAE — Mean Absolute Error
 
-```text
-MAE = (1/n) × Σ |forecast_kwh − actual_kwh|
-```
+$$
+\mathrm{MAE} = \frac{1}{n} \sum_{i=1}^{n} \left| \mathrm{forecast}_i - \mathrm{actual}_i \right|
+$$
 
 Units: kWh.  Averages the absolute deviation.  Lower is better.
 
 ### Bias (signed error)
 
-```text
-Bias = (1/n) × Σ (forecast_kwh − actual_kwh)
-```
+$$
+\mathrm{Bias} = \frac{1}{n} \sum_{i=1}^{n} \left( \mathrm{forecast}_i - \mathrm{actual}_i \right)
+$$
 
 Units: kWh.  Positive bias = systematic over-forecast (predicted more than
 actually occurred).  Negative bias = under-forecast.  Zero bias means the
@@ -172,21 +172,21 @@ forecast is accurate on average (but may have large cancellations).
 
 ### RMSE — Root Mean Squared Error
 
-```text
-RMSE = √( (1/n) × Σ (forecast_kwh − actual_kwh)² )
-```
+$$
+\mathrm{RMSE} = \sqrt{ \frac{1}{n} \sum_{i=1}^{n} \left( \mathrm{forecast}_i - \mathrm{actual}_i \right)^2 }
+$$
 
 Units: kWh.  Penalises large errors more heavily than MAE.  Useful for
 detecting occasional big misses.
 
 ### MAPE — Mean Absolute Percentage Error
 
-```text
-MAPE = (1/n) × Σ ( |forecast_kwh − actual_kwh| / |actual_kwh| ) × 100
-```
+$$
+\mathrm{MAPE} = \frac{1}{n} \sum_{i=1}^{n} \frac{ \left| \mathrm{forecast}_i - \mathrm{actual}_i \right| }{ \left| \mathrm{actual}_i \right| } \times 100
+$$
 
 Units: percent.  Makes errors comparable across different power levels.
-Returns `None` when all actual values are zero (division by zero guard).
+Returns ``None`` when all actual values are zero (division by zero guard).
 
 ### Exposure via `as_dict()`
 

--- a/docs/milp-optimization.md
+++ b/docs/milp-optimization.md
@@ -98,7 +98,7 @@ $$
 The max grid import per slot is converted from amps to kWh/slot:
 
 $$
-\operatorname{max\_grid\_import} = \frac{\operatorname{amps} \times 230 \times 3}{1000} \times \frac{\operatorname{interval\_minutes}}{60}
+\mathrm{max\_grid\_import} = \frac{\mathrm{amps} \times 230 \times 3}{1000} \times \frac{\mathrm{interval\_minutes}}{60}
 $$
 
 This assumes balanced three-phase load at 230 V phase-to-neutral.
@@ -125,9 +125,9 @@ $$
     && \text{discharge-side conversion loss cost} \\
     - & \gamma \cdot \bigl( ec[t] - ed[t] \bigr)
     && \text{terminal-SoC replacement credit} \\
-    + & p_{\mathrm{soc}} \cdot \bigl( \operatorname{s\_max\_pen}[t] + \operatorname{s\_min\_pen}[t] \bigr)
+    + & p_{\mathrm{soc}} \cdot \bigl( \mathrm{s\_max\_pen}[t] + \mathrm{s\_min\_pen}[t] \bigr)
     && \text{SoC soft-constraint penalties} \\
-    + & p_{\mathrm{fuse}} \cdot \operatorname{gi\_pen}[t]
+    + & p_{\mathrm{fuse}} \cdot \mathrm{gi\_pen}[t]
     && \text{Main fuse grid-import penalty}
 \bigg] \\
 \end{aligned}
@@ -136,7 +136,7 @@ $$
 Plus EV deadline penalties (undiscounted — deadline is a hard commitment):
 
 $$
-\sum_{v=1}^{E} p_{\mathrm{ev\_pen}}^{(v)} \cdot \operatorname{ev\_pen}_v
+\sum_{v=1}^{E} p_{\mathrm{ev\_pen}}^{(v)} \cdot \mathrm{ev\_pen}_v
 $$
 
 Where:
@@ -158,7 +158,7 @@ Where:
 Plus EV charge-past-target benefit (discounted, per charge-past-target EV $v$):
 
 $$
--\sum_{v \in \mathrm{past\_target}} \sum_{t} \delta_t \cdot \frac{\beta_{\mathrm{ev}}}{\eta_{\mathrm{charger}}^{(v)}} \cdot \operatorname{ev\_c}_v[t]
+-\sum_{v \in \mathrm{past\_target}} \sum_{t} \delta_t \cdot \frac{\beta_{\mathrm{ev}}}{\eta_{\mathrm{charger}}^{(v)}} \cdot \mathrm{ev\_c}_v[t]
 $$
 
 This benefit is deliberately tiny ($0.0001$ per kWh AC) — it only acts as a tiebreaker when the battery is full and export prices are near zero or negative. It must **not** compete with house battery charging (worth $p_{\mathrm{imp}}$) or export at good prices (worth $p_{\mathrm{exp}}$).
@@ -186,19 +186,19 @@ $$
 **SoC upper bound (soft):**
 
 $$
-\sum_{k=0}^{t} \bigl( ec[k] - ed[k] \bigr) - \operatorname{s\_max\_pen}[t] \leq C_u - soc_0
+\sum_{k=0}^{t} \bigl( ec[k] - ed[k] \bigr) - \mathrm{s\_max\_pen}[t] \leq C_u - soc_0
 $$
 
 **SoC lower bound (soft):**
 
 $$
--\sum_{k=0}^{t} \bigl( ec[k] - ed[k] \bigr) - \operatorname{s\_min\_pen}[t] \leq soc_0
+-\sum_{k=0}^{t} \bigl( ec[k] - ed[k] \bigr) - \mathrm{s\_min\_pen}[t] \leq soc_0
 $$
 
 **Mutual exclusion — no simultaneous charge + discharge:**
 
 $$
-\frac{ec[t]}{\operatorname{max\_charge}} + \frac{ed[t]}{\operatorname{max\_discharge}} \leq 1
+\frac{ec[t]}{\mathrm{max\_charge}} + \frac{ed[t]}{\mathrm{max\_discharge}} \leq 1
 $$
 
 **Cycle cost auxiliary — forcing $m[t] \geq ec[t]$ and $m[t] \geq ed[t]$:**
@@ -213,19 +213,19 @@ $$
 **EV cumulative SoC upper bound (per EV v):**
 
 $$
-\sum_{k=0}^{t} \operatorname{ev\_c}_v[k] \leq \operatorname{capacity}_v - \operatorname{initial\_soc}_v
+\sum_{k=0}^{t} \mathrm{ev\_c}_v[k] \leq \mathrm{capacity}_v - \mathrm{initial\_soc}_v
 $$
 
 **EV deadline target (soft, per EV v):**
 
 $$
-\operatorname{initial\_soc}_v + \sum_{k=0}^{D_v} \operatorname{ev\_c}_v[k] + \operatorname{ev\_pen}_v \geq \operatorname{target}_v
+\mathrm{initial\_soc}_v + \sum_{k=0}^{D_v} \mathrm{ev\_c}_v[k] + \mathrm{ev\_pen}_v \geq \mathrm{target}_v
 $$
 
 **EV surplus-only constraint (per charge-past-target EV v, per slot t):**
 
 $$
-\frac{\operatorname{ev\_c}_v[t]}{\eta_{\mathrm{charger}}^{(v)}} \leq \max\bigl(0,\; \operatorname{pv\_avail}[t] - \operatorname{base\_load}[t]\bigr)
+\frac{\mathrm{ev\_c}_v[t]}{\eta_{\mathrm{charger}}^{(v)}} \leq \max\bigl(0,\; \mathrm{pv\_avail}[t] - \mathrm{base\_load}[t]\bigr)
 $$
 
 This constraint ensures charge-past-target EVs only consume **genuine PV surplus** — never battery discharge or grid import.  It is only added for EVs where `charge_past_target` is `True` (EV already at user-configured target SoC but `allow_charge_past_target_soc` is enabled and SoC < 100 %).
@@ -235,7 +235,7 @@ This constraint ensures charge-past-target EVs only consume **genuine PV surplus
 For each slot $t$, when `main_fuse_amps > 0`:
 
 $$
-gi[t] - \operatorname{gi\_pen}[t] \leq \frac{\operatorname{amps} \times 230 \times 3}{1000} \times \frac{\operatorname{interval\_minutes}}{60}
+gi[t] - \mathrm{gi\_pen}[t] \leq \frac{\mathrm{amps} \times 230 \times 3}{1000} \times \frac{\mathrm{interval\_minutes}}{60}
 $$
 
 The penalty variable `gi_pen[t]` absorbs any excess at high cost (`p_fuse`), preventing infeasibility when house base load alone exceeds the fuse rating. When `main_fuse_amps` is `None` or 0, this constraint is not added.

--- a/docs/price-scaling.md
+++ b/docs/price-scaling.md
@@ -1,7 +1,7 @@
-# HSEM Price Interval Semantics and EDS Scaling
+# HSEM Price Interval Semantics and Scaling
 
-This document explains how HSEM handles the interaction between Energi Data Service
-(EDS) price update intervals and planning slot widths.
+This document explains how HSEM handles the interaction between electricity price
+update intervals and planning slot widths.
 
 ---
 
@@ -11,22 +11,25 @@ HSEM supports two independent interval settings:
 
 | Setting | Values | What it controls |
 |---|---|---|
-| `energi_data_service_update_interval` | 15 or 60 minutes | How often EDS publishes price records |
+| `electricity_price_update_interval` | 15, 30, or 60 minutes | How often the price source publishes records |
 | `recommendation_interval_minutes` | 15 or 60 minutes | The width of each planning slot |
 
-When these differ (most commonly: EDS 60 min, slots 15 min), the price rate must
+When these differ (most commonly: price update 60 min, slots 15 min), the price rate must
 be correctly scaled so the planner always sees the full currency/kWh rate.
 
 ---
 
-## The `eds_share` conversion factor
+## The `price_share` conversion factor
 
-$$ eds\\_share = \frac{\mathrm{EDS interval}}{\mathrm{Slot width}} $$
+$$
+\mathrm{price\_share} = \frac{\text{Price update interval}}{\text{Slot width}}
+$$
 
-| EDS interval | Slot width | `eds_share` | Effect |
+| Price update interval | Slot width | `price_share` | Effect |
 |---|---|---|---|
 | 60 min | 15 min | 4.0 | Price ÷ 4 stored; planner gets price × 4 back |
 | 15 min | 15 min | 1.0 | No scaling |
+| 30 min | 15 min | 2.0 | Price ÷ 2 stored; planner gets price × 2 back |
 | 60 min | 60 min | 1.0 | No scaling |
 
 ---
@@ -35,23 +38,41 @@ $$ eds\\_share = \frac{\mathrm{EDS interval}}{\mathrm{Slot width}} $$
 
 ```mermaid
 flowchart TD
-    A[EDS raw price P\nfull hourly currency per kWh]
-    B[HourlyDataPopulator._async_update_hourly_field]
+    A[Price source raw price P\nfull hourly currency per kWh]
+    B[HourlyDataPopulator.async_populate_price_and_solcast]
     C[Recommendation slot storage\nHourlyRecommendation objects]
     D[coordinator._build_planner_input]
     E[Planner engine PricePoint\nimport_price = P]
 
     A --> B
-    B -->|Per-slot stored value = P / eds_share| C
+    B -->|Per-slot stored value = P / price_share| C
     C --> D
-    D -->|Planner input value = stored value × eds_share = P| E
+    D -->|Planner input value = stored value × price_share = P| E
 ```
 
 ### What this is NOT
 
-- `eds_share` is **not** a VAT multiplier
-- `eds_share` is **not** a currency conversion
-- `eds_share` is **not** an energy-splitting factor (prices are rates, not energy)
+- `price_share` is **not** a VAT multiplier
+- `price_share` is **not** a currency conversion
+- `price_share` is **not** an energy-splitting factor (prices are rates, not energy)
+
+---
+
+## Price sources
+
+HSEM is provider-agnostic. Prices are read from generic electricity price sensors:
+
+| Config key | Purpose |
+|---|---|
+| `hsem_import_electricity_price_sensor` | Live import price (required) |
+| `hsem_export_electricity_price_sensor` | Live export price (required) |
+| `hsem_import_electricity_price_forecast_sensor` | Optional dedicated import forecast (e.g. Amber Electric) |
+| `hsem_export_electricity_price_forecast_sensor` | Optional dedicated export forecast |
+
+Supported providers include Energi Data Service, Nordpool, Amber Electric, and any
+sensor that publishes hourly (or sub-hourly) price records with a `raw_today` / `raw_tomorrow`
+attribute structure. The populator reads the full time-series from sensor attributes
+and projects them onto the planning horizon.
 
 ---
 
@@ -59,10 +80,10 @@ flowchart TD
 
 For any configuration:
 
-1. A 60-min EDS price of `P` must reach the planner as `P` (not `P/4` or `P*4`)
-2. A 15-min EDS price of `P` must reach the planner as `P`
-3. Intermediate per-slot stored values must equal `P / eds_share`
-4. Changing `energi_data_service_update_interval` from 60 to 15 with the same
+1. A 60-min price source value of `P` must reach the planner as `P` (not `P/4` or `P*4`)
+2. A 15-min price source value of `P` must reach the planner as `P`
+3. Intermediate per-slot stored values must equal `P / price_share`
+4. Changing `electricity_price_update_interval` from 60 to 15 with the same
    price input must not change the price seen by the planner engine
 5. Negative prices must survive the full pipeline unchanged (no absolute-value
    clipping, no zero-flooring)
@@ -76,9 +97,9 @@ time-series index per calendar day:
 
 | Field | Source | Day offset |
 |---|---|---|
-| Today's prices | Live EDS sensor | `day_offset = 0` |
-| Tomorrow's prices | EDS tomorrow sensor | `day_offset = 1` |
-| Day+2 prices | EDS day+2 sensor | `day_offset = 2` |
+| Today's prices | Live price sensor attributes | `day_offset = 0` |
+| Tomorrow's prices | Tomorrow sensor attributes (or same sensor) | `day_offset = 1` |
+| Day+2 prices | Day+2 sensor attributes (if available) | `day_offset = 2` |
 
 Missing future-day data is surfaced in `DataQuality` as:
 - `tomorrow_price_missing_hours`

--- a/docs/quality-checks.md
+++ b/docs/quality-checks.md
@@ -2,16 +2,20 @@
 
 This document describes the static quality tools available in HSEM and how to run them locally.
 
+---
+
 ## Tools
 
 | Tool | Purpose | Config |
 |------|---------|--------|
 | **Pyright** | Type checking (CI-friendly Pylance equivalent) | `pyrightconfig.json` |
 | **Vulture** | Dead-code and unused-symbol detection | `vulture_whitelist.py` |
-| **mypy** | Legacy type checking | `pyproject.toml [tool.mypy]` |
+| **mypy** | Type checking | `pyproject.toml [tool.mypy]` |
 | **ruff** | Linting and formatting | `pyproject.toml [tool.ruff]` |
 | **black** | Code formatting | `tox.ini [testenv:lint]` |
 | **isort** | Import sorting | `tox.ini [testenv:lint]` |
+
+---
 
 ## Local Commands
 
@@ -19,6 +23,15 @@ This document describes the static quality tools available in HSEM and how to ru
 
 ```bash
 tox -e lint
+```
+
+This runs isort, black, ruff format, and ruff check in sequence. All four must pass
+before a PR can be opened.
+
+### Run mypy type checking
+
+```bash
+tox -e typing
 ```
 
 ### Run Pyright type checker
@@ -45,11 +58,29 @@ unused because they are called dynamically by HA.
 tox -e quality
 ```
 
-### Run tests
+### Run tests with coverage
 
 ```bash
-pytest tests/
+tox -e py314
 ```
+
+This runs `pytest` with coverage reporting. The `py314` tox environment runs on Python 3.14
+and includes HA test dependencies.
+
+### QA pipeline quick reference
+
+```mermaid
+flowchart TD
+    A[Code Changes] --> B[tox -e lint]
+    B --> C[tox -e typing]
+    C --> D[tox -e quality]
+    D --> E[tox -e py314]
+    E --> F{All pass?}
+    F -->|Yes| G[Open PR]
+    F -->|No| H[Fix issues] --> B
+```
+
+---
 
 ## Pyright Configuration
 
@@ -81,6 +112,8 @@ not bugs in HSEM:
    Tests use partial mocks, `MagicMock`, and stub objects that don't have full type
    annotations.  These are safe and intentional.
 
+---
+
 ## Vulture Whitelist
 
 `vulture_whitelist.py` documents all HA dynamic entry points.  **Before deleting any function
@@ -93,6 +126,8 @@ that Vulture flags**, check whether it belongs to one of these categories:
 - Entity properties used by HA: `device_info`, `native_value`, `is_on`, etc.
 
 If in doubt, **add to the whitelist** rather than deleting.
+
+---
 
 ## CI Integration
 

--- a/docs/sensors-reference.md
+++ b/docs/sensors-reference.md
@@ -11,10 +11,10 @@ HSEM exposes these entity types:
 
 | Type | Count | Description |
 |---|---|---|
-| **Sensor** | ~20+ | Read-only state, plan, and diagnostic entities |
-| **Select** | 2 | Working-mode override and Solcast likelihood selector |
-| **Switch** | 6+ | Toggle entities for schedules and configuration |
-| **Time** | 6 | Start/end time inputs for battery schedules |
+| **Sensor** | ~20 | Read-only state, plan, and diagnostic entities |
+| **Select** | 2 | Force working mode override and Solcast likelihood selector |
+| **Switch** | 13 | Toggle entities for schedules, EV settings, and ML options |
+| **Time** | 8 | Start/end time inputs for battery schedules and EV deadlines |
 | **Number** | 4 | Charge/discharge efficiency and EV target SoC inputs |
 
 ---
@@ -110,6 +110,7 @@ Each entry in the `hourly_recommendations` list is a dictionary with these keys:
 | `estimated_battery_soc_pct` | float | Simulated absolute SoC at slot end (0–100 %) |
 | `grid_import_kwh` | float | Energy imported from grid (kWh) |
 | `grid_export_kwh` | float | Energy exported to grid (kWh) |
+| `is_ev_surplus_only_slot` | bool | Slot restricted to EV surplus-only charging |
 
 ### Extended attributes (when enabled)
 
@@ -266,6 +267,17 @@ Diagnostic sensors displaying the EV charging plan details.
 
 ---
 
+## Daily plan-vs-actual sensor
+
+Diagnostic sensor tracking daily cumulative plan-vs-actual energy deviations.
+
+**Entity:** `sensor.hsem_daily_plan_vs_actual`
+
+Tracks planned kWh vs actual kWh for import, export, PV, consumption, and battery
+throughput on a per-calendar-day basis using cumulative energy meter readings.
+
+---
+
 ## EV charging active sensor
 
 Boolean sensor indicating whether any EV is actively drawing power.
@@ -297,18 +309,23 @@ Snapshot of the battery state of charge.
 |---|---|---|---|
 | `sensor.hsem_applier_status_sensor` | Inverter Apply Status | Hardware write success/failure | `ok`, `unverified`, `failed`, `skipped` |
 | `sensor.hsem_battery_soc_sensor` | Battery State of Charge | Battery SoC snapshot | Percentage (0–100) |
+| `sensor.hsem_daily_plan_vs_actual` | Daily Plan vs Actual | Daily energy plan-vs-actual tracking | Dict with cumulative metrics |
 | `sensor.hsem_degraded_mode_sensor` | System Health | Overall system health | `ok`, `degraded`, `error` |
 | `sensor.hsem_ev_charging_sensor` | EV Charging Active | Any EV actively charging | `on`, `off` |
+| `sensor.hsem_ev_optimal_charging_plan` | EV Optimal Charging Plan | Primary EV plan state | `charging`, `waiting`, etc. |
+| `sensor.hsem_ev_second_optimal_charging_plan` | EV Second Optimal Charging Plan | Second EV plan state | `charging`, `waiting`, etc. |
 | `sensor.hsem_force_mode_sensor` | Force Working Mode | Override active indicator | `auto` or override mode name |
+| `sensor.hsem_forecast_accuracy` | Forecast Accuracy | PV & load forecast-vs-actual | PV MAE (kWh) |
 | `sensor.hsem_hardware_writes_sensor` | Hardware Writes | Writes allowed/blocked by safety gate | `allowed`, `blocked` |
 | `sensor.hsem_read_only_sensor` | Read-Only Mode | Read-only mode indicator | `on`, `off` |
-| `sensor.hsem_house_consumption_power_sensor_*_*` | House Consumption Power | House load for a time range | Watts (W) |
 | `sensor.hsem_net_consumption_sensor` | Net Consumption | Net load (house minus solar) | Watts (W) |
 | `sensor.hsem_last_updated_sensor` | Last Updated | Last coordinator cycle timestamp | ISO-8601 timestamp |
 | `sensor.hsem_next_update_sensor` | Next Update | Next scheduled coordinator cycle | ISO-8601 timestamp |
 | `sensor.hsem_missing_entities_sensor` | Missing Input Entities | Count of missing input entities | Integer |
+| `sensor.hsem_plan_explanation` | Plan Explanation | Planner strategy and cost breakdown | Winning candidate name |
 | `sensor.hsem_recommendation_interval_sensor` | Recommendation Interval | Slot width and horizon info | Minutes |
 | `sensor.hsem_update_interval_sensor` | Update Interval | Current polling interval | Minutes |
+| `sensor.hsem_working_mode` | Working Mode | Active battery recommendation | Working mode state |
 
 ---
 
@@ -345,9 +362,16 @@ This setting is also configurable in the options flow.
 | `switch.hsem_read_only` | Block all hardware writes |
 | `switch.hsem_extended_attributes` | Enable extended diagnostic attributes |
 | `switch.hsem_verbose_logging` | Enable verbose logging |
-| `switch.hsem_batteries_schedule_1` | Toggle battery schedule 1 |
-| `switch.hsem_batteries_schedule_2` | Toggle battery schedule 2 |
-| `switch.hsem_batteries_schedule_3` | Toggle battery schedule 3 |
+| `switch.hsem_batteries_enable_batteries_schedule_1` | Toggle battery schedule 1 |
+| `switch.hsem_batteries_enable_batteries_schedule_2` | Toggle battery schedule 2 |
+| `switch.hsem_batteries_enable_batteries_schedule_3` | Toggle battery schedule 3 |
+| `switch.hsem_ev_force_discharge` | Force EV maximum discharge power |
+| `switch.hsem_ev_smart_charging` | Enable smart EV charging scheduling |
+| `switch.hsem_ev_force_charge_now` | Force immediate EV charging |
+| `switch.hsem_ev_second_smart_charging` | Enable smart charging for second EV |
+| `switch.hsem_ev_second_force_charge_now` | Force immediate second EV charging |
+| `switch.hsem_ml_consumption` | Enable ML-based consumption prediction |
+| `switch.hsem_ml_sequential` | Enable sequential (intra-day momentum) ML mode |
 
 ---
 
@@ -372,6 +396,8 @@ This setting is also configurable in the options flow.
 | `time.hsem_batteries_schedule_2_end` | Schedule 2 end time |
 | `time.hsem_batteries_schedule_3_start` | Schedule 3 start time |
 | `time.hsem_batteries_schedule_3_end` | Schedule 3 end time |
+| `time.hsem_ev_deadline` | Primary EV charge deadline |
+| `time.hsem_ev_second_deadline` | Second EV charge deadline |
 
 ---
 


### PR DESCRIPTION
## Summary

Updates all 9 documentation files to match the current codebase state.

### Changes

| File | What changed |
|---|---|
| `milp-optimization.md` | Replace `\operatorname` with `\mathrm` (12 instances — not allowed by renderer) |
| `consumption-prediction.md` | Replace `\operatorname{diag}` with `\mathrm{diag}` |
| `price-scaling.md` | Rewrite as provider-agnostic: add 30-min interval, price sources section, rename `eds_share` → `price_share` |
| `candidate-generation.md` | Update for MILP-only mode: remove partial-SoC and deduplication sections, add historical candidates table and EV co-optimisation |
| `config-flow-reference.md` | Rename `energidataservice` → `prices`, add forecast sensors, new EV fields, `ev_second` step, `charger_min_power_w`, `ev_second_planned_load` step |
| `ev-charge-plan-setup.md` | Add mermaid diagrams, math notation for net load formula, inputs table, charger min power field, minimum power floor troubleshooting |
| `forecast-accuracy-tracking.md` | Convert error metrics (MAE, Bias, RMSE, MAPE) to math notation, add energy accumulation formula |
| `sensors-reference.md` | Add `daily_plan_vs_actual`, all 13 switches, EV deadline time entities, new sensors |
| `quality-checks.md` | Add QA pipeline mermaid diagram, `tox -e typing` and `tox -e py314` commands |

### Checklist

- [x] All `\operatorname` macros removed (verified with grep)
- [x] Config flow step names match `flows/*.py` module names
- [x] Entity counts match `sensor.py`, `switch.py`, `time.py` registrations
- [x] Price config keys match `const.py` and `flows/prices.py`
- [x] Candidate list matches `candidate_generator.py` (MILP-only mode)