### PR TITLE
fix(milp): clamp export price to never exceed import price

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -170,6 +170,26 @@ LP prefers curtailment (cost 0) over export (cost > 0).
 The raw `slot.price.export_price` is **not** mutated — clamping only affects
 optimisation and scoring.
 
+## MILP Export-≤-Import Clamp (Issue #635 — Unbounded LP Fix)
+
+In `milp_optimizer.py`, after the `min_export_price` clamp, `p_exp` is
+further clamped so it never exceeds `p_imp` for the same slot:
+
+```python
+p_exp = np.minimum(p_exp, p_imp)
+```
+
+This prevents an unbounded LP (HiGHS status=3) when any slot has
+`p_exp > p_imp`.  Without this clamp, the LP can drive both `gi[t]` and
+`ge[t]` to infinity (import cheap, export expensive) while the terms
+cancel in the energy-balance equality, causing `solve_milp()` to return
+`None` for the entire horizon.
+
+- This is applied **after** the `min_export_price` clamp.
+- A debug log line reports how many slots were clamped and the max delta.
+- This must **never** be silently reverted in future refactors — it is
+  a solver-stability requirement, not a cosmetic convenience.
+
 ---
 
 ## Candidate Deduplication

--- a/custom_components/hsem/planner/milp_optimizer.py
+++ b/custom_components/hsem/planner/milp_optimizer.py
@@ -55,6 +55,26 @@ The ``curt[t]`` variable allows the LP to explicitly curtail PV when the
 battery is full and export prices are low/negative. Without it, the LP
 is forced to "use" all PV surplus even when curtailment would be optimal.
 
+Price sanitisation
+------------------
+Before solving, ``p_exp`` is sanitised in two steps:
+
+1. **Min-export-price clamp**: slots where ``p_exp < min_export_price`` are
+   clamped to 0 because the applier physically blocks export for those
+   slots (sets inverter to ``GRID_EXPORT_LIMIT_WATT``).
+2. **Export-≤-import clamp**: ``p_exp = min(p_exp, p_imp)`` — ensures
+   ``p_exp[t]`` never exceeds ``p_imp[t]`` for the same slot.  Without this,
+   slots where ``p_exp > p_imp`` create an unbounded LP (HiGHS status=3)
+   because ``gi[t]`` and ``ge[t]`` are both ``[0, ∞)`` and linked only
+   through the energy-balance equality.  The LP could drive both to
+   infinity (import cheap, export expensive) while the terms cancel.
+
+   This clamp is economically correct — no rational agent imports and
+   exports simultaneously for profit — and prevents the entire MILP from
+   silently returning ``None`` for the whole horizon whenever this common
+   real-world condition (negative import prices, asymmetric grid tariffs)
+   occurs.
+
 Solving
 -------
 ``scipy.optimize.linprog(method='highs')``.  96-slot horizon < 50 ms.
@@ -303,6 +323,28 @@ def solve_milp(
                 float(np.max(p_exp[blocked])),
             )
         p_exp = np.where(blocked, 0.0, p_exp)
+
+    # Clamp export price to never exceed import price for the same slot.
+    # Without this, slots where p_exp[t] > p_imp[t] create an unbounded LP
+    # (HiGHS status=3): both gi[t] and ge[t] are [0, ∞) and linked only
+    # through the energy-balance equality, so the LP can drive both to
+    # infinity (import cheap, export expensive) while the terms cancel in
+    # the balance equation.  This is economically correct — no rational
+    # agent imports and exports the same commodity in the same instant for
+    # profit — and capping the achievable arbitrage spread removes the
+    # unbounded direction without changing any other behavior.
+    export_exceeds_import = p_exp > p_imp
+    n_clamped = int(np.sum(export_exceeds_import))
+    if n_clamped > 0:
+        deltas = p_exp[export_exceeds_import] - p_imp[export_exceeds_import]
+        log_planner(
+            "debug",
+            "[milp] Clamping %d export prices that exceed import price "
+            "(max delta=%.4f)",
+            n_clamped,
+            float(np.max(deltas)),
+        )
+        p_exp = np.minimum(p_exp, p_imp)
 
     # Net load = house consumption + EV extra load − PV estimate.
     # A positive value means the battery/grid must supply extra energy.

