### PR TITLE
feat(planner): inject live solar and consumption into current slot

### DIFF
--- a/custom_components/hsem/coordinator_builder.py
+++ b/custom_components/hsem/coordinator_builder.py
@@ -218,6 +218,9 @@ def build_planner_input(
         months_winter=list(cfg.months_winter or []),
         house_power_includes_ev=bool(cfg.house_power_includes_ev_charger_power),
         live_net_consumption_w=convert_to_float(live.net_consumption_w) or 0.0,
+        live_solar_production_w=convert_to_float(live.solar_production_power_w) or 0.0,
+        live_house_consumption_w=convert_to_float(live.house_consumption_power_w)
+        or 0.0,
         is_read_only=bool(cfg.read_only),
         # EV planned load
         ev_planned_load_enabled=bool(cfg.ev_planned_load_enabled),

--- a/custom_components/hsem/models/planner_input.py
+++ b/custom_components/hsem/models/planner_input.py
@@ -168,6 +168,18 @@ class PlannerInput:
     #: in Pass 3 (charge-past-target on surplus PV).
     live_net_consumption_w: float = 0.0
 
+    #: Live solar production power in Watts from the inverter's input power
+    #: sensor.  Injected into the current slot's solcast_pv_estimate_kwh so
+    #: the MILP and all candidates use measured (not forecast) PV for the
+    #: partially-elapsed slot.
+    live_solar_production_w: float = 0.0
+
+    #: Live house consumption power in Watts from the house power meter.
+    #: Injected into the current slot's avg_house_consumption_kwh so the
+    #: MILP and all candidates use measured (not forecast) load for the
+    #: partially-elapsed slot.
+    live_house_consumption_w: float = 0.0
+
     # --- time discount for selector score ---
     #: Per-hour exponential discount factor applied to the selector score
     #: (not to total_cost).  A value of 1.0 disables the discount entirely.

--- a/custom_components/hsem/planner/engine_core.py
+++ b/custom_components/hsem/planner/engine_core.py
@@ -180,6 +180,70 @@ def _populate_slots(
     return dq, warnings, missing_inputs
 
 
+def _inject_live_data_into_current_slot(
+    slots: list,
+    inp: PlannerInput,
+    now: datetime,
+) -> None:
+    """Replace forecast PV and consumption in the current slot with live measurements.
+
+    The current (partially-elapsed) slot's ``solcast_pv_estimate_kwh`` and
+    ``avg_house_consumption_kwh`` are overwritten with values derived from
+    live power sensors.  This ensures the MILP and all candidates use
+    measured (not forecast) data for the slot that is already in progress.
+
+    The live power in Watts is converted to kWh by multiplying by the
+    slot's full duration in hours.  This gives the *projected* full-slot
+    energy if the current power level were sustained for the entire slot.
+    The MILP's energy balance constraint then correctly accounts for the
+    remaining portion of the slot.
+
+    Args:
+        slots: Fully populated slot list (after ``_populate_slots``).
+        inp: Planner input containing live power readings.
+        now: Timezone-aware current datetime.
+    """
+    slot_hours = inp.interval_minutes / 60.0
+
+    for slot in slots:
+        s_start = as_tz(slot.start, now.tzinfo)
+        s_end = as_tz(slot.end, now.tzinfo)
+        if s_start <= now < s_end:
+            # Convert live Watts to projected full-slot kWh.
+            if inp.live_solar_production_w > 1e-9:
+                live_pv_kwh = (inp.live_solar_production_w / 1000.0) * slot_hours
+                log_planner(
+                    "debug",
+                    "[core] _inject_live_data  slot=%s  "
+                    "pv: forecast=%.3f → live=%.3f kWh",
+                    slot.start.isoformat(),
+                    slot.solcast_pv_estimate_kwh,
+                    live_pv_kwh,
+                )
+                slot.solcast_pv_estimate_kwh = round(live_pv_kwh, 3)
+
+            if inp.live_house_consumption_w > 1e-9:
+                live_load_kwh = (inp.live_house_consumption_w / 1000.0) * slot_hours
+                log_planner(
+                    "debug",
+                    "[core] _inject_live_data  slot=%s  "
+                    "load: forecast=%.3f → live=%.3f kWh",
+                    slot.start.isoformat(),
+                    slot.avg_house_consumption_kwh,
+                    live_load_kwh,
+                )
+                slot.avg_house_consumption_kwh = round(live_load_kwh, 3)
+
+            # Also update the sub-window averages so they stay consistent
+            # with the main average (used by spike detection in
+            # populate_consumption).
+            slot.avg_house_consumption_1d_kwh = slot.avg_house_consumption_kwh
+            slot.avg_house_consumption_3d_kwh = slot.avg_house_consumption_kwh
+            slot.avg_house_consumption_7d_kwh = slot.avg_house_consumption_kwh
+            slot.avg_house_consumption_14d_kwh = slot.avg_house_consumption_kwh
+            break
+
+
 def _schedule_slots(
     slots: list,
     inp: PlannerInput,
@@ -739,6 +803,9 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
         len(warnings),
         len(missing_inputs),
     )
+    # Step 1b — inject live solar and consumption into the current slot
+    _inject_live_data_into_current_slot(slots, inp, now)
+
     # Step 2 — EV planned load injection
     ev_cp: EVChargingPlan | None = None
     ev2_cp: EVChargingPlan | None = None


### PR DESCRIPTION
## What

Inject live solar production and house consumption power into the current (partially-elapsed) slot so the MILP and all candidates use measured data instead of Solcast forecasts.

## Why

The planner previously used Solcast forecast PV and historical-average consumption for **every** slot, including the one already in progress. If actual solar or load differed significantly from the forecast, the MILP's decisions for the current slot were based on wrong data.

## How

1. **`PlannerInput`** — added `live_solar_production_w` and `live_house_consumption_w` fields
2. **`coordinator_builder.py`** — wires `live.solar_production_power_w` and `live.house_consumption_power_w` from `LiveState`
3. **`engine_core.py`** — new `_inject_live_data_into_current_slot()` function called at Step 1b (after forecast population, before `populate_net_consumption`):
   - Finds the current slot by time range
   - Converts live Watts to projected full-slot kWh
   - Overwrites `solcast_pv_estimate_kwh` and `avg_house_consumption_kwh`
   - Updates sub-window averages for consistency

### Data flow
```
_populate_slots (forecast data)
    ↓
_inject_live_data_into_current_slot (overwrites current slot with live data)
    ↓
populate_net_consumption (recomputes from live values)
    ↓
EV planner, MILP, all candidates
```

## Files changed

| File | Change |
|---|---|
| `custom_components/hsem/models/planner_input.py` | +12 lines — two new fields |
| `custom_components/hsem/coordinator_builder.py` | +3 lines — wire live values |
| `custom_components/hsem/planner/engine_core.py` | +67 lines — injection function + call site |

## Checklist

- [x] Ruff lint passes
- [x] No existing tests broken (new fields have `0.0` defaults)
- [ ] Add regression test for live data injection
- [ ] Run full test suite (`tox -e py314`)