### PR TITLE
fix(entity): add missing async_added_to_hass, should_poll, and available to sensors

### DIFF
--- a/custom_components/hsem/custom_selectors/working_mode.py
+++ b/custom_components/hsem/custom_selectors/working_mode.py
@@ -74,6 +74,11 @@ class HSEMWorkingModeSelector(HSEMEntity, SelectEntity):
         # resolve the name via entity_description.translation_key.
 
     @override
+    async def async_added_to_hass(self) -> None:
+        """Register lifecycle when entity is added to Home Assistant."""
+        await super().async_added_to_hass()
+
+    @override
     async def async_select_option(self, option: str) -> None:
         """Handle the user selecting a new option.
 

--- a/custom_components/hsem/custom_sensors/avg_sensor.py
+++ b/custom_components/hsem/custom_sensors/avg_sensor.py
@@ -129,6 +129,12 @@ class HSEMAvgSensor(RestoreEntity, SensorEntity, HSEMEntity):
     def should_poll(self) -> bool:
         return True
 
+    @property
+    @override
+    def available(self) -> bool:
+        """Return True when the sensor has a valid state."""
+        return self._state is not None
+
     async def async_update(self, event: Any | None = None) -> None:
         """Manually trigger the sensor update."""
         return await self._async_handle_update(event)

--- a/custom_components/hsem/custom_sensors/daily_plan_vs_actual_sensor.py
+++ b/custom_components/hsem/custom_sensors/daily_plan_vs_actual_sensor.py
@@ -26,7 +26,7 @@ from typing import Any, cast, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, EntityCategory
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from custom_components.hsem.coordinator import (
@@ -77,10 +77,23 @@ class HSEMDailyPlanVsActualSensor(
         )
         self._attr_name = get_daily_plan_vs_actual_sensor_name()
         self.entity_id = get_daily_plan_vs_actual_sensor_entity_id()
+        self._restored_state: str | None = None
 
     # ------------------------------------------------------------------
     # HA entity properties
     # ------------------------------------------------------------------
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Restore the last-known state after a restart."""
+        await super().async_added_to_hass()
+        restored = await self.async_get_last_state()
+        if restored is not None and restored.state not in (
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
+            None,
+        ):
+            self._restored_state = restored.state
 
     @property
     @override
