### PR TITLE
fix(planner): move optimization into selector, fix MILP curtailment and terminal-SoC

### DIFF
--- a/custom_components/hsem/planner/candidate_selector.py
+++ b/custom_components/hsem/planner/candidate_selector.py
@@ -203,16 +203,16 @@ def select_best_candidate(  # NOSONAR
         # with BatteriesDischargeMode for summer months).
         if candidate.name == CANDIDATE_MILP:
             continue
-        # Concentrate discharge on expensive slots (per-candidate)
-        concentrate_discharge_on_expensive_slots(
-            candidate.slots,
-            now,
-            current_kwh,
-            usable_kwh,
-            max_discharge_per_slot,
-            discharge_efficiency_pct=discharge_efficiency_pct,
-        )
-        # Apply seasonal optimization strategy
+        # Apply seasonal optimization strategy BEFORE concentration.
+        # The seasonal fill marks unassigned summer slots as
+        # BatteriesDischargeMode; concentrate_discharge then clears the
+        # cheap discharge slots the battery cannot serve.  Running
+        # concentrate first would find no discharge slots (e.g. on the
+        # passive candidate, whose recs are cleared), after which the
+        # seasonal fill would mark every slot as BatteriesDischargeMode
+        # with nothing left to thin them out — collapsing the whole
+        # horizon into a single discharge window.  This matches the
+        # original engine_core pipeline order.
         apply_optimization_strategy(
             candidate.slots,
             now,
@@ -221,6 +221,15 @@ def select_best_candidate(  # NOSONAR
             required_capacity,
             months_winter,
             export_min_price=export_min_price,
+        )
+        # Concentrate discharge on expensive slots (per-candidate)
+        concentrate_discharge_on_expensive_slots(
+            candidate.slots,
+            now,
+            current_kwh,
+            usable_kwh,
+            max_discharge_per_slot,
+            discharge_efficiency_pct=discharge_efficiency_pct,
         )
 
     # --- Step 1 & 2: simulate and validate each candidate ---------------

--- a/custom_components/hsem/planner/candidate_selector.py
+++ b/custom_components/hsem/planner/candidate_selector.py
@@ -42,6 +42,10 @@ from custom_components.hsem.planner.candidate_generator import (
     CandidatePlan,
 )
 from custom_components.hsem.planner.cost_function import CostWeights, score_plan
+from custom_components.hsem.planner.discharge_scheduler import (
+    apply_optimization_strategy,
+    concentrate_discharge_on_expensive_slots,
+)
 from custom_components.hsem.planner.soc_simulation import simulate_soc
 from custom_components.hsem.utils.datetime_utils import as_tz
 from custom_components.hsem.utils.logger import log_planner
@@ -101,6 +105,10 @@ def select_best_candidate(  # NOSONAR
     charge_efficiency_pct: float = 100.0,
     discharge_efficiency_pct: float = 100.0,
     replacement_price_per_kwh: float | None = None,
+    # Optimization strategy parameters (score divergence fix)
+    required_capacity: float = 0.0,
+    months_winter: list[int] | None = None,
+    export_min_price: float = 0.0,
     # Hysteresis parameters (issue #372)
     hysteresis_enabled: bool = False,
     hysteresis_absolute: float = 0.0,
@@ -182,6 +190,32 @@ def select_best_candidate(  # NOSONAR
         non-selected candidate, and *hysteresis_result* describes the
         hysteresis decision.
     """
+    # --- Step 0: apply optimization strategy to each candidate ------------
+    # This ensures all candidates are scored on their final form, preventing
+    # score divergence between selector and final output.
+    if months_winter is None:
+        months_winter = []
+    for candidate in candidates:
+        # Concentrate discharge on expensive slots (per-candidate)
+        concentrate_discharge_on_expensive_slots(
+            candidate.slots,
+            now,
+            current_kwh,
+            usable_kwh,
+            max_discharge_per_slot,
+            discharge_efficiency_pct=discharge_efficiency_pct,
+        )
+        # Apply seasonal optimization strategy
+        apply_optimization_strategy(
+            candidate.slots,
+            now,
+            current_kwh,
+            usable_kwh,
+            required_capacity,
+            months_winter,
+            export_min_price=export_min_price,
+        )
+    
     # --- Step 1 & 2: simulate and validate each candidate ---------------
     for candidate in candidates:
         simulate_soc(

--- a/custom_components/hsem/planner/candidate_selector.py
+++ b/custom_components/hsem/planner/candidate_selector.py
@@ -38,6 +38,7 @@ from datetime import datetime, timedelta
 from custom_components.hsem.models.rejected_plan import RejectedPlan
 from custom_components.hsem.planner.candidate_generator import (
     CANDIDATE_BASELINE,
+    CANDIDATE_MILP,
     CANDIDATE_NO_ACTION,
     CandidatePlan,
 )
@@ -196,6 +197,12 @@ def select_best_candidate(  # NOSONAR
     if months_winter is None:
         months_winter = []
     for candidate in candidates:
+        # Skip MILP candidate — the solver already determines the optimal
+        # recommendations.  Applying the optimization strategy here would
+        # overwrite the LP's optimal plan (e.g., filling idle None slots
+        # with BatteriesDischargeMode for summer months).
+        if candidate.name == CANDIDATE_MILP:
+            continue
         # Concentrate discharge on expensive slots (per-candidate)
         concentrate_discharge_on_expensive_slots(
             candidate.slots,

--- a/custom_components/hsem/planner/candidate_selector.py
+++ b/custom_components/hsem/planner/candidate_selector.py
@@ -215,7 +215,7 @@ def select_best_candidate(  # NOSONAR
             months_winter,
             export_min_price=export_min_price,
         )
-    
+
     # --- Step 1 & 2: simulate and validate each candidate ---------------
     for candidate in candidates:
         simulate_soc(

--- a/custom_components/hsem/planner/engine_core.py
+++ b/custom_components/hsem/planner/engine_core.py
@@ -1129,6 +1129,7 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
     _EV_KEEP = frozenset(
         {
             Recommendations.BatteriesChargeGrid.value,
+            Recommendations.BatteriesChargeSolar.value,
             Recommendations.ForceBatteriesDischarge.value,
             Recommendations.ForceExport.value,
             Recommendations.TimePassed.value,

--- a/custom_components/hsem/planner/engine_core.py
+++ b/custom_components/hsem/planner/engine_core.py
@@ -554,6 +554,7 @@ def _select_candidate(
     rppk: float | None,
     cw: CostWeights,
     sdh: float,
+    rc: float,
     ev_configs: list[EVConfig] | None = None,
 ) -> tuple:
     """Generate and select best candidate plan."""
@@ -583,6 +584,9 @@ def _select_candidate(
         charge_efficiency_pct=inp.battery_charge_efficiency_pct,
         discharge_efficiency_pct=inp.battery_discharge_efficiency_pct,
         replacement_price_per_kwh=rppk,
+        required_capacity=rc,
+        months_winter=inp.months_winter,
+        export_min_price=inp.export_min_price,
         hysteresis_enabled=inp.planner_hysteresis_enabled,
         hysteresis_absolute=inp.planner_hysteresis_absolute,
         hysteresis_percentage=inp.planner_hysteresis_percentage,
@@ -950,14 +954,9 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
         top_n,
         f"{rppk:.6f}" if rppk is not None else "None",
     )
-    concentrate_discharge_on_expensive_slots(
-        slots,
-        now,
-        current_kwh,
-        usable_kwh,
-        mdps,
-        discharge_efficiency_pct=inp.battery_discharge_efficiency_pct,
-    )
+    # Note: concentrate_discharge_on_expensive_slots() is now applied per-candidate
+    # in the selector before scoring, so we don't run it on the baseline here.
+    
     # Build EV configs for MILP co-optimisation (when EVs are active)
     ev_configs = _build_ev_configs_for_milp(inp, slots, now)
     candidates, winner, candidate_rejected, hysteresis_result = _select_candidate(
@@ -972,6 +971,7 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
         rppk,
         cw,
         sdh,
+        rc,
         ev_configs=ev_configs,
     )
     # Surface MILP penalty violations in warnings if the winner used penalties
@@ -995,29 +995,11 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
                 f"or main fuse limit."
             )
     # Step 5 — finalize plan from winner
+    # Note: apply_optimization_strategy() and simulate_soc() are now applied
+    # in the selector before scoring, so the winner's slots are already fully
+    # populated. We do NOT re-run simulate_soc() here to avoid double-simulation
+    # drift and to ensure the final score matches the selector's score.
     slots = winner.slots
-    apply_optimization_strategy(
-        slots,
-        now,
-        current_kwh,
-        usable_kwh,
-        rc,
-        inp.months_winter,
-        export_min_price=inp.export_min_price,
-    )
-    simulate_soc(
-        slots,
-        now,
-        current_kwh,
-        usable_kwh,
-        max_soc_kwh,
-        mcps,
-        mdps,
-        rated_kwh=inp.battery_rated_capacity_kwh,
-        end_of_discharge_soc_pct=inp.battery_end_of_discharge_soc_pct,
-        charge_efficiency_pct=inp.battery_charge_efficiency_pct,
-        discharge_efficiency_pct=inp.battery_discharge_efficiency_pct,
-    )
 
     # Post-hoc main fuse check — runs regardless of which candidate won.
     # If any slot exceeds the fuse rating, throttle EV charger power and
@@ -1103,6 +1085,11 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
         if as_tz(s.start, now.tzinfo) <= now < s_end_tz:
             remaining_h = max((s_end_tz - now).total_seconds() / 3600.0, 1.0 / 3600.0)
             ac_power_w = round((total_ev_ac / remaining_h) * 1000.0)
+            # Cap at the full-slot power — the charger physically
+            # cannot deliver more than its rated power, even if the
+            # MILP allocated a full slot's energy to a partial slot.
+            full_slot_power_w = round((total_ev_ac / _slot_hours) * 1000.0)
+            ac_power_w = min(ac_power_w, full_slot_power_w)
         else:
             ac_power_w = round((total_ev_ac / _slot_hours) * 1000.0)
 

--- a/custom_components/hsem/planner/engine_core.py
+++ b/custom_components/hsem/planner/engine_core.py
@@ -34,7 +34,6 @@ from custom_components.hsem.planner.discharge_scheduler import (
     apply_excess_export,
     apply_optimization_strategy,
     calculate_required_battery_until_solar,
-    concentrate_discharge_on_expensive_slots,
 )
 from custom_components.hsem.planner.engine_explanation import (
     _build_explanation,
@@ -59,7 +58,6 @@ from custom_components.hsem.planner.slot_population import (
     populate_solcast,
     usable_capacity,
 )
-from custom_components.hsem.planner.soc_simulation import simulate_soc
 from custom_components.hsem.utils.datetime_utils import as_tz
 from custom_components.hsem.utils.logger import log_planner
 from custom_components.hsem.utils.misc import (
@@ -956,7 +954,7 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
     )
     # Note: concentrate_discharge_on_expensive_slots() is now applied per-candidate
     # in the selector before scoring, so we don't run it on the baseline here.
-    
+
     # Build EV configs for MILP co-optimisation (when EVs are active)
     ev_configs = _build_ev_configs_for_milp(inp, slots, now)
     candidates, winner, candidate_rejected, hysteresis_result = _select_candidate(

--- a/custom_components/hsem/planner/milp_optimizer.py
+++ b/custom_components/hsem/planner/milp_optimizer.py
@@ -779,6 +779,19 @@ def solve_milp(
         out_slots[i].ev_second_charger_calculated_power = 0.0
 
     # Write MILP-derived charge/discharge actions
+    # Pre-compute which slots have EV charging — when both battery and
+    # EV charge in the same slot, the battery must use BatteriesChargeGrid
+    # (not BatteriesChargeSolar) because the EV will consume the solar
+    # surplus, leaving nothing for the battery.
+    ev_charging_slots: set[int] = set()
+    if active_evs:
+        for ev_idx in range(len(active_evs)):
+            ev_off = ev_var_offsets[ev_idx]
+            ev_c_sol = result.x[ev_off : ev_off + m]
+            for lp_t in range(m):
+                if float(ev_c_sol[lp_t]) >= _MIN_ACTION_KWH:
+                    ev_charging_slots.add(lp_t)
+
     for lp_t, slot_i in enumerate(future_idx):
         ec_kwh = float(ec_sol[lp_t])
         ed_kwh = float(ed_sol[lp_t])
@@ -804,8 +817,11 @@ def solve_milp(
 
         if ec_kwh > _MIN_ACTION_KWH:
             # Use BatteriesChargeSolar when PV surplus is available,
-            # BatteriesChargeGrid otherwise.
-            if pv_avail[lp_t] > _MIN_ACTION_KWH:
+            # BatteriesChargeGrid otherwise.  When EV is also charging
+            # in this slot, always use BatteriesChargeGrid — the EV
+            # will consume the solar surplus, so the battery must draw
+            # from grid to actually receive the energy the MILP allocated.
+            if pv_avail[lp_t] > _MIN_ACTION_KWH and lp_t not in ev_charging_slots:
                 out_slots[
                     slot_i
                 ].recommendation = Recommendations.BatteriesChargeSolar.value

--- a/custom_components/hsem/planner/milp_optimizer.py
+++ b/custom_components/hsem/planner/milp_optimizer.py
@@ -10,7 +10,7 @@ via ``scipy.optimize.linprog``.  Binary charge/discharge flags are
 relaxed to continuous because the mutual-exclusion constraint already
 prevents simultaneous charge + discharge.
 
-Decision variables (flattened into ``x`` of length 8*n)
+Decision variables (flattened into ``x`` of length 9*n)
 ----------------------------------------------------------
 For each slot ``t ∈ 0…n-1``:
 
@@ -22,17 +22,20 @@ For each slot ``t ∈ 0…n-1``:
 - ``m[t]`` — max(ec[t], ed[t]) for cycle cost (kWh)
 - ``s_max_pen[t]`` — kWh SoC exceeds usable_kwh
 - ``s_min_pen[t]`` — kWh SoC drops below 0
+- ``curt[t]`` — PV curtailment this slot (kWh, ≥ 0)
 
 ``soc[t]`` is derived from ``ec``/``ed`` via forward recurrence.
 
 Objective (minimise)
 --------------------
 ``Σ_t [ p_imp[t]*gi[t] - p_exp[t]*ge[t] + α*m[t]
-       + γ*(ed[t]-ec[t]) + p_soc*s_max_pen[t] + p_soc*s_min_pen[t] ]``
+       + p_soc*s_max_pen[t] + p_soc*s_min_pen[t] ]``
 
-where ``α`` = battery cycle cost/kWh, ``γ`` = terminal-SoC replacement
-price, ``p_soc = max(p_imp) * 100`` ensures penalties are only used when
-forced (e.g., initial SoC outside bounds).
+where ``α`` = battery cycle cost/kWh, ``p_soc = max(p_imp) * 100`` ensures
+penalties are only used when forced (e.g., initial SoC outside bounds).
+
+Terminal-SoC credit is computed at end-of-horizon (not per-slot) to match
+the cost function's ``terminal_soc_value`` calculation.
 
 Constraints
 -----------
@@ -43,8 +46,14 @@ Constraints
 4. Discharge limit: ``ed[t] ≤ max_discharge_per_slot``
 5. Mutual exclusion: ``ec[t]/mc + ed[t]/md ≤ 1``
 6. Energy balance:
-   ``gi + pv + ed·η_disch = load + ec/η_chg + ge``
+   ``gi + pv + ed·η_disch = load + ec/η_chg + ge + curt``
 7. Non-negativity: all ≥ 0. Past slots fixed at zero.
+
+Curtailment
+-----------
+The ``curt[t]`` variable allows the LP to explicitly curtail PV when the
+battery is full and export prices are low/negative. Without it, the LP
+is forced to "use" all PV surplus even when curtailment would be optimal.
 
 Solving
 -------
@@ -373,14 +382,16 @@ def solve_milp(
     # Variable layout:
     #   x = [ec(0..m-1), ed(0..m-1), gi(0..m-1), ge(0..m-1),
     #        pv(0..m-1), m(0..m-1),
-    #        s_max_pen(0..m-1), s_min_pen(0..m-1)]
+    #        s_max_pen(0..m-1), s_min_pen(0..m-1),
+    #        curt(0..m-1)]
     #   + [evN_c(0..m-1) for each active EV]      ← EV DC charge per slot
     #   + [evN_target_pen for each active EV]      ← deadline target slack
     # ------------------------------------------------------------------
     ec_off, ed_off, gi_off, ge_off, pv_off, m_off = 0, m, 2 * m, 3 * m, 4 * m, 5 * m
     s_max_off = 6 * m
     s_min_off = 7 * m
-    n_vars = 8 * m
+    curt_off = 8 * m
+    n_vars = 9 * m
 
     # --- EV variable layout ---
     ev_var_offsets: list[int] = []  # start of ev_c[t] block per EV
@@ -430,8 +441,9 @@ def solve_milp(
 
     # ------------------------------------------------------------------
     # Objective vector: minimise grid_import_cost - export_revenue + cycle_cost
-    # + conversion_loss_cost - terminal_soc_credit.
+    # + conversion_loss_cost.
     # pv[t] has zero objective cost (it's free).
+    # curt[t] has zero objective cost (curtailment is free).
     #
     # Cycle cost is counted once per slot (matching cost_function.py's
     # max(charge, discharge) counting).  cycle_cost_per_kwh already includes
@@ -439,9 +451,13 @@ def solve_milp(
     # (charge + discharge) correctly costs 2 × usable_kwh × cycle_cost_per_kwh
     # per direction.
     #
-    # Terminal-SoC credit: energy left in the battery at end of horizon
-    # avoids importing at the next discharge window price.  This mirrors
-    # terminal_soc_value in cost_function.py.
+    # Conversion loss: priced at the slot's own import price where the loss
+    # occurs.  Charge-side loss at charge slot price, discharge-side loss at
+    # discharge slot price.  This matches cost_function.py's per-slot pricing.
+    #
+    # Terminal-SoC credit is NOT applied per-slot.  It is computed at
+    # end-of-horizon after the LP solves, matching cost_function.py's
+    # terminal_soc_value = (initial_kwh - final_kwh) * replacement_price.
     #
     # Apply time discount so the MILP objective matches the selector's
     # discounted score (distant savings are worth less).
@@ -464,26 +480,18 @@ def solve_milp(
             hours_ahead = max((slot_mid - now).total_seconds() / 3600.0, 0.0)
             discount = time_discount_rate**hours_ahead
 
-        # Charge-side: energy lost during charge, priced at import price
+        # Charge-side conversion loss: energy lost during charge, priced at
+        # this slot's import price (where the charge occurs).
         c_obj[ec_off + t] = (charge_loss * p_imp[t]) * discount
-        # Discharge-side: energy lost during discharge, priced at import price
+        # Discharge-side conversion loss: energy lost during discharge, priced
+        # at this slot's import price (where the discharge occurs).
         c_obj[ed_off + t] = (discharge_loss * p_imp[t]) * discount
         # Cycle cost through auxiliary variable m[t] (= max(ec, ed))
         c_obj[m_off + t] = cycle_cost_per_kwh * discount
         c_obj[gi_off + t] = p_imp[t] * discount  # grid import cost
         c_obj[ge_off + t] = -p_exp[t] * discount  # export revenue (negative = gain)
         # pv[t] has zero objective cost
-
-        # Terminal-SoC credit: storing energy (ec) reduces future import cost;
-        # discharging (ed) increases future import cost.  The terminal value
-        # is undiscounted to match the selector's cost_function.score_plan()
-        # (which keeps terminal_soc_value raw regardless of time_discount_rate).
-        if (
-            replacement_price_per_kwh is not None
-            and abs(replacement_price_per_kwh) > 1e-9
-        ):
-            c_obj[ec_off + t] -= replacement_price_per_kwh
-            c_obj[ed_off + t] += replacement_price_per_kwh
+        # curt[t] has zero objective cost (curtailment is free)
 
         # Penalty costs: high enough that penalties are zero when SoC is
         # within bounds, but absorb violations when the initial SoC is
@@ -496,10 +504,13 @@ def solve_milp(
     # when it is physically possible within the available slots.
     for ev_idx, ev in enumerate(active_evs):
         if ev.deadline_slot is not None and ev.target_kwh > ev.initial_soc_kwh + 1e-9:
-            # Penalty per kWh shortfall: >= max_import_cost_for_full_charge
-            # This ensures the MILP will import at the most expensive price
-            # rather than miss the deadline target.
-            ev_penalty_cost = max(p_imp_max, 0.1) * max(ev.capacity_kwh, 1.0) * 100.0
+            # Penalty per kWh shortfall: proportional to energy needed,
+            # not full capacity. This ensures the MILP prioritizes the EV
+            # when it needs significant energy, but doesn't force EV charging
+            # when it only needs a small top-up (e.g., 90% -> 100%) at the
+            # expense of a critically low house battery.
+            energy_needed = ev.target_kwh - ev.initial_soc_kwh
+            ev_penalty_cost = max(p_imp_max, 0.1) * max(energy_needed, 1.0) * 10.0
             c_obj[ev_pen_offsets[ev_idx]] = ev_penalty_cost
 
     # --- EV charge-past-target benefit ---
@@ -549,13 +560,16 @@ def solve_milp(
     # ------------------------------------------------------------------
     # Equality constraints: energy balance per slot
     # gi[t] + pv[t] + ed[t]*discharge_eff
-    #     = base_load[t] + ec[t]/charge_eff + ge[t] + Σ ev_c/eff
-    # ->  gi - ec/η_chg + ed·η_dis + pv - ge - Σ ev_c/eff = base_load
+    #     = base_load[t] + ec[t]/charge_eff + ge[t] + curt[t] + Σ ev_c/eff
+    # ->  gi - ec/η_chg + ed·η_dis + pv - ge - curt - Σ ev_c/eff = base_load
     #
     # EV charge energy ev_c[t] is DC-side (delivered to EV battery).
     # The AC grid/PV draw is ev_c[t] / charger_efficiency — that is the
     # load the house must supply.  base_load already EXCLUDES EV load
     # when ev_configs is active (net_load was rebuilt without EV).
+    #
+    # curt[t] allows the LP to explicitly curtail PV when battery is full
+    # and export prices are low/negative.
     # ------------------------------------------------------------------
     A_eq = np.zeros((m, n_vars))  # NOSONAR
     for t in range(m):
@@ -564,6 +578,7 @@ def solve_milp(
         A_eq[t, gi_off + t] = 1.0  # +gi[t]
         A_eq[t, ge_off + t] = -1.0  # -ge[t]
         A_eq[t, pv_off + t] = 1.0  # +pv[t] (fixed to pv_avail[t])
+        A_eq[t, curt_off + t] = -1.0  # -curt[t] (curtailment reduces available PV)
         # EV AC load: -ev_c[t] / charger_eff per active EV
         for ev_idx, ev in enumerate(active_evs):
             A_eq[t, ev_var_offsets[ev_idx] + t] = -1.0 / ev.charger_efficiency
@@ -722,6 +737,7 @@ def solve_milp(
         + [(0.0, None)] * m  # m[t] (auxiliary, unbounded above, ≥ 0)
         + [(0.0, None)] * m  # s_max_pen[t] (penalty, ≥ 0)
         + [(0.0, None)] * m  # s_min_pen[t] (penalty, ≥ 0)
+        + [(0.0, None)] * m  # curt[t] (curtailment, ≥ 0)
     )
     # --- EV bounds ---
     for ev in active_evs:
@@ -761,10 +777,34 @@ def solve_milp(
         return None
 
     # ------------------------------------------------------------------
-    # Decode solution and build output slot list
+    # Compute terminal-SoC credit at end-of-horizon (not per-slot)
+    # This matches cost_function.py's terminal_soc_value calculation:
+    # terminal_soc_value = (initial_kwh - final_kwh) * replacement_price
+    #
+    # The LP objective does NOT include terminal-SoC credit.  We add it
+    # here as a post-hoc adjustment to the objective value so the selector
+    # sees the correct total score.
     # ------------------------------------------------------------------
     ec_sol = result.x[ec_off : ec_off + m]
     ed_sol = result.x[ed_off : ed_off + m]
+
+    # Compute final SoC from the LP solution
+    final_soc_kwh = current_kwh + float(np.sum(ec_sol)) - float(np.sum(ed_sol))
+    final_soc_kwh = max(0.0, min(final_soc_kwh, usable_kwh))  # clamp to bounds
+
+    # Terminal-SoC credit: positive when plan ends with less energy (penalty),
+    # negative when plan ends with more energy (credit).
+    terminal_soc_credit = 0.0
+    if replacement_price_per_kwh is not None and abs(replacement_price_per_kwh) > 1e-9:
+        terminal_soc_credit = (current_kwh - final_soc_kwh) * replacement_price_per_kwh
+        log_planner(
+            "debug",
+            "[milp] Terminal-SoC credit: initial=%.3f  final=%.3f  repl_price=%.4f  credit=%.4f",
+            current_kwh,
+            final_soc_kwh,
+            replacement_price_per_kwh,
+            terminal_soc_credit,
+        )
 
     out_slots: list[PlannedSlot] = [copy.copy(s) for s in slots]
 
@@ -1015,11 +1055,15 @@ def solve_milp(
                 total_fuse_violation_kwh,
             )
 
+    # Extract curtailment solution
+    curt_sol = result.x[curt_off : curt_off + m]
+    total_curtailment_kwh = float(np.sum(curt_sol))
+
     log_planner(
         "debug",
         "[milp] LP solved: objective=%.4f  charge_slots=%d  discharge_slots=%d"
         "  replacement_price=%s  penalty_total=%.4f  has_violations=%s"
-        "  ev_slots=%d",
+        "  ev_slots=%d  terminal_soc_credit=%.4f  curtailment=%.4f",
         float(result.fun),
         sum(
             1
@@ -1044,6 +1088,8 @@ def solve_milp(
         total_violation,
         has_violations,
         sum(1 for s in out_slots if abs(s.ev_total_planned_load_kwh) > _MIN_ACTION_KWH),
+        terminal_soc_credit,
+        total_curtailment_kwh,
     )
 
     diagnostics: dict = {
@@ -1052,6 +1098,8 @@ def solve_milp(
         "has_violations": has_violations,
         "total_violation_kwh": round(total_violation, 4),
         "total_fuse_violation_kwh": round(total_fuse_violation_kwh, 4),
+        "terminal_soc_credit": round(terminal_soc_credit, 4),
+        "total_curtailment_kwh": round(total_curtailment_kwh, 4),
     }
 
     # --- EV diagnostics ---

--- a/custom_components/hsem/utils/units.py
+++ b/custom_components/hsem/utils/units.py
@@ -118,6 +118,9 @@ def energy_to_power_kw(energy_kwh: float, duration_h: float) -> float:
     Returns:
         Average power in kiloWatts (kW).
     """
+    if duration_h <= 0:
+        return 0.0
+
     return energy_kwh / duration_h
 
 

--- a/docs/dashboard.yaml
+++ b/docs/dashboard.yaml
@@ -1,0 +1,2302 @@
+views:
+  - title: HSEM
+    badges: []
+    sections:
+      # ═══════════════════════════════════════════════════════════
+      # SECTION 1 — SYSTEM STATUS OVERVIEW
+      # ═══════════════════════════════════════════════════════════
+      - type: grid
+        cards:
+          - type: heading
+            heading: System Status
+            heading_style: title
+            grid_options:
+              columns: full
+              rows: 1
+          - type: tile
+            entity: sensor.hsem_degraded_mode_sensor
+            name: System Health
+            icon: mdi:heart-pulse
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 3
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: sensor.hsem_workingmode_sensor
+            name: Working Mode
+            icon: mdi:chart-timeline-variant
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: sensor.hsem_force_mode_sensor
+            name: Force Mode
+            icon: mdi:hand-pointing-right
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 2
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: sensor.hsem_read_only_sensor
+            name: Read-Only
+            icon: mdi:lock
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 2
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: sensor.hsem_hardware_writes_sensor
+            name: HW Writes
+            icon: mdi:pencil
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 2
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: sensor.hsem_applier_status_sensor
+            name: Inverter Apply
+            icon: mdi:swap-horizontal
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 3
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: sensor.hsem_missing_entities_sensor
+            name: Missing Inputs
+            icon: mdi:alert-circle-outline
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 3
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: sensor.hsem_ev_charging_sensor
+            name: EV Charging Active
+            icon: mdi:ev-station
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 3
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "{{ state_attr('sensor.hsem_workingmode_sensor', 'degraded_mode') }}"
+            secondary: Degraded Mode
+            icon: mdi:alert
+            icon_color: >
+              {% set d = state_attr('sensor.hsem_workingmode_sensor', 'degraded_mode') %}
+              {% if d == 'ok' %}green{% elif d == 'degraded' %}orange{% else %}red{% endif %}
+            grid_options:
+              columns: 3
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "{{ state_attr('sensor.hsem_workingmode_sensor', 'batteries_current_capacity') }} kWh"
+            secondary: "Current / Usable: {{ state_attr('sensor.hsem_workingmode_sensor', 'batteries_usable_capacity') }} kWh"
+            icon: mdi:battery
+            icon_color: yellow
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "{{ state_attr('sensor.hsem_workingmode_sensor', 'net_consumption') }} W"
+            secondary: "Solar: {{ state_attr('sensor.hsem_workingmode_sensor', 'solar_production_power_state') }} W"
+            icon: mdi:transmission-tower
+            icon_color: blue
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "{{ state_attr('sensor.hsem_workingmode_sensor', 'import_electricity_price_state') }}"
+            secondary: "Import / Export: {{ state_attr('sensor.hsem_workingmode_sensor', 'export_electricity_price_state') }}"
+            icon: mdi:currency-eur
+            icon_color: green
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+        column_span: 2
+
+      # ═══════════════════════════════════════════════════════════
+      # SECTION 2 — WORKING MODE TIMELINE (48h)
+      # ═══════════════════════════════════════════════════════════
+      - type: grid
+        cards:
+          - type: heading
+            heading: Working Mode Timeline (48h)
+            heading_style: title
+            grid_options:
+              columns: full
+              rows: 1
+          - type: custom:apexcharts-card
+            update_interval: 5m
+            experimental:
+              disable_config_validation: true
+            grid_options:
+              columns: full
+            graph_span: 48h
+            span:
+              start: day
+            now:
+              show: true
+              color: red
+              label: Now
+            apex_config:
+              chart:
+                height: 160
+              stroke:
+                curve: stepline
+              legend:
+                show: true
+                position: bottom
+                fontSize: 11px
+              xaxis:
+                labels:
+                  format: HH
+                  rotate: -45
+                  rotateAlways: true
+                  hideOverlappingLabels: true
+                  style:
+                    fontSize: 10
+                    fontWeight: 500
+              yaxis:
+                show: false
+                min: 0
+                max: 1
+                tickAmount: 1
+            series:
+              - name: Charge From Grid
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: area
+                opacity: 1
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end, recommendation })
+                  => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    const on = recommendation === 'batteries_charge_grid' ? 1 : null;
+                    out.push([s, on], [e, on]);
+                  }); return out;
+                color: "#ef4444"
+              - name: Charge From Solar
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: area
+                opacity: 1
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end, recommendation })
+                  => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    const on = recommendation === 'batteries_charge_solar' ? 1 : null;
+                    out.push([s, on], [e, on]);
+                  }); return out;
+                color: "#22c55e"
+              - name: Discharge
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: area
+                opacity: 1
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end, recommendation })
+                  => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    const on = recommendation === 'batteries_discharge_mode' ? 1 : null;
+                    out.push([s, on], [e, on]);
+                  }); return out;
+                color: "#f97316"
+              - name: Wait
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: area
+                opacity: 1
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end, recommendation })
+                  => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    const on = recommendation === 'batteries_wait_mode' ? 1 : null;
+                    out.push([s, on], [e, on]);
+                  }); return out;
+                color: "#8b5cf6"
+              - name: EV Smart Charging
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: area
+                opacity: 1
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end, recommendation })
+                  => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    const on = recommendation === 'ev_smart_charging' ? 1 : null;
+                    out.push([s, on], [e, on]);
+                  }); return out;
+                color: "#06b6d4"
+              - name: Force Discharge
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: area
+                opacity: 1
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end, recommendation })
+                  => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    const on = recommendation === 'force_batteries_discharge' ? 1 : null;
+                    out.push([s, on], [e, on]);
+                  }); return out;
+                color: "#ec4899"
+              - name: Time Passed
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: area
+                opacity: 1
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end, recommendation })
+                  => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    const on = recommendation === 'time_passed' ? 1 : null;
+                    out.push([s, on], [e, on]);
+                  }); return out;
+                color: "#64748b"
+        column_span: 2
+
+      # ═══════════════════════════════════════════════════════════
+      # SECTION 3 — PLANNING & INTELLIGENCE
+      # ═══════════════════════════════════════════════════════════
+      - type: grid
+        cards:
+          - type: heading
+            heading: Planning & Intelligence
+            heading_style: title
+            grid_options:
+              columns: full
+              rows: 1
+          - type: tile
+            entity: sensor.hsem_plan_explanation_sensor
+            name: Plan Strategy
+            icon: mdi:brain
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: sensor.hsem_forecast_accuracy_sensor
+            name: Forecast Accuracy
+            icon: mdi:chart-line
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: sensor.daily_plan_vs_actual
+            name: Plan vs Actual
+            icon: mdi:scale-balance
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: sensor.hsem_next_update_sensor
+            name: Next Update
+            icon: mdi:timer-sand
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: sensor.hsem_last_updated_sensor
+            name: Last Updated
+            icon: mdi:clock-check
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: sensor.hsem_update_interval_sensor
+            name: Update Interval
+            icon: mdi:timer-sync
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: sensor.hsem_recommendation_interval_sensor
+            name: Recomm. Interval
+            icon: mdi:timer-music
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "Spread: {{ state_attr('sensor.hsem_plan_explanation_sensor', 'price_spread') }}"
+            secondary: "Peak: {{ state_attr('sensor.hsem_plan_explanation_sensor', 'peak_import_price') }} / Off: {{ state_attr('sensor.hsem_plan_explanation_sensor', 'off_peak_import_price') }}"
+            icon: mdi:swap-horizontal-bold
+            icon_color: >
+              {% set s = state_attr('sensor.hsem_plan_explanation_sensor', 'price_spread') | float(0) %}
+              {% if s > 0.01 %}green{% else %}grey{% endif %}
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:apexcharts-card
+            update_interval: 5m
+            experimental:
+              disable_config_validation: true
+            header:
+              show: true
+              title: Rejected Plans — Costs
+            graph_span: 48h
+            apex_config:
+              chart:
+                height: 200
+              legend:
+                show: true
+                position: bottom
+                fontSize: 11px
+              xaxis:
+                type: category
+                labels:
+                  style:
+                    fontSize: 10
+              yaxis:
+                decimalsInFloat: 4
+                title:
+                  text: Currency
+              plotOptions:
+                bar:
+                  horizontal: true
+            series:
+              - name: Total Cost
+                entity: sensor.hsem_plan_explanation_sensor
+                attribute: rejected_plans
+                type: bar
+                color: "#8b5cf6"
+                float_precision: 4
+                show:
+                  legend_value: false
+                data_generator: >
+                  const plans = Array.isArray(entity.attributes.rejected_plans) ?
+                    entity.attributes.rejected_plans : [];
+                  const out = [];
+                  plans.forEach(p => {
+                    if (p.estimated_cost !== undefined) out.push({x: p.name, y: p.estimated_cost});
+                  });
+                  return out;
+              - name: Score (lower=better)
+                entity: sensor.hsem_plan_explanation_sensor
+                attribute: rejected_plans
+                type: bar
+                color: "#f97316"
+                float_precision: 4
+                show:
+                  legend_value: false
+                data_generator: >
+                  const plans = Array.isArray(entity.attributes.rejected_plans) ?
+                    entity.attributes.rejected_plans : [];
+                  const out = [];
+                  plans.forEach(p => {
+                    if (p.score !== undefined) out.push({x: p.name, y: p.score});
+                  });
+                  return out;
+            grid_options:
+              columns: full
+              rows: 1
+        column_span: 2
+
+      # ═══════════════════════════════════════════════════════════
+      # SECTION 4b — DAILY PLAN vs ACTUAL HISTORY
+      # ═══════════════════════════════════════════════════════════
+      - type: grid
+        cards:
+          - type: heading
+            heading: Daily Plan vs Actual — 30 Day History
+            heading_style: title
+            grid_options:
+              columns: full
+              rows: 1
+          - type: custom:apexcharts-card
+            update_interval: 5m
+            header:
+              show: true
+              title: Net Cost per Day — Last 30 Days
+            graph_span: 30d
+            apex_config:
+              chart:
+                height: 220
+              stroke:
+                curve: stepline
+                width: 1
+              markers:
+                size: 3
+              legend:
+                show: true
+                position: bottom
+                fontSize: 11px
+              xaxis:
+                type: datetime
+                labels:
+                  format: dd MMM
+                  datetimeUTC: false
+                  rotate: -45
+                  rotateAlways: true
+                  hideOverlappingLabels: true
+                  style:
+                    fontSize: 10
+              yaxis:
+                decimalsInFloat: 2
+                title:
+                  text: Currency
+            series:
+              - name: Plan
+                entity: sensor.daily_plan_vs_actual
+                attribute: history
+                type: line
+                color: "#3b82f6"
+                float_precision: 2
+                show:
+                  legend_value: false
+                data_generator: >
+                  const days = Array.isArray(entity.attributes.history) ?
+                    entity.attributes.history.slice().reverse() : [];
+                  const out = [];
+                  days.forEach(d => {
+                    if (!d || !d.plan || !d.date) return;
+                    const ts = new Date(d.date + 'T12:00:00').getTime();
+                    const planNet = (d.plan.grid_import_cost || 0) - (d.plan.grid_export_rev || 0);
+                    out.push([ts, planNet]);
+                  });
+                  return out;
+              - name: Actual
+                entity: sensor.daily_plan_vs_actual
+                attribute: history
+                type: line
+                color: "#f97316"
+                float_precision: 2
+                show:
+                  legend_value: false
+                data_generator: >
+                  const days = Array.isArray(entity.attributes.history) ?
+                    entity.attributes.history.slice().reverse() : [];
+                  const out = [];
+                  days.forEach(d => {
+                    if (!d || !d.actual || !d.date) return;
+                    const ts = new Date(d.date + 'T12:00:00').getTime();
+                    const actualNet = (d.actual.grid_import_cost || 0) - (d.actual.grid_export_rev || 0);
+                    out.push([ts, actualNet]);
+                  });
+                  return out;
+              - name: Diff
+                entity: sensor.daily_plan_vs_actual
+                attribute: history
+                type: column
+                color: "#22c55e"
+                float_precision: 2
+                opacity: 0.6
+                show:
+                  legend_value: true
+                data_generator: >
+                  const days = Array.isArray(entity.attributes.history) ?
+                    entity.attributes.history.slice().reverse() : [];
+                  const out = [];
+                  days.forEach(d => {
+                    if (!d || !d.plan || !d.actual || !d.date) return;
+                    const ts = new Date(d.date + 'T12:00:00').getTime();
+                    const planNet = (d.plan.grid_import_cost || 0) - (d.plan.grid_export_rev || 0);
+                    const actualNet = (d.actual.grid_import_cost || 0) - (d.actual.grid_export_rev || 0);
+                    out.push([ts, actualNet - planNet]);
+                  });
+                  return out;
+          - type: custom:mushroom-template-card
+            primary: "Today: {{ state_attr('sensor.daily_plan_vs_actual', 'today').actual.grid_import_cost }} / {{ state_attr('sensor.daily_plan_vs_actual', 'today').plan.grid_import_cost }}"
+            secondary: "Actual/Plan Import Cost"
+            icon: mdi:currency-eur
+            icon_color: blue
+            grid_options:
+              columns: 6
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "{{ state_attr('sensor.daily_plan_vs_actual', 'history') | length }} days"
+            secondary: "History Window"
+            icon: mdi:calendar-range
+            icon_color: purple
+            grid_options:
+              columns: 6
+              rows: 1
+            tap_action:
+              action: more-info
+        column_span: 2
+
+      # ═══════════════════════════════════════════════════════════
+      # SECTION 4c — FORECAST ACCURACY INSIGHTS
+      # ═══════════════════════════════════════════════════════════
+      - type: grid
+        cards:
+          - type: heading
+            heading: PV & Load Forecast Accuracy
+            heading_style: title
+            grid_options:
+              columns: full
+              rows: 1
+          - type: custom:mushroom-template-card
+            primary: "PV MAE: {{ state_attr('sensor.hsem_forecast_accuracy_sensor', 'mae_pv_kwh') }} kWh"
+            secondary: "RMSE: {{ state_attr('sensor.hsem_forecast_accuracy_sensor', 'rmse_pv_kwh') }} kWh"
+            icon: mdi:solar-power
+            icon_color: orange
+            grid_options:
+              columns: 3
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "PV Bias: {{ state_attr('sensor.hsem_forecast_accuracy_sensor', 'bias_pv_kwh') }} kWh"
+            secondary: "MAPE: {{ state_attr('sensor.hsem_forecast_accuracy_sensor', 'mape_pv_pct') }}%"
+            icon: mdi:chart-bell-curve
+            icon_color: >
+              {% set b = state_attr('sensor.hsem_forecast_accuracy_sensor', 'bias_pv_kwh') | float(0) %}
+              {% if b | abs < 0.1 %}green{% elif b > 0 %}orange{% else %}blue{% endif %}
+            grid_options:
+              columns: 3
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "Load MAE: {{ state_attr('sensor.hsem_forecast_accuracy_sensor', 'mae_load_kwh') }} kWh"
+            secondary: "RMSE: {{ state_attr('sensor.hsem_forecast_accuracy_sensor', 'rmse_load_kwh') }} kWh"
+            icon: mdi:home-lightning-bolt
+            icon_color: blue
+            grid_options:
+              columns: 3
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "Load Bias: {{ state_attr('sensor.hsem_forecast_accuracy_sensor', 'bias_load_kwh') }} kWh"
+            secondary: "MAPE: {{ state_attr('sensor.hsem_forecast_accuracy_sensor', 'mape_load_pct') }}%"
+            icon: mdi:chart-bell-curve
+            icon_color: >
+              {% set b = state_attr('sensor.hsem_forecast_accuracy_sensor', 'bias_load_kwh') | float(0) %}
+              {% if b | abs < 0.1 %}green{% elif b > 0 %}orange{% else %}blue{% endif %}
+            grid_options:
+              columns: 3
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "Slots: {{ state_attr('sensor.hsem_forecast_accuracy_sensor', 'finalised_slots') }}"
+            secondary: "Window: {{ state_attr('sensor.hsem_forecast_accuracy_sensor', 'window_slots') }}"
+            icon: mdi:counter
+            icon_color: grey
+            grid_options:
+              columns: 3
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: >
+              PV: {{ state_attr('sensor.hsem_forecast_accuracy_sensor', 'latest_pv_forecast_kwh') }} &rarr;
+              {{ state_attr('sensor.hsem_forecast_accuracy_sensor', 'latest_pv_actual_kwh') }} kWh
+            secondary: "Latest Slot (Forecast &rarr; Actual)"
+            icon: mdi:swap-horizontal
+            icon_color: yellow
+            grid_options:
+              columns: 3
+              rows: 1
+            tap_action:
+              action: more-info
+        column_span: 2
+
+      # ═══════════════════════════════════════════════════════════
+      # SECTION 4d — LIVE POWER FLOW
+      # ═══════════════════════════════════════════════════════════
+      - type: grid
+        cards:
+          - type: heading
+            heading: Live Power Flow
+            heading_style: title
+            grid_options:
+              columns: full
+              rows: 1
+          - type: custom:mushroom-template-card
+            primary: "{{ state_attr('sensor.hsem_workingmode_sensor', 'solar_production_power_state') }} W"
+            secondary: Solar Production
+            icon: mdi:solar-power
+            icon_color: orange
+            grid_options:
+              columns: 3
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "{{ state_attr('sensor.hsem_workingmode_sensor', 'house_consumption_power_state') }} W"
+            secondary: House Consumption
+            icon: mdi:home-lightning-bolt
+            icon_color: blue
+            grid_options:
+              columns: 3
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "{{ state_attr('sensor.hsem_workingmode_sensor', 'net_consumption') }} W"
+            secondary: Net (Grid) Consumption
+            icon: mdi:transmission-tower
+            icon_color: >
+              {% set n = state_attr('sensor.hsem_workingmode_sensor', 'net_consumption') | float(0) %}
+              {% if n > 0 %}red{% else %}green{% endif %}
+            grid_options:
+              columns: 3
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "{{ state_attr('sensor.hsem_workingmode_sensor', 'net_consumption_with_ev') }} W"
+            secondary: Net (incl. EV)
+            icon: mdi:ev-station
+            icon_color: >
+              {% set n = state_attr('sensor.hsem_workingmode_sensor', 'net_consumption_with_ev') | float(0) %}
+              {% if n > 0 %}red{% else %}green{% endif %}
+            grid_options:
+              columns: 3
+              rows: 1
+            tap_action:
+              action: more-info
+        column_span: 2
+
+      # ═══════════════════════════════════════════════════════════
+      # SECTION 4e — HUAWEI SOLAR INVERTER STATE
+      # ═══════════════════════════════════════════════════════════
+      - type: grid
+        cards:
+          - type: heading
+            heading: Huawei Solar — Inverter & Battery Status
+            heading_style: title
+            grid_options:
+              columns: full
+              rows: 1
+          - type: custom:mushroom-template-card
+            primary: "{{ state_attr('sensor.hsem_workingmode_sensor', 'huawei_solar_batteries_working_mode_state') }}"
+            secondary: Battery Working Mode
+            icon: mdi:battery-sync
+            icon_color: blue
+            grid_options:
+              columns: 3
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "{{ state_attr('sensor.hsem_workingmode_sensor', 'huawei_solar_inverter_active_power_control_state_state') }}"
+            secondary: Active Power Control
+            icon: mdi:flash
+            icon_color: yellow
+            grid_options:
+              columns: 3
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "{{ state_attr('sensor.hsem_workingmode_sensor', 'huawei_solar_batteries_excess_pv_energy_use_in_tou_state') }}"
+            secondary: Excess PV in TOU
+            icon: mdi:solar-power
+            icon_color: green
+            grid_options:
+              columns: 3
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "{{ state_attr('sensor.hsem_workingmode_sensor', 'huawei_solar_batteries_maximum_charging_power_state') }} W"
+            secondary: Max Charge Power
+            icon: mdi:battery-plus
+            icon_color: green
+            grid_options:
+              columns: 3
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "{{ state_attr('sensor.hsem_workingmode_sensor', 'huawei_solar_batteries_maximum_discharging_power_state') }} W"
+            secondary: Max Discharge Power
+            icon: mdi:battery-minus
+            icon_color: orange
+            grid_options:
+              columns: 3
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "{{ state_attr('sensor.hsem_workingmode_sensor', 'huawei_solar_batteries_state_of_capacity_state') }}%"
+            secondary: Battery SoC (Huawei)
+            icon: mdi:battery-high
+            icon_color: yellow
+            grid_options:
+              columns: 3
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "{{ state_attr('sensor.hsem_workingmode_sensor', 'huawei_solar_batteries_charging_cutoff_capacity_state') }}%"
+            secondary: Charging Cutoff SoC
+            icon: mdi:battery-off
+            icon_color: grey
+            grid_options:
+              columns: 3
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "{{ state_attr('sensor.hsem_workingmode_sensor', 'huawei_solar_batteries_grid_charge_cutoff_soc_state') }}%"
+            secondary: Grid Charge Cutoff SoC
+            icon: mdi:transmission-tower
+            icon_color: red
+            grid_options:
+              columns: 3
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "{{ state_attr('sensor.hsem_workingmode_sensor', 'huawei_solar_batteries_rated_capacity_max_state') }} Wh"
+            secondary: Rated Capacity (max)
+            icon: mdi:battery
+            icon_color: purple
+            grid_options:
+              columns: 3
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "{{ state_attr('sensor.hsem_workingmode_sensor', 'huawei_solar_batteries_tou_charging_and_discharging_periods_state') }}"
+            secondary: TOU Periods State
+            icon: mdi:calendar-clock
+            icon_color: blue
+            grid_options:
+              columns: 3
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "{{ state_attr('sensor.hsem_workingmode_sensor', 'apply_status') }}"
+            secondary: Last Apply Status
+            icon: mdi:swap-horizontal
+            icon_color: >
+              {% set s = state_attr('sensor.hsem_workingmode_sensor', 'apply_status') %}
+              {% if s == 'ok' %}green{% elif s == 'failed' %}red{% else %}orange{% endif %}
+            grid_options:
+              columns: 3
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "{{ state_attr('sensor.hsem_workingmode_sensor', 'huawei_solar_batteries_tou_charging_and_discharging_periods_periods') | length }} periods"
+            secondary: TOU Schedule Periods
+            icon: mdi:format-list-bulleted
+            icon_color: purple
+            grid_options:
+              columns: 3
+              rows: 1
+            tap_action:
+              action: more-info
+        column_span: 2
+
+      # ═══════════════════════════════════════════════════════════
+      # SECTION 3 (continued) — PLANNING & INTELLIGENCE
+      # ═══════════════════════════════════════════════════════════
+      - type: grid
+        cards:
+          - type: heading
+            heading: Controls & Config
+            heading_style: title
+            grid_options:
+              columns: full
+              rows: 1
+          - type: tile
+            entity: select.hsem_solcast_likelihood
+            name: Solcast Likelihood
+            icon: mdi:solar-power
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: select.hsem_force_working_mode
+            name: Force Working Mode
+            icon: mdi:chart-timeline-variant
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: switch.hsem_extended_attributes
+            name: Extended Attrs
+            icon: mdi:code-json
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: switch.hsem_verbose_logging
+            name: Verbose Logging
+            icon: mdi:message-text
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: switch.hsem_read_only
+            name: Read Only Switch
+            icon: mdi:shield-lock
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+        column_span: 2
+
+      # ═══════════════════════════════════════════════════════════
+      # SECTION 4 — MILP & ML INSIGHTS
+      # ═══════════════════════════════════════════════════════════
+      - type: grid
+        cards:
+          - type: heading
+            heading: Planner — MILP & ML Insights
+            heading_style: title
+            grid_options:
+              columns: full
+              rows: 1
+          - type: custom:mushroom-template-card
+            primary: "{{ state_attr('sensor.hsem_plan_explanation_sensor', 'winner_name') }}"
+            secondary: "{{ state_attr('sensor.hsem_plan_explanation_sensor', 'summary') }}"
+            icon: mdi:chart-gantt
+            icon_color: >
+              {% set w = state_attr('sensor.hsem_plan_explanation_sensor', 'winner_name') %}
+              {% if w == 'milp' %}amber{% elif w == 'passive' %}blue{% else %}grey{% endif %}
+            grid_options:
+              columns: 6
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "Score: {{ state_attr('sensor.hsem_plan_explanation_sensor', 'score') }}"
+            secondary: "Cost: {{ state_attr('sensor.hsem_plan_explanation_sensor', 'estimated_total_cost') }}"
+            icon: mdi:currency-eur
+            icon_color: green
+            grid_options:
+              columns: 5
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "{{ state_attr('sensor.hsem_plan_explanation_sensor', 'selected_strategy') }}"
+            secondary: Strategy
+            icon: mdi:strategy
+            icon_color: purple
+            grid_options:
+              columns: 5
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "PV: {{ state_attr('sensor.hsem_plan_explanation_sensor', 'forecast_pv_kwh') }} kWh"
+            secondary: "Net: {{ state_attr('sensor.hsem_plan_explanation_sensor', 'forecast_net_consumption_kwh') }} kWh"
+            icon: mdi:solar-power
+            icon_color: orange
+            grid_options:
+              columns: 6
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "SoC: {{ state_attr('sensor.hsem_plan_explanation_sensor', 'battery_soc_pct') }}% &rarr; {{ state_attr('sensor.hsem_plan_explanation_sensor', 'battery_soc_at_end_pct') }}%"
+            secondary: "Spread: {{ state_attr('sensor.hsem_plan_explanation_sensor', 'price_spread') }}"
+            icon: mdi:battery-charging
+            icon_color: yellow
+            grid_options:
+              columns: 6
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "Hysteresis: {{ state_attr('sensor.hsem_plan_explanation_sensor', 'hysteresis_active') }}"
+            secondary: "{{ state_attr('sensor.hsem_plan_explanation_sensor', 'hysteresis_reason') }}"
+            icon: mdi:animation
+            icon_color: >
+              {% if state_attr('sensor.hsem_plan_explanation_sensor', 'hysteresis_active') %}orange{% else %}grey{% endif %}
+            grid_options:
+              columns: 6
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "Data Quality: {{ state_attr('sensor.hsem_plan_explanation_sensor', 'data_quality_complete') }}"
+            secondary: "Horizon: {{ state_attr('sensor.hsem_plan_explanation_sensor', 'planning_horizon_hours') }}h / {{ state_attr('sensor.hsem_plan_explanation_sensor', 'forecast_mode') }}"
+            icon: mdi:checkbox-marked-circle-outline
+            icon_color: >
+              {% if state_attr('sensor.hsem_plan_explanation_sensor', 'data_quality_complete') %}green{% else %}red{% endif %}
+            grid_options:
+              columns: 6
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: "ML Enabled: {{ states('switch.hsem_ml_consumption_enabled') }}"
+            secondary: "Sequential: {{ states('switch.hsem_ml_consumption_sequential') }}"
+            icon: mdi:chart-bell-curve
+            icon_color: >
+              {% if states('switch.hsem_ml_consumption_enabled') == 'on' %}blue{% else %}grey{% endif %}
+            grid_options:
+              columns: 6
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: switch.hsem_ml_consumption_enabled
+            name: ML Consumption
+            icon: mdi:chart-bell-curve
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 5
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: switch.hsem_ml_consumption_sequential
+            name: ML Sequential
+            icon: mdi:chart-timeline
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 5
+              rows: 1
+            tap_action:
+              action: more-info
+        column_span: 2
+
+      # ═══════════════════════════════════════════════════════════
+      # SECTION 5 — BATTERY & POWER
+      # ═══════════════════════════════════════════════════════════
+      - type: grid
+        cards:
+          - type: heading
+            heading: Battery & Power
+            heading_style: title
+            grid_options:
+              columns: full
+              rows: 1
+          - type: custom:apexcharts-card
+            update_interval: 10m
+            graph_span: 24h
+            span:
+              start: day
+            now:
+              show: true
+              color: red
+              label: Now
+            header:
+              show: true
+              title: Battery SoC & Grid Import
+              show_states: false
+            apex_config:
+              chart:
+                height: 200
+              legend:
+                show: true
+                position: bottom
+              xaxis:
+                labels:
+                  format: HH
+                  rotate: -45
+                  rotateAlways: true
+                  hideOverlappingLabels: true
+                  style:
+                    fontSize: 10
+                    fontWeight: 500
+              yaxis:
+                - id: pct
+                  show: true
+                  opposite: false
+                  decimals: 0
+                  max: 100
+                  min: 0
+                  title:
+                    text: SoC %
+                - id: watt
+                  show: true
+                  opposite: true
+                  decimals: 0
+                  min: 0
+                  title:
+                    text: Watts
+            series:
+              - entity: sensor.batteries_state_of_capacity
+                name: Battery SoC
+                type: line
+                color: "#eab308"
+                yaxis_id: pct
+                opacity: 1
+                stroke_width: 2
+              - entity: sensor.power_import
+                name: Grid Import
+                color: "#ef4444"
+                yaxis_id: watt
+                type: area
+                opacity: 0.3
+                stroke_width: 1
+                group_by:
+                  func: avg
+                  duration: 5min
+          - type: tile
+            entity: sensor.hsem_battery_soc_sensor
+            name: Battery SoC (HSEM)
+            icon: mdi:battery-high
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: sensor.hsem_net_consumption_sensor
+            name: Net Consumption
+            icon: mdi:transmission-tower
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: number.hsem_battery_charge_efficiency
+            name: Charge Efficiency
+            icon: mdi:battery-plus
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: number.hsem_battery_discharge_efficiency
+            name: Discharge Efficiency
+            icon: mdi:battery-minus
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+        column_span: 2
+
+      # ═══════════════════════════════════════════════════════════
+      # SECTION 6 — BATTERY SCHEDULES
+      # ═══════════════════════════════════════════════════════════
+      - type: grid
+        cards:
+          - type: heading
+            heading: Batteries Discharge Schedules
+            heading_style: title
+            grid_options:
+              columns: full
+              rows: 1
+          - type: tile
+            entity: switch.hsem_batteries_enable_batteries_schedule_1
+            name: Schedule 1
+            icon: mdi:calendar-clock
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: time.hsem_batteries_enable_batteries_schedule_1_start
+            name: S1 Start
+            icon: mdi:clock-start
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: time.hsem_batteries_enable_batteries_schedule_1_end
+            name: S1 End
+            icon: mdi:clock-end
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: switch.hsem_batteries_enable_batteries_schedule_2
+            name: Schedule 2
+            icon: mdi:calendar-clock
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: time.hsem_batteries_enable_batteries_schedule_2_start
+            name: S2 Start
+            icon: mdi:clock-start
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: time.hsem_batteries_enable_batteries_schedule_2_end
+            name: S2 End
+            icon: mdi:clock-end
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: switch.hsem_batteries_enable_batteries_schedule_3
+            name: Schedule 3
+            icon: mdi:calendar-clock
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: time.hsem_batteries_enable_batteries_schedule_3_start
+            name: S3 Start
+            icon: mdi:clock-start
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: time.hsem_batteries_enable_batteries_schedule_3_end
+            name: S3 End
+            icon: mdi:clock-end
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+        column_span: 2
+
+      # ═══════════════════════════════════════════════════════════
+      # SECTION 7 — ENERGY ECONOMICS
+      # ═══════════════════════════════════════════════════════════
+      - type: grid
+        cards:
+          - type: heading
+            heading: Energy Economics
+            heading_style: title
+            grid_options:
+              columns: full
+              rows: 1
+          - type: custom:apexcharts-card
+            update_interval: 5m
+            header:
+              show: true
+              title: Import & Export Price
+            graph_span: 48h
+            span:
+              start: day
+            now:
+              show: true
+              color: red
+              label: Now
+            apex_config:
+              chart:
+                height: 200
+              stroke:
+                curve: stepline
+                width: 1
+              markers:
+                size: 0
+              legend:
+                show: true
+                position: bottom
+              xaxis:
+                labels:
+                  format: HH
+                  rotate: -45
+                  rotateAlways: true
+                  hideOverlappingLabels: true
+                  style:
+                    fontSize: 10
+                    fontWeight: 500
+              yaxis:
+                decimalsInFloat: 4
+                opposite: true
+                title:
+                  text: Currency/kWh
+            series:
+              - name: Import Price
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: line
+                color: "#ef4444"
+                float_precision: 4
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end, import_price }) =>
+                  {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, import_price], [e, import_price]);
+                  }); return out;
+              - name: Export Price
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: line
+                color: "#22c55e"
+                float_precision: 4
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end, export_price }) =>
+                  {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, export_price], [e, export_price]);
+                  }); return out;
+          - type: custom:apexcharts-card
+            update_interval: 5m
+            header:
+              show: true
+              title: Estimated Cost & Net Consumption
+            graph_span: 48h
+            span:
+              start: day
+            now:
+              show: true
+              color: red
+              label: Now
+            apex_config:
+              chart:
+                height: 200
+              stroke:
+                curve: stepline
+                width: 1
+              markers:
+                size: 0
+              legend:
+                show: true
+                position: bottom
+              xaxis:
+                labels:
+                  format: HH
+                  rotate: -45
+                  rotateAlways: true
+                  hideOverlappingLabels: true
+                  style:
+                    fontSize: 10
+                    fontWeight: 500
+              yaxis:
+                - id: cost
+                  show: true
+                  opposite: false
+                  decimalsInFloat: 2
+                  title:
+                    text: Currency
+                - id: kwh
+                  show: true
+                  opposite: true
+                  decimalsInFloat: 3
+                  title:
+                    text: kWh
+            series:
+              - name: Estimated Cost
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: line
+                color: "#22c55e"
+                yaxis_id: cost
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end,
+                  estimated_cost_currency }) => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, estimated_cost_currency], [e, estimated_cost_currency]);
+                  }); return out;
+              - name: Net Consumption
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: line
+                color: "#06b6d4"
+                yaxis_id: kwh
+                float_precision: 3
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end,
+                  estimated_net_consumption_kwh }) => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, estimated_net_consumption_kwh], [e, estimated_net_consumption_kwh]);
+                  }); return out;
+        column_span: 2
+
+      # ═══════════════════════════════════════════════════════════
+      # SECTION 8 — CONSUMPTION & SOLAR
+      # ═══════════════════════════════════════════════════════════
+      - type: grid
+        cards:
+          - type: heading
+            heading: Consumption & Solar
+            heading_style: title
+            grid_options:
+              columns: full
+              rows: 1
+          - type: custom:apexcharts-card
+            update_interval: 1m
+            experimental:
+              disable_config_validation: true
+            graph_span: 24h
+            span:
+              start: day
+            now:
+              show: true
+              color: red
+              label: Now
+            header:
+              show: true
+              title: House Consumption Averages
+            apex_config:
+              chart:
+                height: 300
+              stroke:
+                width: 2
+              legend:
+                show: true
+                position: bottom
+              xaxis:
+                labels:
+                  format: HH
+                  rotate: -45
+                  rotateAlways: true
+                  hideOverlappingLabels: true
+                  style:
+                    fontSize: 10
+                    fontWeight: 500
+              yaxis:
+                decimalsInFloat: 3
+                title:
+                  text: kWh
+            series:
+              - name: Hourly Consumption
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: area
+                color: "#f97316"
+                float_precision: 3
+                opacity: 0.3
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end,
+                  avg_house_consumption_kwh }) => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, avg_house_consumption_kwh], [e, avg_house_consumption_kwh]);
+                  }); return out;
+              - name: Avg 1 Day
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: line
+                color: "#3b82f6"
+                float_precision: 3
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end,
+                  avg_house_consumption_1d_kwh }) => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, avg_house_consumption_1d_kwh], [e, avg_house_consumption_1d_kwh]);
+                  }); return out;
+              - name: Avg 3 Day
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: line
+                color: "#eab308"
+                float_precision: 3
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end,
+                  avg_house_consumption_3d_kwh }) => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, avg_house_consumption_3d_kwh], [e, avg_house_consumption_3d_kwh]);
+                  }); return out;
+              - name: Avg 7 Day
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: line
+                color: "#8b5cf6"
+                float_precision: 3
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end,
+                  avg_house_consumption_7d_kwh }) => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, avg_house_consumption_7d_kwh], [e, avg_house_consumption_7d_kwh]);
+                  }); return out;
+              - name: Avg 14 Day
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: line
+                color: "#22c55e"
+                float_precision: 3
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end,
+                  avg_house_consumption_14d_kwh }) => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, avg_house_consumption_14d_kwh], [e, avg_house_consumption_14d_kwh]);
+                  }); return out;
+          - type: custom:apexcharts-card
+            update_interval: 5m
+            header:
+              show: true
+              title: Solar & Battery (Planned)
+            graph_span: 48h
+            span:
+              start: day
+            now:
+              show: true
+              color: red
+              label: Now
+            apex_config:
+              chart:
+                height: 300
+              stroke:
+                curve: stepline
+                width: 1
+              markers:
+                size: 0
+              legend:
+                show: true
+                position: bottom
+              xaxis:
+                labels:
+                  format: HH
+                  rotate: -45
+                  rotateAlways: true
+                  hideOverlappingLabels: true
+                  style:
+                    fontSize: 10
+                    fontWeight: 500
+              yaxis:
+                - id: kwh
+                  show: true
+                  opposite: false
+                  decimalsInFloat: 3
+                  title:
+                    text: kWh
+                - id: pct_axis
+                  show: true
+                  opposite: true
+                  decimals: 0
+                  max: 100
+                  min: 0
+                  title:
+                    text: SoC %
+            series:
+              - name: Solcast PV Estimate
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: line
+                color: "#f59e0b"
+                yaxis_id: kwh
+                float_precision: 3
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end,
+                  solcast_pv_estimate_kwh }) => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, solcast_pv_estimate_kwh], [e, solcast_pv_estimate_kwh]);
+                  }); return out;
+              - name: Battery kWh Charged
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: line
+                color: "#22c55e"
+                yaxis_id: kwh
+                float_precision: 3
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end,
+                  batteries_charged_kwh }) => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, batteries_charged_kwh], [e, batteries_charged_kwh]);
+                  }); return out;
+              - name: Est. Battery Capacity
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: line
+                color: "#06b6d4"
+                yaxis_id: kwh
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end,
+                  estimated_battery_capacity_kwh }) => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, estimated_battery_capacity_kwh], [e, estimated_battery_capacity_kwh]);
+                  }); return out;
+              - name: Est. Battery SoC
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: line
+                color: "#eab308"
+                yaxis_id: pct_axis
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end,
+                  estimated_battery_soc_pct }) => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, estimated_battery_soc_pct], [e, estimated_battery_soc_pct]);
+                  }); return out;
+        column_span: 2
+
+      # ═══════════════════════════════════════════════════════════
+      # SECTION 9 — EV 1 (PRIMARY)
+      # ═══════════════════════════════════════════════════════════
+      - type: grid
+        cards:
+          - type: heading
+            heading: EV 1 — Smart Charging Plan
+            heading_style: title
+            grid_options:
+              columns: full
+              rows: 1
+          - type: tile
+            entity: sensor.hsem_ev_optimal_charging_plan
+            name: EV 1 Charging Plan
+            icon: mdi:ev-station
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 6
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: switch.hsem_ev_smart_charging
+            name: Smart Charging
+            icon: mdi:flash
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: switch.hsem_ev_force_charge_now
+            name: Force Charge Now
+            icon: mdi:battery-charging
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 5
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: number.hsem_ev_target_soc
+            name: Target SoC
+            icon: mdi:battery-arrow-up
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: time.hsem_ev_deadline_time
+            name: Charge Deadline
+            icon: mdi:clock-end
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 5
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: switch.hsem_ev_charger_force_max_discharge_power
+            name: Force Max Discharge
+            icon: mdi:battery-arrow-down
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:apexcharts-card
+            update_interval: 5m
+            header:
+              show: true
+              title: EV 1 Planned Charging (kWh)
+            graph_span: 48h
+            span:
+              start: day
+            now:
+              show: true
+              color: red
+              label: Now
+            apex_config:
+              chart:
+                height: 180
+              stroke:
+                curve: stepline
+                width: 1
+              markers:
+                size: 0
+              legend:
+                show: true
+                position: bottom
+                fontSize: 11px
+              xaxis:
+                labels:
+                  format: HH
+                  rotate: -45
+                  rotateAlways: true
+                  hideOverlappingLabels: true
+                  style:
+                    fontSize: 10
+                    fontWeight: 500
+              yaxis:
+                decimalsInFloat: 3
+                opposite: false
+                title:
+                  text: kWh
+            series:
+              - name: AC Load
+                entity: sensor.hsem_ev_optimal_charging_plan
+                attribute: charging_slots
+                type: area
+                color: "#06b6d4"
+                float_precision: 3
+                opacity: 0.7
+                show:
+                  legend_value: false
+                data_generator: >
+                  const slots =
+                  (Array.isArray(entity.attributes.charging_slots) ?
+                  entity.attributes.charging_slots : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; slots.forEach(({ start, end, ac_load_kwh })
+                  => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, ac_load_kwh], [e, ac_load_kwh]);
+                  }); return out;
+              - name: Import Needed
+                entity: sensor.hsem_ev_optimal_charging_plan
+                attribute: charging_slots
+                type: area
+                color: "#ef4444"
+                float_precision: 3
+                opacity: 0.5
+                show:
+                  legend_value: false
+                data_generator: >
+                  const slots =
+                  (Array.isArray(entity.attributes.charging_slots) ?
+                  entity.attributes.charging_slots : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; slots.forEach(({ start, end, import_needed_kwh })
+                  => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, import_needed_kwh], [e, import_needed_kwh]);
+                  }); return out;
+              - name: Solar Surplus
+                entity: sensor.hsem_ev_optimal_charging_plan
+                attribute: charging_slots
+                type: area
+                color: "#22c55e"
+                float_precision: 3
+                opacity: 0.5
+                show:
+                  legend_value: false
+                data_generator: >
+                  const slots =
+                  (Array.isArray(entity.attributes.charging_slots) ?
+                  entity.attributes.charging_slots : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; slots.forEach(({ start, end, solar_surplus_kwh })
+                  => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, solar_surplus_kwh], [e, solar_surplus_kwh]);
+                  }); return out;
+          - type: custom:mushroom-template-card
+            primary: >
+              {% set p = state_attr('sensor.hsem_ev_optimal_charging_plan', 'current_soc') %}
+              {{ p if p != None else '?' }}% &rarr;
+              {% set t = state_attr('sensor.hsem_ev_optimal_charging_plan', 'target_soc') %}
+              {{ t if t != None else '?' }}%
+            secondary: >
+              {% set cap = state_attr('sensor.hsem_ev_optimal_charging_plan', 'battery_capacity_kwh') %}
+              {% set need = state_attr('sensor.hsem_ev_optimal_charging_plan', 'total_kwh_needed') %}
+              {{ cap if cap != None else '?' }} kWh cap / {{ need if need != None else '?' }} kWh needed
+            icon: mdi:battery-50
+            icon_color: green
+            grid_options:
+              columns: 6
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: >
+              {% set s = state_attr('sensor.hsem_ev_optimal_charging_plan', 'charge_power_kw') %}
+              {{ s if s != None else '?' }} kW
+            secondary: >
+              {% set d = state_attr('sensor.hsem_ev_optimal_charging_plan', 'deadline') %}
+              {{ d[:16] if d else 'No deadline' }}
+            icon: mdi:lightning-bolt
+            icon_color: yellow
+            grid_options:
+              columns: 6
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:apexcharts-card
+            update_interval: 5m
+            header:
+              show: true
+              title: EV 1 Slot Cost
+            graph_span: 48h
+            span:
+              start: day
+            now:
+              show: true
+              color: red
+              label: Now
+            apex_config:
+              chart:
+                height: 140
+              stroke:
+                curve: stepline
+                width: 1
+              markers:
+                size: 0
+              legend:
+                show: false
+              xaxis:
+                labels:
+                  format: HH
+                  rotate: -45
+                  rotateAlways: true
+                  hideOverlappingLabels: true
+                  style:
+                    fontSize: 10
+                    fontWeight: 500
+              yaxis:
+                decimalsInFloat: 3
+                opposite: true
+                title:
+                  text: Currency
+            series:
+              - name: Cost
+                entity: sensor.hsem_ev_optimal_charging_plan
+                attribute: charging_slots
+                type: line
+                color: "#22c55e"
+                float_precision: 3
+                show:
+                  legend_value: false
+                data_generator: >
+                  const slots =
+                  (Array.isArray(entity.attributes.charging_slots) ?
+                  entity.attributes.charging_slots : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; slots.forEach(({ start, end, estimated_cost })
+                  => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, estimated_cost], [e, estimated_cost]);
+                  }); return out;
+        column_span: 2
+
+      # ═══════════════════════════════════════════════════════════
+      # SECTION 10 — EV 2 (SECOND)
+      # ═══════════════════════════════════════════════════════════
+      - type: grid
+        cards:
+          - type: heading
+            heading: EV 2 — Second Charging Plan
+            heading_style: title
+            grid_options:
+              columns: full
+              rows: 1
+          - type: tile
+            entity: sensor.hsem_ev_second_optimal_charging_plan
+            name: EV 2 Charging Plan
+            icon: mdi:ev-station
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 6
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: switch.hsem_ev_second_smart_charging
+            name: Smart Charging
+            icon: mdi:flash
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: switch.hsem_ev_second_force_charge_now
+            name: Force Charge Now
+            icon: mdi:battery-charging
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: number.hsem_ev_second_target_soc
+            name: Target SoC
+            icon: mdi:battery-arrow-up
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: tile
+            entity: time.hsem_ev_second_deadline_time
+            name: Charge Deadline
+            icon: mdi:clock-end
+            vertical: false
+            hide_state: false
+            grid_options:
+              columns: 4
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:apexcharts-card
+            update_interval: 5m
+            header:
+              show: true
+              title: EV 2 Planned Charging (kWh)
+            graph_span: 48h
+            span:
+              start: day
+            now:
+              show: true
+              color: red
+              label: Now
+            apex_config:
+              chart:
+                height: 180
+              stroke:
+                curve: stepline
+                width: 1
+              markers:
+                size: 0
+              legend:
+                show: true
+                position: bottom
+                fontSize: 11px
+              xaxis:
+                labels:
+                  format: HH
+                  rotate: -45
+                  rotateAlways: true
+                  hideOverlappingLabels: true
+                  style:
+                    fontSize: 10
+                    fontWeight: 500
+              yaxis:
+                decimalsInFloat: 3
+                opposite: false
+                title:
+                  text: kWh
+            series:
+              - name: AC Load
+                entity: sensor.hsem_ev_second_optimal_charging_plan
+                attribute: charging_slots
+                type: area
+                color: "#06b6d4"
+                float_precision: 3
+                opacity: 0.7
+                show:
+                  legend_value: false
+                data_generator: >
+                  const slots =
+                  (Array.isArray(entity.attributes.charging_slots) ?
+                  entity.attributes.charging_slots : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; slots.forEach(({ start, end, ac_load_kwh })
+                  => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, ac_load_kwh], [e, ac_load_kwh]);
+                  }); return out;
+              - name: Import Needed
+                entity: sensor.hsem_ev_second_optimal_charging_plan
+                attribute: charging_slots
+                type: area
+                color: "#ef4444"
+                float_precision: 3
+                opacity: 0.5
+                show:
+                  legend_value: false
+                data_generator: >
+                  const slots =
+                  (Array.isArray(entity.attributes.charging_slots) ?
+                  entity.attributes.charging_slots : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; slots.forEach(({ start, end, import_needed_kwh })
+                  => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, import_needed_kwh], [e, import_needed_kwh]);
+                  }); return out;
+              - name: Solar Surplus
+                entity: sensor.hsem_ev_second_optimal_charging_plan
+                attribute: charging_slots
+                type: area
+                color: "#22c55e"
+                float_precision: 3
+                opacity: 0.5
+                show:
+                  legend_value: false
+                data_generator: >
+                  const slots =
+                  (Array.isArray(entity.attributes.charging_slots) ?
+                  entity.attributes.charging_slots : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; slots.forEach(({ start, end, solar_surplus_kwh })
+                  => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, solar_surplus_kwh], [e, solar_surplus_kwh]);
+                  }); return out;
+          - type: custom:mushroom-template-card
+            primary: >
+              {% set p = state_attr('sensor.hsem_ev_second_optimal_charging_plan', 'current_soc') %}
+              {{ p if p != None else '?' }}% &rarr;
+              {% set t = state_attr('sensor.hsem_ev_second_optimal_charging_plan', 'target_soc') %}
+              {{ t if t != None else '?' }}%
+            secondary: >
+              {% set cap = state_attr('sensor.hsem_ev_second_optimal_charging_plan', 'battery_capacity_kwh') %}
+              {% set need = state_attr('sensor.hsem_ev_second_optimal_charging_plan', 'total_kwh_needed') %}
+              {{ cap if cap != None else '?' }} kWh cap / {{ need if need != None else '?' }} kWh needed
+            icon: mdi:battery-50
+            icon_color: green
+            grid_options:
+              columns: 5
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:mushroom-template-card
+            primary: >
+              {% set s = state_attr('sensor.hsem_ev_second_optimal_charging_plan', 'charge_power_kw') %}
+              {{ s if s != None else '?' }} kW
+            secondary: >
+              {% set d = state_attr('sensor.hsem_ev_second_optimal_charging_plan', 'deadline') %}
+              {{ d[:16] if d else 'No deadline' }}
+            icon: mdi:lightning-bolt
+            icon_color: yellow
+            grid_options:
+              columns: 5
+              rows: 1
+            tap_action:
+              action: more-info
+          - type: custom:apexcharts-card
+            update_interval: 5m
+            header:
+              show: true
+              title: EV 2 Slot Cost
+            graph_span: 48h
+            span:
+              start: day
+            now:
+              show: true
+              color: red
+              label: Now
+            apex_config:
+              chart:
+                height: 140
+              stroke:
+                curve: stepline
+                width: 1
+              markers:
+                size: 0
+              legend:
+                show: false
+              xaxis:
+                labels:
+                  format: HH
+                  rotate: -45
+                  rotateAlways: true
+                  hideOverlappingLabels: true
+                  style:
+                    fontSize: 10
+                    fontWeight: 500
+              yaxis:
+                decimalsInFloat: 3
+                opposite: true
+                title:
+                  text: Currency
+            series:
+              - name: Cost
+                entity: sensor.hsem_ev_second_optimal_charging_plan
+                attribute: charging_slots
+                type: line
+                color: "#22c55e"
+                float_precision: 3
+                show:
+                  legend_value: false
+                data_generator: >
+                  const slots =
+                  (Array.isArray(entity.attributes.charging_slots) ?
+                  entity.attributes.charging_slots : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; slots.forEach(({ start, end, estimated_cost })
+                  => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, estimated_cost], [e, estimated_cost]);
+                  }); return out;
+        column_span: 2
+
+    type: sections
+    max_columns: 2
+    cards: []

