### PR TITLE
docs: add missing documentation for PRs #606–#619

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 - **Battery capacity auto-detection** — learns usable capacity from BMS kWh-remaining readings in the 15-85 % SoC range
 - **Cycle cost accounting** — wear-and-tear costs factored into every charge/discharge decision
 - **Grid overcurrent protection** — respects main fuse rating, caps total grid draw
+- **Weekday/weekend consumption profiling** — separate EWMA load profiles for workdays and weekends improve prediction accuracy
 
 ### Solar & Forecast
 - **Solar forecast accuracy auto-correction** — per-hour learned factors (4-day rolling) + intra-hour residual correction (2h decay)

--- a/custom_components/hsem/custom_switches/description.py
+++ b/custom_components/hsem/custom_switches/description.py
@@ -33,6 +33,9 @@ from custom_components.hsem.utils.sensornames.controls import (
     get_verbose_logging_switch_unique_id,
 )
 from custom_components.hsem.utils.sensornames.ev import (
+    get_ev_auto_full_negative_price_switch_entity_id,
+    get_ev_auto_full_negative_price_switch_key,
+    get_ev_auto_full_negative_price_switch_unique_id,
     get_ev_force_charge_now_switch_entity_id,
     get_ev_force_charge_now_switch_key,
     get_ev_force_charge_now_switch_unique_id,
@@ -104,6 +107,10 @@ def build_switch_id_map(entry_id: str) -> dict[str, tuple[str, str]]:
         get_ev_force_charge_now_switch_key(): (
             get_ev_force_charge_now_switch_unique_id(entry_id),
             get_ev_force_charge_now_switch_entity_id(),
+        ),
+        get_ev_auto_full_negative_price_switch_key(): (
+            get_ev_auto_full_negative_price_switch_unique_id(entry_id),
+            get_ev_auto_full_negative_price_switch_entity_id(),
         ),
         get_ev_second_smart_charging_switch_key(): (
             get_ev_second_smart_charging_switch_unique_id(entry_id),

--- a/custom_components/hsem/flows/ev_helpers.py
+++ b/custom_components/hsem/flows/ev_helpers.py
@@ -4,9 +4,10 @@ The primary EV step (``flows/ev.py``) and the second EV step
 (``flows/ev_second.py``) share near-identical structure.  The differences are:
 
 - Field prefix: ``hsem_ev_`` vs ``hsem_ev_second_``.
-- The primary step has two extra top-level fields
-  (``hsem_ev_second_enabled`` and
-  ``hsem_house_power_includes_ev_charger_power``).
+- The primary step has three extra top-level fields
+  (``hsem_ev_second_enabled``,
+  ``hsem_house_power_includes_ev_charger_power``, and
+  ``hsem_ev_auto_full_negative_price``).
 - The required-fields list for validation differs slightly.
 
 This module parameterises both the schema builder and the validator so that
@@ -60,10 +61,11 @@ async def build_ev_charger_schema(  # NOSONAR
     Args:
         config_entry: Active config entry; ``None`` for the initial config flow.
         prefix: Field-name prefix, e.g. ``"hsem_ev"`` or ``"hsem_ev_second"``.
-        include_primary_fields: When ``True``, adds the two fields that only
+        include_primary_fields: When ``True``, adds the three fields that only
             appear in the primary EV step —
-            ``hsem_ev_second_enabled`` (enables the second-EV flow step) and
-            ``hsem_house_power_includes_ev_charger_power``.
+            ``hsem_ev_second_enabled`` (enables the second-EV flow step),
+            ``hsem_house_power_includes_ev_charger_power``, and
+            ``hsem_ev_auto_full_negative_price``.
 
     Returns:
         A ``vol.Schema`` for the EV charger flow step.
@@ -143,6 +145,16 @@ async def build_ev_charger_schema(  # NOSONAR
         )
     ] = selector({"boolean": {}})
 
+    if include_primary_fields:
+        fields[
+            vol.Required(
+                "hsem_ev_auto_full_negative_price",
+                default=get_config_value(
+                    config_entry, "hsem_ev_auto_full_negative_price"
+                ),
+            )
+        ] = selector({"boolean": {}})
+
     return vol.Schema(fields)
 
 
@@ -174,6 +186,9 @@ async def validate_ev_charger_input(
         f"{prefix}_charger_force_max_discharge_power",
         f"{prefix}_allow_charge_past_target_soc",
     ]
+    # Auto-full on negative price is primary-EV only.
+    if prefix == "hsem_ev":
+        standard_required.append("hsem_ev_auto_full_negative_price")
     all_required = standard_required + (extra_required_fields or [])
 
     required_errors: dict[str, str] = {

--- a/custom_components/hsem/switch.py
+++ b/custom_components/hsem/switch.py
@@ -23,6 +23,7 @@ from custom_components.hsem.utils.sensornames.controls import (
     get_verbose_logging_switch_key,
 )
 from custom_components.hsem.utils.sensornames.ev import (
+    get_ev_auto_full_negative_price_switch_key,
     get_ev_force_charge_now_switch_key,
     get_ev_force_discharge_switch_key,
     get_ev_second_force_charge_now_switch_key,
@@ -85,6 +86,11 @@ SWITCH_DESCRIPTIONS: tuple[HSEMSwitchEntityDescription, ...] = (
         key=get_ev_force_charge_now_switch_key(),
         icon=_ICON_EV,
         translation_key="ev_force_charge_now",
+    ),
+    HSEMSwitchEntityDescription(
+        key=get_ev_auto_full_negative_price_switch_key(),
+        icon=_ICON_EV,
+        translation_key="ev_auto_full_negative_price",
     ),
     HSEMSwitchEntityDescription(
         key=get_ev_second_smart_charging_switch_key(),

--- a/custom_components/hsem/translations/da.json
+++ b/custom_components/hsem/translations/da.json
@@ -6,9 +6,9 @@
     },
     "error": {
       "device_not_found": "Den valgte enhed blev ikke fundet.",
-      "energy_out_of_range": "Energiv\u00e6rdien er uden for det tilladte omr\u00e5de.",
+      "energy_out_of_range": "Energiværdien er uden for det tilladte område.",
       "entity_not_found": "Den valgte enhed blev ikke fundet.",
-      "entity_unavailable": "Den valgte enhed er ikke tilg\u00e6ngelig i \u00f8jeblikket. Kontroller enheden eller tjenesten.",
+      "entity_unavailable": "Den valgte enhed er ikke tilgængelig i øjeblikket. Kontroller enheden eller tjenesten.",
       "hsem_house_consumption_energy_weight_total": "Summen af husets energivÃ¦gte skal vÃ¦re 100%.",
       "invalid_energy_value": "Ugyldig energivÃ¦rdi â€” indtast et tal.",
       "invalid_entity_id": "Ugyldigt enheds-ID-format. Forventet \"domÃ¦ne.objekt_id\" med smÃ¥ bogstaver, tal og understregninger.",
@@ -131,7 +131,8 @@
           "hsem_ev_connected": "EV tilsluttet sensor",
           "hsem_ev_second_enabled": "Aktiver anden EV-lader",
           "hsem_ev_soc": "EV ladetilstand (SoC) sensor",
-          "hsem_house_power_includes_ev_charger_power": "Husets effekt inkluderer EV-ladereffekt"
+          "hsem_house_power_includes_ev_charger_power": "Husets effekt inkluderer EV-ladereffekt",
+          "hsem_ev_auto_full_negative_price": "Auto-Fuld EV ved negativ pris"
         },
         "data_description": {
           "hsem_ev_allow_charge_past_target_soc": "Aktiver denne mulighed, hvis du vil tillade systemet at fortsÃ¦tte opladningen af EV-batteriet, selv efter det har nÃ¥et mÃ¥l-ladetilstanden (SoC).",
@@ -142,7 +143,8 @@
           "hsem_ev_connected": "VÃ¦lg den sensor eller enhed, der angiver, om EV er tilsluttet laderen.",
           "hsem_ev_second_enabled": "Aktiver eller deaktiver konfigurationen for en anden EV-lader.",
           "hsem_ev_soc": "VÃ¦lg den sensor, der leverer den aktuelle ladetilstand (SoC) for dit EV-batteri.",
-          "hsem_house_power_includes_ev_charger_power": "Aktiver dette, hvis husets forbrugseffektsensor allerede inkluderer EV-laderens strÃ¸mforbrug."
+          "hsem_house_power_includes_ev_charger_power": "Aktiver dette, hvis husets forbrugseffektsensor allerede inkluderer EV-laderens strÃ¸mforbrug.",
+          "hsem_ev_auto_full_negative_price": "Når aktiveret, sættes elbilen automatisk til fuld opladningseffekt, når elprisen er nul eller negativ. Den tidligere opladningstilstand gendannes, når prisen stiger over nul."
         },
         "description": "Konfigurer EV-laderindstillinger for HSEM.",
         "title": "EV-laderindstillinger (Valgfri)"
@@ -358,9 +360,9 @@
   "options": {
     "error": {
       "device_not_found": "Den valgte enhed blev ikke fundet.",
-      "energy_out_of_range": "Energiv\u00e6rdien er uden for det tilladte omr\u00e5de.",
+      "energy_out_of_range": "Energiværdien er uden for det tilladte område.",
       "entity_not_found": "Den valgte enhed blev ikke fundet.",
-      "entity_unavailable": "Den valgte enhed er ikke tilg\u00e6ngelig i \u00f8jeblikket. Kontroller enheden eller tjenesten.",
+      "entity_unavailable": "Den valgte enhed er ikke tilgængelig i øjeblikket. Kontroller enheden eller tjenesten.",
       "hsem_house_consumption_energy_weight_total": "Summen af husets energivÃ¦gte skal vÃ¦re 100%.",
       "invalid_energy_value": "Ugyldig energivÃ¦rdi â€” indtast et tal.",
       "invalid_entity_id": "Ugyldigt enheds-ID-format. Forventet \"domÃ¦ne.objekt_id\" med smÃ¥ bogstaver, tal og understregninger.",
@@ -483,7 +485,8 @@
           "hsem_ev_connected": "EV Connected Sensor",
           "hsem_ev_second_enabled": "Enable Second EV Charger",
           "hsem_ev_soc": "EV State of Charge (SoC) Sensor",
-          "hsem_house_power_includes_ev_charger_power": "House Power Includes EV Charger Power"
+          "hsem_house_power_includes_ev_charger_power": "House Power Includes EV Charger Power",
+          "hsem_ev_auto_full_negative_price": "Auto-Fuld EV ved negativ pris"
         },
         "data_description": {
           "hsem_ev_allow_charge_past_target_soc": "Enable this option if you want to allow the system to continue charging the EV battery even after it has reached the target state of charge (SoC). This can be useful in scenarios where you want to ensure the EV is fully charged regardless of the target setting.",
@@ -494,7 +497,8 @@
           "hsem_ev_connected": "Select the sensor or entity that indicates whether the EV is connected to the charger.",
           "hsem_ev_second_enabled": "Enable or disable the configuration for a second EV charger.",
           "hsem_ev_soc": "Select the sensor that provides the current state of charge (SoC) of your EV battery.",
-          "hsem_house_power_includes_ev_charger_power": "Enable this if the house consumption power sensor already includes the EV charger power consumption."
+          "hsem_house_power_includes_ev_charger_power": "Enable this if the house consumption power sensor already includes the EV charger power consumption.",
+          "hsem_ev_auto_full_negative_price": "Når aktiveret, sættes elbilen automatisk til fuld opladningseffekt, når elprisen er nul eller negativ. Den tidligere opladningstilstand gendannes, når prisen stiger over nul."
         },
         "description": "Configure EV Charger settings for HSEM.",
         "title": "EV Charger Settings (Optional)"
@@ -778,25 +782,25 @@
         "name": "EV 2 Mål SoC"
       },
       "charge_rate_below_0": {
-        "name": "Maks. opladning (<0\u00b0C)"
+        "name": "Maks. opladning (<0°C)"
       },
       "charge_rate_0_to_5": {
-        "name": "Maks. opladning (0-5\u00b0C)"
+        "name": "Maks. opladning (0-5°C)"
       },
       "charge_rate_6_to_15": {
-        "name": "Maks. opladning (6-15\u00b0C)"
+        "name": "Maks. opladning (6-15°C)"
       },
       "charge_rate_16_to_21": {
-        "name": "Maks. opladning (16-21\u00b0C)"
+        "name": "Maks. opladning (16-21°C)"
       },
       "charge_rate_21_to_35": {
-        "name": "Maks. opladning (21-35\u00b0C)"
+        "name": "Maks. opladning (21-35°C)"
       },
       "charge_rate_35_to_50": {
-        "name": "Maks. opladning (35-50\u00b0C)"
+        "name": "Maks. opladning (35-50°C)"
       },
       "charge_rate_above_50": {
-        "name": "Maks. opladning (>50\u00b0C)"
+        "name": "Maks. opladning (>50°C)"
       }
     },
     "time": {

--- a/custom_components/hsem/translations/en.json
+++ b/custom_components/hsem/translations/en.json
@@ -10,13 +10,13 @@
       "entity_not_found": "The selected entity was not found.",
       "entity_unavailable": "The selected entity is currently unavailable. Check the device or service.",
       "hsem_house_consumption_energy_weight_total": "The total of the house consumption energy weights must be 100%.",
-      "invalid_energy_value": "Invalid energy value \u00e2\u20ac\u201d please enter a number.",
+      "invalid_energy_value": "Invalid energy value â€” please enter a number.",
       "invalid_entity_id": "Invalid entity ID format. Expected \"domain.object_id\" with lowercase letters, digits, and underscores.",
       "invalid_month_value": "One or more month values are invalid. Months must be integers between 1 and 12.",
-      "invalid_power_value": "Invalid power value \u00e2\u20ac\u201d please enter a number.",
-      "invalid_price_value": "Invalid price value \u00e2\u20ac\u201d please enter a number.",
+      "invalid_power_value": "Invalid power value â€” please enter a number.",
+      "invalid_price_value": "Invalid price value â€” please enter a number.",
       "invalid_sensor": "Invalid input sensor. Please choose a valid sensor.",
-      "invalid_time_format": "Invalid time format \u00e2\u20ac\u201d expected HH:MM:SS.",
+      "invalid_time_format": "Invalid time format â€” expected HH:MM:SS.",
       "months_summer_empty": "At least one month must remain in summer. Assign fewer months to winter.",
       "months_winter_empty": "Winter season must have at least one month.",
       "only_one_entry_allowed": "Only one configuration of HSEM is allowed.",
@@ -24,7 +24,7 @@
       "price_out_of_range": "Price value is outside the allowed range.",
       "required": "This field is required.",
       "start_time_after_end_time": "Start time must be before end time.",
-      "start_time_equals_end_time": "Start time and end time cannot be the same \u00e2\u20ac\u201d this creates a zero-length window. Disable the schedule instead."
+      "start_time_equals_end_time": "Start time and end time cannot be the same â€” this creates a zero-length window. Disable the schedule instead."
     },
     "step": {
       "batteries_excess_export": {
@@ -52,7 +52,7 @@
           "hsem_ev_planned_load_battery_capacity_kwh": "Nameplate battery capacity of the EV in kWh.",
           "hsem_ev_planned_load_charger_power_kw": "AC output power of the EV charger in kW.",
           "hsem_ev_planned_load_charger_efficiency": "Charger efficiency as a percentage (1-100). Default: 100.",
-          "hsem_ev_planned_load_charger_min_power_w": "Minimum AC power (W) the EV charger needs to start charging. Below this the charger will not operate. Default: 1380 W (230 V \u00c3\u2014 6 A)."
+          "hsem_ev_planned_load_charger_min_power_w": "Minimum AC power (W) the EV charger needs to start charging. Below this the charger will not operate. Default: 1380 W (230 V Ã— 6 A)."
         },
         "description": "Configure optional planned EV charging load integration. When enabled, HSEM accounts for upcoming EV charging demand per planner slot.",
         "title": "EV Planned Load Integration"
@@ -70,7 +70,7 @@
           "hsem_ev_second_planned_load_battery_capacity_kwh": "Nameplate battery capacity of the second EV in kWh.",
           "hsem_ev_second_planned_load_charger_power_kw": "AC output power of the second EV charger in kW.",
           "hsem_ev_second_planned_load_charger_efficiency": "Second EV charger efficiency as a percentage (1-100). Default: 100.",
-          "hsem_ev_second_planned_load_charger_min_power_w": "Minimum AC power (W) the second EV charger needs to start charging. Default: 1380 W (230 V \u00c3\u2014 6 A)."
+          "hsem_ev_second_planned_load_charger_min_power_w": "Minimum AC power (W) the second EV charger needs to start charging. Default: 1380 W (230 V Ã— 6 A)."
         },
         "description": "Configure optional planned charging load integration for the second EV. Only shown when a second EV charger is enabled.",
         "title": "EV 2 Planned Load Integration"
@@ -84,7 +84,7 @@
           "hsem_ocpp_stop_window_s": "Stop Window (s)"
         },
         "data_description": {
-          "hsem_ocpp_enabled": "Enable the embedded OCPP 1.6 WebSocket server for direct EV charger control. LAN-only \u2014 do not expose the port to the internet.",
+          "hsem_ocpp_enabled": "Enable the embedded OCPP 1.6 WebSocket server for direct EV charger control. LAN-only — do not expose the port to the internet.",
           "hsem_ocpp_port": "TCP port for the OCPP WebSocket server. Default: 9000. Must be above 1024.",
           "hsem_ocpp_cpid": "Expected charge-point identifier of the EV charger. Leave empty to accept any charger.",
           "hsem_ocpp_start_window_s": "Seconds of sustained surplus required before starting a charge. Prevents rapid start-stop cycling. Default: 60.",
@@ -165,7 +165,8 @@
           "hsem_ev_connected": "EV Connected Sensor",
           "hsem_ev_second_enabled": "Enable Second EV Charger",
           "hsem_ev_soc": "EV State of Charge (SoC) Sensor",
-          "hsem_house_power_includes_ev_charger_power": "House Power Includes EV Charger Power"
+          "hsem_house_power_includes_ev_charger_power": "House Power Includes EV Charger Power",
+          "hsem_ev_auto_full_negative_price": "Auto-Full EV on Negative Price"
         },
         "data_description": {
           "hsem_ev_allow_charge_past_target_soc": "Enable this option if you want to allow the system to continue charging the EV battery even after it has reached the target state of charge (SoC). This can be useful in scenarios where you want to ensure the EV is fully charged regardless of the target setting.",
@@ -176,7 +177,8 @@
           "hsem_ev_connected": "Select the sensor or entity that indicates whether the EV is connected to the charger.",
           "hsem_ev_second_enabled": "Enable or disable the configuration for a second EV charger.",
           "hsem_ev_soc": "Select the sensor that provides the current state of charge (SoC) of your EV battery.",
-          "hsem_house_power_includes_ev_charger_power": "Enable this if the house consumption power sensor already includes the EV charger power consumption."
+          "hsem_house_power_includes_ev_charger_power": "Enable this if the house consumption power sensor already includes the EV charger power consumption.",
+          "hsem_ev_auto_full_negative_price": "When enabled, the EV is automatically set to full charging power when the electricity price is zero or negative. The previous charging mode is restored when the price rises above zero."
         },
         "description": "Configure EV Charger settings for HSEM.",
         "title": "EV Charger Settings (Optional)"
@@ -227,15 +229,15 @@
           "hsem_huawei_solar_inverter_active_power_control": "Huawei Inverter Active Power Control Sensor"
         },
         "data_description": {
-          "hsem_batteries_charge_efficiency": "Specify the charge-side efficiency of your battery as a percentage (0\u00e2\u20ac\u201c100). Energy stored in the battery equals the input energy multiplied by this factor. Typical lithium batteries achieve 95\u00e2\u20ac\u201c98 %. Defaults to 98 %.",
-          "hsem_batteries_discharge_efficiency": "Specify the discharge-side efficiency of your battery as a percentage (0\u00e2\u20ac\u201c100). Energy delivered to the house equals the battery energy removed multiplied by this factor. Typical lithium batteries achieve 95\u00e2\u20ac\u201c98 %. Defaults to 98 %.",
+          "hsem_batteries_charge_efficiency": "Specify the charge-side efficiency of your battery as a percentage (0â€“100). Energy stored in the battery equals the input energy multiplied by this factor. Typical lithium batteries achieve 95â€“98 %. Defaults to 98 %.",
+          "hsem_batteries_discharge_efficiency": "Specify the discharge-side efficiency of your battery as a percentage (0â€“100). Energy delivered to the house equals the battery energy removed multiplied by this factor. Typical lithium batteries achieve 95â€“98 %. Defaults to 98 %.",
           "hsem_batteries_cycle_cost": "Optional extra per-kWh cost of cycling the battery (EUR/kWh). Added on top of the auto-calculated depreciation threshold. Set to 0 to rely solely on the depreciation guard. Example: 0.02 means the planner requires 2 cent extra spread per kWh cycled before approving grid charging.",
-          "hsem_batteries_expected_cycles": "Enter the expected number of full charge/discharge cycles over the battery's lifetime. Used to calculate depreciation cost per kWh and the recommended minimum export price threshold. Typical LiFePO4 batteries support 4000\u00e2\u20ac\u201c8000 cycles.",
+          "hsem_batteries_expected_cycles": "Enter the expected number of full charge/discharge cycles over the battery's lifetime. Used to calculate depreciation cost per kWh and the recommended minimum export price threshold. Typical LiFePO4 batteries support 4000â€“8000 cycles.",
           "hsem_batteries_purchase_price": "Enter the total purchase price of your battery system in EUR. Used together with expected cycles and usable capacity to calculate the depreciation cost per kWh and the recommended minimum export price threshold.",
           "hsem_huawei_solar_batteries_excess_pv_energy_use_in_tou": "Select the sensor that provides setting for excess PV energy use in TOU periods.",
           "hsem_huawei_solar_batteries_forcible_charge": "Sensor showing current forcible charge/discharge state (e.g. Stopped, Discharging at 5000W for 60 minutes)",
           "hsem_huawei_solar_batteries_end_of_discharge_soc": "Specify the end of discharge SOC percentage for your Huawei batteries. When the battery reaches this SOC level, it will stop discharging to prevent deep discharge and potential damage to the battery.",
-          "hsem_huawei_solar_batteries_charging_cutoff_capacity": "Select the entity that defines the maximum state of charge (SoC) the battery is allowed to reach during charging (register STORAGE_CHARGING_CUTOFF_CAPACITY). Typically 90\u00e2\u20ac\u201c10\u00e2\u20ac\u00af%. Used by the SoC simulation as the upper SoC ceiling so the planner never schedules charging beyond this limit.",
+          "hsem_huawei_solar_batteries_charging_cutoff_capacity": "Select the entity that defines the maximum state of charge (SoC) the battery is allowed to reach during charging (register STORAGE_CHARGING_CUTOFF_CAPACITY). Typically 90â€“10â€¯%. Used by the SoC simulation as the upper SoC ceiling so the planner never schedules charging beyond this limit.",
           "hsem_huawei_solar_batteries_grid_charge_cutoff_soc": "Specify the grid charge cutoff SOC percentage for your Huawei batteries.",
           "hsem_huawei_solar_batteries_maximum_charging_power": "Select the sensor that provides the maximum charging power for your Huawei batteries in kilowatts (W).",
           "hsem_huawei_solar_batteries_maximum_discharging_power": "Select the sensor that provides the maximum discharging power for your Huawei batteries.",
@@ -262,11 +264,11 @@
         },
         "data_description": {
           "hsem_batteries_purchase_price": "Enter the total purchase price of your battery system in EUR. Used together with expected cycles and usable capacity to calculate the depreciation cost per kWh and the recommended minimum export price threshold.",
-          "hsem_batteries_expected_cycles": "Enter the expected number of full charge/discharge cycles over the battery's lifetime. Used to calculate depreciation cost per kWh and the recommended minimum export price threshold. Typical LiFePO4 batteries support 4000\u00e2\u20ac\u201c8000 cycles.",
+          "hsem_batteries_expected_cycles": "Enter the expected number of full charge/discharge cycles over the battery's lifetime. Used to calculate depreciation cost per kWh and the recommended minimum export price threshold. Typical LiFePO4 batteries support 4000â€“8000 cycles.",
           "hsem_batteries_cycle_cost": "Optional extra per-kWh cost of cycling the battery (EUR/kWh). Added on top of the auto-calculated depreciation threshold. Set to 0 to rely solely on the depreciation guard. Example: 0.02 means the planner requires 2 cent extra spread per kWh cycled before approving grid charging.",
           "hsem_batteries_capacity_loss_pct": "Expected capacity loss at end-of-life as a percentage. LiFePO4 typically reaches 80% capacity after ~6000 cycles (20% loss). Default 30% adds margin for calendar ageing.",
-          "hsem_batteries_charge_efficiency": "Specify the charge-side efficiency of your battery as a percentage (0\u00e2\u20ac\u201c100). Energy stored in the battery equals the input energy multiplied by this factor. Typical lithium batteries achieve 95\u00e2\u20ac\u201c98 %. Defaults to 98 %.",
-          "hsem_batteries_discharge_efficiency": "Specify the discharge-side efficiency of your battery as a percentage (0\u00e2\u20ac\u201c100). Energy delivered to the house equals the battery energy removed multiplied by this factor. Typical lithium batteries achieve 95\u00e2\u20ac\u201c98 %. Defaults to 98 %."
+          "hsem_batteries_charge_efficiency": "Specify the charge-side efficiency of your battery as a percentage (0â€“100). Energy stored in the battery equals the input energy multiplied by this factor. Typical lithium batteries achieve 95â€“98 %. Defaults to 98 %.",
+          "hsem_batteries_discharge_efficiency": "Specify the discharge-side efficiency of your battery as a percentage (0â€“100). Energy delivered to the house equals the battery energy removed multiplied by this factor. Typical lithium batteries achieve 95â€“98 %. Defaults to 98 %."
         },
         "description": "Configure battery economics parameters that affect depreciation calculations and round-trip efficiency.",
         "title": "Battery Economics"
@@ -381,7 +383,7 @@
           "use_quick_setup": "Enable to use auto-detected entities and skip the full entity-by-entity setup wizard. Disable for Advanced Setup."
         },
         "description": "HSEM has auto-detected the following entities. {warning}Review the detected entities below. You can confirm to use them or choose Advanced Setup to select entities manually.",
