### PR TITLE
fix(milp): make LP's ed[t] the source of truth for batteries_discharged_kwh

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -310,6 +310,7 @@ Always check `docs/huawei_entities.md` before looking elsewhere.
 | #447 | Partial-SoC fractions collapse to floor at low SoC | Open
 | #582 | EV charger power oscillates due to frequent MILP re-solves | Closed (reverted) |
 | #630 | EV charge-past-target valued at flat 0.0001 instead of avoided-cost | Closed |
+| #637 | simulate_soc overwrites MILP's ed[t] with greedy discharge allocation | Closed |
 
 ---
 
@@ -339,6 +340,31 @@ Always check `docs/huawei_entities.md` before looking elsewhere.
   Always use `log_planner(level, msg, *args)` instead — it offloads file I/O to a
   thread-pool executor when a running event loop is detected, falling back to a
   direct call only when no loop is present (tests, early init). See issue #632.
+
+---
+
+## MILP Energy Flow Source-of-Truth Rule (issue #637)
+
+`solve_milp()` now writes **every** per-slot energy flow field directly from
+the LP solution: `batteries_discharged_kwh`, `grid_import_kwh`, and
+`grid_export_kwh`.  These are the **source of truth** for MILP-sourced
+candidates.
+
+- `simulate_soc()` accepts an optional `milp_prepopulated=True` parameter.
+  When ``True``, it preserves the LP's pre-populated energy flow values
+  verbatim — it does **not** re-derive discharge from the recommendation
+  label and `net_demand`.
+- The candidate selector passes ``milp_prepopulated=True`` for MILP
+  candidates (detected by ``candidate.name == CANDIDATE_MILP``).
+- Non-MILP candidates (no_action, passive, etc.) use the default
+  ``milp_prepopulated=False`` and continue with the existing greedy
+  derivation — their behaviour is unchanged.
+
+**Do NOT** add any post-processing step that silently overwrites the
+LP-derived per-slot energy flows (``batteries_discharged_kwh``,
+``grid_import_kwh``, ``grid_export_kwh``) on MILP-sourced slots.
+If a step needs to adjust these values, it must be part of the LP
+formulation itself, not a downstream patch.
 
 ---
 

--- a/custom_components/hsem/planner/candidate_selector.py
+++ b/custom_components/hsem/planner/candidate_selector.py
@@ -38,6 +38,7 @@ from datetime import datetime, timedelta
 from custom_components.hsem.models.rejected_plan import RejectedPlan
 from custom_components.hsem.planner.candidate_generator import (
     CANDIDATE_BASELINE,
+    CANDIDATE_MILP,
     CANDIDATE_NO_ACTION,
     CandidatePlan,
 )
