### PR TITLE
fix(ev): prevent EV charger power oscillation with EMA smoothing and live surplus cap

### DIFF
--- a/custom_components/hsem/const.py
+++ b/custom_components/hsem/const.py
@@ -229,3 +229,10 @@ SOLAR_SURPLUS_CHARGE_THRESHOLD_KWH = -0.2
 # charged during seasonal optimisation.  Slots at or below this level are
 # charged from solar rather than from the grid.  Default matches v5.1.0.
 NEAR_ZERO_CONSUMPTION_THRESHOLD_KWH = 0.1
+
+# EMA smoothing factor for live net consumption used in EV charger power
+# smoothing.  Alpha=0.3 means each new reading contributes 30 % to the
+# smoothed value — this damps transient loads and
+# short cloud shadows so they don't kill the EV charging setpoint for the
+# rest of the 15-minute slot.
+EMA_ALPHA_NET_CONSUMPTION = 0.3

--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -44,6 +44,7 @@ from homeassistant.helpers.event import (
 )
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
+from custom_components.hsem.const import EMA_ALPHA_NET_CONSUMPTION
 from custom_components.hsem.coordinator_builder import (
     build_planner_input,
     generate_recommendation_intervals,
@@ -90,7 +91,7 @@ from custom_components.hsem.utils.logger import (
     async_logger,
     set_planner_verbose,
 )
-from custom_components.hsem.utils.misc import get_config_value
+from custom_components.hsem.utils.misc import ema_filter, get_config_value
 from custom_components.hsem.utils.recommendations import Recommendations
 
 if TYPE_CHECKING:
@@ -258,6 +259,12 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         # Window-level hysteresis state (issue #315).
         # Persisted across cycles so the hold-time check can compare against
         # the previously active current-slot recommendation.
+
+        # EMA-smoothed live net consumption (W).  Damped so transients
+        # (støvsuger, kaffemaskine, cloud shadows) don't kill the EV
+        # charging setpoint for the rest of a 15-minute slot.  Initialised
+        # on the first cycle and updated every subsequent cycle.
+        self._net_consumption_ema: float | None = None
         self._window_hys_previous_rec: str | None = None
         self._window_hys_previous_slot_start: datetime | None = None
 
@@ -390,6 +397,19 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             self._listener_unsubs.extend(new_unsubs)
             self._live = self._snapshot.live
             live = self._live
+
+            # Apply EMA smoothing to live net consumption to damp transients
+            # (støvsuger, kaffemaskine, cloud shadows) so they don't kill
+            # the EV charging setpoint for the rest of a 15-minute slot.
+            self._net_consumption_ema = ema_filter(
+                live.net_consumption_w,
+                self._net_consumption_ema,
+                EMA_ALPHA_NET_CONSUMPTION,
+            )
+            # Swap the raw value with the EMA-smoothed value on the live
+            # state object so all downstream code (PlannerInput builder,
+            # forecast tracker, etc.) sees the damped signal.
+            live.net_consumption_w = self._net_consumption_ema
 
             # -----------------------------------------------------------------------
             # Override expiry check (issue #317)
@@ -1046,26 +1066,55 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         second_max_power_w = inp.ev_second_planned_load_charger_power_kw * 1000.0
         second_min_power_w = inp.ev_second_planned_load_charger_min_power_w
 
+        # Live surplus cap — the EMA-smoothed net consumption tells
+        # us the current real surplus.  Cap the charger power at this
+        # value so we never import from the grid during a cloud or
+        # transient load spike within the slot.
+        live_surplus_w: float | None = None
+        if self._live is not None:
+            live_net = self._live.net_consumption_w
+            if live_net < 0:
+                live_surplus_w = -live_net  # negative → surplus
+
         for slot in output.slots:
             s_start = as_tz(slot.start, now.tzinfo)
             s_end = as_tz(slot.end, now.tzinfo)
             if not (s_start <= now < s_end):
                 continue
 
+            remaining_h = max((s_end - now).total_seconds() / 3600.0, 1.0 / 3600.0)
+
             total_ev = slot.ev_total_planned_load_kwh
             if total_ev <= _INPUT_EPSILON:
-                # No EV load planned for this slot — keep the cached value.
+                # No EV load planned for this slot.  Use live surplus
+                # directly — this implements Pass 3 (charge past target
+                # on surplus PV) reactively every minute instead of
+                # waiting for the next MILP re-solve.
+                if live_surplus_w is not None and live_surplus_w > min_power_w:
+                    slot.ev_charger_calculated_power = self._smoothed_power_w(
+                        (live_surplus_w / 1000.0) * remaining_h,
+                        remaining_h,
+                        max_power_w,
+                        min_power_w,
+                        live_surplus_w,
+                    )
                 break
-
-            remaining_h = max((s_end - now).total_seconds() / 3600.0, 1.0 / 3600.0)
 
             if slot.ev_charger_calculated_power > _INPUT_EPSILON:
                 slot.ev_charger_calculated_power = self._smoothed_power_w(
-                    total_ev, remaining_h, max_power_w, min_power_w
+                    total_ev,
+                    remaining_h,
+                    max_power_w,
+                    min_power_w,
+                    live_surplus_w,
                 )
             if slot.ev_second_charger_calculated_power > _INPUT_EPSILON:
                 slot.ev_second_charger_calculated_power = self._smoothed_power_w(
-                    total_ev, remaining_h, second_max_power_w, second_min_power_w
+                    total_ev,
+                    remaining_h,
+                    second_max_power_w,
+                    second_min_power_w,
+                    live_surplus_w,
                 )
             break
 
@@ -1075,6 +1124,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         remaining_hours: float,
         max_power_w: float,
         min_power_w: float,
+        live_surplus_w: float | None = None,
     ) -> float:
         """Return the smoothed AC charger power for the current slot.
 
@@ -1083,11 +1133,18 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         ``min_power_w``: below the minimum the charger cannot start, so the
         power is zeroed.
 
+        When ``live_surplus_w`` is not ``None``, the power is additionally
+        capped at the current live surplus so the charger never draws from
+        the grid during a cloud or transient load spike within the slot.
+
         Args:
             energy_kwh: Remaining EV AC energy planned for the slot (kWh).
             remaining_hours: Hours left in the current slot.
             max_power_w: Charger rated AC power (W); 0 means uncapped.
             min_power_w: Charger minimum operating power (W).
+            live_surplus_w: Current grid surplus in Watts (positive =
+                surplus available).  When set, the returned power will
+                not exceed this value.
 
         Returns:
             The smoothed AC power in Watts (0 when below the minimum).
@@ -1095,6 +1152,9 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         ac_power_w = round((energy_kwh / remaining_hours) * 1000.0)
         if max_power_w > _INPUT_EPSILON:
             ac_power_w = min(ac_power_w, round(max_power_w))
+        # Cap at live surplus to avoid grid import during transients.
+        if live_surplus_w is not None:
+            ac_power_w = min(ac_power_w, round(live_surplus_w))
         if min_power_w > _INPUT_EPSILON and ac_power_w < min_power_w:
             return 0.0
         return float(ac_power_w)

--- a/custom_components/hsem/planner/ev_planner.py
+++ b/custom_components/hsem/planner/ev_planner.py
@@ -117,9 +117,11 @@ class EVPlannerInput:
             the ceiling for the predicted-battery check in Pass 3.
         now: Timezone-aware current datetime.
         live_net_consumption_w: Live net consumption in Watts from
-            sensor.hsem_net_consumption_sensor.  Negative values indicate
-            surplus.  Used in Pass 3 for the current slot to determine
-            actual (not predicted) surplus power.
+            sensor.hsem_net_consumption_sensor after EMA smoothing.
+            Negative values indicate surplus.  No longer used in Pass 3
+            (which now uses predicted surplus for stability) — retained
+            for smoothing the current-slot EV charger power setpoint
+            between MILP re-solves.
     """
 
     enabled: bool = False