-        "title": "Quick Setup \u2014 Auto-Detected Entities"
+        "title": "Quick Setup — Auto-Detected Entities"
       },
       "solcast": {
         "data": {
@@ -450,14 +452,14 @@
           "hsem_ml_consumption_sequential": "Sequential prediction (lag feature)"
         },
         "data_description": {
-          "hsem_grid_import_energy_entity": "Optional\u00e2\u20ac\u201dcumulative grid import energy meter (kWh).",
-          "hsem_grid_export_energy_entity": "Optional\u00e2\u20ac\u201dcumulative grid export energy meter (kWh).",
-          "hsem_pv_energy_entity": "Optional\u00e2\u20ac\u201dcumulative PV production energy meter (kWh).",
+          "hsem_grid_import_energy_entity": "Optionalâ€”cumulative grid import energy meter (kWh).",
+          "hsem_grid_export_energy_entity": "Optionalâ€”cumulative grid export energy meter (kWh).",
+          "hsem_pv_energy_entity": "Optionalâ€”cumulative PV production energy meter (kWh).",
           "hsem_ml_consumption_enabled": "When enabled, uses ridge regression on recorder history instead of rolling averages. Requires 14+ days of history.",
           "hsem_ml_consumption_energy_entity": "Cumulative house consumption energy meter (kWh). Must exclude battery AND EV charging - use a sensor upstream of both. Falls back to grid import if not set.",
-          "hsem_ml_consumption_history_days": "Days of recorder history for ML training (7\u00e2\u20ac\u201c90).",
+          "hsem_ml_consumption_history_days": "Days of recorder history for ML training (7â€“90).",
           "hsem_ml_consumption_net_consumption": "Subtract grid export from import for net house consumption.",
-          "hsem_ml_consumption_temperature_entity": "Optional\u00e2\u20ac\u201doutdoor temperature sensor in \u00c2\u00b0C. Use an outdoor sensor, not an indoor thermostat.",
+          "hsem_ml_consumption_temperature_entity": "Optionalâ€”outdoor temperature sensor in Â°C. Use an outdoor sensor, not an indoor thermostat.",
           "hsem_ml_consumption_sequential": "Feed each slot prediction as input to the next. Captures intra-hour momentum (e.g. cooking spikes carry forward)."
         },
         "description": "Configure energy meters and enable ML-based consumption prediction.",
@@ -472,13 +474,13 @@
       "entity_not_found": "The selected entity was not found.",
       "entity_unavailable": "The selected entity is currently unavailable. Check the device or service.",
       "hsem_house_consumption_energy_weight_total": "The total of the house consumption energy weights must be 100%.",
-      "invalid_energy_value": "Invalid energy value \u00e2\u20ac\u201d please enter a number.",
+      "invalid_energy_value": "Invalid energy value â€” please enter a number.",
       "invalid_entity_id": "Invalid entity ID format. Expected \"domain.object_id\" with lowercase letters, digits, and underscores.",
       "invalid_month_value": "One or more month values are invalid. Months must be integers between 1 and 12.",
-      "invalid_power_value": "Invalid power value \u00e2\u20ac\u201d please enter a number.",
-      "invalid_price_value": "Invalid price value \u00e2\u20ac\u201d please enter a number.",
+      "invalid_power_value": "Invalid power value â€” please enter a number.",
+      "invalid_price_value": "Invalid price value â€” please enter a number.",
       "invalid_sensor": "Invalid input sensor. Please choose a valid sensor.",
-      "invalid_time_format": "Invalid time format \u00e2\u20ac\u201d expected HH:MM:SS.",
+      "invalid_time_format": "Invalid time format â€” expected HH:MM:SS.",
       "months_summer_empty": "At least one month must remain in summer. Assign fewer months to winter.",
       "months_winter_empty": "Winter season must have at least one month.",
       "only_one_entry_allowed": "Only one configuration of HSEM is allowed.",
@@ -486,7 +488,7 @@
       "price_out_of_range": "Price value is outside the allowed range.",
       "required": "This field is required.",
       "start_time_after_end_time": "Start time must be before end time.",
-      "start_time_equals_end_time": "Start time and end time cannot be the same \u00e2\u20ac\u201d this creates a zero-length window. Disable the schedule instead."
+      "start_time_equals_end_time": "Start time and end time cannot be the same â€” this creates a zero-length window. Disable the schedule instead."
     },
     "step": {
       "batteries_excess_export": {
@@ -514,7 +516,7 @@
           "hsem_ev_planned_load_battery_capacity_kwh": "Nameplate battery capacity of the EV in kWh.",
           "hsem_ev_planned_load_charger_power_kw": "AC output power of the EV charger in kW.",
           "hsem_ev_planned_load_charger_efficiency": "Charger efficiency as a percentage (1-100). Default: 100.",
-          "hsem_ev_planned_load_charger_min_power_w": "Minimum AC power (W) the EV charger needs to start charging. Below this the charger will not operate. Default: 1380 W (230 V \u00c3\u2014 6 A)."
+          "hsem_ev_planned_load_charger_min_power_w": "Minimum AC power (W) the EV charger needs to start charging. Below this the charger will not operate. Default: 1380 W (230 V Ã— 6 A)."
         },
         "description": "Configure optional planned EV charging load integration. When enabled, HSEM accounts for upcoming EV charging demand per planner slot.",
         "title": "EV Planned Load Integration"
@@ -532,7 +534,7 @@
           "hsem_ev_second_planned_load_battery_capacity_kwh": "Nameplate battery capacity of the second EV in kWh.",
           "hsem_ev_second_planned_load_charger_power_kw": "AC output power of the second EV charger in kW.",
           "hsem_ev_second_planned_load_charger_efficiency": "Second EV charger efficiency as a percentage (1-100). Default: 100.",
-          "hsem_ev_second_planned_load_charger_min_power_w": "Minimum AC power (W) the second EV charger needs to start charging. Default: 1380 W (230 V \u00c3\u2014 6 A)."
+          "hsem_ev_second_planned_load_charger_min_power_w": "Minimum AC power (W) the second EV charger needs to start charging. Default: 1380 W (230 V Ã— 6 A)."
         },
         "description": "Configure optional planned charging load integration for the second EV. Only shown when a second EV charger is enabled.",
         "title": "EV 2 Planned Load Integration"