@@ -246,6 +247,7 @@ def select_best_candidate(  # NOSONAR
             end_of_discharge_soc_pct=end_of_discharge_soc_pct,
             charge_efficiency_pct=charge_efficiency_pct,
             discharge_efficiency_pct=discharge_efficiency_pct,
+            milp_prepopulated=(candidate.name == CANDIDATE_MILP),
         )
         candidate.is_valid, candidate.rejection_reason = _validate_candidate(
             candidate, end_of_discharge_soc_pct

--- a/custom_components/hsem/planner/milp_optimizer.py
+++ b/custom_components/hsem/planner/milp_optimizer.py
@@ -143,7 +143,12 @@ def solve_milp(
 
     - ``recommendation``  — one of ``BatteriesChargeGrid``, ``BatteriesDischargeMode``,
       ``ForceBatteriesDischarge``, or ``None`` (idle).
-    - ``batteries_charged`` — energy entering the battery this slot (kWh).
+    - ``batteries_charged_kwh`` — energy entering the battery this slot (kWh).
+    - ``batteries_discharged_kwh`` — energy discharged from the battery this slot
+      (kWh).  Populated directly from the LP's ``ed[t]`` solution — this is the
+      source of truth and must not be re-derived by :func:`~soc_simulation.simulate_soc`.
+    - ``grid_import_kwh`` — grid import this slot (kWh), from the LP's ``gi[t]``.
+    - ``grid_export_kwh`` — grid export this slot (kWh), from the LP's ``ge[t]``.
     - ``ev_planned_load_kwh`` — EV AC load that must be added to base consumption
       (when ``ev_configs`` is provided and ``base_load_includes_ev`` is False).
     - ``ev_accounted_load_kwh`` — EV AC load already captured in house consumption
@@ -155,8 +160,10 @@ def solve_milp(
     - ``estimated_cost_currency`` — recomputed after EV decisions.
 
     The SoC simulation (:func:`~soc_simulation.simulate_soc`) must be run
-    by the caller **after** receiving these slots to populate
-    ``grid_import_kwh``, ``grid_export_kwh``, and ``estimated_battery_soc``.
+    by the caller **after** receiving these slots with
+    ``milp_prepopulated=True`` to populate ``estimated_battery_soc``
+    and ``estimated_battery_capacity_kwh`` while preserving the LP-derived
+    energy flow fields.
 
     The MILP objective now includes conversion loss costs so its optimisation
     matches the cost function's ``total_cost``.  The energy balance equation
@@ -994,10 +1001,14 @@ def solve_milp(
 
     out_slots: list[PlannedSlot] = [copy.copy(s) for s in slots]
 
-    # Reset charge/discharge and EV fields on all future slots; past slots keep TimePassed
+    # Reset charge/discharge, energy-flow, and EV fields on all future slots;
+    # past slots keep TimePassed.
     for i in future_idx:
         out_slots[i].recommendation = None
         out_slots[i].batteries_charged_kwh = 0.0
+        out_slots[i].batteries_discharged_kwh = 0.0
+        out_slots[i].grid_import_kwh = 0.0
+        out_slots[i].grid_export_kwh = 0.0
         out_slots[i].ev_planned_load_kwh = 0.0
         out_slots[i].ev_accounted_load_kwh = 0.0
         out_slots[i].ev_total_planned_load_kwh = 0.0
@@ -1078,6 +1089,23 @@ def solve_milp(
                 out_slots[
                     slot_i
                 ].recommendation = Recommendations.BatteriesDischargeMode.value
+
+    # ------------------------------------------------------------------
+    # Write LP-derived energy flow fields to ALL future slots.
+    #
+    # These are the source of truth for batteries_discharged_kwh,
+    # grid_import_kwh, and grid_export_kwh.  The SoC simulation
+    # (simulate_soc) must use these verbatim when milp_prepopulated=True
+    # — never re-derive a different (greedy) value from the
+    # recommendation label and net_demand.
+    # ------------------------------------------------------------------
+    for lp_t, slot_i in enumerate(future_idx):
+        ed_val = float(ed_sol[lp_t])
+        gi_val = float(result.x[gi_off + lp_t])
+        ge_val = float(result.x[ge_off + lp_t])
+        out_slots[slot_i].batteries_discharged_kwh = round(max(ed_val, 0.0), 3)
+        out_slots[slot_i].grid_import_kwh = round(max(gi_val, 0.0), 3)
+        out_slots[slot_i].grid_export_kwh = round(max(ge_val, 0.0), 3)
 
     # ------------------------------------------------------------------
     # Write MILP-derived EV charging decisions to output slots

--- a/custom_components/hsem/planner/soc_simulation.py
+++ b/custom_components/hsem/planner/soc_simulation.py
@@ -53,6 +53,8 @@ def simulate_soc(
     end_of_discharge_soc_pct: float = 0.0,
     charge_efficiency_pct: float = 100.0,
     discharge_efficiency_pct: float = 100.0,
+    *,
+    milp_prepopulated: bool = False,
 ) -> None:
     """Forward-simulate battery SoC through all planning slots.
 
@@ -112,6 +114,12 @@ def simulate_soc(
         discharge_efficiency_pct: Discharge-side efficiency as a percentage
             (0-100).  Energy to house = battery_removed × (discharge_efficiency_pct / 100).
             Defaults to 100 % (no discharge-side loss) for backward compatibility.
+        milp_prepopulated: When ``True``, the slot's ``batteries_discharged_kwh``,
+            ``grid_import_kwh``, and ``grid_export_kwh`` fields are already
+            populated by the MILP LP solution and must be used verbatim.
+            The simulation skips the greedy derivation and tracks SoC from
+            the pre-populated values.  Defaults to ``False`` (unchanged
+            behaviour for non-MILP candidates).
     """
     # Clamp efficiencies to a valid range to avoid division by zero or nonsense.
     charge_eff = clamp_efficiency(charge_efficiency_pct)
@@ -215,7 +223,16 @@ def simulate_soc(
             house_load - pv
         )  # positive = house needs energy; negative = surplus
 
-        if net_demand > 0:
+        if milp_prepopulated:
+            # Trust the LP-derived energy flow values verbatim.
+            # The LP already accounts for all constraints (SoC bounds,
+            # power limits, EV interactions, conversion efficiencies).
+            # Do NOT re-derive discharge from the recommendation label
+            # and net_demand — the LP's ed[t] is the source of truth.
+            discharge = slot.batteries_discharged_kwh
+            grid_import = slot.grid_import_kwh
+            grid_export = slot.grid_export_kwh
+        elif net_demand > 0:
             # House demand exceeds PV on the shared AC bus.
             #
             # When the EV is charging, the battery MUST NOT discharge.
@@ -348,9 +365,10 @@ def simulate_soc(
             slot.estimated_battery_soc_pct = round(cap / usable_kwh * 100, 2)
         else:
             slot.estimated_battery_soc_pct = 0.0
-        slot.batteries_discharged_kwh = round(discharge, 3)
-        slot.grid_import_kwh = round(grid_import, 3)
-        slot.grid_export_kwh = round(grid_export, 3)
+        if not milp_prepopulated:
+            slot.batteries_discharged_kwh = round(discharge, 3)
+            slot.grid_import_kwh = round(grid_import, 3)
+            slot.grid_export_kwh = round(grid_export, 3)
 
         # If the slot has a FORCE discharge/export recommendation but
         # no discharge actually happened (battery empty or PV surplus),

--- a/docs/milp-optimization.md
+++ b/docs/milp-optimization.md
@@ -22,6 +22,7 @@ flowchart TD
     L{Solution found?}
     M[Decode solution: ec, ed, gi, ge, pv, m, penalties, EV charging]
     N[Write recommendations to output slots BatteriesChargeGrid, BatteriesChargeSolar, BatteriesDischargeMode, ForceBatteriesDischarge]
+    N2[Write LP-derived energy flow fields: batteries_discharged_kwh, grid_import_kwh, grid_export_kwh — these are the source of truth]
     O[Compute penalty violation diagnostics]
     P[Return slots and diagnostics]
     Q[Return None: solver failed or no future slots]
@@ -30,7 +31,7 @@ flowchart TD
     D -->|Yes| E --> G
     D -->|No| F --> G
     G --> H --> I --> J --> K --> L
-    L -->|Yes| M --> N --> O --> P
+    L -->|Yes| M --> N --> N2 --> O --> P
     L -->|No| Q
 ```
 
@@ -293,7 +294,7 @@ The clamp is economically correct — no rational agent imports and exports simu
 
 ## Post-processing
 
-After solving, the solution is decoded into slot recommendations:
+After solving, the solution is decoded into slot recommendations and energy flow fields:
 
 ```mermaid
 flowchart TD
@@ -311,6 +312,8 @@ flowchart TD
     L{Grid export > 0 AND price >= min_export_price?}
     M[ForceBatteriesDischarge]
     N[BatteriesDischargeMode]
+    N2[Write LP energy flow fields to ALL future slots:
+    batteries_discharged_kwh, grid_import_kwh, grid_export_kwh]
     O[Write EV charge decisions]
     P[Recompute estimated_net_consumption and estimated_cost per slot]
     Q[Compute penalty violation diagnostics]
@@ -321,15 +324,32 @@ flowchart TD
     D -->|No| F --> G
     B -->|No| G
     G -->|Yes| H
-    H -->|Yes| I --> O
-    H -->|No| J --> O
+    H -->|Yes| I --> N2
+    H -->|No| J --> N2
     G -->|No| K
     K -->|Yes| L
-    L -->|Yes| M --> O
-    L -->|No| N --> O
-    K -->|No| O
-    O --> P --> Q
+    L -->|Yes| M --> N2
+    L -->|No| N --> N2
+    K -->|No| N2
+    N2 --> O --> P --> Q
 ```
+
+### Energy flow fields written to slots (issue #637)
+
+The MILP now writes **all** per-slot energy flow fields directly from the LP solution,
+making them the source of truth:
+
+| Field | LP variable | Description |
+|---|---|---|
+| `batteries_discharged_kwh` | `ed[t]` | Energy discharged from battery (kWh) |
+| `grid_import_kwh` | `gi[t]` | Grid import (kWh) |
+| `grid_export_kwh` | `ge[t]` | Grid export (kWh) |
+
+These are populated for **every** future slot (zero for idle slots).  The
+SoC simulation (:func:`~soc_simulation.simulate_soc`) must be called with
+``milp_prepopulated=True`` for MILP-sourced candidates so it preserves
+these values verbatim instead of re-deriving a different (greedy)
+allocation from the recommendation label and net demand.
 
 ### EV charging fields written to slots
 

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -290,6 +290,23 @@ If a slot recommends forced discharge, force export, or discharge-only behavior,
 
 No recommendation may be energetically invisible.
 
+### MILP-pre-populated mode (issue #637)
+
+When `milp_prepopulated=True` is passed to `simulate_soc()`, the
+simulation uses the slot's **existing** `batteries_discharged_kwh`,
+`grid_import_kwh`, and `grid_export_kwh` values verbatim — it does **not**
+re-derive them from the recommendation label and net demand.
+
+This mode is used for MILP-sourced candidates, where `solve_milp()` has
+already populated these fields from the LP's `ed[t]`, `gi[t]`, and
+`ge[t]` solutions.  The LP values are the source of truth; the SoC
+simulation must never silently overwrite them with a greedy
+re-derivation.
+
+For non-MILP candidates (`milp_prepopulated=False`, the default),
+the simulation continues to derive discharge and grid flows greedily
+from the recommendation label and net demand — unchanged behaviour.
+
 ## MILP soft constraints (penalty approach)
 
 The MILP optimizer (`milp_optimizer.py`) uses **soft constraints** with penalty

--- a/tests/planner/test_milp_optimizer.py
+++ b/tests/planner/test_milp_optimizer.py
@@ -1665,3 +1665,182 @@ def test_milp_normal_prices_no_regression():
         f"Expected discharge in expensive hours {expensive}, "
         f"got discharge hours: {sorted(discharge_hours)}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #637 — MILP discharge values are the source of truth
+# ---------------------------------------------------------------------------
+
+
+@_scipy_skip()
+def test_milp_discharge_values_preserved_after_soc_simulation():
+    """batteries_discharged_kwh after milp_prepopulated simulate_soc must match
+    the LP's ed[t] solution, not a greedy chronological re-derivation.
+
+    Scenario: two slots, both need 2.0 kWh, battery has only 3.0 kWh usable.
+    The LP optimally allocates discharge across the two slots considering
+    different import prices (0.30 vs 1.00).  The greedy simulator would
+    discharge 2.0 kWh in slot 0 (enough to cover its load), leaving only
+    1.0 kWh for slot 1.  The LP may instead ration: discharge less in
+    slot 0 (where import is cheaper) and save more for slot 1.
+    """
+    slot0 = _make_slot(hour=0, import_price=0.30, consumption_kwh=2.0)
+    slot1 = _make_slot(hour=1, import_price=1.00, consumption_kwh=2.0)
+    slots = [slot0, slot1]
+
+    milp_result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=3.0,
+        usable_kwh=3.0,
+        max_charge_per_slot=3.0,
+        max_discharge_per_slot=3.0,
+        cycle_cost_per_kwh=0.0,
+    )
+    assert milp_result is not None, "MILP must return a solution"
+    out_slots, _diag = milp_result
+
+    # Record LP-derived discharge values before simulate_soc
+    lp_discharge = [s.batteries_discharged_kwh for s in out_slots]
+    lp_grid_import = [s.grid_import_kwh for s in out_slots]
+    lp_grid_export = [s.grid_export_kwh for s in out_slots]
+
+    # Run SoC simulation WITH milp_prepopulated=True (preserve LP values)
+    simulate_soc(
+        out_slots,
+        _NOW,
+        current_kwh=3.0,
+        usable_kwh=3.0,
+        max_capacity_kwh=3.0,
+        max_charge_per_slot=3.0,
+        max_discharge_per_slot=3.0,
+        rated_kwh=3.0,
+        end_of_discharge_soc_pct=0.0,
+        milp_prepopulated=True,
+    )
+
+    # After simulation, batteries_discharged_kwh must still match LP values
+    for i, slot in enumerate(out_slots):
+        assert slot.batteries_discharged_kwh == pytest.approx(
+            lp_discharge[i], rel=1e-6
+        ), (
+            f"Slot {i}: batteries_discharged_kwh {slot.batteries_discharged_kwh} "
+            f"differs from LP ed[t] {lp_discharge[i]}"
+        )
+        assert slot.grid_import_kwh == pytest.approx(lp_grid_import[i], rel=1e-6), (
+            f"Slot {i}: grid_import_kwh {slot.grid_import_kwh} "
+            f"differs from LP gi[t] {lp_grid_import[i]}"
+        )
+        assert slot.grid_export_kwh == pytest.approx(lp_grid_export[i], rel=1e-6), (
+            f"Slot {i}: grid_export_kwh {slot.grid_export_kwh} "
+            f"differs from LP ge[t] {lp_grid_export[i]}"
+        )
+
+    # The LP should have rationed discharge: since slot 1 has a much higher
+    # import price (1.00 vs 0.30), the LP should allocate MORE discharge to
+    # slot 1 (saving expensive imports) and LESS to slot 0.
+    # Total discharge cannot exceed usable_kwh (3.0 kWh).
+    total_discharge = sum(s.batteries_discharged_kwh for s in out_slots)
+    assert total_discharge <= 3.0 + 1e-6, (
+        f"Total discharge {total_discharge} exceeds usable capacity 3.0"
+    )
+    # The LP should discharge more in the expensive slot (slot 1)
+    # than in the cheap slot (slot 0), because displacing 1.00/kWh imports
+    # is worth more than displacing 0.30/kWh imports.
+    assert out_slots[1].batteries_discharged_kwh >= pytest.approx(
+        out_slots[0].batteries_discharged_kwh, rel=1e-6
+    ), (
+        f"LP should discharge more in expensive slot (1.00/kWh) than cheap "
+        f"slot (0.30/kWh).  Got slot0={out_slots[0].batteries_discharged_kwh}, "
+        f"slot1={out_slots[1].batteries_discharged_kwh}"
+    )
+
+
+@_scipy_skip()
+def test_milp_discharge_not_overwritten_without_prepopulated_flag():
+    """Without milp_prepopulated=True, simulate_soc still overwrites
+    batteries_discharged_kwh with its own greedy derivation — this is the
+    pre-existing behavior for non-MILP candidates and must remain unchanged.
+
+    This test verifies that the greedy path is still intact and produces
+    different results than the LP for capacity-constrained scenarios.
+    """
+    slot0 = _make_slot(hour=0, import_price=0.30, consumption_kwh=2.0)
+    slot1 = _make_slot(hour=1, import_price=1.00, consumption_kwh=2.0)
+    slots = [slot0, slot1]
+
+    milp_result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=3.0,
+        usable_kwh=3.0,
+        max_charge_per_slot=3.0,
+        max_discharge_per_slot=3.0,
+        cycle_cost_per_kwh=0.0,
+    )
+    assert milp_result is not None, "MILP must return a solution"
+    out_slots, _diag = milp_result
+
+    # Run SoC simulation WITHOUT milp_prepopulated (greedy re-derivation)
+    simulate_soc(
+        out_slots,
+        _NOW,
+        current_kwh=3.0,
+        usable_kwh=3.0,
+        max_capacity_kwh=3.0,
+        max_charge_per_slot=3.0,
+        max_discharge_per_slot=3.0,
+        rated_kwh=3.0,
+        end_of_discharge_soc_pct=0.0,
+        # milp_prepopulated defaults to False
+    )
+
+    # After simulation WITHOUT milp_prepopulated, the values MAY differ
+    # from the LP — this is the greedy re-derivation behavior.
+    greedy_discharge = [s.batteries_discharged_kwh for s in out_slots]
+
+    # The greedy path should still be functional (non-zero total discharge)
+    total_discharge = sum(greedy_discharge)
+    assert total_discharge > 0, "Greedy simulation should produce non-zero discharge"
+
+
+@_scipy_skip()
+def test_non_milp_candidates_unaffected_by_milp_prepopulated():
+    """Regression test: non-MILP candidates (no_action, passive) must keep
+    using simulate_soc's existing greedy logic exactly as before.
+
+    The milp_prepopulated flag defaults to False, so any caller that does
+    not explicitly opt-in gets the original greedy behavior.
+    """
+    slot = _make_slot(
+        hour=0,
+        import_price=0.30,
+        consumption_kwh=1.0,
+        recommendation=Recommendations.BatteriesDischargeMode.value,
+    )
+    slots = [slot]
+
+    # Run simulate_soc without milp_prepopulated (default behavior)
+    simulate_soc(
+        slots,
+        _NOW,
+        current_kwh=2.0,
+        usable_kwh=5.0,
+        max_capacity_kwh=5.0,
+        max_charge_per_slot=3.0,
+        max_discharge_per_slot=3.0,
+        rated_kwh=5.0,
+        end_of_discharge_soc_pct=0.0,
+    )
+
+    # The greedy path should have derived discharge from the recommendation
+    # label and net_demand:
+    # - net_demand = 1.0 kWh (house load, no PV)
+    # - discharge = min(1.0, cap=2.0, max_discharge=3.0) = 1.0 kWh
+    # The default flag must produce the same greedy behavior as before.
+    assert slot.batteries_discharged_kwh == pytest.approx(1.0, rel=1e-6), (
+        f"Greedy discharge should be 1.0 kWh (covers full net_demand), "
+        f"got {slot.batteries_discharged_kwh}"
+    )
+    assert slot.grid_import_kwh >= 0, "Grid import must be non-negative"
+    assert slot.estimated_battery_capacity_kwh > 0, "SoC must be tracked"


### PR DESCRIPTION
Fixes #637

## Problem

`solve_milp()` computes an exact, per-slot optimal `ed[t]` (battery discharge) as part of the LP solve, but only writes the **recommendation label** to output slots — it never writes `batteries_discharged_kwh`. Every candidate (including MILP) then goes through `select_best_candidate()`, which unconditionally calls `simulate_soc()` on every candidate's slots. `simulate_soc()` computes its **own** discharge value from each slot's `net_demand` and the recommendation label, independent of and potentially different from the LP's actual `ed[t]` — especially when the battery is capacity-constrained across multiple discharge-labeled slots with different prices.

### Reproduction

```
LP discharge:   [0.938, 2.062]   ← LP optimally rations: more in expensive slot
Greedy discharge: [2.0, 1.0]     ← simulate_soc drains first slot greedily
```

The LP correctly allocates more discharge to the 1.00/kWh slot (saving expensive imports) and less to the 0.30/kWh slot. The greedy simulator does the opposite.

## Solution

**Option (b):** Extend `simulate_soc()` with a `milp_prepopulated` flag that, when `True`, preserves the LP's pre-populated energy flow values verbatim instead of re-deriving them greedily.

1. **`milp_optimizer.py`**: `solve_milp()` now writes `batteries_discharged_kwh`, `grid_import_kwh`, and `grid_export_kwh` from the LP's `ed[t]`, `gi[t]`, `ge[t]` to **all** future slots (previously it only wrote the recommendation label).

2. **`soc_simulation.py`**: `simulate_soc()` gains a keyword-only `milp_prepopulated: bool = False` parameter. When `True`, the simulation uses the slot's existing energy flow values verbatim (skipping the greedy derivation) but still tracks SoC and writes `estimated_battery_capacity_kwh` / `estimated_battery_soc_pct`.

3. **`candidate_selector.py`**: The selector passes `milp_prepopulated=True` for MILP candidates (detected by `candidate.name == CANDIDATE_MILP`).

Non-MILP candidates (no_action, passive, etc.) use the default `milp_prepopulated=False` — their behavior is **unchanged**.

## Tests added

- **`test_milp_discharge_values_preserved_after_soc_simulation`**: Capacity-constrained two-slot scenario — asserts `batteries_discharged_kwh` matches the LP's `ed[t]` after `simulate_soc(milp_prepopulated=True)`.
- **`test_milp_discharge_not_overwritten_without_prepopulated_flag`**: Without the flag, the greedy path still runs (pre-existing behavior preserved).
- **`test_non_milp_candidates_unaffected_by_milp_prepopulated`**: Regression — non-MILP candidates keep using greedy logic exactly as before.

## Quality gates

- ✅ `tox -e lint` — ruff format + ruff check
- ✅ `tox -e typing` — mypy (252 source files, no issues)
- ✅ `tox -e quality` — pyright + vulture (0 errors, 27 pre-existing warnings)
- ⚠️ `tox -e py314` — cannot run due to pre-existing bcrypt/Python 3.14 incompatibility in this environment

## Docs updated

- `docs/milp-optimization.md` — pipeline diagram, post-processing section, new "Energy flow fields written to slots" table
- `docs/planner-spec.md` — new "MILP-pre-populated mode" subsection under SoC simulation
- `.github/memories.md` — issue #637 marked closed; new "MILP Energy Flow Source-of-Truth Rule" section