--- a/docs/ev-surplus-charging-automation.md
+++ b/docs/ev-surplus-charging-automation.md
@@ -11,33 +11,40 @@ signal — it needs to know the **grid surplus** so it can dynamically adjust.
 
 1. [Concept](#concept)
 2. [The formula](#the-formula)
-3. [Safe template pattern](#safe-template-pattern)
-4. [go-e Charger (MQTT)](#go-e-charger-mqtt)
-5. [Easee Charger](#easee-charger)
-6. [Zaptec Charger](#zaptec-charger)
+3. [go-e Charger (MQTT)](#go-e-charger-mqtt)
+4. [Easee Charger](#easee-charger)
+5. [Zaptec Charger](#zaptec-charger)
 
 ---
 
 ## Concept
 
-HSEM's `ev_charger_calculated_power` (from `sensor.hsem_workingmode_sensor`
-→ `hourly_recommendation`) tells you the **target AC power** the EV should
-draw right now. For example, `2900` means "charge at 2.9 kW."
+HSEM recalculates `ev_charger_calculated_power` every 5 minutes (the planner's
+update interval). It tells you the target AC power the EV should draw right now —
+e.g. `2900` means "charge at 2.9 kW."
 
-Dynamic chargers (go-e, Easee, Zaptec) don't accept a direct charge-power
-command. Instead, they monitor the grid import/export and adjust their draw
-to keep the grid near zero — consuming exactly the available surplus.
+There are two ways to control a dynamic charger with this value:
 
-If you send `pGrid = -2900` (exporting 2.9 kW), the charger sees surplus and
-ramps up. But once it reaches 2.9 kW, the grid is balanced and `pGrid` should
-be near zero. If you keep sending `-2900`, the charger thinks there's still
-surplus and may overshoot or behave erratically.
+**Option A — HSEM directly controls the charge rate:**
+Feed `ev_charger_calculated_power` into the charger. The charger draws exactly
+that amount. Simple, but if a cloud passes between HSEM updates the charger
+keeps drawing the old target — importing from the grid for up to 5 minutes.
 
-**The fix:** subtract the charger's **current actual power** from the target.
+**Option B — Charger chases real surplus, HSEM sets a ceiling:**
+Feed your real grid power sensor into the charger's surplus input so it
+responds to clouds instantly. Use HSEM's value as a maximum current limit
+so the charger never exceeds what the MILP planned. Requires two automations
+(or one script) per charger.
+
+Both options are documented below. Choose Option B if your goal is "never
+import from grid for the EV."
 
 ---
 
 ## The formula
+
+For Option A (HSEM direct control), the charger needs to know the **remaining**
+surplus after accounting for what it's already drawing:
 
 ```
 pGrid = (ev_charger_calculated_power × -1) + current_charge_power
@@ -64,53 +71,17 @@ the charger that it's importing from the grid and should back off.
 
 ---
 
-## Safe template pattern
-
-Always guard against unavailable sensors. If `sensor.hsem_workingmode_sensor`
-is offline, `state_attr()` returns `None` and accessing `.ev_charger_calculated_power`
-will crash the template.
-
-Use this pattern in all charger automations:
-
-```jinja2
-{% set rec = state_attr('sensor.hsem_workingmode_sensor', 'hourly_recommendation') %}
-{% set target = rec.ev_charger_calculated_power | int(0) if rec is not none else 0 %}
-{% set charge = states('sensor.<your_charger_power>') | int(0) %}
-{{ (target * -1 + charge) }}
-```
-
-If the HSEM sensor is unavailable, `target` defaults to `0` and the charger
-is told to back off rather than the template crashing.
-
----
-
 ## go-e Charger (MQTT)
 
 go-e chargers accept `pGrid`, `pAkku`, and `pPv` via MQTT on the
-`go-eCharger/<serial>/ids/set` topic.
+`go-eCharger/<serial>/ids/set` topic. The `ids` value decays after 10–15
+seconds, so it must be refreshed continuously — the charger's PID loop then
+adjusts the actual charge power to drive `pGrid` toward zero.
 
-The recommended approach combines two signals:
-
-- **`pGrid`** — fed with your **real grid power sensor** every few seconds.
-  The go-e charger's built-in PID loop chases actual surplus in real time,
-  responding to clouds and load changes instantly.
-- **`amp` (requested current)** — set to HSEM's `ev_charger_calculated_power`
-  converted to amps. This acts as a **ceiling** — the charger will never
-  draw more than the MILP-optimized target, but it will draw less (or nothing)
-  when real surplus is low.
-
-> **Why two signals?** HSEM recalculates `ev_charger_calculated_power` every
-> 5 minutes (the planner's update interval). If you feed that directly into
-> `pGrid`, the charger can't respond to a passing cloud — it keeps drawing
-> the old target and imports from the grid. With real grid power in `pGrid`,
-> the charger adjusts second-by-second. The `amp` ceiling ensures it never
-> exceeds what HSEM planned.
-
-> **Why `pGrid` instead of setting amps only?** The `ids` topic (which carries
-> `pGrid`) is designed for frequent updates — the value decays after 10–15
-> seconds and is expected to be refreshed continuously. Setting the charge
-> current via config keys like `amp` writes to persistent storage, so we only
-> update it when HSEM recalculates (every 5 minutes). See the
+> **Why `pGrid` instead of setting amps?** The `ids` topic uses RAM-only
+> registers designed for frequent writes. Setting the charge current directly
+> via config keys like `amp`/`ama` writes to persistent storage (flash) on
+> every update. See the
 > [go-eCharger MQTT docs](https://github.com/syssi/homeassistant-goecharger-mqtt#charge-with-pv-surplus)
 > for details.
 
@@ -119,13 +90,56 @@ The recommended approach combines two signals:
 | Entity | Purpose |
 |---|---|
 | `sensor.hsem_workingmode_sensor` | HSEM hourly recommendation with `ev_charger_calculated_power` |
-| `sensor.power_meter_active_power` | Real grid import/export power in watts (negative = export) |
 | `binary_sensor.go_echarger_<serial>_car` | `on` when car is plugged in |
-| `number.go_echarger_<serial>_amp` | Requested current number entity (for the ceiling) |
+| `sensor.go_echarger_<serial>_nrg_12` | Current charging power in watts |
 
-### Automation 1: Real-time surplus signal (every 3 seconds)
+### Option A: HSEM direct control
 
-This feeds actual grid power into `pGrid` so the charger chases real surplus.
+Single automation — HSEM's `ev_charger_calculated_power` directly drives the
+charge rate. The go-e charger sees remaining surplus and ramps up/down to
+match the target.
+
+```yaml
+alias: go-e Surplus Charging from HSEM
+description: >-
+  Sends grid surplus to go-e charger so it dynamically follows HSEM's
+  EV charging recommendation.
+triggers:
+  - trigger: time_pattern
+    seconds: /3
+conditions:
+  - condition: state
+    entity_id: binary_sensor.go_echarger_222819_car
+    state: "on"
+actions:
+  - data:
+      qos: "0"
+      topic: go-eCharger/222819/ids/set
+      retain: false
+      payload: |-
+        {% set rec = state_attr('sensor.hsem_workingmode_sensor', 'hourly_recommendation') %}
+        {% set target = rec.ev_charger_calculated_power | int(0) if rec is not none else 0 %}
+        {% set charge = states('sensor.go_echarger_222819_nrg_12') | int(0) %}
+        {
+          "pGrid": "{{ (target * -1 + charge) }}",
+          "pAkku": "0",
+          "pPv": "0"
+        }
+    action: mqtt.publish
+mode: single
+```
+
+### Option B: Real surplus with HSEM ceiling
+
+Two automations working together:
+
+1. **Surplus signal** (every 3s) — feeds real grid power into `pGrid` so the
+   charger's PID loop chases actual surplus second-by-second.
+2. **HSEM ceiling** (on state change) — sets `number.go_echarger_<serial>_pgt`
+   (grid target in watts) to HSEM's `ev_charger_calculated_power`. The charger
+   will never exceed this, but will draw less when real surplus is low.
+
+**Automation B1 — Real-time surplus signal:**
 
 ```yaml
 alias: go-e Surplus Signal from Grid Power
@@ -145,9 +159,8 @@ actions:
       topic: go-eCharger/222819/ids/set
       retain: false
       payload: |-
-        {% set grid = states('sensor.power_meter_active_power') | int(0) %}
         {
-          "pGrid": "{{ grid }}",
+          "pGrid": "{{ states('sensor.power_meter_active_power') | int(0) }}",
           "pAkku": "0",
           "pPv": "0"
         }
@@ -155,48 +168,32 @@ actions:
 mode: single
 ```
 
-### Automation 2: HSEM ceiling (every 5 minutes)
-
-This sets the maximum charge current from HSEM's MILP-optimized target.
-Only updates when the target changes, avoiding unnecessary writes to
-persistent storage.
+**Automation B2 — HSEM ceiling:**
 
 ```yaml
-alias: go-e Charge Ceiling from HSEM
+alias: go-e Surplus Charging from HSEM
 description: >-
-  Sets go-e charger's maximum current from HSEM's ev_charger_calculated_power.
-  Acts as a ceiling — the charger won't exceed this, but will draw less
-  when real surplus is low.
+  Simple automation to update values needed for using solar surplus with go-e
+  Chargers
 triggers:
   - trigger: time_pattern
-    minutes: /5
-  - trigger: state
-    entity_id:
-      - sensor.hsem_workingmode_sensor
+    seconds: /3
 conditions:
   - condition: state
     entity_id: binary_sensor.go_echarger_222819_car
     state: "on"
 actions:
-  - variables:
-      rec: >-
-        {{ state_attr('sensor.hsem_workingmode_sensor', 'hourly_recommendation') }}
-      target_w: >-
-        {{ rec.ev_charger_calculated_power | int(0) if rec is not none else 0 }}
-      target_amps: >-
-        {{ (target_w / 690) | round(0, 'floor') | int }}
-      clamped_amps: >-
-        {{ ([6, target_amps, 32] | sort)[1] }}
-  - if:
-      - condition: template
-        value_template: >-
-          {{ (clamped_amps - states('number.go_echarger_222819_amp') | int(0)) | abs > 0 }}
-    then:
-      - action: number.set_value
-        target:
-          entity_id: number.go_echarger_222819_amp
-        data:
-          value: "{{ clamped_amps }}"
+  - data:
+      qos: "0"
+      topic: go-eCharger/222819/ids/set
+      retain: false
+      payload: |-
+        {
+          "pGrid": "{{ (state_attr('sensor.hsem_workingmode_sensor', 'hourly_recommendation').ev_charger_calculated_power | int(0) * -1 + states('sensor.go_echarger_222819_nrg_12') | int(0)) }}",
+          "pAkku": "0",
+          "pPv": "0"
+        }
+    action: mqtt.publish
 mode: single
 ```
 
@@ -204,14 +201,10 @@ mode: single
 > - Replace `222819` with your charger's serial number.
 > - Replace `sensor.power_meter_active_power` with your actual grid power
 >   sensor (negative = export, positive = import).
-> - Replace `690` with `230` if you have a single-phase installation.
-> - `clamped_amps` keeps the ceiling between 6 A (minimum most EVs accept)
->   and 32 A (typical installation limit). Adjust to match your circuit
->   breaker.
+> - `pgt` expects a negative value for surplus (export), so HSEM's positive
+>   watt target is negated (`target * -1`).
 > - The `pAkku` and `pPv` fields are set to `0` because HSEM manages the
 >   home battery separately — the charger only needs the grid surplus signal.
-> - The ceiling automation only calls `number.set_value` when the target
->   actually changes, avoiding writes to persistent storage on every tick.
 
 ---
 
@@ -258,37 +251,23 @@ description: >-
   Sets Easee charger dynamic current limit based on HSEM's
   EV charging recommendation.
 triggers:
-  - trigger: time_pattern
-    seconds: /10
+  - trigger: state
+    entity_id:
+      - sensor.hsem_workingmode_sensor
 conditions:
   - condition: state
     entity_id: binary_sensor.easee_12345_cable_connected
     state: "on"
 actions:
-  - variables:
-      rec: >-
-        {{ state_attr('sensor.hsem_workingmode_sensor', 'hourly_recommendation') }}
-      target_w: >-
-        {{ rec.ev_charger_calculated_power | int(0) if rec is not none else 0 }}
-      target_amps: >-
-        {{ (target_w / 690) | round(0, 'floor') | int }}
-      clamped_amps: >-
-        {{ ([0, target_amps, 32] | sort)[1] }}
-  - if:
-      - condition: template
-        value_template: "{{ target_amps > 0 }}"
-    then:
-      - action: easee.set_charger_dynamic_limit
-        data:
-          charger_id: "12345"
-          current: "{{ clamped_amps }}"
-          time_to_live: 30
-    else:
-      - action: easee.set_charger_dynamic_limit
-        data:
-          charger_id: "12345"
-          current: 0
-          time_to_live: 30
+  - action: easee.set_charger_dynamic_limit
+    data:
+      charger_id: "12345"
+      current: >-
+        {% set rec = state_attr('sensor.hsem_workingmode_sensor', 'hourly_recommendation') %}
+        {% set target = rec.ev_charger_calculated_power | int(0) if rec is not none else 0 %}
+        {% set amps = (target / 690) | round(0, 'floor') | int %}
+        {{ ([0, amps, 32] | sort)[1] }}
+      time_to_live: 30
 mode: single
 ```
 
@@ -296,13 +275,11 @@ mode: single
 > - Replace `12345` with your charger ID (find it in the Easee integration
 >   device list).
 > - Replace `690` with `230` if you have a single-phase installation.
-> - `clamped_amps` keeps the value between 0 and 32 A (Easee's range is 0–40 A;
->   adjust the upper bound to match your installation's circuit breaker).
+> - The `([0, amps, 32] | sort)[1]` pattern clamps between 0 and 32 A (Easee's
+>   range is 0–40 A; adjust the upper bound to match your circuit breaker).
 > - `time_to_live: 30` means the limit expires after 30 seconds if HA stops
 >   sending updates — a safety net that prevents the charger from getting
 >   stuck at a high limit.
-> - The trigger interval is `/10` seconds (not `/3` like go-e) because Easee's
->   cloud API has rate limits. Do not go below 5 seconds.
 
 ### Alternative: circuit-level control
 
@@ -314,9 +291,11 @@ actions:
   - action: easee.set_circuit_dynamic_limit
     data:
       circuit_id: 12345
-      current_p1: "{{ clamped_amps }}"
-      current_p2: "{{ clamped_amps }}"
-      current_p3: "{{ clamped_amps }}"
+      current_p1: >-
+        {% set amps = (states('...') | int(0) / 690) | round(0, 'floor') | int %}
+        {{ ([0, amps, 32] | sort)[1] }}
+      current_p2: "{{ ([0, amps, 32] | sort)[1] }}"
+      current_p3: "{{ ([0, amps, 32] | sort)[1] }}"
       time_to_live: 30
 ```
 
@@ -332,9 +311,8 @@ Like Easee, Zaptec does not use a grid-surplus signal. You convert HSEM's power
 target to amps and set it as the available current.
 
 > **Important:** Zaptec recommends not changing the available current more
-> often than every **15 minutes**. The automation below uses a 15-second
-> trigger for responsiveness but only calls the service when the target
-> changes significantly.
+> often than every **15 minutes**. The automation below triggers on HSEM
+> state changes only.
 
 ### Prerequisites
 
@@ -356,32 +334,23 @@ description: >-
   Sets Zaptec installation available current based on HSEM's
   EV charging recommendation.
 triggers:
-  - trigger: time_pattern
-    seconds: /15
+  - trigger: state
+    entity_id:
+      - sensor.hsem_workingmode_sensor
 conditions:
   - condition: state
     entity_id: binary_sensor.zaptec_my_charger_connected
     state: "on"
 actions:
-  - variables:
-      rec: >-
-        {{ state_attr('sensor.hsem_workingmode_sensor', 'hourly_recommendation') }}
-      target_w: >-
-        {{ rec.ev_charger_calculated_power | int(0) if rec is not none else 0 }}
-      target_amps: >-
-        {{ (target_w / 690) | round(0, 'floor') | int }}
-      clamped_amps: >-
-        {{ ([6, target_amps, 32] | sort)[1] }}
-  - if:
-      - condition: template
-        value_template: >-
-          {{ (target_amps - states('number.my_installation_available_current') | int(0)) | abs > 1 }}
-    then:
-      - action: number.set_value
-        target:
-          entity_id: number.my_installation_available_current
-        data:
-          value: "{{ clamped_amps }}"
+  - action: number.set_value
+    target:
+      entity_id: number.my_installation_available_current
+    data:
+      value: >-
+        {% set rec = state_attr('sensor.hsem_workingmode_sensor', 'hourly_recommendation') %}
+        {% set target = rec.ev_charger_calculated_power | int(0) if rec is not none else 0 %}
+        {% set amps = (target / 690) | round(0, 'floor') | int %}
+        {{ ([6, amps, 32] | sort)[1] }}
 mode: single
 ```
 
@@ -389,10 +358,8 @@ mode: single
 > - Replace `my_charger` and `my_installation` with your actual Zaptec entity
 >   names.
 > - Replace `690` with `230` if you have a single-phase installation.
-> - `clamped_amps` keeps the value between 6 A (minimum most EVs accept) and
->   32 A (typical installation limit). Adjust to match your circuit breaker.
-> - The condition `abs > 1` prevents unnecessary API calls — the service is
->   only called when the target changes by more than 1 A.
+> - `([6, amps, 32] | sort)[1]` clamps between 6 A (minimum most EVs accept)
+>   and 32 A (typical installation limit). Adjust to match your circuit breaker.
 > - If you have multiple chargers on one installation, changing the
 >   installation-level current affects **all** of them.
 
@@ -406,9 +373,11 @@ actions:
   - action: zaptec.limit_current
     data:
       device_id: abc123def456
-      available_current_phase1: "{{ clamped_amps }}"
-      available_current_phase2: "{{ clamped_amps }}"
-      available_current_phase3: "{{ clamped_amps }}"
+      available_current_phase1: >-
+        {% set amps = (states('...') | int(0) / 690) | round(0, 'floor') | int %}
+        {{ ([6, amps, 32] | sort)[1] }}
+      available_current_phase2: "{{ ([6, amps, 32] | sort)[1] }}"
+      available_current_phase3: "{{ ([6, amps, 32] | sort)[1] }}"
 ```
 
 > This sets the current on a specific charger rather than the whole


### PR DESCRIPTION
## Summary

This PR fixes multiple planner issues discovered during EV smart charging development:

### 1. Score divergence between selector and final output
**Problem:** Optimization strategy (`apply_optimization_strategy` and `concentrate_discharge_on_expensive_slots`) was applied *after* candidate selection, causing the final plan's score to diverge from the selector's score.

**Fix:** Moved both optimizations into `select_best_candidate()` so they're applied per-candidate *before* scoring. The winner's slots are now fully populated when returned, and `engine_core.py` no longer re-runs `simulate_soc()` or `apply_optimization_strategy()` on the baseline.

### 2. MILP terminal-SoC credit applied per-slot instead of at horizon end
**Problem:** Terminal-SoC credit was baked into the per-slot objective coefficients, which doesn't match `cost_function.py`'s end-of-horizon calculation.

**Fix:** Removed per-slot terminal-SoC credit from the LP objective. Now computed post-hoc after the LP solves, matching `cost_function.py`'s `terminal_soc_value = (initial_kwh - final_kwh) * replacement_price`.

### 3. MILP missing PV curtailment variable
**Problem:** Energy balance forced the LP to "use" all PV surplus even when curtailment would be optimal (battery full, export prices low/negative).

**Fix:** Added `curt[t]` variable (9th decision variable per slot) to the energy balance constraint, allowing explicit curtailment.

### 4. EV penalty over-prioritization
**Problem:** EV deadline penalty was proportional to full battery capacity, forcing EV charging even for small top-ups (90% → 100%) at the expense of a critically low house battery.

**Fix:** Penalty now proportional to `energy_needed` (target - initial SoC) with a 10x multiplier instead of 100x.

### 5. EV partial-slot power uncapped
**Problem:** When the current slot is partially elapsed, EV power was scaled up by `remaining_h` without capping at the charger's rated power.

**Fix:** Added `min(ac_power_w, full_slot_power_w)` cap.

### 6. Division by zero in `energy_to_power_kw`
**Problem:** `energy_to_power_kw()` didn't guard against `duration_h <= 0`.

**Fix:** Added early return of `0.0` when `duration_h <= 0`.

## Files changed

- `custom_components/hsem/planner/candidate_selector.py` — apply optimization strategy per-candidate before scoring
- `custom_components/hsem/planner/engine_core.py` — remove post-selection optimization, cap EV partial-slot power, pass `rc` to selector
- `custom_components/hsem/planner/milp_optimizer.py` — curtailment variable, end-of-horizon terminal-SoC, EV penalty fix
- `custom_components/hsem/utils/units.py` — guard against zero duration
- `docs/ev-surplus-charging-automation.md` — documentation updates
- `docs/dashboard.yaml` — new dashboard example

## Testing

- [ ] `tox -e lint` passes
- [ ] `tox -e typing` passes
- [ ] `tox -e quality` passes
- [ ] `tox -e py314` passes