@@ -546,7 +548,7 @@
           "hsem_ocpp_stop_window_s": "Stop Window (s)"
         },
         "data_description": {
-          "hsem_ocpp_enabled": "Enable the embedded OCPP 1.6 WebSocket server for direct EV charger control. LAN-only \u2014 do not expose the port to the internet.",
+          "hsem_ocpp_enabled": "Enable the embedded OCPP 1.6 WebSocket server for direct EV charger control. LAN-only — do not expose the port to the internet.",
           "hsem_ocpp_port": "TCP port for the OCPP WebSocket server. Default: 9000. Must be above 1024.",
           "hsem_ocpp_cpid": "Expected charge-point identifier of the EV charger. Leave empty to accept any charger.",
           "hsem_ocpp_start_window_s": "Seconds of sustained surplus required before starting a charge. Prevents rapid start-stop cycling. Default: 60.",
@@ -627,7 +629,8 @@
           "hsem_ev_connected": "EV Connected Sensor",
           "hsem_ev_second_enabled": "Enable Second EV Charger",
           "hsem_ev_soc": "EV State of Charge (SoC) Sensor",
-          "hsem_house_power_includes_ev_charger_power": "House Power Includes EV Charger Power"
+          "hsem_house_power_includes_ev_charger_power": "House Power Includes EV Charger Power",
+          "hsem_ev_auto_full_negative_price": "Auto-Full EV on Negative Price"
         },
         "data_description": {
           "hsem_ev_allow_charge_past_target_soc": "Enable this option if you want to allow the system to continue charging the EV battery even after it has reached the target state of charge (SoC). This can be useful in scenarios where you want to ensure the EV is fully charged regardless of the target setting.",
@@ -638,7 +641,8 @@
           "hsem_ev_connected": "Select the sensor or entity that indicates whether the EV is connected to the charger.",
           "hsem_ev_second_enabled": "Enable or disable the configuration for a second EV charger.",
           "hsem_ev_soc": "Select the sensor that provides the current state of charge (SoC) of your EV battery.",
-          "hsem_house_power_includes_ev_charger_power": "Enable this if the house consumption power sensor already includes the EV charger power consumption."
+          "hsem_house_power_includes_ev_charger_power": "Enable this if the house consumption power sensor already includes the EV charger power consumption.",
+          "hsem_ev_auto_full_negative_price": "When enabled, the EV is automatically set to full charging power when the electricity price is zero or negative. The previous charging mode is restored when the price rises above zero."
         },
         "description": "Configure EV Charger settings for HSEM.",
         "title": "EV Charger Settings (Optional)"