--- a/docs/milp-optimization.md
+++ b/docs/milp-optimization.md
@@ -149,7 +149,7 @@ Where:
 |---|---|
 | $\delta_t$ | Time discount per slot: $\delta_t = r^{\Delta t}$ where $\Delta t$ is hours from now |
 | $p_{\mathrm{imp}}[t]$ | Grid import price (currency/kWh) |
-| $p_{\mathrm{exp}}[t]$ | Grid export price (currency/kWh), clamped to 0 when below `min_export_price` |
+| $p_{\mathrm{exp}}[t]$ | Grid export price (currency/kWh). Before solving, `p_exp` is sanitised: (1) clamped to 0 when below `min_export_price` (physically blocked export), and (2) clamped to `min(p_exp, p_imp)` to prevent an unbounded LP when `p_exp > p_imp` in any slot (issue #635). |
 | $\alpha$ | Battery cycle cost per kWh: $\alpha = \frac{P \cdot L_{pct}/100}{2 \cdot N \cdot C_u}$ |
 | $\epsilon_{\mathrm{chg}}$ | Charge-side loss fraction: $\epsilon_{\mathrm{chg}} = 1 - \eta_{\mathrm{chg}}$ |
 | $\epsilon_{\mathrm{dis}}$ | Discharge-side loss fraction: $\epsilon_{\mathrm{dis}} = 1 - \eta_{\mathrm{dis}}$ |
@@ -264,6 +264,30 @@ $$
 The penalty variable `gi_pen[t]` absorbs any excess at high cost (`p_fuse`), preventing infeasibility when house base load alone exceeds the fuse rating. When `main_fuse_amps` is `None` or 0, this constraint is not added.
 
 Where $D_v$ is the deadline slot index for EV v.
+
+---
+
+## Price sanitisation
+
+Before the LP is built, two sanitisation steps are applied to `p_exp` to prevent solver instability and maintain consistency with physical constraints:
+
+### 1. Min-export-price clamp
+
+Slots where `p_exp < min_export_price` are clamped to 0. The applier physically blocks export for these slots by setting the inverter to `GRID_EXPORT_LIMIT_WATT`, so the LP must not optimise around a price signal that will never be realised. Negative export prices are **not** clamped — the `curt[t]` variable (zero objective cost) naturally handles them.
+
+### 2. Export-≤-import clamp (issue #635)
+
+`p_exp` is clamped to never exceed `p_imp` for the same slot:
+
+$$
+p_{\mathrm{exp}}[t] = \min\bigl(p_{\mathrm{exp}}[t],\; p_{\mathrm{imp}}[t]\bigr)
+$$
+
+Without this, slots where `p_exp > p_imp` create an **unbounded LP** (HiGHS status=3). `gi[t]` and `ge[t]` are both `[0, ∞)` and linked only through the per-slot energy-balance equality, so the LP can drive both to infinity (import cheap, export expensive) while the terms cancel. A single such slot causes `solve_milp()` to return `None` for the **entire horizon**, silently falling back to weaker heuristic candidates.
+
+This condition occurs in practice whenever negative import spot prices coincide with positive export tariffs (common in DK/DE/NL markets during high wind/solar hours), or when asymmetric import/export grid fees create an apparent export-price premium.
+
+The clamp is economically correct — no rational agent imports and exports simultaneously for profit — and capping the achievable arbitrage spread removes the unbounded direction without changing any other optimisation behaviour.
 
 ---
 

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -645,6 +645,30 @@ cost) and the LP prefers curtailment (cost 0) over export (cost > 0).
 Invariant: ``export_price < export_min_price`` → planner treats export
 revenue as 0 in both optimisation and scoring.
 
