### PR TITLE
fix(milp): cap EV pre-deadline charging at target SoC, not full capacity

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -228,6 +228,34 @@ When no future price data is available, the MILP falls back to a tiny fixed
 tiebreaker (0.0001/kWh AC) in `milp_optimizer.py`. Never hardcode a
 replacement constant here — always source it from `ev_future_charge_value_per_kwh()`.
 
+## EV Pre-Deadline Target Cap (Issue #636 — Overcharge Fix)
+
+In `milp_optimizer.py`, the EV deadline benefit coefficient (`-ev_penalty_cost`)
+is applied to **every** kWh of `ev_c[t]` before the deadline.  Without an
+additional constraint, the LP sees a net positive benefit for charging all the
+way to `capacity_kwh` — not just to `target_kwh`.
+
+To fix this, a **hard upper-bound row** is added per EV (only when
+`deadline_slot` is set, `target_kwh > initial_soc_kwh + 1e-9`, and
+`charge_past_target` is **not** enabled):
+
+```python
+# Σ_{k≤D} ev_c[k] ≤ target_kwh - initial_soc_kwh
+shortfall = ev.target_kwh - ev.initial_soc_kwh
+for k in range(d + 1):
+    A_ub[ev_row, ev_off + k] = 1.0
+b_ub[ev_row] = shortfall
+```
+
+- This is **separate** from the existing `ev_soc_rows` capacity constraint
+  (which caps at `capacity_kwh - initial_soc_kwh` — the physical ceiling).
+- This must **never** apply to `charge_past_target=True` EVs — that mode
+  intentionally allows charging beyond `target_kwh` via its own surplus-only
+  mechanism.
+- The row count variable `ev_target_rows` (1 per eligible EV) is included
+  in `ev_total_rows` alongside `ev_soc_rows`, `ev_deadline_rows`,
+  `ev_post_deadline_rows`, and `ev_surplus_rows`.
+
 ---
 
 ## Discharge Concentration — Per-Day Budget Pools

--- a/custom_components/hsem/planner/milp_optimizer.py
+++ b/custom_components/hsem/planner/milp_optimizer.py
@@ -736,10 +736,25 @@ def solve_milp(
         and ev.target_kwh > ev.initial_soc_kwh + 1e-9
         and not ev.charge_past_target
     )
+    # Target-cap rows: for EVs with a deadline and no charge-past-target,
+    # Σ_{k≤D} ev_c[k] ≤ target_kwh - initial_soc_kwh
+    # Caps EV charging at the economic target for pre-deadline slots,
+    # preventing overcharge to full capacity_kwh.
+    ev_target_rows = sum(
+        1
+        for ev in active_evs
+        if ev.deadline_slot is not None
+        and ev.target_kwh > ev.initial_soc_kwh + 1e-9
+        and not ev.charge_past_target
+    )
     # Surplus-only rows: for charge-past-target EVs, ev_c[t]/eff ≤ max(0, pv[t] - base_load[t])
     ev_surplus_rows = sum(1 for ev in active_evs if ev.charge_past_target) * m
     ev_total_rows = (
-        ev_soc_rows + ev_deadline_rows + ev_post_deadline_rows + ev_surplus_rows
+        ev_soc_rows
+        + ev_deadline_rows
+        + ev_target_rows
+        + ev_post_deadline_rows
+        + ev_surplus_rows
     )
 
     if ev_total_rows > 0:
@@ -779,6 +794,28 @@ def solve_milp(
                     A_ub[ev_row, ev_off + k] = -1.0
                 A_ub[ev_row, ev_pen_offsets[ev_idx]] = -1.0
                 b_ub[ev_row] = ev.initial_soc_kwh - ev.target_kwh
+                ev_row += 1
+
+            # EV target-cap constraint:
+            # Σ_{k≤D} ev_c[k] ≤ target_kwh - initial_soc_kwh
+            # Caps EV charging at the economic target for pre-deadline
+            # slots.  Without this, the benefit coefficient on ev_c[t]
+            # would drive charging all the way to capacity_kwh
+            # regardless of the actual shortfall.
+            # Does NOT apply when charge_past_target is enabled — that
+            # mode intentionally allows charging beyond target_kwh via
+            # a separate surplus-only mechanism.
+            if (
+                ev.deadline_slot is not None
+                and ev.target_kwh > ev.initial_soc_kwh + 1e-9
+                and not ev.charge_past_target
+            ):
+                shortfall = ev.target_kwh - ev.initial_soc_kwh
+                d = ev.deadline_slot
+                d = max(0, min(d, m - 1))
+                for k in range(d + 1):
+                    A_ub[ev_row, ev_off + k] = 1.0
+                b_ub[ev_row] = shortfall
                 ev_row += 1
 
             # Post-deadline zero-charge constraint:

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -348,6 +348,12 @@ the MILP decides **when and how much each EV charges**.
   LP-slot index of the effective deadline.
 - **Post-deadline zero-charge**: For EVs with a deadline and `charge_past_target=False`,
   `ev_c[t] = 0` for all `t > D`. This prevents charging after the deadline.
+- **Target-cap constraint** (issue #636): For EVs with a deadline and
+  `charge_past_target=False`, a hard upper bound caps cumulative pre-deadline
+  charge at the economic shortfall:
+  `Σ_{k≤D} ev_c[k] ≤ target_kwh − initial_soc_kwh`.
+  Without this, the benefit coefficient on `ev_c[t]` would drive charging all the
+  way to `capacity_kwh` regardless of the actual shortfall.
 - **Surplus-only for charge-past-target**: When `charge_past_target=True`,
   `ev_c[t]/η_charger ≤ max(0, pv[t] − base_load[t])` — charging only from PV surplus.
 - No discharge: `ev_c[t] ≥ 0` (via bounds).
@@ -390,6 +396,8 @@ to reflect the new EV loads.
   (backward compatible).
 - EV charge per slot never exceeds `ev.max_charge_per_slot`.
 - Cumulative EV SoC never exceeds `ev.capacity_kwh`.
+- For EVs with a deadline and `charge_past_target=False`, cumulative
+  pre-deadline charge `Σ_{k≤D} ev_c[k]` never exceeds `target_kwh − initial_soc_kwh`.
 - When `ev.deadline_slot` is provided and the target is reachable, the
   deadline penalty `ev_pen` is zero.
 - When the target is unreachable within the available slots, `ev_pen > 0`

--- a/test-results.xml
+++ b/test-results.xml
@@ -1,0 +1,3069 @@
+<?xml version="1.0" encoding="utf-8"?><testsuites name="pytest tests"><testsuite name="pytest" errors="77" failures="0" skipped="0" tests="77" time="39.491" timestamp="2026-07-12T10:48:07.544631+02:00" hostname="APILOT-n7oEOiYz"><testcase classname="" name="tests.custom_sensors.test_financial_sensors" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\custom_sensors\test_financial_sensors.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\custom_sensors\test_financial_sensors.py:9: in &lt;module&gt;
+    from homeassistant.components.sensor.const import SensorDeviceClass, SensorStateClass
+.tox\py314\Lib\site-packages\homeassistant\components\sensor\__init__.py:15: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.custom_sensors.test_ocpp_server" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\custom_sensors\test_ocpp_server.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\custom_sensors\test_ocpp_server.py:23: in &lt;module&gt;
+    from custom_components.hsem.custom_sensors.ocpp_server import OCPPServer
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.models.test_financial_tracker" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\models\test_financial_tracker.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\models\test_financial_tracker.py:9: in &lt;module&gt;
+    from custom_components.hsem.models.financial_tracker import (
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.models.test_savings_tracker" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\models\test_savings_tracker.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\models\test_savings_tracker.py:7: in &lt;module&gt;
+    from custom_components.hsem.models.savings_day import SavingsDay
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_48h_second_day" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_48h_second_day.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_48h_second_day.py:29: in &lt;module&gt;
+    from custom_components.hsem.models.battery_schedule_input import BatteryScheduleInput
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_arbitrage_grid_charge" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_arbitrage_grid_charge.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_arbitrage_grid_charge.py:29: in &lt;module&gt;
+    from custom_components.hsem.models.battery_schedule_input import BatteryScheduleInput
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_candidate_generation" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_candidate_generation.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_candidate_generation.py:25: in &lt;module&gt;
+    from custom_components.hsem.models.planned_slot import PlannedSlot
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_candidate_generator_placement" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_candidate_generator_placement.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_candidate_generator_placement.py:21: in &lt;module&gt;
+    from custom_components.hsem.models.planned_slot import PlannedSlot
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_charge_scheduler_capacity" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_charge_scheduler_capacity.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_charge_scheduler_capacity.py:15: in &lt;module&gt;
+    from custom_components.hsem.models.battery_schedule_input import BatteryScheduleInput
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_concentrate_discharge" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_concentrate_discharge.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_concentrate_discharge.py:18: in &lt;module&gt;
+    from custom_components.hsem.models.planned_slot import PlannedSlot
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_cost_function" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_cost_function.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_cost_function.py:24: in &lt;module&gt;
+    from custom_components.hsem.models.planned_slot import PlannedSlot
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_cost_score_split" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_cost_score_split.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_cost_score_split.py:37: in &lt;module&gt;
+    from custom_components.hsem.models.planned_slot import PlannedSlot
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_cycle_cost_guard" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_cycle_cost_guard.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_cycle_cost_guard.py:24: in &lt;module&gt;
+    from custom_components.hsem.models.battery_schedule_input import BatteryScheduleInput
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_ev_future_charge_value" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_ev_future_charge_value.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_ev_future_charge_value.py:16: in &lt;module&gt;
+    from custom_components.hsem.models.planned_slot import PlannedSlot
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_ev_past_target_config_wiring" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_ev_past_target_config_wiring.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_ev_past_target_config_wiring.py:17: in &lt;module&gt;
+    from custom_components.hsem.models.planned_slot import PlannedSlot
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_ev_planned_load" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_ev_planned_load.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_ev_planned_load.py:21: in &lt;module&gt;
+    from custom_components.hsem.models.hourly_consumption_average import (
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_hysteresis" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_hysteresis.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_hysteresis.py:37: in &lt;module&gt;
+    from custom_components.hsem.models.planned_slot import PlannedSlot
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_invariants" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_invariants.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_invariants.py:41: in &lt;module&gt;
+    from custom_components.hsem.models.battery_schedule_input import BatteryScheduleInput
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_mid_hour_planner" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_mid_hour_planner.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_mid_hour_planner.py:31: in &lt;module&gt;
+    from custom_components.hsem.models.hourly_consumption_average import (
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_milp_ev" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_milp_ev.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_milp_ev.py:20: in &lt;module&gt;
+    from custom_components.hsem.models.ev_config import EVConfig
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_milp_optimizer" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_milp_optimizer.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_milp_optimizer.py:25: in &lt;module&gt;
+    from custom_components.hsem.models.ev_config import EVConfig
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_missing_tomorrow_data" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_missing_tomorrow_data.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_missing_tomorrow_data.py:19: in &lt;module&gt;
+    from custom_components.hsem.models.data_quality import DataQuality
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_multi_day_price_preservation" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_multi_day_price_preservation.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_multi_day_price_preservation.py:33: in &lt;module&gt;
+    from custom_components.hsem.models.battery_schedule_input import BatteryScheduleInput
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_plan_explanation" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_plan_explanation.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_plan_explanation.py:23: in &lt;module&gt;
+    from custom_components.hsem.models.plan_explanation import PlanExplanation
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_planner_harness" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_planner_harness.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_planner_harness.py:20: in &lt;module&gt;
+    from custom_components.hsem.models.battery_schedule_input import BatteryScheduleInput
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_planning_horizon" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_planning_horizon.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_planning_horizon.py:21: in &lt;module&gt;
+    from custom_components.hsem.models.battery_schedule_input import BatteryScheduleInput
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_roundtrip_efficiency" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_roundtrip_efficiency.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_roundtrip_efficiency.py:19: in &lt;module&gt;
+    from custom_components.hsem.models.planned_slot import PlannedSlot
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_session_ev" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_session_ev.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_session_ev.py:17: in &lt;module&gt;
+    from custom_components.hsem.models.ev_config import EVConfig
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_slot_ownership" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_slot_ownership.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_slot_ownership.py:42: in &lt;module&gt;
+    from custom_components.hsem.custom_sensors.recommendation_resolver import (
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_soc_simulation" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_soc_simulation.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_soc_simulation.py:23: in &lt;module&gt;
+    from custom_components.hsem.models.battery_schedule_input import BatteryScheduleInput
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_solar_charge_no_double_count" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_solar_charge_no_double_count.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_solar_charge_no_double_count.py:27: in &lt;module&gt;
+    from custom_components.hsem.models.battery_schedule_input import BatteryScheduleInput
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.planner.test_window_hysteresis" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\planner\test_window_hysteresis.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\planner\test_window_hysteresis.py:24: in &lt;module&gt;
+    from custom_components.hsem.planner.charge_scheduler import apply_window_hysteresis
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.sensors.test_applier" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\sensors\test_applier.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\sensors\test_applier.py:10: in &lt;module&gt;
+    from custom_components.hsem.custom_sensors.applier import _parse_power_control_pct
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.sensors.test_hourly_data_populator" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\sensors\test_hourly_data_populator.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\sensors\test_hourly_data_populator.py:11: in &lt;module&gt;
+    from custom_components.hsem.planner.slot_population import (
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.sensors.test_plan_explanation_sensor" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\sensors\test_plan_explanation_sensor.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\sensors\test_plan_explanation_sensor.py:24: in &lt;module&gt;
+    from custom_components.hsem.coordinator import CoordinatorData
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.sensors.test_recommendation_resolver" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\sensors\test_recommendation_resolver.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\sensors\test_recommendation_resolver.py:11: in &lt;module&gt;
+    from custom_components.hsem.custom_sensors.recommendation_resolver import (
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.sensors.test_state_collector" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\sensors\test_state_collector.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\sensors\test_state_collector.py:15: in &lt;module&gt;
+    from custom_components.hsem.custom_sensors.state_collector import (
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_capacity_learner" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_capacity_learner.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_capacity_learner.py:7: in &lt;module&gt;
+    from custom_components.hsem.utils.capacity_learner import CapacityLearner
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_config_flow_single_entry_guard" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_config_flow_single_entry_guard.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_config_flow_single_entry_guard.py:36: in &lt;module&gt;
+    from custom_components.hsem.config_flow import HSEMConfigFlow
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_config_flow_state_isolation" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_config_flow_state_isolation.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_config_flow_state_isolation.py:27: in &lt;module&gt;
+    from custom_components.hsem.config_flow import HSEMConfigFlow
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_config_flow_user_journeys" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_config_flow_user_journeys.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_config_flow_user_journeys.py:21: in &lt;module&gt;
+    from custom_components.hsem.config_flow import HSEMConfigFlow
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_config_validation" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_config_validation.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_config_validation.py:20: in &lt;module&gt;
+    from custom_components.hsem.utils.config_validator import (
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_convert_to_float_none" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_convert_to_float_none.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_convert_to_float_none.py:19: in &lt;module&gt;
+    from custom_components.hsem.models.live_state import LiveState
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_coordinator" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_coordinator.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_coordinator.py:37: in &lt;module&gt;
+    from custom_components.hsem.coordinator import (
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_cross_day_charge_windows" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_cross_day_charge_windows.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_cross_day_charge_windows.py:19: in &lt;module&gt;
+    from custom_components.hsem.utils.time_windows import (
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_daily_plan_vs_actual" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_daily_plan_vs_actual.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_daily_plan_vs_actual.py:13: in &lt;module&gt;
+    from custom_components.hsem.models.daily_diff import DailyDiff
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_datetime_utils" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_datetime_utils.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_datetime_utils.py:32: in &lt;module&gt;
+    from custom_components.hsem.models.hourly_recommendation import HourlyRecommendation
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_degraded_mode" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_degraded_mode.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_degraded_mode.py:18: in &lt;module&gt;
+    from custom_components.hsem.models.live_state import LiveState
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_diagnostics_dump" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_diagnostics_dump.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_diagnostics_dump.py:21: in &lt;module&gt;
+    from custom_components.hsem.models.planner_input import PlannerInput
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_dst_transitions" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_dst_transitions.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_dst_transitions.py:23: in &lt;module&gt;
+    from custom_components.hsem.models.planner_input import PlannerInput
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_entity_platform_classes" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_entity_platform_classes.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_entity_platform_classes.py:22: in &lt;module&gt;
+    from homeassistant.components.select import SelectEntity
+.tox\py314\Lib\site-packages\homeassistant\components\select\__init__.py:10: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_exception_handling" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_exception_handling.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_exception_handling.py:30: in &lt;module&gt;
+    from custom_components.hsem.utils.ha_helpers import (
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_excess_battery_export" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_excess_battery_export.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_excess_battery_export.py:12: in &lt;module&gt;
+    from custom_components.hsem.const import DEFAULT_CONFIG_VALUES
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_excess_export_negative_consumption" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_excess_export_negative_consumption.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_excess_export_negative_consumption.py:25: in &lt;module&gt;
+    from custom_components.hsem.models.planned_slot import PlannedSlot
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_forecast_tracker" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_forecast_tracker.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_forecast_tracker.py:19: in &lt;module&gt;
+    from custom_components.hsem.utils.forecast_tracker import (
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_ha_mock_integration" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_ha_mock_integration.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_ha_mock_integration.py:46: in &lt;module&gt;
+    from custom_components.hsem.coordinator import (
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_hourly_price_expansion" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_hourly_price_expansion.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_hourly_price_expansion.py:28: in &lt;module&gt;
+    from custom_components.hsem.models.time_series import MISSING_SENTINEL
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_house_consumption_sensor_lifecycle" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_house_consumption_sensor_lifecycle.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_house_consumption_sensor_lifecycle.py:36: in &lt;module&gt;
+    from homeassistant.components.sensor.const import SensorDeviceClass, SensorStateClass
+.tox\py314\Lib\site-packages\homeassistant\components\sensor\__init__.py:15: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_huawei_service_calls" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_huawei_service_calls.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_huawei_service_calls.py:31: in &lt;module&gt;
+    from custom_components.hsem.utils.huawei import (
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_logger_no_file_handler" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_logger_no_file_handler.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_logger_no_file_handler.py:27: in &lt;module&gt;
+    from custom_components.hsem.utils import logger as logger_module
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_midnight_rollover" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_midnight_rollover.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_midnight_rollover.py:19: in &lt;module&gt;
+    from custom_components.hsem.utils.time_windows import (
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_months_validation" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_months_validation.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_months_validation.py:12: in &lt;module&gt;
+    from custom_components.hsem.flows.months import get_months_schema, validate_months_input
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_platform_entity_refactor" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_platform_entity_refactor.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_platform_entity_refactor.py:28: in &lt;module&gt;
+    from homeassistant.components.select import SelectEntity, SelectEntityDescription
+.tox\py314\Lib\site-packages\homeassistant\components\select\__init__.py:10: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_power_thresholds" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_power_thresholds.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_power_thresholds.py:19: in &lt;module&gt;
+    from custom_components.hsem.const import (
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_prediction_tracker" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_prediction_tracker.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_prediction_tracker.py:19: in &lt;module&gt;
+    from custom_components.hsem.utils.prediction_tracker import (
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_safety_gates" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_safety_gates.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_safety_gates.py:33: in &lt;module&gt;
+    from custom_components.hsem.custom_sensors.applier import (
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_schedule_validation" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_schedule_validation.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_schedule_validation.py:13: in &lt;module&gt;
+    from custom_components.hsem.const import DEFAULT_CONFIG_VALUES
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_services" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_services.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_services.py:23: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntryState
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_solar_corrector" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_solar_corrector.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_solar_corrector.py:17: in &lt;module&gt;
+    from custom_components.hsem.utils.solar_corrector import (
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_time_series_model" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_time_series_model.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_time_series_model.py:30: in &lt;module&gt;
+    from custom_components.hsem.models.time_series import (
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_unit_conversions" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_unit_conversions.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_unit_conversions.py:12: in &lt;module&gt;
+    from custom_components.hsem.utils.units import (
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_version_comparison" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_version_comparison.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_version_comparison.py:12: in &lt;module&gt;
+    from custom_components.hsem import _parse_version
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_working_mode_task_lifecycle" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_working_mode_task_lifecycle.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_working_mode_task_lifecycle.py:22: in &lt;module&gt;
+    from custom_components.hsem.custom_sensors.working_mode_sensor import (
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.test_write_verify_applier" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\test_write_verify_applier.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\test_write_verify_applier.py:17: in &lt;module&gt;
+    from custom_components.hsem.utils.inverter_verify import (
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.utils.test_charge_rate_learner" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\utils\test_charge_rate_learner.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\utils\test_charge_rate_learner.py:10: in &lt;module&gt;
+    from custom_components.hsem.utils.charge_rate_learner import (
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.utils.test_dynamic_floor" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\utils\test_dynamic_floor.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\utils\test_dynamic_floor.py:14: in &lt;module&gt;
+    from custom_components.hsem.utils.dynamic_floor import (
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase><testcase classname="" name="tests.utils.test_weekday_profile" time="0.000"><error message="collection failure">ImportError while importing test module 'C:\Users\andreas.kruger\Github\hsem\tests\utils\test_weekday_profile.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+.tox\py314\Lib\site-packages\_pytest\python.py:508: in importtestmodule
+    mod = import_path(
+.tox\py314\Lib\site-packages\_pytest\pathlib.py:596: in import_path
+    importlib.import_module(module_name)
+..\..\.pyenv\pyenv-win\versions\3.14.2\Lib\importlib\__init__.py:88: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+&lt;frozen importlib._bootstrap&gt;:1398: in _gcd_import
+    ???
+&lt;frozen importlib._bootstrap&gt;:1371: in _find_and_load
+    ???
+&lt;frozen importlib._bootstrap&gt;:1342: in _find_and_load_unlocked
+    ???
+&lt;frozen importlib._bootstrap&gt;:938: in _load_unlocked
+    ???
+.tox\py314\Lib\site-packages\_pytest\assertion\rewrite.py:188: in exec_module
+    exec(co, module.__dict__)
+tests\utils\test_weekday_profile.py:7: in &lt;module&gt;
+    from custom_components.hsem.utils.weekday_profile import WeekdayProfile
+custom_components\__init__.py:1: in &lt;module&gt;
+    from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+custom_components\hsem\__init__.py:13: in &lt;module&gt;
+    from homeassistant.config_entries import ConfigEntry
+.tox\py314\Lib\site-packages\homeassistant\config_entries.py:78: in &lt;module&gt;
+    from .setup import (
+.tox\py314\Lib\site-packages\homeassistant\setup.py:15: in &lt;module&gt;
+    from . import config as conf_util, core, loader, requirements
+.tox\py314\Lib\site-packages\homeassistant\config.py:25: in &lt;module&gt;
+    from .core_config import _PACKAGE_DEFINITION_SCHEMA, _PACKAGES_CONFIG_SCHEMA
+.tox\py314\Lib\site-packages\homeassistant\core_config.py:17: in &lt;module&gt;
+    from . import auth
+.tox\py314\Lib\site-packages\homeassistant\auth\__init__.py:29: in &lt;module&gt;
+    from .providers.homeassistant import HassAuthProvider
+.tox\py314\Lib\site-packages\homeassistant\auth\providers\homeassistant.py:9: in &lt;module&gt;
+    import bcrypt
+.tox\py314\Lib\site-packages\bcrypt\__init__.py:13: in &lt;module&gt;
+    from ._bcrypt import (
+E   ImportError: PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process</error></testcase></testsuite></testsuites>

--- a/tests/planner/test_milp_ev.py
+++ b/tests/planner/test_milp_ev.py
@@ -729,6 +729,137 @@ def test_charge_past_target_falls_back_to_tiebreaker_when_value_none():
 
 
 # ---------------------------------------------------------------------------
+# Target-cap constraint (issue #636)
+# ---------------------------------------------------------------------------
+
+
+@_pytestmark_scipy
+def test_ev_target_capped_not_to_capacity():
+    """EV charging is capped at target_kwh, not capacity_kwh (issue #636).
+
+    EV at 50/80 kWh needs only +5 kWh to reach 55 kWh target.
+    Grid price is extreme (3.00/kWh) for the whole horizon, no PV.
+    Total EV DC charge must stay at ~5 kWh (the shortfall), never the
+    full 30 kWh capacity headroom.
+    """
+    slots = _build_slots(10, start_hour=14, import_price=3.00)
+    ev = EVConfig(
+        enabled=True,
+        initial_soc_kwh=50.0,
+        target_kwh=55.0,  # needs only 5 kWh
+        capacity_kwh=80.0,
+        max_charge_per_slot=10.0,
+        charger_efficiency=0.90,
+        deadline_slot=9,
+    )
+
+    result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=0.0,
+        usable_kwh=0.001,
+        max_charge_per_slot=0.001,
+        max_discharge_per_slot=None,
+        ev_configs=[ev],
+    )
+
+    assert result is not None
+    out_slots, _diag = result
+
+    ev_total_dc = sum(
+        s.ev_total_planned_load_kwh * 0.9  # AC -> DC
+        for s in out_slots
+    )
+    assert ev_total_dc == pytest.approx(5.0, rel=0.05), (
+        f"Expected ~5 kWh DC (shortfall), got {ev_total_dc} kWh "
+        f"(full capacity headroom would be 30 kWh)"
+    )
+
+
+@_pytestmark_scipy
+def test_ev_target_capped_large_reachable_shortfall():
+    """EV with large but reachable shortfall charges to target, not capacity.
+
+    EV at 10/60 kWh needs 40 kWh, max 10 kWh/slot, 6 slots before deadline
+    = 60 kWh reachable.  At moderate prices the EV should charge to target
+    (50 kWh) not to full capacity (60 kWh).
+    """
+    slots = _build_slots(10, start_hour=14, import_price=0.20)
+    ev = EVConfig(
+        enabled=True,
+        initial_soc_kwh=10.0,
+        target_kwh=50.0,  # needs 40 kWh
+        capacity_kwh=60.0,
+        max_charge_per_slot=10.0,
+        charger_efficiency=0.90,
+        deadline_slot=5,  # slots 0-5 = 6 slots, 6*10 = 60 kWh max
+    )
+
+    result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=0.0,
+        usable_kwh=10.0,
+        max_charge_per_slot=5.0,
+        max_discharge_per_slot=None,
+        ev_configs=[ev],
+    )
+
+    assert result is not None
+    out_slots, _diag = result
+
+    ev_total_dc = sum(
+        s.ev_total_planned_load_kwh * 0.9  # AC -> DC
+        for s in out_slots
+    )
+    assert ev_total_dc == pytest.approx(40.0, rel=0.05), (
+        f"Expected ~40 kWh DC (target shortfall), got {ev_total_dc}"
+    )
+
+
+@_pytestmark_scipy
+def test_charge_past_target_unaffected_by_target_cap():
+    """charge_past_target=True is NOT capped by the new target constraint.
+
+    The target-cap constraint only applies to EVs without charge_past_target.
+    When charge_past_target=True, the EV must still be able to charge past
+    target using surplus PV.
+    """
+    # Single slot with PV surplus, EV already at target
+    slots = [
+        _make_slot(hour=14, day=15, import_price=1.50, export_price=0.05, pv_kwh=5.0)
+    ]
+    ev = EVConfig(
+        enabled=True,
+        initial_soc_kwh=40.0,
+        target_kwh=40.0,  # already at target
+        capacity_kwh=50.0,
+        max_charge_per_slot=5.0,
+        charger_efficiency=1.0,
+        charge_past_target=True,
+        future_value_per_kwh=1.20,  # high enough to prefer EV over export
+    )
+
+    result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=0.0,
+        usable_kwh=0.001,
+        max_charge_per_slot=0.001,
+        max_discharge_per_slot=None,
+        ev_configs=[ev],
+    )
+
+    assert result is not None
+    out_slots, _diag = result
+    # EV should have charged past target (absorbed PV surplus)
+    assert out_slots[0].ev_total_planned_load_kwh > 0.5, (
+        "charge_past_target EV should absorb surplus even though "
+        "it is already at target"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Integration test: full planner with EV config
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

The MILP's EV deadline benefit coefficient (`-ev_penalty_cost`) was applied to **every** kWh of `ev_c[t]` before the deadline, with no constraint capping total charge at the actual shortfall (`target_kwh - initial_soc_kwh`). The result: the EV charged all the way to its physical `capacity_kwh` regardless of price, even when it only needed a small top-up.

This was already causing two live test failures on `main`:
- `tests/planner/test_session_ev.py::test_session_charge_overrides_probabilistic_demand`
- `tests/planner/test_session_ev.py::test_session_ev_fallback_beyond_eight_slots`

## What Changed

### `custom_components/hsem/planner/milp_optimizer.py`
- Added `ev_target_rows` count (1 per eligible EV)
- Included `ev_target_rows` in `ev_total_rows` alongside existing EV rows
- Added a new hard upper-bound row per EV: `Σ_{k≤D} ev_c[k] ≤ target_kwh - initial_soc_kwh`
- Only applies when `deadline_slot` is set, `target_kwh > initial_soc_kwh`, and `charge_past_target=False`
- Existing `ev_soc_rows` capacity constraint (caps at `capacity_kwh - initial_soc_kwh`) remains unchanged

### `tests/planner/test_milp_ev.py`
- `test_ev_target_capped_not_to_capacity` — small shortfall (+5 kWh, 30 kWh headroom) at extreme price → total EV DC stays at ~5 kWh
- `test_ev_target_capped_large_reachable_shortfall` — large reachable shortfall at moderate prices → total EV DC reaches target, not capacity
- `test_charge_past_target_unaffected_by_target_cap` — charge_past_target=True EV still charges past target using surplus PV

### `docs/planner-spec.md`
- Documented new target-cap constraint in EV co-optimisation section
- Added invariant: pre-deadline cumulative charge never exceeds shortfall

### `.github/memories.md`
- Added canonical pattern: "EV Pre-Deadline Target Cap (Issue #636)"

## Verification

- [x] `tox -e lint` — all checks passed
- [x] `tox -e typing` — no issues found
- [x] `tox -e quality` — 0 errors (26 pre-existing warnings)
- [ ] `tox -e py314` — blocked by pre-existing bcrypt/Python 3.14 incompatibility

Fixes #636