@@ -689,15 +693,15 @@
           "hsem_huawei_solar_inverter_active_power_control": "Huawei Inverter Active Power Control Sensor"
         },
         "data_description": {
-          "hsem_batteries_charge_efficiency": "Specify the charge-side efficiency of your battery as a percentage (0\u00e2\u20ac\u201c100). Energy stored in the battery equals the input energy multiplied by this factor. Typical lithium batteries achieve 95\u00e2\u20ac\u201c98 %. Defaults to 98 %.",
-          "hsem_batteries_discharge_efficiency": "Specify the discharge-side efficiency of your battery as a percentage (0\u00e2\u20ac\u201c100). Energy delivered to the house equals the battery energy removed multiplied by this factor. Typical lithium batteries achieve 95\u00e2\u20ac\u201c98 %. Defaults to 98 %.",
+          "hsem_batteries_charge_efficiency": "Specify the charge-side efficiency of your battery as a percentage (0â€“100). Energy stored in the battery equals the input energy multiplied by this factor. Typical lithium batteries achieve 95â€“98 %. Defaults to 98 %.",
+          "hsem_batteries_discharge_efficiency": "Specify the discharge-side efficiency of your battery as a percentage (0â€“100). Energy delivered to the house equals the battery energy removed multiplied by this factor. Typical lithium batteries achieve 95â€“98 %. Defaults to 98 %.",
           "hsem_batteries_cycle_cost": "Optional extra per-kWh cost of cycling the battery (EUR/kWh). Added on top of the auto-calculated depreciation threshold. Set to 0 to rely solely on the depreciation guard. Example: 0.02 means the planner requires 2 cent extra spread per kWh cycled before approving grid charging.",
-          "hsem_batteries_expected_cycles": "Enter the expected number of full charge/discharge cycles over the battery's lifetime. Used to calculate depreciation cost per kWh and the recommended minimum export price threshold. Typical LiFePO4 batteries support 4000\u00e2\u20ac\u201c8000 cycles.",
+          "hsem_batteries_expected_cycles": "Enter the expected number of full charge/discharge cycles over the battery's lifetime. Used to calculate depreciation cost per kWh and the recommended minimum export price threshold. Typical LiFePO4 batteries support 4000â€“8000 cycles.",
           "hsem_batteries_purchase_price": "Enter the total purchase price of your battery system in EUR. Used together with expected cycles and usable capacity to calculate the depreciation cost per kWh and the recommended minimum export price threshold.",
           "hsem_huawei_solar_batteries_excess_pv_energy_use_in_tou": "Select the sensor that provides setting for excess PV energy use in TOU periods.",
           "hsem_huawei_solar_batteries_forcible_charge": "Sensor showing current forcible charge/discharge state (e.g. Stopped, Discharging at 5000W for 60 minutes)",
           "hsem_huawei_solar_batteries_end_of_discharge_soc": "Specify the end of discharge SOC percentage for your Huawei batteries. When the battery reaches this SOC level, it will stop discharging to prevent deep discharge and potential damage to the battery.",
-          "hsem_huawei_solar_batteries_charging_cutoff_capacity": "Select the entity that defines the maximum state of charge (SoC) the battery is allowed to reach during charging (register STORAGE_CHARGING_CUTOFF_CAPACITY). Typically 90\u00e2\u20ac\u201c10\u00e2\u20ac\u00af%. Used by the SoC simulation as the upper SoC ceiling so the planner never schedules charging beyond this limit.",
+          "hsem_huawei_solar_batteries_charging_cutoff_capacity": "Select the entity that defines the maximum state of charge (SoC) the battery is allowed to reach during charging (register STORAGE_CHARGING_CUTOFF_CAPACITY). Typically 90â€“10â€¯%. Used by the SoC simulation as the upper SoC ceiling so the planner never schedules charging beyond this limit.",
           "hsem_huawei_solar_batteries_grid_charge_cutoff_soc": "Specify the grid charge cutoff SOC percentage for your Huawei batteries.",
           "hsem_huawei_solar_batteries_maximum_charging_power": "Select the sensor that provides the maximum charging power for your Huawei batteries in kilowatts (W).",
           "hsem_huawei_solar_batteries_maximum_discharging_power": "Select the sensor that provides the maximum discharging power for your Huawei batteries.",
@@ -724,11 +728,11 @@
         },
         "data_description": {
           "hsem_batteries_purchase_price": "Enter the total purchase price of your battery system in EUR. Used together with expected cycles and usable capacity to calculate the depreciation cost per kWh and the recommended minimum export price threshold.",
-          "hsem_batteries_expected_cycles": "Enter the expected number of full charge/discharge cycles over the battery's lifetime. Used to calculate depreciation cost per kWh and the recommended minimum export price threshold. Typical LiFePO4 batteries support 4000\u00e2\u20ac\u201c8000 cycles.",
+          "hsem_batteries_expected_cycles": "Enter the expected number of full charge/discharge cycles over the battery's lifetime. Used to calculate depreciation cost per kWh and the recommended minimum export price threshold. Typical LiFePO4 batteries support 4000â€“8000 cycles.",
           "hsem_batteries_cycle_cost": "Optional extra per-kWh cost of cycling the battery (EUR/kWh). Added on top of the auto-calculated depreciation threshold. Set to 0 to rely solely on the depreciation guard. Example: 0.02 means the planner requires 2 cent extra spread per kWh cycled before approving grid charging.",
           "hsem_batteries_capacity_loss_pct": "Expected capacity loss at end-of-life as a percentage. LiFePO4 typically reaches 80% capacity after ~6000 cycles (20% loss). Default 30% adds margin for calendar ageing.",
-          "hsem_batteries_charge_efficiency": "Specify the charge-side efficiency of your battery as a percentage (0\u00e2\u20ac\u201c100). Energy stored in the battery equals the input energy multiplied by this factor. Typical lithium batteries achieve 95\u00e2\u20ac\u201c98 %. Defaults to 98 %.",
-          "hsem_batteries_discharge_efficiency": "Specify the discharge-side efficiency of your battery as a percentage (0\u00e2\u20ac\u201c100). Energy delivered to the house equals the battery energy removed multiplied by this factor. Typical lithium batteries achieve 95\u00e2\u20ac\u201c98 %. Defaults to 98 %."
+          "hsem_batteries_charge_efficiency": "Specify the charge-side efficiency of your battery as a percentage (0â€“100). Energy stored in the battery equals the input energy multiplied by this factor. Typical lithium batteries achieve 95â€“98 %. Defaults to 98 %.",
+          "hsem_batteries_discharge_efficiency": "Specify the discharge-side efficiency of your battery as a percentage (0â€“100). Energy delivered to the house equals the battery energy removed multiplied by this factor. Typical lithium batteries achieve 95â€“98 %. Defaults to 98 %."
         },
         "description": "Configure battery economics parameters that affect depreciation calculations and round-trip efficiency.",
         "title": "Battery Economics"
