### PR TITLE
refactor: MILP sole authority for EV charging, unified logging, cleanup

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -155,8 +155,10 @@ by setting the inverter to `GRID_EXPORT_LIMIT_WATT` for any slot where
   applies the same clamping in `score_plan()` so that scored costs match
   the MILP's assumptions.
 
-Both locations also clamp negative export prices to 0 because the inverter
-curtails PV rather than pay to export.
+Negative export prices are **not** clamped.  The LP's `curt[t]` variable
+(zero objective cost) naturally handles them: when `p_exp < 0`, exporting
+costs money (`−p_exp·ge` becomes a positive cost in the objective) and the
+LP prefers curtailment (cost 0) over export (cost > 0).
 
 The raw `slot.price.export_price` is **not** mutated — clamping only affects
 optimisation and scoring.

--- a/custom_components/hsem/const.py
+++ b/custom_components/hsem/const.py
@@ -236,3 +236,11 @@ NEAR_ZERO_CONSUMPTION_THRESHOLD_KWH = 0.1
 # short cloud shadows so they don't kill the EV charging setpoint for the
 # rest of the 15-minute slot.
 EMA_ALPHA_NET_CONSUMPTION = 0.3
+
+# EV state-of-charge change (percentage points) that forces a MILP re-solve.
+# Smaller changes within the staleness window are ignored (issue #582).
+EV_SOC_RESOLVE_THRESHOLD_PCT = 2.0
+
+# Per-slot price/PV epsilon below which two values are treated as unchanged
+# for MILP re-solve gating.  Used in _should_rerun_milp and EV power smoothing.
+INPUT_EPSILON = 1e-6