+**Export-≤-import clamp (MILP unbounded-LP fix, issue #635):**
+Before solving, the MILP also clamps ``export_price[t]`` to never
+exceed ``import_price[t]`` for the same slot:
+
+```text
+export_price[t] = min(export_price[t], import_price[t])
+```
+
+Without this, slots where ``export_price > import_price`` create an
+**unbounded LP** (HiGHS status=3).  ``gi[t]`` and ``ge[t]`` are both
+``[0, ∞)`` and linked only through the energy-balance equality, so the
+LP can drive both to infinity (import cheap, export expensive) while
+the terms cancel.  A single such slot in the horizon causes
+``solve_milp()`` to return ``None`` for the entire cycle.
+
+This condition occurs whenever negative import spot prices coincide
+with positive export tariffs (DK/DE/NL markets), or when asymmetric
+import/export grid fees create an apparent price spread.  The clamp is
+economically correct — no rational agent imports and exports
+simultaneously for profit — and removes the unbounded direction
+without changing any other optimisation behaviour.
+
+This clamp is applied **after** the ``min_export_price`` clamp.
+
 ### Battery cycle cost
 
 Cycle cost should count physical battery throughput.

--- a/tests/planner/test_milp_optimizer.py
+++ b/tests/planner/test_milp_optimizer.py
@@ -1477,3 +1477,191 @@ def test_main_fuse_has_violations_flag():
     assert diag.get("has_violations", False), (
         "has_violations must be True when fuse violations exist"
     )
+
+
+# ---------------------------------------------------------------------------
+# Export price > import price — unbounded LP fix (issue #635)
+# ---------------------------------------------------------------------------
+
+
+@_scipy_skip()
+def test_milp_export_above_import_returns_solution():
+    """Single slot with export > import (both positive) must return non-None.
+
+    Before the fix, p_exp > p_imp in any slot caused an unbounded LP
+    (HiGHS status=3) and solve_milp() returned None for the entire horizon.
+    """
+    slots = [_make_slot(hour=0, import_price=0.05, export_price=0.10)]
+    result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=2.0,
+        usable_kwh=10.0,
+        max_charge_per_slot=3.0,
+        max_discharge_per_slot=3.0,
+    )
+    assert result is not None, (
+        "MILP must return a solution when export_price > import_price"
+    )
+
+
+@_scipy_skip()
+def test_milp_negative_import_positive_export_returns_solution():
+    """Single slot with negative import and positive export must return non-None.
+
+    This is a common real-world condition during high wind/solar production
+    hours in DK/DE/NL markets.
+    """
+    slots = [_make_slot(hour=0, import_price=-0.05, export_price=0.10)]
+    result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=2.0,
+        usable_kwh=10.0,
+        max_charge_per_slot=3.0,
+        max_discharge_per_slot=3.0,
+    )
+    assert result is not None, (
+        "MILP must return a solution when import_price < 0 and export_price > 0"
+    )
+
+
+@_scipy_skip()
+def test_milp_bad_slot_at_start_of_288_slot_horizon():
+    """A bad slot (export > import) at index 0 in a 288-slot horizon must not fail."""
+    import copy
+
+    # 288 slots (72 hours × 15 min per slot)
+    base_slot = _make_slot(hour=0, import_price=0.20, export_price=0.05)
+    slots: list[PlannedSlot] = []
+    for i in range(288):
+        s = copy.copy(base_slot)
+        s.start = _NOW + timedelta(minutes=i * 15)
+        s.end = s.start + timedelta(minutes=15)
+        if i == 0:
+            s.price = SlotPrice(import_price=0.05, export_price=0.10)
+        else:
+            s.price = SlotPrice(import_price=0.20, export_price=0.05)
+        slots.append(s)
+
+    result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=2.0,
+        usable_kwh=10.0,
+        max_charge_per_slot=3.0,
+        max_discharge_per_slot=3.0,
+    )
+    assert result is not None, (
+        "MILP must return a solution when bad slot is at index 0 in 288-slot horizon"
+    )
+
+
+@_scipy_skip()
+def test_milp_bad_slot_at_midpoint_of_288_slot_horizon():
+    """A bad slot (export > import) at the midpoint in a 288-slot horizon must not fail."""
+    import copy
+
+    base_slot = _make_slot(hour=0, import_price=0.20, export_price=0.05)
+    slots: list[PlannedSlot] = []
+    for i in range(288):
+        s = copy.copy(base_slot)
+        s.start = _NOW + timedelta(minutes=i * 15)
+        s.end = s.start + timedelta(minutes=15)
+        if i == 144:  # midpoint
+            s.price = SlotPrice(import_price=0.05, export_price=0.10)
+        else:
+            s.price = SlotPrice(import_price=0.20, export_price=0.05)
+        slots.append(s)
+
+    result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=2.0,
+        usable_kwh=10.0,
+        max_charge_per_slot=3.0,
+        max_discharge_per_slot=3.0,
+    )
+    assert result is not None, (
+        "MILP must return a solution when bad slot is at midpoint in 288-slot horizon"
+    )
+
+
+@_scipy_skip()
+def test_milp_bad_slot_at_end_of_288_slot_horizon():
+    """A bad slot (export > import) at the last slot in a 288-slot horizon must not fail."""
+    import copy
+
+    base_slot = _make_slot(hour=0, import_price=0.20, export_price=0.05)
+    slots: list[PlannedSlot] = []
+    for i in range(288):
+        s = copy.copy(base_slot)
+        s.start = _NOW + timedelta(minutes=i * 15)
+        s.end = s.start + timedelta(minutes=15)
+        if i == 287:  # last slot
+            s.price = SlotPrice(import_price=0.05, export_price=0.10)
+        else:
+            s.price = SlotPrice(import_price=0.20, export_price=0.05)
+        slots.append(s)
+
+    result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=2.0,
+        usable_kwh=10.0,
+        max_charge_per_slot=3.0,
+        max_discharge_per_slot=3.0,
+    )
+    assert result is not None, (
+        "MILP must return a solution when bad slot is at last position in 288-slot horizon"
+    )
+
+
+@_scipy_skip()
+def test_milp_normal_prices_no_regression():
+    """Normal prices (import > export in all slots) must produce same results.
+
+    The fix must not change behavior when p_imp > p_exp for all slots,
+    which is the normal case.
+    """
+    # Standard arbitrage case — import > export everywhere
+    cheap = [0, 1, 2, 3]
+    expensive = [20, 21, 22, 23]
+    slots = _make_arbitrage_slots(
+        cheap, expensive, cheap_price=0.05, expensive_price=3.0
+    )
+
+    milp_result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=0.0,
+        usable_kwh=9.0,
+        max_charge_per_slot=5.0,
+        max_discharge_per_slot=5.0,
+    )
+
+    assert milp_result is not None, (
+        "MILP must still return a solution on the standard arbitrage case"
+    )
+    result, _diag = milp_result
+
+    # Verify charge/discharge still works as expected (same assertions
+    # as test_milp_charges_in_cheap_slots_and_discharges_in_expensive)
+    charge_hours = {
+        s.start.hour
+        for s in result
+        if s.recommendation == Recommendations.BatteriesChargeGrid.value
+    }
+    discharge_hours = {
+        s.start.hour
+        for s in result
+        if s.recommendation == Recommendations.BatteriesDischargeMode.value
+    }
+
+    assert charge_hours & set(cheap), (
+        f"Expected charge in cheap hours {cheap}, got charge hours: {sorted(charge_hours)}"
+    )
+    assert discharge_hours & set(expensive), (
+        f"Expected discharge in expensive hours {expensive}, "
+        f"got discharge hours: {sorted(discharge_hours)}"
+    )