@@ -850,14 +854,14 @@
           "hsem_ml_consumption_sequential": "Sequential prediction (lag feature)"
         },
         "data_description": {
-          "hsem_grid_import_energy_entity": "Optional\u00e2\u20ac\u201dcumulative grid import energy meter (kWh).",
-          "hsem_grid_export_energy_entity": "Optional\u00e2\u20ac\u201dcumulative grid export energy meter (kWh).",
-          "hsem_pv_energy_entity": "Optional\u00e2\u20ac\u201dcumulative PV production energy meter (kWh).",
+          "hsem_grid_import_energy_entity": "Optionalâ€”cumulative grid import energy meter (kWh).",
+          "hsem_grid_export_energy_entity": "Optionalâ€”cumulative grid export energy meter (kWh).",
+          "hsem_pv_energy_entity": "Optionalâ€”cumulative PV production energy meter (kWh).",
           "hsem_ml_consumption_enabled": "When enabled, uses ridge regression on recorder history instead of rolling averages. Requires 14+ days of history.",
           "hsem_ml_consumption_energy_entity": "Cumulative house consumption energy meter (kWh). Must exclude battery AND EV charging - use a sensor upstream of both. Falls back to grid import if not set.",
-          "hsem_ml_consumption_history_days": "Days of recorder history for ML training (7\u00e2\u20ac\u201c90).",
+          "hsem_ml_consumption_history_days": "Days of recorder history for ML training (7â€“90).",
           "hsem_ml_consumption_net_consumption": "Subtract grid export from import for net house consumption.",
-          "hsem_ml_consumption_temperature_entity": "Optional\u00e2\u20ac\u201doutdoor temperature sensor in \u00c2\u00b0C. Use an outdoor sensor, not an indoor thermostat.",
+          "hsem_ml_consumption_temperature_entity": "Optionalâ€”outdoor temperature sensor in Â°C. Use an outdoor sensor, not an indoor thermostat.",
           "hsem_ml_consumption_sequential": "Feed each slot prediction as input to the next. Captures intra-hour momentum (e.g. cooking spikes carry forward)."
         },
         "description": "Configure energy meters and enable ML-based consumption prediction.",