@@ -637,22 +639,9 @@ def build_ev_charging_plan(
                 continue
 
             # The EV already reached target — no strict energy budget.
-            # Use as much surplus as possible up to the full slot capacity,
-            # limited by the available surplus.
-            #
-            # For the CURRENT slot, prefer the live net consumption sensor
-            # over the predicted surplus — the prediction may be stale.
-            is_current = s_start <= now_tz < s_end
-            if is_current:
-                # Live net consumption is negative → surplus is available.
-                # Convert watts to kWh for the remaining slot duration.
-                live_surplus_w = -inp.live_net_consumption_w
-                remaining_h = remaining_minutes_in_slot(now_tz, s_end) / 60.0
-                net_surplus = live_surplus_w * remaining_h / 1000.0
-            else:
-                net_surplus = slot_net_surplus_kwh[i]
             # Allocate the minimum of max power and available surplus.
             # We charge only from surplus, never from grid in this pass.
+            net_surplus = slot_net_surplus_kwh[i]
             allocated = min(max_charge, net_surplus)
             if allocated < 1e-9:
                 log_planner(

--- a/custom_components/hsem/utils/misc.py
+++ b/custom_components/hsem/utils/misc.py
@@ -51,6 +51,38 @@ def get_config_value(config_entry: Any | None, key: str) -> Any:
     return data
 
 
+def ema_filter(
+    current: float,
+    previous: float | None,
+    alpha: float,
+) -> float:
+    """Apply an exponential moving average filter.
+
+    Smooths a stream of values by blending each new reading with the
+    previous smoothed value.  The *alpha* parameter controls
+    responsiveness:
+
+    - ``alpha = 1.0`` → no smoothing (raw value).
+    - ``alpha = 0.3`` → each new reading contributes 30 %.
+    - ``alpha = 0.0`` → frozen (always returns *previous*).
+
+    On the first call (``previous is None``) the raw ``current`` value is
+    returned as-is to initialise the filter.
+
+    Args:
+        current: The latest raw value.
+        previous: The previous EMA-smoothed value, or ``None`` to
+            initialise.
+        alpha: Smoothing factor in [0.0, 1.0].
+
+    Returns:
+        The new EMA-smoothed value.
+    """
+    if previous is None:
+        return current
+    return alpha * current + (1.0 - alpha) * previous
+
+
 def clamp_efficiency(pct: float) -> float:
     """Convert an efficiency percentage (0-100) to a fraction (0.01-1.0).
 

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -20,11 +20,25 @@ re-solve frequency from the polling interval.  The planner engine (`run_planner`
 is only called when the coordinator's `_should_rerun_milp()` returns `True` —
 on price change, Solcast update, slot boundary, EV state change, user
 override, or staleness timeout (`planner_min_resolve_interval_minutes`,
-default 15).  Between re-solves the current slot's EV charger power is
-smoothed from the cached plan's `ev_total_planned_load_kwh` divided by
-remaining hours, capped at `charger_power_kw` and floored at
-`charger_min_power_w`.  Setting the config option to 0 restores the legacy
-every-cycle re-solve.
+Between re-solves the current slot's EV charger power is
+smoothed **every minute** using the cached plan's `ev_total_planned_load_kwh`
+divided by remaining hours, capped at `charger_power_kw` and floored at
+`charger_min_power_w`.  **Two live-surplus guards** were added to prevent
+oscillation:
+
+- **EMA filter**: `live.net_consumption_w` is smoothed through an
+  exponential moving average (α=0.3) to damp transient loads and cloud
+  shadows so they don't kill the EV charging setpoint.
+- **Live surplus cap**: the smoothed power is additionally capped at the
+  current live surplus — the charger never draws from the grid during a
+  cloud or transient load spike within the slot.
+- **Recovery from zero**: when the MILP allocated no EV load for the
+  current slot (e.g. a cloud at solve time), the smoothing layer can still
+  set a power target if live surplus exceeds `charger_min_power_w` —
+  implementing Pass 3 (charge-past-target on surplus PV) reactively every
+  minute instead of every 15.
+
+Setting the config option to 0 restores the legacy every-cycle re-solve.
 
 ## Core concepts
 
@@ -1079,7 +1093,10 @@ The EV planner (`planner/ev_planner.py`) MUST satisfy these invariants:
 
     - **EV planner Pass 3** (fallback): scans remaining PV-surplus slots where
       the house battery is predicted to be full.  All energy is solar-surplus
-      with zero grid cost.
+      with zero grid cost.  Pass 3 now uses **predicted** surplus
+      (`slot_net_surplus_kwh`) for the current slot, not a live reading —
+      this prevents a single cloud at MILP-solve time from locking the EV
+      out for an entire 15-minute slot.
     - **MILP** (primary): when the MILP wins, it co-optimises the EV alongside
       the battery.  The EV is included with `charge_past_target=True`:
       `target_kwh = capacity_kwh`, `deadline_slot = None` (no grid import
@@ -1090,6 +1107,13 @@ The EV planner (`planner/ev_planner.py`) MUST satisfy these invariants:
     The MILP's decisions replace the EV planner's when the MILP wins.
     When the MILP fails or is unavailable, the EV planner's Pass 3 slots
     are used as a fallback.
+
+    **Between MILP re-solves**, the coordinator's smoothing layer
+    (`_smooth_current_slot_ev_power`) implements Pass 3 reactively every
+    minute: if live surplus exceeds `charger_min_power_w`, it sets
+    `ev_charger_calculated_power` even when the MILP allocated no EV
+    load for the current slot.  This prevents 14-minute dead zones when
+    the MILP sampled an unlucky live reading at the slot boundary.
 
 12. **EV charger power field**: `ev_charger_calculated_power` is computed
     from the per-slot EV AC load (`ev_planned_load_kwh + ev_accounted_load_kwh`)

--- a/tests/test_coordinator_milp_gating.py
+++ b/tests/test_coordinator_milp_gating.py
@@ -51,6 +51,8 @@ def _make_coordinator() -> HSEMDataUpdateCoordinator:
     coord._last_milp_current_slot_start = None
     coord._last_planner_output = None
     coord._force_milp_rerun = False
+    coord._live = None
+    coord._net_consumption_ema = None
     return coord
 
 

--- a/tests/test_ha_mock_integration.py
+++ b/tests/test_ha_mock_integration.py
@@ -225,6 +225,7 @@ def make_bare_coordinator(
     coord._current_required_battery = 0.0
     coord._live = None
     coord._snapshot = None
+    coord._net_consumption_ema = None
 
     from custom_components.hsem.models.data_quality import DataQuality
     from custom_components.hsem.models.plan_explanation import PlanExplanation


### PR DESCRIPTION
## What changed

Three layers of protection against EV charger power oscillation (11000W ↔ 0W at slot boundaries):

### 1. Pass 3 uses predicted surplus instead of live reading

`ev_planner.py` Pass 3 (charge-past-target on surplus PV) previously used a single `live_net_consumption_w` sample at MILP-solve time. A cloud at exactly that instant would lock the EV out for an entire 15-minute slot.

Now Pass 3 reads `slot_net_surplus_kwh[i]` — the predicted surplus — consistent with the rest of the planner.

### 2. EMA filter on live net consumption

`live.net_consumption_w` is now smoothed through an exponential moving average (α=0.3) before entering the planner pipeline. This damps transient loads (vacuum cleaners, coffee machines, cloud shadows) so they don't kill the EV charging setpoint.

- `const.py` — `EMA_ALPHA_NET_CONSUMPTION = 0.3`
- `utils/misc.py` — `ema_filter()` utility
- `coordinator.py` — applied after live state collection, before planner input

### 3. Live surplus cap + recovery from zero

`_smooth_current_slot_ev_power` now:

- **Caps** the charger power at the current live surplus — the charger never draws from the grid during a cloud or load spike within a slot.
- **Recovers from zero**: even when the MILP allocated no EV load for the current slot, the smoothing layer can set a power target if live surplus exceeds `charger_min_power_w` — implementing Pass 3 reactively every minute instead of every 15.

## Files changed

| File | Change |
|---|---|
| `custom_components/hsem/const.py` | Add `EMA_ALPHA_NET_CONSUMPTION = 0.3` |
| `custom_components/hsem/utils/misc.py` | Add `ema_filter()` utility |
| `custom_components/hsem/coordinator.py` | EMA on live consumption, live surplus cap, zero-recovery |
| `custom_components/hsem/planner/ev_planner.py` | Pass 3 uses predicted surplus, updated docstring |
| `docs/planner-spec.md` | Document smoothing layer and Pass 3 changes |

## Why this matters

Before this fix, a cloud passing at the wrong second could cause:
```
15:30 → ev_charger_calculated_power = 11000W
15:31 → 0W (locked for 14 minutes)
15:45 → 11000W (next slot starts)
```

The go-e charger would get `pGrid = +2000` (importing) in the middle of the slot and shut down — while the house was actually exporting 3.8 kW of solar.