### PR DESCRIPTION
## Summary

Clamp `p_exp[t]` to never exceed `p_imp[t]` in the same slot before building the MILP objective. Without this, any slot where `export_price > import_price` creates an unbounded LP (HiGHS status=3) because `gi[t]` and `ge[t]` are both `[0, ∞)` and linked only through the energy-balance equality — the LP can drive both to infinity while the terms cancel. A single such slot silently disables the MILP for the entire horizon.

This is a common real-world condition: negative import spot prices in DK/DE/NL markets, feed-in tariffs, or asymmetric import/export grid fees.

## Changes

### `milp_optimizer.py`
- Added `p_exp = np.minimum(p_exp, p_imp)` after the existing `min_export_price` clamp.
- Added a `debug` log line reporting how many slots were clamped and the max delta.
- Updated the module docstring with a new "Price sanitisation" section explaining both clamp steps.

### Tests (`tests/planner/test_milp_optimizer.py`)
- Single slot, both prices positive (`import=0.05, export=0.10`) → returns non-None.
- Single slot, negative import, positive export (`import=-0.05, export=0.10`) → returns non-None.
- Bad slot at index 0, midpoint, and last position of a 288-slot horizon → returns non-None in all three.
- No regression: normal prices (`import > export`) still produce correct charge/discharge recommendations.

### Docs
- `docs/planner-spec.md`: Added Export-≤-import clamp section after existing export price clamping.
- `docs/milp-optimization.md`: Updated symbol table entry for `p_exp` and added Price sanitisation section.
- `.github/memories.md`: Added canonical MILP Export-≤-Import Clamp pattern.

## Quality gates
- `tox -e lint` — passes
- `tox -e typing` — passes
- `tox -e quality` — passes (all warnings pre-existing)
- `tox -e py314` — cannot run due to pre-existing bcrypt/PyO3 CPython 3.14 incompatibility in this environment

Fixes #635