@@ -1054,25 +1058,25 @@
         "name": "EV 2 Target SoC"
       },
       "charge_rate_below_0": {
-        "name": "Max Charge Rate (<0\u00b0C)"
+        "name": "Max Charge Rate (<0°C)"
       },
       "charge_rate_0_to_5": {
-        "name": "Max Charge Rate (0-5\u00b0C)"
+        "name": "Max Charge Rate (0-5°C)"
       },
       "charge_rate_6_to_15": {
-        "name": "Max Charge Rate (6-15\u00b0C)"
+        "name": "Max Charge Rate (6-15°C)"
       },
       "charge_rate_16_to_21": {
-        "name": "Max Charge Rate (16-21\u00b0C)"
+        "name": "Max Charge Rate (16-21°C)"
       },
       "charge_rate_21_to_35": {
-        "name": "Max Charge Rate (21-35\u00b0C)"
+        "name": "Max Charge Rate (21-35°C)"
       },
       "charge_rate_35_to_50": {
-        "name": "Max Charge Rate (35-50\u00b0C)"
+        "name": "Max Charge Rate (35-50°C)"
       },
       "charge_rate_above_50": {
-        "name": "Max Charge Rate (>50\u00b0C)"
+        "name": "Max Charge Rate (>50°C)"
       }
     },
     "time": {

--- a/docs/adr/adr-005-forecast-confidence.md
+++ b/docs/adr/adr-005-forecast-confidence.md
@@ -1,10 +1,16 @@
 # ADR-005: Forecast Confidence
 
-**Status:** Accepted
+**Status:** Accepted (partially superseded by [ADR-006](adr-006-solar-correction.md))
 
 **Date:** 2026-05-11
 
 **Deciders:** Project maintainers
+
+> **Note:** The original "diagnostic-only, non-adaptive" decision was
+> amended in June 2026 by ADR-006, which introduces adaptive per-hour PV
+> correction.  The deterministic decay factors for future-day PV, the
+> non-adaptive load and price treatment, and the diagnostic tracking
+> infrastructure remain unchanged.
 
 ---
 

--- a/docs/adr/adr-006-solar-correction.md
+++ b/docs/adr/adr-006-solar-correction.md
@@ -1,0 +1,197 @@
+# ADR-006: Solar Forecast Auto-Correction
+
+**Status:** Accepted
+
+**Date:** 2026-06-26
+
+**Deciders:** Project maintainers
+
+---
+
+## Context
+
+ADR-005 established a **diagnostic-only, non-adaptive** approach to forecast
+confidence.  PV forecast errors were tracked and reported but never fed back
+into the planner.  The rationale was stability: adaptive confidence creates
+feedback loops, and non-stationary errors mean a system tuned for one season
+fails in another.
+
+Real-world operation of HSEM revealed a problem with this approach.  Solcast
+PV forecasts exhibit **systematic per-hour bias patterns** — for example,
+consistently over-forecasting morning production by 15 % while under-forecasting
+midday production by 5 %.  The tracker reported these biases but offered no
+mechanism to compensate for them.  Users with persistent forecast errors saw
+the planner make suboptimal decisions based on systematically wrong PV values,
+with no automated correction path.
+
+The key questions were:
+
+- Can we apply adaptive PV correction without introducing instability?
+- How do we prevent the correction from over-fitting to short-term noise?
+- Should the correction use the same data as the diagnostic tracker?
+
+---
+
+## Decision
+
+We introduce **adaptive per-hour PV forecast correction** via the
+`SolarForecastCorrector` (`utils/solar_corrector.py`).  The corrector learns
+from historical actual-vs-forecast PV ratios and applies corrections at
+slot-population time — **before** the planner runs.  Raw Solcast data is
+never mutated.
+
+This partially supersedes ADR-005's "non-adaptive" stance for PV data.
+Load forecasts and price data remain non-adaptive, and the diagnostic
+tracker infrastructure is unchanged.
+
+### Per-hour accuracy factors (4-day rolling window)
+
+For each clock-hour (0–23), the corrector maintains a rolling window of the
+last 4 days of **actual / forecast** PV ratios for that hour.  The correction
+factor is the mean ratio, clamped to **[0.3, 1.5]** to prevent extreme values
+from a single bad forecast day.
+
+```
+factor[h] = clamp(mean(actual_pv / forecast_pv for last 4 days at hour h), 0.3, 1.5)
+corrected_pv[t] = raw_pv[t] × factor[hour_of(t)]
+```
+
+A 4-day window was chosen as a compromise: short enough to adapt to seasonal
+changes, long enough to filter out single-day noise.  Each hour is learned
+independently, so the corrector captures intra-day pattern differences
+(e.g., morning fog vs. afternoon clear skies).
+
+### Intra-hour residual correction (2h linear decay)
+
+In addition to the per-hour factor, a **residual correction** is applied to
+the current and next few slots.  The residual is the mean of the last 4
+**closed** slots' actual/forecast ratios.  It decays linearly to 1.0 over
+2 hours (8 slots at 15-min granularity).
+
+```
+residual = mean(actual/forecast for last 4 closed slots)
+decay[t] = 1.0 + (residual - 1.0) × max(0, 1 - elapsed_slots / 8)
+final_pv[t] = corrected_pv[t] × decay[t]
+```
+
+This handles short-term weather transitions — if clouds rolled in 30 minutes
+ago and PV is under-performing, the next few slots are adjusted downward
+before the per-hour factor catches up.
+
+### Configurable confidence percentile
+
+A user-configurable **solar confidence** percentile (default 0.50, range
+0.10–0.90) scales how aggressively the correction is applied.  At 0.10
+(pessimistic), only the bottom 10 % of historical ratios inform the factor.
+At 0.90 (optimistic), the top 90 % are used.  At 0.50 (median), the
+correction is neutral.
+
+This is exposed via `sensor.hsem_solar_confidence` (a `number` entity) so
+users can tune it from the dashboard without restarting.
+
+### Integration point: slot population
+
+Corrections are applied in `planner/slot_population.py` → `populate_solcast()`
+**before** the planner runs.  The raw Solcast values from the HA sensor are
+never modified — only the per-slot copies in `PlannedSlot` receive the
+correction.  This keeps the data pipeline auditable: the original forecast
+is always available for comparison.
+
+### Why this avoids the ADR-005 stability concerns
+
+| ADR-005 concern | How ADR-006 addresses it |
+|---|---|
+| Feedback loops | The correction is applied once per slot-population, before the planner. It does not depend on planner output — only on observed actuals vs forecasts. No loop. |
+| Non-stationary errors | The 4-day rolling window adapts to seasonal changes. The [0.3, 1.5] clamp prevents a single bad week from poisoning the factors. |
+| User transparency | The per-hour factors and residual are exposed as sensor attributes. The confidence percentile is user-configurable. The corrected PV is logged alongside the raw value. |
+| Minimal benefit | The correction is demonstrably beneficial: systematic per-hour bias of ±15 % over a full day translates to ±2–3 kWh of PV energy, which is enough to change the planner's charge/discharge decision. |
+
+---
+
+## Consequences
+
+### Positive
+
+- **Systematic PV bias is compensated automatically:** A Solcast over-forecast
+  of 3 kWh/day no longer causes the planner to over-allocate solar surplus.
+- **Per-hour granularity captures intra-day patterns:** Morning fog bias is
+  corrected independently from midday clear-sky bias.
+- **Short-term weather transitions are handled:** The residual correction
+  adjusts within 30 minutes of a cloud event.
+- **User-tunable:** The confidence percentile lets risk-averse users plan
+  conservatively and risk-tolerant users plan optimistically.
+- **No raw data mutation:** Solcast API values are preserved for audit.
+- **No new dependencies:** Pure Python, zero additional HA imports.
+
+### Negative
+
+- **Added complexity:** The planner pipeline now has an additional correction
+  step that must be understood when debugging PV-related planning issues.
+- **Cold start:** After a HA restart, the corrector has no history. It takes
+  4 days to build full per-hour factors. During this period, only the residual
+  correction is active (which itself needs 4 closed slots to initialise).
+- **Confidence percentile interaction:** At extremes (0.10 or 0.90), the
+  correction can be aggressive. Users who set the percentile too low may see
+  the planner ignore real PV surplus.
+- **Divergence from ADR-005:** The original "non-adaptive" principle is now
+  qualified. Future contributors must understand that PV correction is adaptive
+  while load and price treatment remain fixed.
+
+### Mitigations
+
+- Cold start: The corrector defaults to factor 1.0 (no correction) for hours
+  with no history. The planner behaves identically to the pre-correction
+  behaviour until data accumulates.
+- Confidence tuning: The default 0.50 (median) is neutral and safe. Extreme
+  values are documented with warnings.
+- Debug logging: Corrected vs raw PV is logged at debug level for every slot.
+- The diagnostic `ForecastTracker` continues to track **raw** forecast errors,
+  providing an independent check on whether the correction is improving accuracy.
+
+---
+
+## Alternatives Considered
+
+### A. Keep non-adaptive (status quo from ADR-005)
+
+Continue reporting forecast errors via the tracker but never correct them.
+
+**Rejected because:** Systematic per-hour bias is a real, measurable problem.
+Users with a consistent 15 % Solcast over-forecast see the planner make
+suboptimal export and charge decisions every day.  "Report but don't fix"
+is insufficient when the fix is straightforward and low-risk.
+
+### B. Full machine-learning correction model
+
+Train a model (e.g., gradient boosting) on weather features + historical
+forecast errors to predict per-slot correction factors.
+
+**Rejected because:**
+- Massive complexity increase for marginal gain over the per-hour rolling mean.
+- Requires weather data integration (cloud cover, irradiance) that HSEM does
+  not currently collect.
+- Training overhead and model persistence add infrastructure burden.
+
+### C. Apply correction inside the MILP objective
+
+Rather than pre-correcting PV values, add a correction term to the MILP
+objective function.
+
+**Rejected because:**
+- Increases MILP variable count and solve time.
+- Makes the correction opaque — the MILP output no longer reflects the
+  physical PV forecast.
+- Harder to audit: "Why did the MILP choose this plan?" is harder to answer
+  when correction is inside the black box.
+
+---
+
+## Related
+
+- ADR-005: Forecast Confidence (partially superseded by this ADR)
+- `docs/forecast-accuracy-tracking.md` — Forecast accuracy technical guide
+- `docs/planner-spec.md` — Solar correction invariant (§ Multi-day planning horizon)
+- `docs/planner-guide.md` — Solar forecast auto-correction (§ Planning inputs → PV forecast)
+- `utils/solar_corrector.py` — Implementation
+- `planner/slot_population.py` — `populate_solcast()` integration point
+- Issue #602 — Solar forecast accuracy auto-correction

--- a/docs/adr/architecture-decision-records.md
+++ b/docs/adr/architecture-decision-records.md
@@ -24,7 +24,8 @@ An Architecture Decision Record is a short document that captures an important a
 | [ADR-002](adr-002-slot-model.md) | Slot Model | Planner engine, data model | Accepted |
 | [ADR-003](adr-003-cost-scoring.md) | Cost Scoring Architecture | Cost function, candidate selection | Accepted |
 | [ADR-004](adr-004-inverter-safety.md) | Inverter Safety — Layered Hardware Write Protection | Safety, hardware interface | Accepted |
-| [ADR-005](adr-005-forecast-confidence.md) | Forecast Confidence | Forecast handling, diagnostics | Accepted |
+| [ADR-005](adr-005-forecast-confidence.md) | Forecast Confidence | Forecast handling, diagnostics | Partially superseded by ADR-006 |
+| [ADR-006](adr-006-solar-correction.md) | Solar Forecast Auto-Correction | Forecast handling, planner engine | Accepted |
 
 ## How to add a new ADR
 

--- a/docs/ev-charge-plan-setup.md
+++ b/docs/ev-charge-plan-setup.md
@@ -225,8 +225,9 @@ periods (e.g. Nordpool, Amber Electric) where charging the EV at full power
 can be profitable or free.
 
 **Configuration:**
-- Toggle `hsem_ev_auto_full_negative_price` in the EV charger config step
-  of the config/options flow.
+- Toggle ``hsem_ev_auto_full_negative_price`` in the EV charger config step
+  of the config/options flow, or at runtime via
+  ``switch.hsem_ev_auto_full_negative_price``.
 - No additional entities are required — it uses the import price sensor
   already configured for the planner.
 

--- a/docs/ev-charge-plan-setup.md
+++ b/docs/ev-charge-plan-setup.md
@@ -211,6 +211,44 @@ flowchart TD
 | Force charge now | `switch.hsem_ev_force_charge_now` | Immediate charge |
 | Allow past target | `hsem_ev_allow_charge_past_target_soc` | Solar-only surplus charging past target |
 | Base load includes EV | `hsem_house_power_includes_ev_charger_power` | CT clamp position |
+| Auto-Full on negative price | `hsem_ev_auto_full_negative_price` | Max-charge EV when price ≤ 0 |
+
+### Auto-Full EV on negative electricity prices
+
+When `hsem_ev_auto_full_negative_price` is enabled (off by default), HSEM
+automatically promotes the EV to **Full** charging mode whenever the import
+electricity price drops to ≤ 0 (including negative prices). The previous
+charging mode is restored automatically when the price rises above 0.
+
+This feature is especially useful in markets with frequent negative-price
+periods (e.g. Nordpool, Amber Electric) where charging the EV at full power
+can be profitable or free.
+
+**Configuration:**
+- Toggle `hsem_ev_auto_full_negative_price` in the EV charger config step
+  of the config/options flow.
+- No additional entities are required — it uses the import price sensor
+  already configured for the planner.
+
+### Session-aware EV demand
+
+When the EV is actively plugged in and drawing power, the MILP planner treats
+the next 2 hours of EV load as **near-certain** demand rather than
+probabilistic. This prevents the battery planner from grid-charging the home
+battery against EV demand that is definitely happening right now.
+
+**How it works:**
+1. The coordinator reads `live.ev.is_charging` and `live.ev.power_w`.
+2. If the EV is actively charging, the first 8 future slots (2 hours at
+   15-minute granularity) get fixed EV load bounds.
+3. A grid-charge prevention constraint blocks battery grid-charging during
+   those session slots.
+4. A post-solve guard overrides any `BatteriesChargeGrid` recommendations
+   in session slots to `BatteriesChargeSolar` or skip.
+
+**Conditions:**
+- Activates only when `live.ev.is_charging == True` AND `live.ev.power_w > 0`.
+- Applies independently to the second EV if configured.
 
 ---
 

--- a/docs/forecast-accuracy-tracking.md
+++ b/docs/forecast-accuracy-tracking.md
@@ -133,7 +133,7 @@ Key methods:
 | `set_forecasts(start, pv_kwh, load_kwh)` | Set forecast values (only if not finalised) |
 | `to_dict()` / `load_from_dict(data)` | Serialize / deserialize the full record list |
 
-The default maximum is 192 records, which covers approximately 48 hours
+The default maximum is 2880 records, which covers approximately 30 days
 of 15-minute slots.  Older records are automatically pruned.
 
 ### Energy accumulation

--- a/docs/planner-guide.md
+++ b/docs/planner-guide.md
@@ -190,6 +190,11 @@ Each `HourlyConsumptionAverage` carries:
 The planner applies a median-ratio outlier detection algorithm that flags anomalous
 windows and redistributes their weight to stable windows before combining the averages.
 
+In addition, the optional **weekday/weekend profiling** feature (`WeekdayProfile`,
+#612) maintains separate 24-slot EWMA profiles for Mon–Fri and Sat–Sun.  When
+active, the appropriate profile is merged into the consumption prediction to
+better capture the distinct usage patterns between workdays and weekends.
+
 ### Price data
 
 | Field | Type | Description |

--- a/docs/services-reference.md
+++ b/docs/services-reference.md
@@ -12,6 +12,7 @@ manual control over the planner and hardware writes.
 | `hsem.force_recalculation` | Trigger an immediate full planner re-run | None |
 | `hsem.set_temporary_override` | Force a specific battery working mode | None |
 | `hsem.clear_override` | Return to automatic planner control | None |
+| `hsem.create_dashboard` | Create or update the bundled Lovelace dashboard | None |
 | `hsem.export_diagnostics` | Export structured diagnostic data | Dict |
 
 ---
@@ -111,7 +112,42 @@ service: hsem.clear_override
 
 ---
 
-## 4. `hsem.export_diagnostics`
+## 4. `hsem.create_dashboard`
+
+Creates or updates the bundled HSEM Lovelace dashboard in Home Assistant.
+The dashboard YAML is bundled with the integration at
+`custom_components/hsem/dashboards/dashboard_en.yaml` and includes 6 views:
+price charts, energy flow, savings, accuracy, EV status, and battery health.
+
+**Schema:**
+
+| Field | Required | Type | Default | Description |
+|---|---|---|---|---|
+| `force` | No | Boolean | `false` | When `true`, overwrites an existing HSEM dashboard. When `false` (default), skips if a dashboard named "HSEM" already exists. |
+
+**Use cases:**
+- First-time dashboard installation after HSEM setup
+- Updating the bundled dashboard to a newer version after an HSEM upgrade
+
+**Implementation notes:**
+- The service logs the path to the bundled dashboard YAML with import instructions.
+- Does not use HA internal storage or Lovelace APIs — relies on the user
+  importing the dashboard via the raw configuration editor or YAML mode.
+
+**Examples:**
+```yaml
+# Create dashboard, skip if already exists
+service: hsem.create_dashboard
+
+# Force-overwrite an existing dashboard
+service: hsem.create_dashboard
+data:
+  force: true
+```
+
+---
+
+## 5. `hsem.export_diagnostics`
 
 Exports a structured diagnostics dump containing the most recent planner input,
 planner output, hardware write status, and integration version. All entity IDs

--- a/tests/test_flow_helpers.py
+++ b/tests/test_flow_helpers.py
@@ -414,6 +414,7 @@ class TestValidateEvChargerInput:
                 "hsem_ev_charger_max_discharge_power": 2000,
                 "hsem_ev_charger_force_max_discharge_power": False,
                 "hsem_ev_allow_charge_past_target_soc": False,
+                "hsem_ev_auto_full_negative_price": False,
                 "hsem_house_power_includes_ev_charger_power": True,
             },
             prefix="hsem_ev",


### PR DESCRIPTION
## Summary

Adds documentation that was missed in the wave of feature PRs #606–#619,
and fixes dead wiring for the auto-full EV on negative price feature (#609).

**13 files changed · +393 / −79 lines · 3 commits**

---

## Documentation fixes (commits 1–2)

### 1. `docs/services-reference.md` — Add `hsem.create_dashboard` service (#614/#618)

The canonical services reference listed only 4 services. Added as service #4
with schema, use cases, and examples.

### 2. `docs/forecast-accuracy-tracking.md` — 30-day window (#613)

Updated stale "192 records / 48 hours" → "2880 records / 30 days".

### 3. `docs/ev-charge-plan-setup.md` — Auto-full EV + session-aware EV (#609, #615)

Documented two EV features with no prior user-facing docs:
auto-full EV on negative price and session-aware EV demand.

### 4. `docs/planner-guide.md` — Weekday/weekend profiling (#612)

Added weekday/weekend EWMA split mention to the consumption prediction section.

### 5. `README.md` — Weekday/weekend profiling bullet (#612)

Added missing feature bullet under "Battery Intelligence".

### 6. `docs/adr/adr-006-solar-correction.md` — New ADR (#602)

ADR-005 declared a "non-adaptive" approach, but solar correction (#602)
is explicitly adaptive. Created ADR-006 documenting the decision to
introduce per-hour PV correction with 4-day rolling window, intra-hour
residual, and configurable confidence percentile.

### 7. `docs/adr/adr-005-forecast-confidence.md` — Mark partially superseded

Updated status and added amendment note referencing ADR-006.

### 8. `docs/adr/architecture-decision-records.md` — Update index

Added ADR-006, updated ADR-005 status.

---

## Wiring fix (commit 3)

### `hsem_ev_auto_full_negative_price` was dead (#609)

The feature had complete backend wiring (const.py default, config_reader,
coordinator usage, sensornames functions, translations) but was **never
exposed** — no flow step field and no switch entity. Users couldn't turn
it on; it was permanently `False`.

**Changes:**
- `flows/ev_helpers.py`: added boolean field to EV flow schema
  (primary EV only, behind `include_primary_fields`)
- `switch.py`: registered `switch.hsem_ev_auto_full_negative_price`
- `translations/en.json`, `da.json`: added config + options flow step
  translations (`data` + `data_description` in both `config.step.ev`
  and `options.step.ev`)
- `flows/ev_helpers.py`: updated docstrings (two → three primary fields)

---

## Verification

- ✅ `tox -e lint` — ruff format + ruff check pass
- ✅ `tox -e typing` — mypy passes (0 errors)
- ✅ JSON valid (en.json, da.json)
- ✅ Flow wiring verified: `config_flow.py` and `options_flow.py` both
  call `include_primary_fields=True` for the primary EV step