@@ -92,6 +105,11 @@ class HSEMDailyPlanVsActualSensor(
         """
         tracker = self._get_tracker()
         if tracker is None:
+            if self._restored_state is not None:
+                try:
+                    return float(self._restored_state)
+                except ValueError:
+                    return self._restored_state
             return None
         today_record = tracker.get_today_record()
         return cast(float, round(today_record.net_cost_actual, 3))
@@ -114,8 +132,9 @@ class HSEMDailyPlanVsActualSensor(
     @property
     @override
     def available(self) -> bool:
-        """True once the coordinator has completed at least one successful cycle."""
-        return self.coordinator.last_update_success
+        """True once the coordinator has completed at least one successful cycle,
+        or when a restored state from the previous HA session exists."""
+        return self.coordinator.last_update_success or self._restored_state is not None
 
     # ------------------------------------------------------------------
     # Helper

--- a/custom_components/hsem/custom_sensors/ev_optimal_charging_plan_sensor.py
+++ b/custom_components/hsem/custom_sensors/ev_optimal_charging_plan_sensor.py
@@ -134,6 +134,12 @@ class HSEMEVOptimalChargingPlanSensor(
         """Return True when the coordinator has data."""
         return self.coordinator.data is not None
 
+    @property
+    @override
+    def should_poll(self) -> bool:
+        """Return False — this sensor is coordinator-driven."""
+        return False
+
     # ------------------------------------------------------------------
     # State restore
     # ------------------------------------------------------------------

--- a/custom_components/hsem/custom_sensors/ev_second_optimal_charging_plan_sensor.py
+++ b/custom_components/hsem/custom_sensors/ev_second_optimal_charging_plan_sensor.py
@@ -106,6 +106,12 @@ class HSEMEVSecondOptimalChargingPlanSensor(
         """Return True when the coordinator has data."""
         return self.coordinator.data is not None
 
+    @property
+    @override
+    def should_poll(self) -> bool:
+        """Return False — this sensor is coordinator-driven."""
+        return False
+
     @override
     async def async_added_to_hass(self) -> None:
         """Restore previous state on startup."""

--- a/custom_components/hsem/custom_sensors/financial_sensors.py
+++ b/custom_components/hsem/custom_sensors/financial_sensors.py
@@ -28,6 +28,7 @@ from typing import Any, cast, override
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.sensor.const import SensorDeviceClass, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from custom_components.hsem.coordinator import (
@@ -82,6 +83,23 @@ class _FinancialSensorMixin(
         HSEMCoordinatorEntity.__init__(self, coordinator)
         HSEMEntity.__init__(self, config_entry)
         self._config_entry = config_entry
+        self._restored_state: str | None = None
+
+    # ------------------------------------------------------------------
+    # HA lifecycle
+    # ------------------------------------------------------------------
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Restore previous state and register coordinator listener."""
+        await super().async_added_to_hass()
+        restored = await self.async_get_last_state()
+        if restored is not None and restored.state not in {
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
+            None,
+        }:
+            self._restored_state = restored.state
 
     # ------------------------------------------------------------------
     # HA entity properties
@@ -97,7 +115,7 @@ class _FinancialSensorMixin(
     @override
     def available(self) -> bool:
         """True once the coordinator has completed at least one successful cycle."""
-        return self.coordinator.last_update_success
+        return self.coordinator.last_update_success or self._restored_state is not None
 
     @property
     @override
@@ -153,6 +171,11 @@ class HSEMExportIncomeSensor(_FinancialSensorMixin):
         """Return cumulative export income."""
         tracker = self._get_tracker()
         if tracker is None:
+            if self._restored_state is not None:
+                try:
+                    return float(self._restored_state)
+                except ValueError, TypeError:
+                    pass
             return None
         return round(tracker.export_income_total, 3)
 
@@ -193,6 +216,11 @@ class HSEMImportCostSensor(_FinancialSensorMixin):
         """Return cumulative import cost."""
         tracker = self._get_tracker()
         if tracker is None:
+            if self._restored_state is not None:
+                try:
+                    return float(self._restored_state)
+                except ValueError, TypeError:
+                    pass
             return None
         return round(tracker.import_cost_total, 3)
 
@@ -233,5 +261,10 @@ class HSEMNetGridBalanceSensor(_FinancialSensorMixin):
         """Return net grid balance (export income − import cost)."""
         tracker = self._get_tracker()
         if tracker is None:
+            if self._restored_state is not None:
+                try:
+                    return float(self._restored_state)
+                except ValueError, TypeError:
+                    pass
             return None
         return round(tracker.export_income_total - tracker.import_cost_total, 3)

--- a/custom_components/hsem/custom_sensors/forecast_accuracy_sensor.py
+++ b/custom_components/hsem/custom_sensors/forecast_accuracy_sensor.py
@@ -28,7 +28,12 @@ from typing import Any, cast, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory, UnitOfEnergy
+from homeassistant.const import (
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    EntityCategory,
+    UnitOfEnergy,
+)
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from custom_components.hsem.coordinator import (
@@ -78,6 +83,21 @@ class HSEMForecastAccuracySensor(
         )
         self._attr_name = get_forecast_accuracy_sensor_name()
         self.entity_id = get_forecast_accuracy_sensor_entity_id()
+        self._restored_state: str | None = None
+
+    @property
+    @override
+    def should_poll(self) -> bool:
+        """This entity does not poll — updates are pushed by the coordinator."""
+        return False
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return True when the coordinator is healthy or a restored state is available."""
+        return (
+            self.coordinator.last_update_success and self.coordinator.data is not None
+        ) or self._restored_state is not None
 
     @property
     @override
@@ -85,10 +105,12 @@ class HSEMForecastAccuracySensor(
         """Return the sensor state.
 
         State is the PV MAE (kWh) when records exist, otherwise
-        ``None`` (unavailable).
+        falls back to the last known restored state.
         """
         data: CoordinatorData | None = self.coordinator.data
         if data is None:
+            if self._restored_state is not None:
+                return float(self._restored_state)
             return None
         tracker = getattr(self.coordinator, "_forecast_tracker", None)
         if tracker is None:
@@ -153,11 +175,15 @@ class HSEMForecastAccuracySensor(
 
     @override
     async def async_added_to_hass(self) -> None:
-        """Restore forecast tracker data from the previous HA session."""
+        """Restore forecast tracker data and sensor state from the previous HA session."""
         await super().async_added_to_hass()
         restored = await self.async_get_last_state()
         if restored is None:
             return
+
+        # Restore sensor state
+        if restored.state not in {STATE_UNAVAILABLE, STATE_UNKNOWN, None}:
+            self._restored_state = restored.state
 
         tracker_data = restored.attributes.get("_forecast_tracker_data")
         if tracker_data is None:

--- a/custom_components/hsem/custom_sensors/prediction_accuracy_sensor.py
+++ b/custom_components/hsem/custom_sensors/prediction_accuracy_sensor.py
@@ -23,7 +23,8 @@ from typing import Any, cast, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, EntityCategory
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from custom_components.hsem.coordinator import HSEMDataUpdateCoordinator
 from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
@@ -36,6 +37,7 @@ from custom_components.hsem.utils.sensornames.diagnostics import (
 
 class HSEMPredictionAccuracySensor(
     HSEMCoordinatorEntity,
+    RestoreEntity,
     SensorEntity,
     HSEMEntity,
 ):
@@ -68,6 +70,18 @@ class HSEMPredictionAccuracySensor(
         )
         self._attr_name = get_prediction_accuracy_sensor_name()
         self.entity_id = get_prediction_accuracy_sensor_entity_id()
+        self._restored_state: str | None = None
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Restore last-known state on startup."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state is not None and last_state.state not in (
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
+        ):
+            self._restored_state = last_state.state
 
     @property
     @override
@@ -77,18 +91,30 @@ class HSEMPredictionAccuracySensor(
 
     @property
     @override
+    def available(self) -> bool:
+        """Available when the coordinator has data or a restored state exists."""
+        if super().available:
+            return True
+        return self._restored_state is not None
+
+    @property
+    @override
     def native_value(self) -> str | float | None:
         """Return the sensor state.
 
         State is the SoC MAE over 7 days (pct) when records exist,
-        otherwise ``None`` (unavailable).
+        falling back to the restored state on startup.
         """
-        if self.coordinator.data is None:
-            return None
-        tracker = getattr(self.coordinator, "_prediction_tracker", None)
-        if tracker is None or tracker.soc_mae_7d is None:
-            return None
-        return cast(float, round(tracker.soc_mae_7d, 3))
+        if self.coordinator.data is not None:
+            tracker = getattr(self.coordinator, "_prediction_tracker", None)
+            if tracker is not None and tracker.soc_mae_7d is not None:
+                return cast(float, round(tracker.soc_mae_7d, 3))
+        if self._restored_state is not None:
+            try:
+                return float(self._restored_state)
+            except ValueError, TypeError:
+                return self._restored_state
+        return None
 
     @property
     @override

--- a/custom_components/hsem/custom_sensors/savings_sensor.py
+++ b/custom_components/hsem/custom_sensors/savings_sensor.py
@@ -27,7 +27,11 @@ from typing import Any, cast, override
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.sensor.const import SensorDeviceClass, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory
+from homeassistant.const import (
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    EntityCategory,
+)
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from custom_components.hsem.coordinator import HSEMDataUpdateCoordinator
@@ -77,6 +81,8 @@ class HSEMSavingsSensor(
         self._attr_name = get_savings_tracker_sensor_name()
         self.entity_id = get_savings_tracker_sensor_entity_id()
 
+        self._restored_state: str | None = None
+
     # ------------------------------------------------------------------
     # HA entity properties
     # ------------------------------------------------------------------
@@ -87,6 +93,11 @@ class HSEMSavingsSensor(
         """Return today's actual savings as the sensor state."""
         tracker = self._get_tracker()
         if tracker is None:
+            if self._restored_state is not None:
+                try:
+                    return float(self._restored_state)
+                except ValueError, TypeError:
+                    pass
             return None
         return cast(float, round(tracker.today_actual, 3))
 
@@ -109,7 +120,23 @@ class HSEMSavingsSensor(
     @override
     def available(self) -> bool:
         """True once the coordinator has completed at least one successful cycle."""
-        return self.coordinator.last_update_success
+        return self.coordinator.last_update_success or self._restored_state is not None
+
+    # ------------------------------------------------------------------
+    # HA lifecycle
+    # ------------------------------------------------------------------
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Restore previous state and register coordinator listener."""
+        await super().async_added_to_hass()
+        restored = await self.async_get_last_state()
+        if restored is not None and restored.state not in {
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
+            None,
+        }:
+            self._restored_state = restored.state
 
     # ------------------------------------------------------------------
     # Helper

--- a/custom_components/hsem/custom_sensors/solar_confidence_sensor.py
+++ b/custom_components/hsem/custom_sensors/solar_confidence_sensor.py
@@ -22,7 +22,11 @@ from typing import Any, cast, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory
+from homeassistant.const import (
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    EntityCategory,
+)
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from custom_components.hsem.coordinator import (
@@ -72,13 +76,30 @@ class HSEMSolarConfidenceSensor(
         )
         self._attr_name = get_solar_confidence_sensor_name()
         self.entity_id = get_solar_confidence_sensor_entity_id()
+        self._restored_state: str | None = None
+
+    @property
+    @override
+    def should_poll(self) -> bool:
+        """This entity does not poll — updates are pushed by the coordinator."""
+        return False
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return True when the coordinator is healthy or a restored state is available."""
+        return (
+            self.coordinator.last_update_success and self.coordinator.data is not None
+        ) or self._restored_state is not None
 
     @property
     @override
     def native_value(self) -> str | float | None:
-        """Return the mean per-hour accuracy factor, or None if no data."""
+        """Return the mean per-hour accuracy factor, or fall back to restored state if no data."""
         data: CoordinatorData | None = self.coordinator.data
         if data is None:
+            if self._restored_state is not None:
+                return float(self._restored_state)
             return None
 
         factors = data.solar_hour_factors
@@ -126,11 +147,15 @@ class HSEMSolarConfidenceSensor(
 
     @override
     async def async_added_to_hass(self) -> None:
-        """Restore solar corrector data from the previous HA session."""
+        """Restore solar corrector data and sensor state from the previous HA session."""
         await super().async_added_to_hass()
         restored = await self.async_get_last_state()
         if restored is None:
             return
+
+        # Restore sensor state
+        if restored.state not in {STATE_UNAVAILABLE, STATE_UNKNOWN, None}:
+            self._restored_state = restored.state
 
         corrector_data = restored.attributes.get("_solar_corrector_data")
         if corrector_data is None:


### PR DESCRIPTION
## Summary

Audit of all 42 HSEM entity classes (sensors, switches, numbers, selectors, times) for compliance with HA entity lifecycle best practices. Fixes 6 missing `async_added_to_hass` state restoration, 4 missing `should_poll`, 4 missing `available`, and 1 missing selector lifecycle.

## Changes

### `async_added_to_hass` with state restoration (6 sensors)

| Sensor | Issue |
|---|---|
| `HSEMDailyPlanVsActualSensor` | No `async_added_to_hass` at all |
| `HSEMExportIncomeSensor` / `HSEMImportCostSensor` / `HSEMNetGridBalanceSensor` | No `async_added_to_hass` in mixin base |
| `HSEMPredictionAccuracySensor` | Missing `RestoreEntity` inheritance AND no `async_added_to_hass` |
| `HSEMSavingsSensor` | No `async_added_to_hass` |
| `HSEMForecastAccuracySensor` | Had `async_added_to_hass` but only restored tracker data, not sensor state |
| `HSEMSolarConfidenceSensor` | Had `async_added_to_hass` but only restored corrector data, not sensor state |

### `should_poll = False` (4 sensors)
- `HSEMEVOptimalChargingPlanSensor`
- `HSEMEVSecondOptimalChargingPlanSensor`
- `HSEMForecastAccuracySensor`
- `HSEMSolarConfidenceSensor`

### `available` property (4 sensors)
- `HSEMForecastAccuracySensor`
- `HSEMPredictionAccuracySensor`
- `HSEMSolarConfidenceSensor`
- `HSEMAvgSensor`

### Selector lifecycle (1 entity)
- `HSEMWorkingModeSelector` — added `async_added_to_hass` for proper lifecycle

## Validation

- ✅ `tox -e lint` — all clean (ruff format + ruff check)
- ✅ `tox -e typing` — mypy: no issues found
- ⚠️ `tox -e py314` — pre-existing bcrypt/PyO3/CPython 3.14 environment issue prevents all tests from collecting (unrelated to these changes)

## Files changed (10)

- `custom_components/hsem/custom_selectors/working_mode.py`
- `custom_components/hsem/custom_sensors/avg_sensor.py`
- `custom_components/hsem/custom_sensors/daily_plan_vs_actual_sensor.py`
- `custom_components/hsem/custom_sensors/ev_optimal_charging_plan_sensor.py`
- `custom_components/hsem/custom_sensors/ev_second_optimal_charging_plan_sensor.py`
- `custom_components/hsem/custom_sensors/financial_sensors.py`
- `custom_components/hsem/custom_sensors/forecast_accuracy_sensor.py`
- `custom_components/hsem/custom_sensors/prediction_accuracy_sensor.py`
- `custom_components/hsem/custom_sensors/savings_sensor.py`
- `custom_components/hsem/custom_sensors/solar_confidence_sensor.py`