--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -44,7 +44,11 @@ from homeassistant.helpers.event import (
 )
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from custom_components.hsem.const import EMA_ALPHA_NET_CONSUMPTION
+from custom_components.hsem.const import (
+    EMA_ALPHA_NET_CONSUMPTION,
+    EV_SOC_RESOLVE_THRESHOLD_PCT,
+    INPUT_EPSILON,
+)
 from custom_components.hsem.coordinator_builder import (
     build_planner_input,
     generate_recommendation_intervals,
@@ -88,23 +92,13 @@ from custom_components.hsem.utils.forecast_tracker import (
 from custom_components.hsem.utils.inverter_verify import CycleApplySummary
 from custom_components.hsem.utils.logger import (
     HSEM_LOGGER as _LOGGER,
-    async_logger,
-    set_planner_verbose,
+    set_hsem_verbose,
 )
 from custom_components.hsem.utils.misc import ema_filter, get_config_value
 from custom_components.hsem.utils.recommendations import Recommendations
 
 if TYPE_CHECKING:
     from custom_components.hsem.ml.consumption_predictor import ConsumptionPredictor
-
-# ---------------------------------------------------------------------------
-# MILP re-solve gating thresholds (issue #582)
-# ---------------------------------------------------------------------------
-
-#: EV state-of-charge change (percentage points) that forces a MILP re-solve.
-_EV_SOC_RESOLVE_THRESHOLD_PCT = 2.0
-#: Per-slot price/PV epsilon below which two values are treated as unchanged.
-_INPUT_EPSILON = 1e-6
 
 # ---------------------------------------------------------------------------
 # Data payload exposed to subscriber entities
@@ -354,8 +348,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
     async def _async_handle_update(self, event: Event | None = None) -> None:
         """Drop concurrent updates; run the update cycle while holding the lock."""
         if self._update_lock.locked():
-            await async_logger(
-                self,
+            _LOGGER.debug(
                 "------ Coordinator update skipped: a previous cycle is still running.",
             )
             return
@@ -371,7 +364,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         Raises:
             UpdateFailed: When an unrecoverable error occurs during the pipeline.
         """
-        await async_logger(self, "------ HSEM Coordinator: starting update cycle")
+        _LOGGER.debug("------ HSEM Coordinator: starting update cycle")
         now = hsem_now()
 
         try:
@@ -422,8 +415,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             # before the expiry — clean up the stored expiry in that case too.
             if self._override_expiry is not None:
                 if now >= self._override_expiry:
-                    await async_logger(
-                        self,
+                    _LOGGER.debug(
                         "Timed override EXPIRED — clearing select entity to 'auto'.",
                     )
                     # Fire-and-forget: set the select entity back to "auto".
@@ -440,8 +432,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                     self._override_expiry = None
                 elif live.force_working_mode_state == "auto":
                     # User manually cleared before expiry — remove the tracking.
-                    await async_logger(
-                        self,
+                    _LOGGER.debug(
                         "Override manually cleared before expiry — removing expiry tracking.",
                     )
                     self._override_expiry = None
@@ -468,7 +459,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             # The ML path is enabled via `hsem_ml_consumption_enabled`.
             # When it fails (insufficient history, misconfigured, …), the
             # coordinator transparently falls back to the legacy pipeline.
-            set_planner_verbose(cfg.verbose_logging)
+            set_hsem_verbose(cfg.verbose_logging)
 
             if cfg.ml_consumption_enabled:
                 # ML consumption prediction from recorder history.
@@ -485,15 +476,13 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                     cfg,
                     self._ml_predictor,
                 )
-                await async_logger(
-                    self,
+                _LOGGER.debug(
                     f"[ml] populate_ml_house_consumption returned {consumption_ok}",
                 )
 
                 if not consumption_ok:
                     # Fallback: ML failed; try legacy avg sensors.
-                    await async_logger(
-                        self,
+                    _LOGGER.debug(
                         "[ml] ML consumption failed"
                         " — falling back to legacy avg sensors.",
                     )
@@ -513,8 +502,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                     self._avg_house_consumption_entity_id_cache,
                     entry_id=self._config_entry.entry_id,
                 )
-                await async_logger(
-                    self,
+                _LOGGER.debug(
                     f"[avg] populate_avg_house_consumption_from_snapshot returned {consumption_ok}, "
                     f"cache has {len(self._avg_house_consumption_entity_id_cache)} entries, "
                     f"snapshot has {len(self._snapshot.energy_average_values)} energy_avg values",
@@ -531,9 +519,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
 
             if live.missing_entities and live.force_working_mode_state == "auto":
                 state = Recommendations.MissingInputEntities.value
-                await async_logger(
-                    self, "Missing input entities, skipping calculations."
-                )
+                _LOGGER.debug("Missing input entities, skipping calculations.")
 
             elif not consumption_ok and live.force_working_mode_state == "auto":
                 # Energy average sensors not yet ready.  Still populate prices
@@ -543,8 +529,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
 
             elif live.force_working_mode_state != "auto":
                 state = str(live.force_working_mode_state)
-                await async_logger(
-                    self,
+                _LOGGER.debug(
                     f"Force working mode is activated. Setting working mode to "
                     f"{live.force_working_mode_state}",
                 )
@@ -588,8 +573,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                 total_1d = sum(
                     c.avg_1d for c in planner_input.consumption_averages if c.avg_1d > 0
                 )
-                await async_logger(
-                    self,
+                _LOGGER.debug(
                     f"[builder] consumption per-hour total reaching planner:"
                     f" avg_1d={total_1d:.2f} kWh"
                     f" over {len(planner_input.consumption_averages)} hours",
@@ -611,7 +595,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                     # planner so detailed slot-level decisions appear in the
                     # standard Home Assistant log when the user enables
                     # verbose logging.
-                    set_planner_verbose(cfg.verbose_logging)
+                    set_hsem_verbose(cfg.verbose_logging)
                     planner_output = run_planner(planner_input)
                     self._last_planner_output = planner_output
 
@@ -625,7 +609,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                     self._force_milp_rerun = False
 
                     for warning in planner_output.warnings:
-                        await async_logger(self, f"[planner] {warning}")
+                        _LOGGER.debug(f"[planner] {warning}")
                 else:
                     # Reuse the cached plan unchanged except for smoothing the
                     # current slot's EV charger power as time elapses within
@@ -633,8 +617,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                     # toggling on/off every cycle.
                     planner_output = cached_output
                     self._smooth_current_slot_ev_power(planner_output, now)
-                    await async_logger(
-                        self,
+                    _LOGGER.debug(
                         "[planner] MILP re-solve skipped — reusing cached plan "
                         "and smoothing current-slot EV charger power.",
                     )
@@ -655,8 +638,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                         if s.end > now
                     )
                     if not has_planned:
-                        await async_logger(
-                            self,
+                        _LOGGER.debug(
                             "[planner] WARNING: EV is physically charging but no "
                             "current or future slot has ev_total_planned_load_kwh > 0. "
                             "The EV load is either outside the planning window, "
@@ -820,7 +802,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
 
         # Notify all subscriber entities atomically.
         self.async_set_updated_data(data)
-        await async_logger(self, "------ HSEM Coordinator: update cycle complete")
+        _LOGGER.debug("------ HSEM Coordinator: update cycle complete")
 
     # ------------------------------------------------------------------
     # DataUpdateCoordinator override
@@ -872,8 +854,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             self._async_handle_update,  # type: ignore[arg-type]  # HA stub expects Callable[[datetime], ...]; our callback also serves as coordinator update callback
             interval,
         )
-        await async_logger(
-            self,
+        _LOGGER.debug(
             f"HSEM Coordinator: update interval set to {interval}",
         )
 
@@ -980,9 +961,9 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         if len(prev.price_points) != len(inp.price_points):
             return True
         for old, new in zip(prev.price_points, inp.price_points, strict=False):
-            if abs(old.import_price - new.import_price) > _INPUT_EPSILON:
+            if abs(old.import_price - new.import_price) > INPUT_EPSILON:
                 return True
-            if abs(old.export_price - new.export_price) > _INPUT_EPSILON:
+            if abs(old.export_price - new.export_price) > INPUT_EPSILON:
                 return True
         return False
 
@@ -992,7 +973,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         if len(prev.solcast_slots) != len(inp.solcast_slots):
             return True
         for old, new in zip(prev.solcast_slots, inp.solcast_slots, strict=False):
-            if abs(old.pv_estimate - new.pv_estimate) > _INPUT_EPSILON:
+            if abs(old.pv_estimate - new.pv_estimate) > INPUT_EPSILON:
                 return True
         return False
 
@@ -1001,7 +982,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         """Return True when any gating EV input changed between inputs.
 
         Covers both EVs: connection state, smart-charging toggle, and SoC
-        change beyond ``_EV_SOC_RESOLVE_THRESHOLD_PCT`` percentage points.
+        change beyond ``EV_SOC_RESOLVE_THRESHOLD_PCT`` percentage points.
         """
         if prev.ev_planned_load_connected != inp.ev_planned_load_connected:
             return True
@@ -1025,7 +1006,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                 prev.ev_planned_load_current_soc_pct
                 - inp.ev_planned_load_current_soc_pct
             )
-            > _EV_SOC_RESOLVE_THRESHOLD_PCT
+            > EV_SOC_RESOLVE_THRESHOLD_PCT
         ):
             return True
         if (
@@ -1033,7 +1014,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                 prev.ev_second_planned_load_current_soc_pct
                 - inp.ev_second_planned_load_current_soc_pct
             )
-            > _EV_SOC_RESOLVE_THRESHOLD_PCT
+            > EV_SOC_RESOLVE_THRESHOLD_PCT
         ):
             return True
         return False
@@ -1046,9 +1027,13 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         When the MILP is not re-solved, the EV charger power setpoint for the
         current (partially-elapsed) slot is recomputed from the cached plan's
         ``ev_total_planned_load_kwh`` divided by the remaining hours, capped at
-        the charger's rated power and floored at its minimum operating power.
-        This keeps the setpoint smooth as time progresses within a slot instead
-        of toggling on/off every cycle (issue #582).
+        the charger's rated power, the live surplus, and floored at its minimum
+        operating power.  This keeps the setpoint smooth as time progresses
+        within a slot instead of toggling on/off every cycle (issue #582).
+
+        Slots where the MILP allocated zero EV load are left untouched — the
+        MILP is the global optimiser and its decision to export or charge the
+        battery instead of the EV is authoritative.
 
         The cached plan's energy allocation is left untouched; only the power
         field is updated in place.
@@ -1085,22 +1070,15 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             remaining_h = max((s_end - now).total_seconds() / 3600.0, 1.0 / 3600.0)
 
             total_ev = slot.ev_total_planned_load_kwh
-            if total_ev <= _INPUT_EPSILON:
-                # No EV load planned for this slot.  Use live surplus
-                # directly — this implements Pass 3 (charge past target
-                # on surplus PV) reactively every minute instead of
-                # waiting for the next MILP re-solve.
-                if live_surplus_w is not None and live_surplus_w > min_power_w:
-                    slot.ev_charger_calculated_power = self._smoothed_power_w(
-                        (live_surplus_w / 1000.0) * remaining_h,
-                        remaining_h,
-                        max_power_w,
-                        min_power_w,
-                        live_surplus_w,
-                    )
+            if total_ev <= INPUT_EPSILON:
+                # No EV load planned for this slot by the MILP.
+                # The MILP is the global optimiser — when it chooses
+                # to export or charge the battery instead of charging
+                # the EV, that decision must be respected.  Do not
+                # second-guess it with a reactive surplus check.
                 break
 
-            if slot.ev_charger_calculated_power > _INPUT_EPSILON:
+            if slot.ev_charger_calculated_power > INPUT_EPSILON:
                 slot.ev_charger_calculated_power = self._smoothed_power_w(
                     total_ev,
                     remaining_h,
@@ -1108,7 +1086,7 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                     min_power_w,
                     live_surplus_w,
                 )
-            if slot.ev_second_charger_calculated_power > _INPUT_EPSILON:
+            if slot.ev_second_charger_calculated_power > INPUT_EPSILON:
                 slot.ev_second_charger_calculated_power = self._smoothed_power_w(
                     total_ev,
                     remaining_h,
@@ -1150,12 +1128,12 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             The smoothed AC power in Watts (0 when below the minimum).
         """
         ac_power_w = round((energy_kwh / remaining_hours) * 1000.0)
-        if max_power_w > _INPUT_EPSILON:
+        if max_power_w > INPUT_EPSILON:
             ac_power_w = min(ac_power_w, round(max_power_w))
         # Cap at live surplus to avoid grid import during transients.
         if live_surplus_w is not None:
             ac_power_w = min(ac_power_w, round(live_surplus_w))
-        if min_power_w > _INPUT_EPSILON and ac_power_w < min_power_w:
+        if min_power_w > INPUT_EPSILON and ac_power_w < min_power_w:
             return 0.0
         return float(ac_power_w)
 

--- a/custom_components/hsem/coordinator_builder.py
+++ b/custom_components/hsem/coordinator_builder.py
@@ -217,7 +217,6 @@ def build_planner_input(
         main_fuse_amps=(float(cfg.main_fuse_amps) if cfg.main_fuse_amps > 0 else None),
         months_winter=list(cfg.months_winter or []),
         house_power_includes_ev=bool(cfg.house_power_includes_ev_charger_power),
-        live_net_consumption_w=convert_to_float(live.net_consumption_w) or 0.0,
         live_solar_production_w=convert_to_float(live.solar_production_power_w) or 0.0,
         live_house_consumption_w=convert_to_float(live.house_consumption_power_w)
         or 0.0,

--- a/custom_components/hsem/custom_sensors/applier.py
+++ b/custom_components/hsem/custom_sensors/applier.py
@@ -64,7 +64,7 @@ from custom_components.hsem.utils.inverter_verify import (
     CycleApplySummary,
     async_write_and_verify,
 )
-from custom_components.hsem.utils.logger import async_logger
+from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
 from custom_components.hsem.utils.misc import (
     generate_hash,
     get_max_discharge_power,
@@ -133,14 +133,10 @@ async def async_apply_inverter_power_control(
 
     # Defense-in-depth: block writes if read_only or degraded mode is Error.
     if cfg.read_only:
-        await async_logger(
-            sensor,
-            "async_apply_inverter_power_control: skipped — read_only=True",
-        )
+        _LOGGER.debug("async_apply_inverter_power_control: skipped — read_only=True")
         return summary
     if not hardware_writes_allowed(live.degraded_mode):
-        await async_logger(
-            sensor,
+        _LOGGER.debug(
             f"async_apply_inverter_power_control: skipped — degraded mode: {live.degraded_mode.value}",
             "warning",
         )
@@ -164,8 +160,7 @@ async def async_apply_inverter_power_control(
     ):
         export_pct = 100
 
-    await async_logger(
-        sensor,
+    _LOGGER.debug(
         f"Determined export power percentage: {export_pct}% "
         f"(export={export_price}, min={min_price}, "
         f"ev1_connected={live.ev.is_connected}, ev2_connected={live.ev_second.is_connected})",
@@ -224,8 +219,7 @@ async def async_apply_inverter_power_control(
 
         if result.status == ApplyStatus.FAILED:
             mode = "W" if export_pct == 0 else "%"
-            await async_logger(
-                sensor,
+            _LOGGER.debug(
                 f"Export power {mode} write FAILED for inverter {inv_id} after all retries. "
                 f"Blocking further writes this cycle.",
                 "error",
@@ -269,14 +263,10 @@ async def async_apply_battery_settings(
 
     # Defense-in-depth: block writes if read_only or degraded mode is Error.
     if cfg.read_only:
-        await async_logger(
-            sensor,
-            "async_apply_battery_settings: skipped — read_only=True",
-        )
+        _LOGGER.debug("async_apply_battery_settings: skipped — read_only=True")
         return summary
     if not hardware_writes_allowed(live.degraded_mode):
-        await async_logger(
-            sensor,
+        _LOGGER.debug(
             f"async_apply_battery_settings: skipped — degraded mode: {live.degraded_mode.value}",
             "warning",
         )
@@ -295,8 +285,7 @@ async def async_apply_battery_settings(
         if live.huawei_batteries_max_discharge_power_w != max_discharge_power:
             discharge_entity = cfg.huawei_solar_batteries_maximum_discharging_power
             if discharge_entity is None:
-                await async_logger(
-                    sensor,
+                _LOGGER.debug(
                     "Max discharge power entity not configured; skipping write.",
                     "warning",
                 )
@@ -310,8 +299,7 @@ async def async_apply_battery_settings(
             )
             summary.results.append(result)
             if result.status == ApplyStatus.FAILED:
-                await async_logger(
-                    sensor,
+                _LOGGER.debug(
                     f"Max discharge power write FAILED for {discharge_entity}. "
                     "Blocking further battery writes this cycle.",
                     "error",
@@ -393,8 +381,7 @@ async def async_apply_battery_settings(
         if live.huawei_batteries_max_discharge_power_w != ev_max:
             discharge_entity = cfg.huawei_solar_batteries_maximum_discharging_power
             if discharge_entity is None:
-                await async_logger(
-                    sensor,
+                _LOGGER.debug(
                     "EV V2H discharge power entity not configured; skipping write.",
                     "warning",
                 )
@@ -408,8 +395,7 @@ async def async_apply_battery_settings(
             )
             summary.results.append(ev_result)
             if ev_result.status == ApplyStatus.FAILED:
-                await async_logger(
-                    sensor,
+                _LOGGER.debug(
                     f"EV V2H discharge power write FAILED for {discharge_entity}. "
                     "Blocking further battery writes this cycle.",
                     "error",
@@ -431,10 +417,8 @@ async def async_apply_battery_settings(
     if live.huawei_batteries_excess_pv_use_in_tou != desired_excess:
         excess_entity = cfg.huawei_solar_batteries_excess_pv_energy_use_in_tou
         if excess_entity is None:
-            await async_logger(
-                sensor,
-                "Excess PV use entity not configured; skipping write.",
-                "warning",
+            _LOGGER.debug(
+                "Excess PV use entity not configured; skipping write.", "warning"
             )
             return summary
         _ee: str = excess_entity  # narrowed for closure
@@ -446,8 +430,7 @@ async def async_apply_battery_settings(
         )
         summary.results.append(excess_result)
         if excess_result.status == ApplyStatus.FAILED:
-            await async_logger(
-                sensor,
+            _LOGGER.debug(
                 f"Excess PV use write FAILED for {excess_entity}. "
                 "Blocking further battery writes this cycle.",
                 "error",
@@ -465,8 +448,7 @@ async def async_apply_battery_settings(
         tou_entity = cfg.huawei_solar_batteries_tou_charging_and_discharging_periods
         battery_device_id = cfg.huawei_solar_device_id_batteries
         if tou_entity is None or battery_device_id is None:
-            await async_logger(
-                sensor,
+            _LOGGER.debug(
                 "TOU entity or battery device ID not configured; skipping write.",
                 "warning",
             )
@@ -489,8 +471,7 @@ async def async_apply_battery_settings(
         )
         summary.results.append(result)
         if result.status == ApplyStatus.FAILED:
-            await async_logger(
-                sensor,
+            _LOGGER.debug(
                 f"TOU period write FAILED for device {cfg.huawei_solar_device_id_batteries}. "
                 "Blocking further battery writes this cycle.",
                 "error",
@@ -501,10 +482,8 @@ async def async_apply_battery_settings(
     if working_mode and live.huawei_batteries_working_mode != working_mode:
         mode_entity = cfg.huawei_solar_batteries_working_mode
         if mode_entity is None:
-            await async_logger(
-                sensor,
-                "Working mode entity not configured; skipping write.",
-                "warning",
+            _LOGGER.debug(
+                "Working mode entity not configured; skipping write.", "warning"
             )
             return summary
         _me: str = mode_entity  # narrowed for closure
@@ -516,8 +495,7 @@ async def async_apply_battery_settings(
         )
         summary.results.append(mode_result)
         if mode_result.status == ApplyStatus.FAILED:
-            await async_logger(
-                sensor,
+            _LOGGER.debug(
                 f"Working mode write FAILED for {mode_entity}. "
                 "Blocking further battery writes this cycle.",
                 "error",
@@ -589,10 +567,9 @@ async def _async_apply_forcible_discharge(
         max_retries=3,
     )
 
-    await async_logger(
-        sensor,
+    _LOGGER.debug(
         f"Excess battery export: Set forcible discharge to {target_soc}% SOC "
-        f"at {max_discharge_power}W power. Verify result: {result.status.value}",
+        f"at {max_discharge_power}W power. Verify result: {result.status.value}"
     )
     return result
 

--- a/custom_components/hsem/custom_sensors/hourly_data_populator/consumption.py
+++ b/custom_components/hsem/custom_sensors/hourly_data_populator/consumption.py
@@ -22,7 +22,7 @@ from custom_components.hsem.utils.conversion import convert_to_float
 from custom_components.hsem.utils.ha_helpers import (
     ha_get_entity_state_and_convert,
 )
-from custom_components.hsem.utils.logger import async_logger, log_planner
+from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER, log_planner
 from custom_components.hsem.utils.sensornames.energy import (
     get_energy_average_sensor_unique_id,
 )
@@ -60,12 +60,10 @@ async def async_populate_avg_house_consumption(
 
     for weight, name in [(w1, "1d"), (w3, "3d"), (w7, "7d"), (w14, "14d")]:
         if weight is None:
-            await async_logger(
-                sensor, f"Weight for {name} is None. Skipping this calculation."
-            )
+            _LOGGER.debug(f"Weight for {name} is None. Skipping this calculation.")
             return False
 
-    await async_logger(sensor, "Calculating hourly data for energy averages...")
+    _LOGGER.debug("Calculating hourly data for energy averages...")
 
     scale_to_interval = 60.0 / cfg.recommendation_interval_minutes
     w_total_config = int(w1) + int(w3) + int(w7) + int(w14)
@@ -85,10 +83,9 @@ async def async_populate_avg_house_consumption(
         eid_14d = await _resolve_cached(sensor, entity_id_cache, uid_14d)
 
         if None in (eid_1d, eid_3d, eid_7d, eid_14d):
-            await async_logger(
-                sensor,
+            _LOGGER.debug(
                 "One of the required sensors for average house consumptions load is "
-                "not ready/found. Waiting for next update.",
+                "not ready/found. Waiting for next update."
             )
             return False
 
@@ -107,8 +104,7 @@ async def async_populate_avg_house_consumption(
                 ha_get_entity_state_and_convert(sensor, eid_14d, "float", 3)
             )
         except (HomeAssistantError, ValueError, TypeError) as exc:
-            await async_logger(
-                sensor,
+            _LOGGER.debug(
                 f"Sensor read failed for hour {h} energy averages "
                 f"(entity_ids={eid_1d},{eid_3d},{eid_7d},{eid_14d}): "
                 f"{type(exc).__name__}: {exc!r}",
@@ -116,10 +112,9 @@ async def async_populate_avg_house_consumption(
             v1 = v3 = v7 = v14 = None
 
         if None in (v1, v3, v7, v14):
-            await async_logger(
-                sensor,
+            _LOGGER.debug(
                 "One of the required sensors for average house consumptions load is "
-                "not ready/found. Waiting for next update.",
+                "not ready/found. Waiting for next update."
             )
             return False
 
@@ -128,7 +123,7 @@ async def async_populate_avg_house_consumption(
         assert v1 is not None and v3 is not None and v7 is not None and v14 is not None
 
         if w_total_config == 0:
-            await async_logger(sensor, "All weights sum to 0. Skipping calculation.")
+            _LOGGER.debug("All weights sum to 0. Skipping calculation.")
             continue
 
         avg, _ = weighted_avg_consumption(

--- a/custom_components/hsem/custom_sensors/hourly_data_populator/prices_solcast.py
+++ b/custom_components/hsem/custom_sensors/hourly_data_populator/prices_solcast.py
@@ -15,7 +15,7 @@ from custom_components.hsem.models.sensor_config import SensorConfig
 from custom_components.hsem.models.state_snapshot import StateSnapshot
 from custom_components.hsem.utils.conversion import convert_to_float
 from custom_components.hsem.utils.datetime_utils import normalize_datetime
-from custom_components.hsem.utils.logger import async_logger
+from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
 
 from . import _resolve_cached  # noqa: F401
 
@@ -155,7 +155,7 @@ async def _async_update_hourly_field(
 
     sensor_state = sensor.hass.states.get(sensor_id)
     if not sensor_state:
-        await async_logger(sensor, f"Input sensor {sensor_id} was not found for data.")
+        _LOGGER.debug(f"Input sensor {sensor_id} was not found for data.")
         return
 
     # Each source exposes a different attribute key / time-key / value-key
@@ -184,7 +184,7 @@ async def _async_update_hourly_field(
         if not sensor_data:
             continue
 
-        await async_logger(sensor, f"Updating data for {field_name}...")
+        _LOGGER.debug(f"Updating data for {field_name}...")
 
         for data in sensor_data:
             for kv in kv_list:

--- a/custom_components/hsem/custom_sensors/state_collector.py
+++ b/custom_components/hsem/custom_sensors/state_collector.py
@@ -78,7 +78,7 @@ async def async_collect_live_state(
 
     Args:
         sensor: The ``HSEMWorkingModeSensor`` instance (used for ``hass`` access,
-            ``entity_id``, and :func:`async_logger`).
+            ``entity_id``, and entity_id).
         cfg: Current sensor configuration (determines which entities to read).
         force_working_mode_cache: Previously resolved entity_id for the force
             working mode select, or ``None`` to trigger resolution.
@@ -674,7 +674,7 @@ async def async_collect_all_states(
 
     Args:
         sensor: The ``HSEMWorkingModeSensor`` instance (used for ``hass`` access,
-            ``entity_id``, and :func:`async_logger`).
+            ``entity_id``, and entity_id).
         cfg: Current sensor configuration.
         force_working_mode_cache: Previously resolved entity_id or ``None``.
         tracked_entities: Mutable set of entity_ids already registered for

--- a/custom_components/hsem/custom_sensors/state_collector.py
+++ b/custom_components/hsem/custom_sensors/state_collector.py
@@ -42,7 +42,7 @@ from custom_components.hsem.utils.ha_helpers import (
     async_resolve_entity_id_from_unique_id,
     ha_get_entity_state_and_convert,
 )
-from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER, async_logger
+from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
 from custom_components.hsem.utils.misc import get_config_value
 from custom_components.hsem.utils.sensornames.diagnostics import (
     get_force_working_mode_selector_key,
@@ -643,10 +643,7 @@ async def _register_listeners(
 
     for entity_id in candidates:
         if entity_id and entity_id not in tracked_entities:
-            await async_logger(
-                sensor,
-                f"Starting to track state changes for {entity_id}",
-            )
+            _LOGGER.debug(f"Starting to track state changes for {entity_id}")
             unsub = async_track_state_change_event(
                 sensor.hass, [entity_id], sensor._async_handle_update
             )
@@ -713,10 +710,9 @@ async def async_collect_all_states(
             eid = await _resolve_cached(sensor, avg_cache, uid)
 
             if eid is None:
-                await async_logger(
-                    sensor,
+                _LOGGER.debug(
                     "One of the required sensors for average house consumptions load is "
-                    "not ready/found. Waiting for next update.",
+                    "not ready/found. Waiting for next update."
                 )
                 continue
 
@@ -727,8 +723,7 @@ async def async_collect_all_states(
             except Exception:
                 val = None
 
-            await async_logger(
-                sensor,
+            _LOGGER.debug(
                 f"[avg] Read {uid} (entity_id={eid}) → "
                 f"{'None' if val is None else val}",
             )
@@ -784,13 +779,9 @@ async def _resolve_cached(
 
         if entity_id is not None:
             cache[unique_id] = entity_id
-            await async_logger(
-                sensor,
-                f"[avg] Resolved {unique_id} → {entity_id}",
-            )
+            _LOGGER.debug(f"[avg] Resolved {unique_id} → {entity_id}")
         else:
-            await async_logger(
-                sensor,
+            _LOGGER.debug(
                 f"[avg] Failed to resolve {unique_id} (registry+construct both returned None)",
             )
 

--- a/custom_components/hsem/custom_sensors/working_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/working_mode_sensor.py
@@ -36,7 +36,7 @@ from custom_components.hsem.custom_sensors.recommendation_resolver import (
 from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
 from custom_components.hsem.utils.degraded_mode import hardware_writes_allowed
 from custom_components.hsem.utils.inverter_verify import ApplyStatus, CycleApplySummary
-from custom_components.hsem.utils.logger import async_logger
+from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
 from custom_components.hsem.utils.misc import calculate_recommended_threshold
 from custom_components.hsem.utils.sensornames.diagnostics import (
     get_working_mode_sensor_entity_id,
@@ -366,11 +366,7 @@ class HSEMWorkingModeSensor(HSEMCoordinatorEntity, SensorEntity, HSEMEntity):
             # Task was cancelled (entity unloaded) — propagate cleanly.
             raise
         except Exception:
-            await async_logger(
-                self,
-                "Hardware-write task failed during coordinator update",
-                level="error",
-            )
+            _LOGGER.error("Hardware-write task failed during coordinator update")
 
     async def _async_apply_hardware_writes(self, data: CoordinatorData) -> None:
         """Perform inverter and battery hardware writes for the current slot.
@@ -404,20 +400,15 @@ class HSEMWorkingModeSensor(HSEMCoordinatorEntity, SensorEntity, HSEMEntity):
             # resolved recommendation (e.g. ev_smart_charging) rather than
             # the raw planner output (e.g. batteries_charge_solar).
             data.state = hourly_rec.recommendation
-            await async_logger(self, f"Current hourly recommendation: {hourly_rec}")
+            _LOGGER.debug(f"Current hourly recommendation: {hourly_rec}")
 
         # Gate hardware writes on read_only and degraded mode.
         writes_safe = hardware_writes_allowed(live.degraded_mode)
         combined_summary = CycleApplySummary()
         if cfg.read_only:
-            await async_logger(
-                self,
-                "Hardware writes SKIPPED — read_only=True",
-                "warning",
-            )
+            _LOGGER.debug("Hardware writes SKIPPED — read_only=True", "warning")
         elif not writes_safe:
-            await async_logger(
-                self,
+            _LOGGER.debug(
                 f"Hardware writes BLOCKED — degraded mode: {live.degraded_mode.value}. Missing: {live.missing_entities_list}",
                 "warning",
             )

--- a/custom_components/hsem/models/planner_input.py
+++ b/custom_components/hsem/models/planner_input.py
@@ -162,12 +162,6 @@ class PlannerInput:
     house_power_includes_ev: bool = True
     is_read_only: bool = False  # False = hardware writes enabled; set True only in dry-run/test scenarios
 
-    #: Live net consumption in Watts from sensor.hsem_net_consumption_sensor.
-    #: Negative values indicate surplus (solar > house load).  Used by the EV
-    #: planner to determine actual (not predicted) surplus for the current slot
-    #: in Pass 3 (charge-past-target on surplus PV).
-    live_net_consumption_w: float = 0.0
-
     #: Live solar production power in Watts from the inverter's input power
     #: sensor.  Injected into the current slot's solcast_pv_estimate_kwh so
     #: the MILP and all candidates use measured (not forecast) PV for the

--- a/custom_components/hsem/planner/engine_core.py
+++ b/custom_components/hsem/planner/engine_core.py
@@ -460,9 +460,6 @@ def _build_and_inject_for_ev(
     combined_ev_raw_load: list[float],
     combined_ev_injected_load: list[float],
     warnings: list[str],
-    predicted_battery_kwh: list[float],
-    usable_battery_kwh: float,
-    live_net_consumption_w: float,
 ) -> EVChargingPlan | None:
     """Build an EV charging plan and accumulate its loads."""
     if not enabled:
@@ -494,9 +491,6 @@ def _build_and_inject_for_ev(
         deadline=deadline,
         base_load_includes_ev=base_includes,
         allow_charge_past_target_soc=allow_past_target,
-        slot_predicted_battery_kwh=predicted_battery_kwh,
-        usable_battery_kwh=usable_battery_kwh,
-        live_net_consumption_w=live_net_consumption_w,
         now=now,
     )
     plan = build_ev_charging_plan(
@@ -815,18 +809,6 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
     combined_ev_inj = [0.0] * len(slots)
     populate_net_consumption(slots)
     sns = [max(-s.estimated_net_consumption_kwh, 0.0) for s in slots]
-    # Predicted battery energy (kWh above floor) at the START of each slot,
-    # assuming no EV charging and no grid charging.  Used to gate Pass 3
-    # in the EV planner: the EV only charges past target when the battery
-    # is already full and the surplus would otherwise be stranded.
-    predicted_battery_kwh: list[float] = []
-    cumulative = current_kwh
-    for s in slots:
-        predicted_battery_kwh.append(cumulative)
-        net = s.estimated_net_consumption_kwh
-        # net positive → battery must cover deficit
-        # net negative → surplus charges battery (up to usable_kwh)
-        cumulative = max(0.0, min(usable_kwh, cumulative - net))
     ss = [s.start for s in slots]
     se = [s.end for s in slots]
     sp = [s.price.import_price for s in slots]
@@ -854,9 +836,6 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
             combined_ev_raw_load=combined_ev_raw,
             combined_ev_injected_load=combined_ev_inj,
             warnings=warnings,
-            predicted_battery_kwh=predicted_battery_kwh,
-            usable_battery_kwh=usable_kwh,
-            live_net_consumption_w=inp.live_net_consumption_w,
         )
     if inp.ev_second_planned_load_enabled:
         ev2_cp = _build_and_inject_for_ev(
@@ -882,9 +861,6 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
             combined_ev_raw_load=combined_ev_raw,
             combined_ev_injected_load=combined_ev_inj,
             warnings=warnings,
-            predicted_battery_kwh=predicted_battery_kwh,
-            usable_battery_kwh=usable_kwh,
-            live_net_consumption_w=inp.live_net_consumption_w,
         )
     for i, s in enumerate(slots):
         s.ev_planned_load_kwh = combined_ev_inj[i]
@@ -1060,10 +1036,7 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
 
     # Recompute ev_charger_calculated_power from the actual per-slot EV
     # load after the MILP (or baseline) has finalized the slots.  This
-    # ensures the power field is always consistent with the load, even
-    # when the MILP didn't write it (e.g. baseline winner) or when the
-    # EV planner's Pass 3 allocated full max_charge_per_slot to a slot
-    # with only a small surplus.
+    # ensures the power field is always consistent with the final load.
     #
     # Also apply the charger_min_power_w floor: if the computed AC power
     # is below the charger's minimum operating power, zero out the power

--- a/custom_components/hsem/planner/ev_planner.py
+++ b/custom_components/hsem/planner/ev_planner.py
@@ -27,7 +27,6 @@ from typing import Any
 from homeassistant.const import STATE_UNAVAILABLE
 
 from custom_components.hsem.utils.datetime_utils import utc_key
-from custom_components.hsem.utils.logger import log_planner
 
 # ---------------------------------------------------------------------------
 # Public data structures
@@ -108,20 +107,8 @@ class EVPlannerInput:
             charging past the target SoC using surplus PV that would otherwise
             be curtailed (e.g. battery full, negative export prices).
             Only applies when the EV has reached target SoC but is below 100 %.
-        slot_predicted_battery_kwh: Per-slot predicted battery energy (kWh
-            above discharge floor) at the *start* of each slot, assuming no
-            EV charging and no grid charging.  Used to gate Pass 3 — the EV
-            only charges past target when the battery is already full and
-            the surplus would otherwise be stranded.
-        usable_battery_kwh: Maximum usable battery capacity (kWh).  Used as
-            the ceiling for the predicted-battery check in Pass 3.
+            Charge-past-target is handled exclusively by the MILP.
         now: Timezone-aware current datetime.
-        live_net_consumption_w: Live net consumption in Watts from
-            sensor.hsem_net_consumption_sensor after EMA smoothing.
-            Negative values indicate surplus.  No longer used in Pass 3
-            (which now uses predicted surplus for stability) — retained
-            for smoothing the current-slot EV charger power setpoint
-            between MILP re-solves.
     """
 
     enabled: bool = False
@@ -136,10 +123,7 @@ class EVPlannerInput:
     deadline: datetime | None = None
     base_load_includes_ev: bool = False
     allow_charge_past_target_soc: bool = False
-    slot_predicted_battery_kwh: list[float] = field(default_factory=list)
-    usable_battery_kwh: float = 0.0
     now: datetime = field(default_factory=lambda: datetime.now(UTC))
-    live_net_consumption_w: float = 0.0
 
 
 @dataclass
@@ -407,21 +391,11 @@ def build_ev_charging_plan(
     plan.deadline = inp.deadline
 
     # When energy_needed ≈ 0 the EV is at or above target SoC.
-    # Normally we return "fully_charged", but when allow_charge_past_target_soc
-    # is enabled and the EV is not already at 100 %, we let the function
-    # continue so Pass 3 can allocate surplus-PV slots (battery already full,
-    # surplus would otherwise be curtailed).
+    # Charge-past-target is handled exclusively by the MILP — the EV
+    # planner plays no role in that decision.
     if abs(energy_needed) < 1e-9:
-        if not inp.allow_charge_past_target_soc or inp.current_soc_pct >= 100:
-            plan.state = "fully_charged"
-            return plan
-        log_planner(
-            "debug",
-            "[ev_planner] SoC at/above target (%.1f%% >= %.1f%%), "
-            "allow_charge_past_target_soc=True — continuing to Pass 3",
-            inp.current_soc_pct,
-            inp.target_soc_pct,
-        )
+        plan.state = "fully_charged"
+        return plan
 
     # --- Candidate slot filtering (before effective deadline) ---
     #
@@ -546,158 +520,12 @@ def build_ev_charging_plan(
         selected.append(ev_slot)
         remaining_energy -= allocated
 
-    # --- Pass 3: charge past target on surplus PV only ---
-    # When allow_charge_past_target_soc is enabled and the EV has reached
-    # its target SoC (remaining_energy ≈ 0), continue charging from any
-    # remaining PV-surplus slots — but only when the house battery is
-    # already predicted to be full at that slot, meaning the surplus
-    # would otherwise be stranded (curtailed).
-    _pass3_battery_data_ready = len(inp.slot_predicted_battery_kwh) > 0
-    _pass3_enter = (
-        inp.allow_charge_past_target_soc
-        and remaining_energy < 1e-9
-        and inp.current_soc_pct < 100
-    )
-    log_planner(
-        "debug",
-        "[ev_planner] Pass 3 check  allow_past=%s  remaining=%.6f  soc=%.1f%%  "
-        "battery_data_ready=%s  surplus_slots=%d  non_surplus=%d  "
-        "pred_len=%d",
-        inp.allow_charge_past_target_soc,
-        remaining_energy,
-        inp.current_soc_pct,
-        _pass3_battery_data_ready,
-        len(surplus_slots),
-        len(non_surplus_slots),
-        len(inp.slot_predicted_battery_kwh),
-    )
-    if _pass3_enter and not _pass3_battery_data_ready:
-        log_planner(
-            "debug",
-            "[ev_planner] Pass 3 SKIPPED — slot_predicted_battery_kwh is empty",
-        )
-    if _pass3_enter and _pass3_battery_data_ready:
-        used_starts = {s.start for s in selected}
-        log_planner(
-            "debug",
-            "[ev_planner] Pass 3 ENTER  usable_battery=%.3f  already_used=%d  "
-            "surplus_candidates=%d",
-            inp.usable_battery_kwh,
-            len(used_starts),
-            len(surplus_slots),
-        )
-        # Re-scan surplus slots, skipping those already allocated.
-        for i in surplus_slots:
-            s_start = slots_start[i]
-            s_end = slots_end[i]
-            if s_start in used_starts:
-                log_planner(
-                    "debug",
-                    "[ev_planner] Pass 3 slot i=%d  %s  SKIP (already used)",
-                    i,
-                    s_start.isoformat(),
-                )
-                continue
-            # Only charge past target when the battery is already full
-            # at this slot — the surplus has nowhere else to go.
-            if (
-                inp.slot_predicted_battery_kwh
-                and i < len(inp.slot_predicted_battery_kwh)
-                and inp.slot_predicted_battery_kwh[i] < inp.usable_battery_kwh - 1e-6
-            ):
-                log_planner(
-                    "debug",
-                    "[ev_planner] Pass 3 slot i=%d  %s  SKIP (battery not full: "
-                    "pred=%.3f  usable=%.3f)",
-                    i,
-                    s_start.isoformat(),
-                    (
-                        inp.slot_predicted_battery_kwh[i]
-                        if i < len(inp.slot_predicted_battery_kwh)
-                        else -1.0
-                    ),
-                    inp.usable_battery_kwh,
-                )
-                continue
-            slot_min = slot_duration_minutes(s_start, s_end)
-            max_charge = max_charge_energy_for_slot(
-                slot_min,
-                inp.charger_power_kw,
-                inp.charger_efficiency_pct,
-            )
-            if max_charge < 1e-9:
-                log_planner(
-                    "debug",
-                    "[ev_planner] Pass 3 slot i=%d  %s  SKIP (zero max charge: "
-                    "dur=%.1f min  pwr=%.2f  eff=%.1f%%)",
-                    i,
-                    s_start.isoformat(),
-                    slot_min,
-                    inp.charger_power_kw,
-                    inp.charger_efficiency_pct,
-                )
-                continue
-
-            # The EV already reached target — no strict energy budget.
-            # Allocate the minimum of max power and available surplus.
-            # We charge only from surplus, never from grid in this pass.
-            net_surplus = slot_net_surplus_kwh[i]
-            allocated = min(max_charge, net_surplus)
-            if allocated < 1e-9:
-                log_planner(
-                    "debug",
-                    "[ev_planner] Pass 3 slot i=%d  %s  SKIP (allocated < 1e-9: "
-                    "max_charge=%.3f  surplus=%.3f)",
-                    i,
-                    s_start.isoformat(),
-                    max_charge,
-                    net_surplus,
-                )
-                continue
-
-            # Check minimum charger power for Pass 3 too.
-            eff = max(inp.charger_efficiency_pct, 1.0) / 100.0
-            slot_hours = slot_min / 60.0
-            ac_power_w = (allocated / eff) / slot_hours * 1000.0
-            if ac_power_w < inp.charger_min_power_w - 1e-9:
-                continue
-
-            ac_load = allocated / eff
-
-            log_planner(
-                "debug",
-                "[ev_planner] Pass 3 slot i=%d  %s  ALLOCATED  dc=%.3f kWh  "
-                "ac_load=%.3f kWh  surplus=%.3f kWh  max_charge=%.3f "
-                "dur=%.1f min  batt_pred=%.3f",
-                i,
-                s_start.isoformat(),
-                allocated,
-                ac_load,
-                net_surplus,
-                max_charge,
-                slot_min,
-                (
-                    inp.slot_predicted_battery_kwh[i]
-                    if i < len(inp.slot_predicted_battery_kwh)
-                    else -1.0
-                ),
-            )
-            ev_slot = EVChargingSlot(
-                start=s_start,
-                end=s_end,
-                estimated_charged_kwh=round(allocated, 3),
-                ac_load_kwh=round(ac_load, 3),
-                solar_surplus_kwh=round(allocated, 3),
-                import_needed_kwh=0.0,
-                import_price=slot_import_price[i],
-                estimated_cost=0.0,
-            )
-            selected.append(ev_slot)
-        log_planner(
-            "debug",
-            "[ev_planner] Pass 3 DONE  total_selected=%d",
-            len(selected),
-        )
+    # --- Pass 3 removed ---
+    # Charge-past-target is now handled exclusively by the MILP.
+    # When the MILP wins, it co-optimises the EV alongside the battery
+    # with a surplus-only constraint and a tiny tiebreaker benefit
+    # (0.0001/kWh AC).  When the MILP fails, the baseline candidate
+    # does not attempt charge-past-target — the MILP is the only path.
 
     # Build output
     plan.charging_slots = selected

--- a/custom_components/hsem/planner/milp_optimizer.py
+++ b/custom_components/hsem/planner/milp_optimizer.py
@@ -280,25 +280,16 @@ def solve_milp(
     p_imp = np.nan_to_num(p_imp, nan=0.0)
     p_exp = np.nan_to_num(p_exp, nan=0.0)
 
-    # Clamp export prices to reflect physical inverter behaviour:
-    # 1. Negative prices → 0 (the inverter curtails PV rather than pay to export).
-    # 2. Prices below min_export_price → 0 (the applier sets the inverter to
-    #    GRID_EXPORT_LIMIT_WATT, blocking export entirely).
+    # Clamp export prices below min_export_price to 0.
+    # The applier physically sets the inverter to GRID_EXPORT_LIMIT_WATT
+    # for these slots, blocking export entirely.  The LP must not optimise
+    # around a price signal that will never be realised.
     #
-    # The MILP cannot model curtailment (pv[t] is fixed), so flooring to 0 is
-    # the best approximation: the LP sees no revenue for blocked-export slots
-    # and does not optimise around a price signal that will never be realised.
-    neg_mask = p_exp < 0.0
-    n_neg = int(np.sum(neg_mask))
-    if n_neg > 0:
-        log_planner(
-            "debug",
-            "[milp] Clamping %d negative export prices to 0 (min=%.4f)",
-            n_neg,
-            float(np.min(p_exp)),
-        )
-    p_exp = np.maximum(p_exp, 0.0)
-
+    # Negative export prices are NOT clamped — the LP has a curt[t]
+    # variable with zero objective cost that naturally handles them:
+    # when p_exp < 0, export costs money (p_exp is negative, so
+    # -p_exp·ge becomes a positive cost), and the LP prefers curtailment
+    # (cost 0) over export (cost > 0).
     if min_export_price > 1e-9:
         blocked = p_exp < min_export_price
         n_blocked = int(np.sum(blocked))

--- a/custom_components/hsem/utils/logger.py
+++ b/custom_components/hsem/utils/logger.py
@@ -1,12 +1,14 @@
-"""Async-safe logger for HSEM sensor pipeline modules.
+"""HSEM dedicated file logger.
 
-Single responsibility: provide :func:`async_logger`, the single logging
-entry-point used throughout the HSEM pipeline.
+Single responsibility: provide the ``HSEM_LOGGER`` logger instance and the
+``log_planner`` helper for synchronous planner code.  All HSEM components
+log to ``HSEM_LOGGER``, which writes to a dedicated ``hsem.log`` file.
 
-Splitting this out of ``utils/misc.py`` removes the ``_hsem_verbose_logging``
-coupling from the old sensor and allows the new pipeline modules (which carry
-their verbose flag inside ``self._cfg.verbose_logging``) to share the same
-logger without circular imports.
+Verbosity is controlled by the logger's own level — call
+:func:`set_hsem_verbose` once per coordinator cycle to sync with the
+user's ``verbose_logging`` config setting.  No per-call gating is needed:
+``HSEM_LOGGER.debug()`` calls are silently filtered when the level is
+``WARNING`` or above.
 
 Logging strategy
 ----------------
@@ -17,7 +19,7 @@ diagnostic detail for troubleshooting.
 
 The HSEM logger does **not** propagate to Home Assistant's root logger
 (``propagate`` is set to ``False``).  All HSEM messages — from both the
-async sensor layer (``async_logger``) and the synchronous planner engine
+async sensor layer (``_LOGGER.debug()``) and the synchronous planner engine
 (``log_planner``) — are captured solely by the file handler.
 
 Users who want HSEM messages in the main HA log can enable them via the
@@ -41,22 +43,15 @@ Design note — blocking I/O:
 ``RotatingFileHandler`` performs synchronous ``open()`` / ``write()`` /
 ``rotate()`` calls.  When invoked from inside the event loop (which all HSEM
 async code is), Home Assistant raises a ``Detected blocking call to open``
-warning.  To avoid this we delegate writes to a global ``ThreadPoolExecutor``
-in both :func:`async_logger` (which is always async) and :func:`log_planner`
-(which is synchronous but offloads file I/O when a running event loop is
-detected, falling back to a direct write only when no loop is present).
+warning.  To avoid this, :func:`log_planner` (called from synchronous planner
+code) offloads file I/O to a global ``ThreadPoolExecutor`` when a running
+event loop is detected, falling back to a direct write only when no loop is
+present.  Async code simply calls ``_LOGGER.debug()`` directly — Python's
+logging module handles the rest.
+
 The init/teardown methods (:func:`init_hsem_logger` / :func:`close_hsem_logger`)
 are exposed as coroutines that offload file-handler setup to the executor so they can be
 safely called from ``async_setup_entry`` / ``async_unload_entry``.
-
-Verbose flag resolution order (first match wins):
-
-1. ``self._cfg.verbose_logging``  — new pipeline sensors (``HSEMWorkingModeSensor``
-   after the #282 refactor)
-2. ``self._hsem_verbose_logging`` — legacy attribute kept for any remaining
-   callers that have not yet migrated
-3. ``True``                       — safe default so no log messages are silently
-   swallowed during start-up before config is loaded
 """
 
 from __future__ import annotations
@@ -66,7 +61,7 @@ import logging
 import logging.handlers
 import os
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, cast
+from typing import cast
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -87,8 +82,9 @@ _HSEM_LOG_BACKUP_COUNT = 2
 # All HSEM modules log to this logger.
 HSEM_LOGGER = logging.getLogger("custom_components.hsem")
 
-# Accept all levels so the file handler can capture anything the planner emits.
-HSEM_LOGGER.setLevel(logging.DEBUG)
+# Start at WARNING — verbose debug logging is enabled later by the
+# coordinator via set_hsem_verbose() once the user's config is loaded.
+HSEM_LOGGER.setLevel(logging.WARNING)
 
 # Stop propagation to Home Assistant's root logger — HSEM uses its own file.
 # Users who also want HSEM messages in home-assistant.log can enable them
@@ -187,80 +183,40 @@ async def async_close_hsem_logger() -> None:
 # ---------------------------------------------------------------------------
 
 
-async def async_logger(self: Any, msg: str, level: str = "debug") -> None:  # NOSONAR
-    """Emit *msg* through the HSEM file logger if verbose logging is on.
+def set_hsem_verbose(enabled: bool) -> None:
+    """Enable or disable verbose debug logging for all HSEM components.
 
-    The write is delegated to a ``ThreadPoolExecutor`` so that the
-    ``RotatingFileHandler``'s synchronous ``open()`` / ``write()`` calls
-    do not block the event loop.
+    When enabled, sets the HSEM logger level to ``DEBUG`` so that all
+    ``HSEM_LOGGER.debug()`` calls (coordinator cycle messages, planner
+    slot-level decisions, etc.) are written to ``hsem.log``.
 
-    Works with both the refactored sensor (``self._cfg.verbose_logging``) and
-    the legacy attribute (``self._hsem_verbose_logging``) so that no callers
-    need to be updated simultaneously.
+    When disabled, sets the level to ``WARNING`` so only warnings and
+    errors are written.
 
-    Args:
-        self: Any sensor/entity instance that exposes its verbose flag via
-              ``self._cfg.verbose_logging`` or ``self._hsem_verbose_logging``.
-        msg: The log message to write.
-        level: Log level string — one of ``"debug"``, ``"info"``,
-               ``"warning"``, ``"error"``, ``"critical"``.
-    """
-    # Resolve verbose flag — try new config object first, then legacy attribute
-    if hasattr(self, "_cfg") and hasattr(self._cfg, "verbose_logging"):
-        verbose = self._cfg.verbose_logging
-    elif hasattr(self, "_hsem_verbose_logging"):
-        verbose = self._hsem_verbose_logging
-    else:
-        verbose = True  # safe default during early init
-
-    if not verbose:
-        return
-
-    log_method = getattr(HSEM_LOGGER, level.lower(), HSEM_LOGGER.debug)
-    log_method(msg)
-
-
-# ---------------------------------------------------------------------------
-# Planner synchronous logging helpers
-# ---------------------------------------------------------------------------
-# The planner engine is intentionally pure Python (no HA imports, no ``self``).
-# :func:`async_logger` requires a sensor object for the verbose-flag
-# resolution, so it cannot be called from planner code.  These helpers bridge
-# that gap by forwarding messages straight to the HSEM file logger with a
-# module-level verbosity gate.
-
-_PLANNER_VERBOSE: bool = False
-
-
-def set_planner_verbose(enabled: bool) -> None:
-    """Enable or disable planner debug logging.
-
-    Should be called once per planning run from the async sensor layer
-    (coordinator or ``HSEMWorkingModeSensor``) before calling the planner.
+    This replaces the previous dual-gating (``async_logger``'s per-call
+    verbose check and ``set_planner_verbose``'s module global).  The
+    logger's own level is now the single source of truth.
 
     Args:
         enabled: ``True`` to enable debug output; ``False`` to suppress.
     """
-    global _PLANNER_VERBOSE  # noqa: PLW0603
-    _PLANNER_VERBOSE = enabled
+    HSEM_LOGGER.setLevel(logging.DEBUG if enabled else logging.WARNING)
 
 
-def is_planner_verbose() -> bool:
-    """Return the current verbosity state.
-
-    Returns:
-        ``True`` when planner debug logging is active.
-    """
-    return _PLANNER_VERBOSE
+# ---------------------------------------------------------------------------
+# Planner synchronous logging helper
+# ---------------------------------------------------------------------------
+# The planner engine is intentionally pure Python (no HA imports).
+# :func:`log_planner` offloads blocking file I/O to a thread-pool when
+# called from synchronous code while the event loop is running.
 
 
 def log_planner(level: str, msg: str, *args: object) -> None:
     """Write a structured log message to the HSEM log file.
 
-    The message is only written when planner verbose logging is enabled
-    (see :func:`set_planner_verbose`).  Uses ``%``-style formatting so that
-    string interpolation is deferred until the handler decides to emit the
-    record — consistent with Home Assistant logging conventions.
+    Uses ``%``-style formatting so that string interpolation is deferred
+    until the handler decides to emit the record — consistent with Home
+    Assistant logging conventions.
 
     This helper may be called from **synchronous** planner code while the
     event loop is running (e.g. from ``run_planner`` invoked by the
@@ -268,6 +224,10 @@ def log_planner(level: str, msg: str, *args: object) -> None:
     the actual file I/O is offloaded to the shared HSEM thread pool
     executor.  If no event loop is running (tests, early init) the write
     falls back to the current thread.
+
+    The HSEM logger's own level gates verbosity — no separate flag check
+    is needed.  Call :func:`set_hsem_verbose` once at the start of each
+    coordinator cycle to sync the user's ``verbose_logging`` setting.
 
     Args:
         level: Log level string — one of ``"debug"``, ``"info"``,
@@ -277,9 +237,6 @@ def log_planner(level: str, msg: str, *args: object) -> None:
              positional substitutions.
         *args: Positional arguments for the ``%``-style format template.
     """
-    if not _PLANNER_VERBOSE:
-        return
-
     log_fn = getattr(HSEM_LOGGER, level.lower(), HSEM_LOGGER.debug)
 
     # Offload blocking file I/O to the thread pool executor so that the

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -32,11 +32,10 @@ oscillation:
 - **Live surplus cap**: the smoothed power is additionally capped at the
   current live surplus — the charger never draws from the grid during a
   cloud or transient load spike within the slot.
-- **Recovery from zero**: when the MILP allocated no EV load for the
-  current slot (e.g. a cloud at solve time), the smoothing layer can still
-  set a power target if live surplus exceeds `charger_min_power_w` —
-  implementing Pass 3 (charge-past-target on surplus PV) reactively every
-  minute instead of every 15.
+- **Recovery from zero**: when the MILP sampled a cloud at solve time and
+  allocated no EV load for the current slot, the next MILP re-solve (triggered
+  by a material input change or slot-boundary crossing) will correct the
+  allocation.  The MILP is the single authority for all EV charging decisions.
 
 Setting the config option to 0 restores the legacy every-cycle re-solve.
 
@@ -405,6 +404,79 @@ to reflect the new EV loads.
 - EV diagnostics (total DC kWh delivered, deadline penalty, deadline met)
   are included in the diagnostics dict under the `"ev"` key.
 
+### MILP decision priority
+
+The MILP solves a single global cost-minimization across all future slots
+simultaneously.  It has no hard-coded priority order — the cost coefficients
+in the objective function create a natural decision hierarchy.  Below is
+how that plays out per slot, from cheapest to most expensive action.
+
+**Objective** (minimise):
+
+```text
+Σ_t [ p_imp[t]·gi[t] − p_exp[t]·ge[t] + α·m[t]
+      + (charge_loss·p_imp[t])·ec[t] + (discharge_loss·p_imp[t])·ed[t]
+      + p_soc·(s_max_pen[t] + s_min_pen[t]) ]
++ Σ_ev [ ev_penalty·ev_pen + tiebreaker·Σ_t ev_c[t] ]
+```
+
+#### 1. Serve house load from PV (free)
+
+PV surplus `pv[t]` has **zero objective cost**.  Curtailment `curt[t]` also
+has zero cost.  The LP always uses available PV to cover house load first.
+
+#### 2. Use remaining PV surplus
+
+| Priority | Action | Cost coefficient | When taken |
+|---|---|---|---|
+| 2a | Charge house battery | `charge_loss × p_imp[t]` | Battery below `usable_kwh`, future savings justify the minor conversion loss |
+| 2b | Charge EV (normal, below target) | `p_imp[t]` (via grid) or `0` (via surplus) | EV below target, deadline approaching — the **deadline penalty** forces charging |
+| 2c | Charge EV (past target) | **−0.0001 / charger_eff** (benefit) | Battery full **and** export price near zero **and** `charge_past_target=True`.  Surplus-only constraint: `ev_c/eff ≤ pv − base_load` |
+| 2d | Export to grid | **−p_exp[t]** (revenue) | Battery full, EV doesn't want surplus, export price > 0 |
+| 2e | Curtail PV | `0` (free) | Battery full, EV doesn't want surplus, `p_exp ≤ 0` (export costs money or is blocked) |
+
+#### 3. Cover house-load deficit
+
+| Priority | Action | Cost coefficient | When taken |
+|---|---|---|---|
+| 3a | Discharge battery | `discharge_loss × p_imp[t] + cycle_cost` | Battery has energy, discharging is cheaper than grid import |
+| 3b | Import from grid | `p_imp[t]` | Battery empty or discharge not worthwhile (cycle cost > import price spread) |
+
+#### 4. EV deadline charging (hard penalty)
+
+When the EV is **below target SoC** with a deadline approaching:
+
+- Penalty: `max(p_imp) × energy_needed × 10` per kWh shortfall
+- Constraint: `initial_soc + Σ ev_c + penalty ≥ target`
+- This penalty dominates everything — the LP will import at high prices
+  to meet the deadline when physically possible.
+
+#### 5. Terminal SoC (horizon-end valuation)
+
+At horizon end, the battery's remaining energy is valued:
+
+- `terminal_soc_credit = (initial_kwh − final_kwh) × replacement_price`
+- Ending with less energy → penalty (encourages recharging)
+- Ending with more energy → credit (discourages wasteful discharging)
+
+#### Key constraint: EV surplus-only for charge-past-target
+
+The constraint `ev_c[t]/charger_eff ≤ max(0, pv[t] − base_load[t])` ensures
+past-target EV charging **never** draws from the battery or grid — only
+genuine PV surplus that has nowhere else to go.
+
+#### Tiebreaker benefit (0.0001/kWh AC)
+
+The charge-past-target EV benefit is deliberately tiny — it **must not**
+compete with:
+- House battery charging (worth `p_imp` via avoided future import, typically
+  ~0.03–0.06/kWh in conversion loss alone)
+- Export at meaningful prices (revenue `p_exp`, typically 0.05–0.50/kWh)
+
+It only acts as a tiebreaker: when battery is full and export prices are
+near zero, the EV gets the surplus instead of exporting it for near-zero
+revenue.
+
 ### Grid import power limit (main fuse / tariff protection)
 
 When `main_fuse_amps` is provided and > 0, the MILP adds a **soft**
@@ -526,6 +598,11 @@ this physical behaviour:
   ``CostWeights.export_min_price``.
 - This clamping only affects the planner's decision-making; the raw slot
   ``export_price`` is preserved for diagnostics.
+
+Negative export prices are **not** clamped — the LP's ``curt[t]``
+variable (zero objective cost) naturally handles them: when
+``p_exp < 0``, exporting costs money (``−p_exp·ge`` becomes a positive
+cost) and the LP prefers curtailment (cost 0) over export (cost > 0).
 
 Invariant: ``export_price < export_min_price`` → planner treats export
 revenue as 0 in both optimisation and scoring.
@@ -1086,34 +1163,35 @@ The EV planner (`planner/ev_planner.py`) MUST satisfy these invariants:
     three EV load fields must be `0.0` and the home battery planner output
     must be identical to the non-EV case.
 
-11. **Charge past target SoC (Pass 3 / MILP)**: When `allow_charge_past_target_soc`
+11. **Charge past target SoC (MILP only)**: When `allow_charge_past_target_soc`
     is enabled and the EV has reached its target SoC but is below 100 %, the
     EV can receive surplus PV that would otherwise be exported at low/negative
-    prices.
+    prices.  This is handled exclusively by the MILP:
 
-    - **EV planner Pass 3** (fallback): scans remaining PV-surplus slots where
-      the house battery is predicted to be full.  All energy is solar-surplus
-      with zero grid cost.  Pass 3 now uses **predicted** surplus
-      (`slot_net_surplus_kwh`) for the current slot, not a live reading —
-      this prevents a single cloud at MILP-solve time from locking the EV
-      out for an entire 15-minute slot.
-    - **MILP** (primary): when the MILP wins, it co-optimises the EV alongside
-      the battery.  The EV is included with `charge_past_target=True`:
-      `target_kwh = capacity_kwh`, `deadline_slot = None` (no grid import
-      pressure), a surplus-only constraint (`ev_c/eff ≤ pv − base_load`), and
-      a tiny tiebreaker benefit (0.0001/kWh AC) so the EV only takes surplus
-      when nothing else wants it (battery full, export prices near zero).
+    - The EV is included with `charge_past_target=True`: `target_kwh = capacity_kwh`,
+      `deadline_slot = None` (no grid import pressure), a surplus-only constraint
+      (`ev_c/eff ≤ pv − base_load`), and a tiny tiebreaker benefit (0.0001/kWh AC)
+      so the EV only takes surplus when nothing else wants it (battery full,
+      export prices near zero).
+    - The EV planner's Pass 3 has been removed — the MILP is the single
+      authority for all EV charging decisions, including charge-past-target.
+    - When the MILP fails (scipy unavailable, solver crash), charge-past-target
+      is simply unavailable for that cycle.  The next successful MILP solve
+      (up to `planner_min_resolve_interval_minutes` later) will pick it up.
 
-    The MILP's decisions replace the EV planner's when the MILP wins.
-    When the MILP fails or is unavailable, the EV planner's Pass 3 slots
-    are used as a fallback.
+    The MILP's decisions are authoritative for all EV charging.
 
     **Between MILP re-solves**, the coordinator's smoothing layer
-    (`_smooth_current_slot_ev_power`) implements Pass 3 reactively every
-    minute: if live surplus exceeds `charger_min_power_w`, it sets
-    `ev_charger_calculated_power` even when the MILP allocated no EV
-    load for the current slot.  This prevents 14-minute dead zones when
-    the MILP sampled an unlucky live reading at the slot boundary.
+    (`_smooth_current_slot_ev_power`) recomputes the EV charger power
+    from the cached plan's per-slot energy allocation (``ev_total_planned_load_kwh``
+    divided by the remaining slot hours), capped at the charger's rated
+    power and the live surplus.  Slots where the MILP allocated zero EV
+    load are left at zero — the MILP is the global optimiser and its
+    decision to export or charge the battery instead of the EV is
+    authoritative.  This prevents 14-minute dead zones when the MILP
+    sampled an unlucky live reading at the slot boundary: the MILP itself
+    re-solves when inputs change materially (price, solcast, EV SoC, slot
+    boundary), so a cloud at solve time is corrected at the next re-solve.
 
 12. **EV charger power field**: `ev_charger_calculated_power` is computed
     from the per-slot EV AC load (`ev_planned_load_kwh + ev_accounted_load_kwh`)
@@ -1133,15 +1211,9 @@ The EV planner (`planner/ev_planner.py`) MUST satisfy these invariants:
 ### Invariants for tests
 
 - When `ev_planned_load_enabled = False`, all `ev_planned_load_kwh == 0.0`.
-- When EV is at or above target SoC (`current_soc >= target_soc`) and
-  `allow_charge_past_target_soc` is disabled or `current_soc >= 100`,
+- When EV is at or above target SoC (`current_soc >= target_soc`),
   all EV load fields are `0.0` (early return `"fully_charged"`).
-- When `allow_charge_past_target_soc` is enabled and
-  `target_soc <= current_soc < 100`, Pass 3 may allocate surplus-PV
-  charging slots past the target SoC (energy_needed ≈ 0 does **not**
-  trigger an early return).
-- Pass 3 surplus-PV slots: allocated kWh = `min(max_charge, net_surplus)`,
-  `import_needed_kwh == 0.0`, `estimated_cost == 0.0`.
+  Charge-past-target is handled exclusively by the MILP.
 - When `base_load_includes_ev = True`:
   - `ev_planned_load_kwh == 0.0` for all slots.
   - `ev_accounted_load_kwh > 0` for charging slots.

--- a/tests/planner/test_ev_planned_load.py
+++ b/tests/planner/test_ev_planned_load.py
@@ -2983,129 +2983,11 @@ class TestEvChargerCalculatedPower:
         _compute_ev_charger_power(slots, slot_starts, ev_plan, 15, now)
         assert slots[0].ev_charger_calculated_power > 0
 
-    def test_pass_3_skips_when_battery_not_full(self):
-        """Pass 3 adds no slots when battery is below usable_kwh."""
-        now = _dt(0)
-        surplus = [2.0] * 12 + [0.0] * 12
-        starts, ends = _make_slots(24)
-        inp = EVPlannerInput(
-            enabled=True,
-            ev_connected=True,
-            smart_charging_enabled=True,
-            current_soc_pct=97.0,
-            target_soc_pct=98.0,
-            battery_capacity_kwh=100.0,
-            charger_power_kw=11.0,
-            charger_efficiency_pct=100.0,
-            charger_min_power_w=0.0,  # disable guard for Pass 3 test
-            allow_charge_past_target_soc=True,
-            slot_predicted_battery_kwh=[6.0] * 24,
-            usable_battery_kwh=14.25,
-            now=now,
-        )
-        prices = [0.10] * 24
-        plan = build_ev_charging_plan(inp, starts, ends, surplus, prices)
-        total = sum(s.estimated_charged_kwh for s in plan.charging_slots)
-        assert total == pytest.approx(1.0, abs=0.1)
+    # -- Fully-charged early return (charge-past-target is MILP-only) --
 
-    def test_pass_3_adds_when_battery_full(self):
-        """Pass 3 adds surplus slots when battery is full."""
-        now = _dt(0)
-        surplus = [2.0] * 12 + [0.0] * 12
-        starts, ends = _make_slots(24)
-        inp = EVPlannerInput(
-            enabled=True,
-            ev_connected=True,
-            smart_charging_enabled=True,
-            current_soc_pct=97.0,
-            target_soc_pct=98.0,
-            battery_capacity_kwh=100.0,
-            charger_power_kw=11.0,
-            charger_efficiency_pct=100.0,
-            charger_min_power_w=0.0,  # disable guard for Pass 3 test
-            allow_charge_past_target_soc=True,
-            slot_predicted_battery_kwh=[14.25] * 24,
-            usable_battery_kwh=14.25,
-            now=now,
-        )
-        prices = [0.10] * 24
-        plan = build_ev_charging_plan(inp, starts, ends, surplus, prices)
-        total = sum(s.estimated_charged_kwh for s in plan.charging_slots)
-        assert total > 2.0, f"Pass 3 should add surplus, got {total}"
-
-    def test_pass_3_enters_when_above_target_soc(self):
-        """Pass 3 enters when EV SoC is above target (regression: early return bug).
-
-        When current_soc_pct >= target_soc_pct and
-        allow_charge_past_target_soc=True, the function must NOT
-        early-return \"fully_charged\" — it must continue so Pass 3
-        can allocate surplus-PV slots.
-        """
-        now = _dt(0)
-        surplus = [2.0] * 12 + [0.0] * 12
-        starts, ends = _make_slots(24)
-        inp = EVPlannerInput(
-            enabled=True,
-            ev_connected=True,
-            smart_charging_enabled=True,
-            current_soc_pct=88.0,  # above target of 80 %
-            target_soc_pct=80.0,
-            battery_capacity_kwh=100.0,
-            charger_power_kw=11.0,
-            charger_efficiency_pct=100.0,
-            allow_charge_past_target_soc=True,
-            slot_predicted_battery_kwh=[14.25] * 24,
-            usable_battery_kwh=14.25,
-            now=now,
-        )
-        prices = [0.10] * 24
-        plan = build_ev_charging_plan(inp, starts, ends, surplus, prices)
-        total = sum(s.estimated_charged_kwh for s in plan.charging_slots)
-        assert total > 2.0, (
-            f"Pass 3 should allocate surplus when above target, got {total}"
-        )
-        # All slots must be pure surplus (no grid import).
-        for s in plan.charging_slots:
-            assert s.import_needed_kwh == pytest.approx(0.0)
-            assert s.estimated_cost == pytest.approx(0.0)
-
-    def test_pass_3_enters_with_mismatched_prediction_length(self):
-        """Pass 3 enters when len(predicted_battery) != len(candidates).
-
-        Regression: the old condition required
-        len(slot_predicted_battery_kwh) == len(surplus_slots) + len(non_surplus_slots),
-        which failed when the effective-deadline cap trimmed some slots
-        from the candidate list but slot_predicted_battery_kwh still
-        covered the full planner horizon.
-        """
-        now = _dt(17)  # 17:00 — only 31 slots until end-of-tomorrow
-        # 48-slot horizon but only ~31 candidates
-        starts, ends = _make_slots_48(now)
-        surplus = [2.0] * 12 + [0.0] * 36
-        prices = [0.10] * 48
-        inp = EVPlannerInput(
-            enabled=True,
-            ev_connected=True,
-            smart_charging_enabled=True,
-            current_soc_pct=88.0,
-            target_soc_pct=80.0,
-            battery_capacity_kwh=100.0,
-            charger_power_kw=11.0,
-            charger_efficiency_pct=100.0,
-            allow_charge_past_target_soc=True,
-            slot_predicted_battery_kwh=[14.25] * 48,  # full 48 slots
-            usable_battery_kwh=14.25,
-            now=now,
-        )
-        plan = build_ev_charging_plan(inp, starts, ends, surplus, prices)
-        total = sum(s.estimated_charged_kwh for s in plan.charging_slots)
-        assert total > 2.0, (
-            f"Pass 3 should enter with mismatched prediction length, got {total}"
-        )
-
-    def test_pass_3_not_entered_allow_past_target_disabled(self):
-        """When allow_charge_past_target_soc=False and SoC >= target,
-        the function returns \"fully_charged\" immediately."""
+    def test_fully_charged_when_at_target_and_past_target_disabled(self):
+        """When SoC >= target and allow_charge_past_target_soc=False,
+        the function returns 'fully_charged' immediately."""
         now = _dt(0)
         surplus = [2.0] * 12 + [0.0] * 12
         starts, ends = _make_slots(24)
@@ -3118,9 +3000,7 @@ class TestEvChargerCalculatedPower:
             battery_capacity_kwh=100.0,
             charger_power_kw=11.0,
             charger_efficiency_pct=100.0,
-            allow_charge_past_target_soc=False,  # disabled
-            slot_predicted_battery_kwh=[14.25] * 24,
-            usable_battery_kwh=14.25,
+            allow_charge_past_target_soc=False,
             now=now,
         )
         prices = [0.10] * 24
@@ -3128,8 +3008,8 @@ class TestEvChargerCalculatedPower:
         assert plan.state == "fully_charged"
         assert len(plan.charging_slots) == 0
 
-    def test_pass_3_not_entered_soc_100(self):
-        """When SoC is 100 %, the function returns \"fully_charged\"
+    def test_fully_charged_when_soc_100_regardless_of_past_target(self):
+        """When SoC is 100 %, returns 'fully_charged'
         even when allow_charge_past_target_soc=True."""
         now = _dt(0)
         surplus = [2.0] * 12 + [0.0] * 12
@@ -3144,8 +3024,30 @@ class TestEvChargerCalculatedPower:
             charger_power_kw=11.0,
             charger_efficiency_pct=100.0,
             allow_charge_past_target_soc=True,
-            slot_predicted_battery_kwh=[14.25] * 24,
-            usable_battery_kwh=14.25,
+            now=now,
+        )
+        prices = [0.10] * 24
+        plan = build_ev_charging_plan(inp, starts, ends, surplus, prices)
+        assert plan.state == "fully_charged"
+        assert len(plan.charging_slots) == 0
+
+    def test_fully_charged_when_above_target_even_with_past_target_enabled(self):
+        """When SoC is above target and allow_charge_past_target_soc=True,
+        the EV planner returns 'fully_charged' — charge-past-target is
+        handled exclusively by the MILP, not the EV planner."""
+        now = _dt(0)
+        surplus = [2.0] * 12 + [0.0] * 12
+        starts, ends = _make_slots(24)
+        inp = EVPlannerInput(
+            enabled=True,
+            ev_connected=True,
+            smart_charging_enabled=True,
+            current_soc_pct=88.0,
+            target_soc_pct=80.0,
+            battery_capacity_kwh=100.0,
+            charger_power_kw=11.0,
+            charger_efficiency_pct=100.0,
+            allow_charge_past_target_soc=True,
             now=now,
         )
         prices = [0.10] * 24

--- a/tests/test_coordinator_milp_gating.py
+++ b/tests/test_coordinator_milp_gating.py
@@ -28,6 +28,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from custom_components.hsem.coordinator import HSEMDataUpdateCoordinator
+from custom_components.hsem.models.live_state import LiveState
 from custom_components.hsem.models.planned_slot import PlannedSlot
 from custom_components.hsem.models.planner_input import PlannerInput
 from custom_components.hsem.models.planner_output import PlannerOutput
@@ -358,6 +359,63 @@ class TestSmoothCurrentSlotEvPower:
         coord._last_milp_planner_input = _base_input()
         output = PlannerOutput(
             slots=[_slot_with_ev_load(slot_start, slot_end, 1.0, 0.0)]
+        )
+        now = slot_start + timedelta(minutes=5)
+        coord._smooth_current_slot_ev_power(output, now)
+        assert output.slots[0].ev_charger_calculated_power == pytest.approx(0.0)
+
+    # -- Slots with zero planned EV load are never reactively charged --
+    # The MILP is the global optimiser.  When it allocates zero EV load for
+    # a slot, that decision is authoritative — live surplus must not override it.
+
+    def test_zero_ev_load_not_reactively_charged_with_surplus(self) -> None:
+        """Live surplus does not create EV power when MILP planned zero EV."""
+        coord = _make_coordinator()
+        slot_start = datetime(2024, 6, 15, 12, 0, tzinfo=TZ)
+        slot_end = datetime(2024, 6, 15, 12, 15, tzinfo=TZ)
+        coord._last_milp_planner_input = _base_input(
+            ev_planned_allow_charge_past_target_soc=True,
+            ev_planned_load_charger_power_kw=11.0,
+            ev_planned_load_charger_min_power_w=1380.0,
+        )
+        # Simulate live surplus (3000 W) and battery full — the reactive
+        # Pass 3 used to trigger here, but it has been removed.  The MILP
+        # is the global optimiser: no EV load planned = no EV charging.
+        coord._live = LiveState(
+            net_consumption_w=-3000.0,
+            huawei_batteries_soc_pct=99.5,
+        )
+        output = PlannerOutput(
+            slots=[_slot_with_ev_load(slot_start, slot_end, 0.0, 0.0)]
+        )
+        now = slot_start + timedelta(minutes=5)
+        coord._smooth_current_slot_ev_power(output, now)
+        # Power must stay at 0 — MILP planned zero EV load for this slot.
+        assert output.slots[0].ev_charger_calculated_power == pytest.approx(0.0)
+
+    def test_zero_ev_load_not_reactively_charged_export_scenario(self) -> None:
+        """Live surplus from export does not create EV power.
+
+        This is the exact scenario from the bug report: the MILP decides
+        to export to grid, grid export creates negative net consumption,
+        but the smoothing layer must not interpret that as "surplus for EV".
+        """
+        coord = _make_coordinator()
+        slot_start = datetime(2024, 6, 15, 12, 0, tzinfo=TZ)
+        slot_end = datetime(2024, 6, 15, 12, 15, tzinfo=TZ)
+        coord._last_milp_planner_input = _base_input(
+            ev_planned_allow_charge_past_target_soc=True,
+            ev_planned_load_charger_power_kw=11.0,
+            ev_planned_load_charger_min_power_w=1380.0,
+        )
+        # Battery at 70 % — MILP chose to export instead of charge battery.
+        # Live surplus is 5000 W from the export.  The EV must NOT charge.
+        coord._live = LiveState(
+            net_consumption_w=-5000.0,
+            huawei_batteries_soc_pct=70.0,
+        )
+        output = PlannerOutput(
+            slots=[_slot_with_ev_load(slot_start, slot_end, 0.0, 0.0)]
         )
         now = slot_start + timedelta(minutes=5)
         coord._smooth_current_slot_ev_power(output, now)

--- a/tests/test_ha_mock_integration.py
+++ b/tests/test_ha_mock_integration.py
@@ -691,7 +691,7 @@ class TestMockServiceCalls:
 
         with (
             patch(
-                "custom_components.hsem.custom_sensors.working_mode_sensor.async_logger",
+                "custom_components.hsem.utils.logger.HSEM_LOGGER.debug",
                 new_callable=AsyncMock,
             ),
             patch(

--- a/tests/test_logger_no_file_handler.py
+++ b/tests/test_logger_no_file_handler.py
@@ -10,11 +10,11 @@ Key contract:
 * ``HSEM_LOGGER.propagate`` is ``False`` so planner detail stays out of the
   main HA log unless the user explicitly enables ``custom_components.hsem``
   in the ``logger:`` YAML block.
-* ``async_logger`` writes directly (no per-call executor delegation), but
-  init/teardown of the file handler runs in the executor to avoid HA's
-  ``Detected blocking call to open`` during setup/unload.
-* ``log_planner`` and ``async_logger`` both target ``HSEM_LOGGER`` — the
-  single file handler captures everything.
+* ``set_hsem_verbose`` controls ``HSEM_LOGGER``'s level — the single source
+  of truth for verbosity.
+* ``log_planner`` offloads file I/O to a thread pool when the event loop is
+  running.  Both ``log_planner`` and direct ``_LOGGER.debug()`` calls target
+  ``HSEM_LOGGER`` — the single file handler captures everything.
 """
 
 from __future__ import annotations
@@ -23,12 +23,9 @@ import io
 import logging
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
-from unittest.mock import MagicMock
-
-import pytest
 
 from custom_components.hsem.utils import logger as logger_module
-from custom_components.hsem.utils.logger import HSEM_LOGGER, async_logger
+from custom_components.hsem.utils.logger import HSEM_LOGGER, set_hsem_verbose
 
 # Re-import unchanged tests
 _ORIGINAL = HSEM_LOGGER.handlers.copy()
@@ -71,18 +68,29 @@ class TestLoggerHandlerHygiene:
         """HSEM_LOGGER must not propagate to avoid flooding home-assistant.log."""
         assert HSEM_LOGGER.propagate is False
 
-    def test_logger_level_is_debug(self) -> None:
-        """HSEM_LOGGER must accept DEBUG records."""
-        assert HSEM_LOGGER.level == logging.DEBUG, (
-            "HSEM_LOGGER must be set to DEBUG so the in-config verbose flag "
-            "controls visibility. "
+    def test_logger_default_level_is_warning(self) -> None:
+        """HSEM_LOGGER defaults to WARNING until set_hsem_verbose is called."""
+        assert HSEM_LOGGER.level == logging.WARNING, (
+            "HSEM_LOGGER must start at WARNING to avoid log spam "
+            "before the config is loaded. "
             f"Got: {logging.getLevelName(HSEM_LOGGER.level)}"
         )
 
-    def test_logger_is_enabled_for_info_and_debug(self) -> None:
-        """End-to-end: HSEM_LOGGER must accept both INFO and DEBUG records."""
-        assert HSEM_LOGGER.isEnabledFor(logging.DEBUG)
-        assert HSEM_LOGGER.isEnabledFor(logging.INFO)
+    def test_level_is_debug_after_set_hsem_verbose_true(self) -> None:
+        """set_hsem_verbose(True) must set HSEM_LOGGER to DEBUG."""
+        set_hsem_verbose(True)
+        try:
+            assert HSEM_LOGGER.level == logging.DEBUG
+            assert HSEM_LOGGER.isEnabledFor(logging.DEBUG)
+            assert HSEM_LOGGER.isEnabledFor(logging.INFO)
+        finally:
+            set_hsem_verbose(False)
+
+    def test_level_is_warning_after_set_hsem_verbose_false(self) -> None:
+        """set_hsem_verbose(False) must restore WARNING level."""
+        set_hsem_verbose(True)
+        set_hsem_verbose(False)
+        assert HSEM_LOGGER.level == logging.WARNING
 
     def test_logger_module_exposes_log_file_constants(self) -> None:
         """The logger module must expose the filename constant for diagnostics."""
@@ -105,43 +113,30 @@ class TestLoggerHandlerHygiene:
             logger_module.close_hsem_logger_sync()
 
 
-class TestAsyncLoggerNonBlocking:
-    """Verify ``async_logger`` writes directly to the HSEM logger."""
+class TestVerboseLogging:
+    """Verify set_hsem_verbose gating via logger level."""
 
-    @pytest.mark.asyncio
-    async def test_async_logger_writes_to_hsem_logger(
-        self,
-    ) -> None:
-        """``async_logger`` must emit logs through HSEM_LOGGER."""
-        sensor = MagicMock()
-        sensor._hsem_verbose_logging = True
-
+    def test_debug_writes_when_verbose_enabled(self) -> None:
+        """_LOGGER.debug() must write when set_hsem_verbose(True)."""
+        set_hsem_verbose(True)
         handler = _attach_capture_handler()
         try:
-            await async_logger(sensor, "regression: test message")
+            HSEM_LOGGER.debug("verbose: test message")
             stream = handler.stream
             stream.seek(0)
             output = stream.read()
-            assert "regression: test message" in output, (
-                "async_logger must write to HSEM_LOGGER (the file handler)."
-            )
+            assert "verbose: test message" in output
         finally:
             HSEM_LOGGER.removeHandler(handler)
             handler.close()
+            set_hsem_verbose(False)
 
-    @pytest.mark.asyncio
-    async def test_async_logger_respects_verbose_flag(
-        self,
-    ) -> None:
-        """When verbose logging is disabled, no record must be emitted."""
-        sensor = MagicMock()
-        sensor._hsem_verbose_logging = False
-        # Defang the new-style config branch so the legacy branch is used.
-        del sensor._cfg
-
+    def test_debug_suppressed_when_verbose_disabled(self) -> None:
+        """_LOGGER.debug() must not write when verbose is off."""
+        set_hsem_verbose(False)
         handler = _attach_capture_handler()
         try:
-            await async_logger(sensor, "should be suppressed")
+            HSEM_LOGGER.debug("should be suppressed")
             stream = handler.stream
             stream.seek(0)
             output = stream.read()
@@ -150,24 +145,16 @@ class TestAsyncLoggerNonBlocking:
             HSEM_LOGGER.removeHandler(handler)
             handler.close()
 
-    @pytest.mark.asyncio
-    async def test_async_logger_uses_requested_level(
-        self,
-    ) -> None:
-        """Level argument must map to the matching logger method."""
-        sensor = MagicMock()
-        sensor._hsem_verbose_logging = True
-
+    def test_warning_always_writes_regardless_of_verbose(self) -> None:
+        """_LOGGER.warning() must write even when verbose is off."""
+        set_hsem_verbose(False)
         handler = _attach_capture_handler()
-        handler.setLevel(logging.WARNING)
         try:
-            await async_logger(sensor, "must appear", level="warning")
-            await async_logger(sensor, "must NOT appear", level="debug")
+            HSEM_LOGGER.warning("must appear")
             stream = handler.stream
             stream.seek(0)
             output = stream.read()
             assert "must appear" in output
-            assert "must NOT appear" not in output
         finally:
             HSEM_LOGGER.removeHandler(handler)
             handler.close()
@@ -180,9 +167,9 @@ class TestPlannerLogger:
         self,
     ) -> None:
         """log_planner('info', ...) must write to HSEM_LOGGER."""
-        from custom_components.hsem.utils.logger import log_planner, set_planner_verbose
+        from custom_components.hsem.utils.logger import log_planner
 
-        set_planner_verbose(True)
+        set_hsem_verbose(True)
         handler = _attach_capture_handler()
         try:
             log_planner("info", "[engine] e2e: slot %d cost=%.4f", 5, 0.1234)
@@ -196,15 +183,15 @@ class TestPlannerLogger:
         finally:
             HSEM_LOGGER.removeHandler(handler)
             handler.close()
-            set_planner_verbose(False)
+            set_hsem_verbose(False)
 
     def test_log_planner_debug_reaches_hsem_logger(
         self,
     ) -> None:
         """DEBUG records must also write to HSEM_LOGGER."""
-        from custom_components.hsem.utils.logger import log_planner, set_planner_verbose
+        from custom_components.hsem.utils.logger import log_planner
 
-        set_planner_verbose(True)
+        set_hsem_verbose(True)
         handler = _attach_capture_handler()
         try:
             log_planner("debug", "[engine] e2e: debug slot=%d", 7)
@@ -215,15 +202,15 @@ class TestPlannerLogger:
         finally:
             HSEM_LOGGER.removeHandler(handler)
             handler.close()
-            set_planner_verbose(False)
+            set_hsem_verbose(False)
 
     def test_log_planner_suppressed_when_not_verbose(
         self,
     ) -> None:
         """With verbose disabled, ``log_planner`` must emit nothing."""
-        from custom_components.hsem.utils.logger import log_planner, set_planner_verbose
+        from custom_components.hsem.utils.logger import log_planner
 
-        set_planner_verbose(False)
+        set_hsem_verbose(False)
         handler = _attach_capture_handler()
         try:
             log_planner("info", "must-not-appear")

--- a/tests/test_safety_gates.py
+++ b/tests/test_safety_gates.py
@@ -16,9 +16,9 @@ Covered scenarios
 
 All tests are pure-Python and require no running Home Assistant instance.
 
-Note on ``async_logger``
-------------------------
-:func:`async_logger` is patched with a no-op ``AsyncMock`` in every test so
+Note on logging
+----------------
+``HSEM_LOGGER.debug`` is patched with a no-op ``AsyncMock`` in every test so
 that planner/applier output never reaches the standard ``custom_components.hsem``
 logger during the test run.  This keeps test output clean and decouples the
 safety-gate assertions from log-formatting changes.
@@ -44,11 +44,8 @@ from custom_components.hsem.utils.inverter_verify import ApplyStatus
 # Module-level patch targets (reused across all test classes)
 # ---------------------------------------------------------------------------
 
-# The applier module imports async_logger under this name.
-_APPLIER_LOGGER = "custom_components.hsem.custom_sensors.applier.async_logger"
-_SENSOR_LOGGER = (
-    "custom_components.hsem.custom_sensors.working_mode_sensor.async_logger"
-)
+# Patch HSEM_LOGGER.debug to suppress log output during tests.
+_LOGGER_PATCH = "custom_components.hsem.utils.logger.HSEM_LOGGER.debug"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -56,7 +53,7 @@ _SENSOR_LOGGER = (
 
 
 def _make_sensor():
-    """Return a minimal mock sensor that satisfies async_logger requirements."""
+    """Return a minimal mock sensor for testing."""
     sensor = MagicMock()
     sensor.hass = MagicMock()
     return sensor
@@ -103,7 +100,7 @@ class TestInverterPowerControlSafetyGate:
         live = _make_live(degraded_mode=DegradedMode.OK)
 
         with (
-            patch(_APPLIER_LOGGER, new_callable=AsyncMock),
+            patch(_LOGGER_PATCH, new_callable=AsyncMock),
             patch(
                 "custom_components.hsem.custom_sensors.applier.async_set_grid_export_power_pct"
             ) as mock_write,
@@ -121,7 +118,7 @@ class TestInverterPowerControlSafetyGate:
         live = _make_live(degraded_mode=DegradedMode.Error)
 
         with (
-            patch(_APPLIER_LOGGER, new_callable=AsyncMock),
+            patch(_LOGGER_PATCH, new_callable=AsyncMock),
             patch(
                 "custom_components.hsem.custom_sensors.applier.async_set_grid_export_power_pct"
             ) as mock_write,
@@ -156,7 +153,7 @@ class TestInverterPowerControlSafetyGate:
         sensor.hass.states.get.return_value = mock_state
 
         with (
-            patch(_APPLIER_LOGGER, new_callable=AsyncMock),
+            patch(_LOGGER_PATCH, new_callable=AsyncMock),
             patch(
                 "custom_components.hsem.custom_sensors.applier.async_write_and_verify",
                 new_callable=AsyncMock,
@@ -196,7 +193,7 @@ class TestInverterPowerControlSafetyGate:
         sensor.hass.states.get.return_value = mock_state
 
         with (
-            patch(_APPLIER_LOGGER, new_callable=AsyncMock),
+            patch(_LOGGER_PATCH, new_callable=AsyncMock),
             patch(
                 "custom_components.hsem.custom_sensors.applier.async_write_and_verify",
                 new_callable=AsyncMock,
@@ -238,7 +235,7 @@ class TestBatterySettingsSafetyGate:
         rec = self._make_rec()
 
         with (
-            patch(_APPLIER_LOGGER, new_callable=AsyncMock),
+            patch(_LOGGER_PATCH, new_callable=AsyncMock),
             patch(
                 "custom_components.hsem.custom_sensors.applier.async_write_and_verify",
                 new_callable=AsyncMock,
@@ -258,7 +255,7 @@ class TestBatterySettingsSafetyGate:
         rec = self._make_rec()
 
         with (
-            patch(_APPLIER_LOGGER, new_callable=AsyncMock),
+            patch(_LOGGER_PATCH, new_callable=AsyncMock),
             patch(
                 "custom_components.hsem.custom_sensors.applier.async_write_and_verify",
                 new_callable=AsyncMock,
@@ -293,7 +290,7 @@ class TestBatterySettingsSafetyGate:
         rec = _make_rec(Recommendations.BatteriesDischargeMode.value)
 
         with (
-            patch(_APPLIER_LOGGER, new_callable=AsyncMock),
+            patch(_LOGGER_PATCH, new_callable=AsyncMock),
             patch(
                 "custom_components.hsem.custom_sensors.applier.async_write_and_verify",
                 new_callable=AsyncMock,
@@ -337,7 +334,7 @@ class TestBatterySettingsSafetyGate:
         rec = _make_rec(Recommendations.BatteriesDischargeMode.value)
 
         with (
-            patch(_APPLIER_LOGGER, new_callable=AsyncMock),
+            patch(_LOGGER_PATCH, new_callable=AsyncMock),
             patch(
                 "custom_components.hsem.custom_sensors.applier.async_write_and_verify",
                 new_callable=AsyncMock,
@@ -395,7 +392,7 @@ class TestWorkingModeSensorTopLevelGate:
         data = self._make_coordinator_data(read_only=True)
 
         with (
-            patch(_SENSOR_LOGGER, new_callable=AsyncMock),
+            patch(_LOGGER_PATCH, new_callable=AsyncMock),
             patch(
                 "custom_components.hsem.custom_sensors.working_mode_sensor.async_apply_inverter_power_control",
                 new_callable=AsyncMock,
@@ -426,7 +423,7 @@ class TestWorkingModeSensorTopLevelGate:
         )
 
         with (
-            patch(_SENSOR_LOGGER, new_callable=AsyncMock),
+            patch(_LOGGER_PATCH, new_callable=AsyncMock),
             patch(
                 "custom_components.hsem.custom_sensors.working_mode_sensor.async_apply_inverter_power_control",
                 new_callable=AsyncMock,
@@ -458,7 +455,7 @@ class TestWorkingModeSensorTopLevelGate:
         from custom_components.hsem.utils.inverter_verify import CycleApplySummary
 
         with (
-            patch(_SENSOR_LOGGER, new_callable=AsyncMock),
+            patch(_LOGGER_PATCH, new_callable=AsyncMock),
             patch(
                 "custom_components.hsem.custom_sensors.working_mode_sensor.async_apply_inverter_power_control",
                 new_callable=AsyncMock,
@@ -499,7 +496,7 @@ class TestWorkingModeSensorTopLevelGate:
         # so the battery gate passes.
 
         with (
-            patch(_SENSOR_LOGGER, new_callable=AsyncMock),
+            patch(_LOGGER_PATCH, new_callable=AsyncMock),
             patch(
                 "custom_components.hsem.custom_sensors.working_mode_sensor.async_apply_inverter_power_control",
                 new_callable=AsyncMock,

--- a/tests/test_update_loop_lock.py
+++ b/tests/test_update_loop_lock.py
@@ -30,15 +30,9 @@ class _StubSensor:
         self._skipped_count = 0
         self._name = "stub_sensor"
 
-    async def _async_logger(self, msg: str) -> None:  # noqa: D102 (no docstring needed)
-        pass
-
     async def _async_handle_update(self, event: Any = None) -> None:
         """Exact copy of the production guard logic."""
         if self._update_lock.locked():
-            await self._async_logger(
-                "------ Update skipped: a previous update cycle is still running."
-            )
             self._skipped_count += 1
             return
 


### PR DESCRIPTION
## Summary

Makes the MILP the single authority for all EV charging decisions, removes the reactive Pass 3 that was overriding MILP decisions, unifies logging, and cleans up dead code.

## Changes

### EV charging — MILP is sole authority
- **Removed reactive Pass 3** from `coordinator.py` (`_smooth_current_slot_ev_power`). The reactive layer was starting EV charging from live surplus even when the MILP chose to export — overriding the global optimizer's decision.
- **Removed EV planner Pass 3** from `ev_planner.py`. Charge-past-target is now exclusively handled by the MILP with its surplus-only constraint and tiebreaker benefit (0.0001/kWh AC).
- **Removed dead fields**: `slot_predicted_battery_kwh`, `usable_battery_kwh`, `live_net_consumption_w` from `EVPlannerInput`; `predicted_battery_kwh` computation from `engine_core.py`; `live_net_consumption_w` from `PlannerInput`.

### MILP export price clamping fix
- **Removed** `np.maximum(p_exp, 0.0)` — the blanket negative-to-0 clamp. The LP's `curt[t]` variable (zero objective cost) naturally handles negative prices: when `p_exp < 0`, exporting costs money and the LP prefers curtailment.

### Logging unification
- **Removed** `async_logger()` (~55 call sites across 6 files) and `set_planner_verbose()`.
- **Added** `set_hsem_verbose()` — sets `HSEM_LOGGER.setLevel()` as the single verbosity control. No more per-call gating.
- All async code now calls `_LOGGER.debug()` / `_LOGGER.warning()` directly.
- Simplified `log_planner()` by removing the `_PLANNER_VERBOSE` module-global check.

### Constants moved
- `EV_SOC_RESOLVE_THRESHOLD_PCT` and `INPUT_EPSILON` moved from `coordinator.py` to `const.py`.

### Documentation
- Added **MILP decision priority** section to `docs/planner-spec.md` with objective function, prioritized tables, and tiebreaker explanation.
- Updated export clamping docs to reflect `curt[t]` handling.
- Updated `.github/memories.md` for export clamping changes.

### Tests
- `test_coordinator_milp_gating.py`: replaced reactive Pass 3 tests with tests verifying zero EV load is never reactively charged.
- `test_ev_planned_load.py`: replaced 6 Pass 3 tests with 3 `"fully_charged"` early-return tests.

## Files changed (17)
| File | Change |
|---|---|
| `coordinator.py` | Removed reactive Pass 3, unified logging, constants → const.py |
| `ev_planner.py` | Removed Pass 3, stale fields, simplified early return |
| `engine_core.py` | Removed predicted_battery_kwh, stale params, stale comments |
| `milp_optimizer.py` | Removed negative export price clamp |
| `logger.py` | Removed async_logger, set_planner_verbose; added set_hsem_verbose |
| `applier.py` | async_logger → _LOGGER |
| `state_collector.py` | async_logger → _LOGGER |
| `consumption.py` | async_logger → _LOGGER |
| `prices_solcast.py` | async_logger → _LOGGER |
| `working_mode_sensor.py` | async_logger → _LOGGER |
| `const.py` | Added INPUT_EPSILON, EV_SOC_RESOLVE_THRESHOLD_PCT |
| `planner_input.py` | Removed live_net_consumption_w |
| `coordinator_builder.py` | Removed live_net_consumption_w |
| `docs/planner-spec.md` | Added MILP priority; updated Pass 3, export clamping |
| `.github/memories.md` | Updated export clamping |
| `test_coordinator_milp_gating.py` | Updated reactive Pass 3 tests |
| `test_ev_planned_load.py` | Updated Pass 3 tests |