### PR TITLE
fix(planner): per-EV charger power corruption and shared min-power bugs

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -414,6 +414,26 @@ phase-dependent power calculations.
 
 ---
 
+## Per-EV Output Fields Must Come From Per-EV Data (issue #646)
+
+**Canonical rule**: per-EV output fields (`ev_charger_calculated_power`,
+`ev_second_charger_calculated_power`) **must always** be derived from
+per-EV data — never recompute a per-EV field from a combined/summed-across-
+all-EVs total.
+
+The slot energy fields (`ev_planned_load_kwh`, `ev_accounted_load_kwh`,
+`ev_total_planned_load_kwh`) are the **sum** across both EVs (accumulated
+via `combined_ev_inj` / `combined_ev_raw`).  Using any of these to derive
+a per-EV power value would write the combined total into a single EV's
+field, corrupting the other EV's allocation.
+
+Each EV's power must be computed from that EV's own `EVChargingPlan`
+(`_compute_ev_charger_power()`) or directly by the MILP's per-EV power
+computation.  The post-candidate minimum-power floor check must use
+each EV's own `charger_min_power_w` — never `max(min1, min2)`.
+
+---
+
 ## File Organization — By Responsibility, Not By Theme
 
 AI agents naturally bucket related things together (e.g. "all planner inputs in one file").

--- a/custom_components/hsem/planner/engine_core.py
+++ b/custom_components/hsem/planner/engine_core.py
@@ -1088,84 +1088,100 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
                     f"(EV/battery throttling insufficient)."
                 )
 
-    # Recompute ev_charger_calculated_power from the actual per-slot EV
-    # load after the MILP (or baseline) has finalized the slots.  This
-    # ensures the power field is always consistent with the final load.
+    # Re-apply per-EV minimum-power floor after MILP and fuse throttling.
     #
-    # Also apply the charger_min_power_w floor: if the computed AC power
-    # is below the charger's minimum operating power, zero out the power
-    # and the EV load — the charger physically cannot start, so the
-    # energy will never be delivered.
+    # Both _compute_ev_charger_power() (for non-MILP candidates) and the
+    # MILP's own EV power computation already set ev_charger_calculated_power
+    # and ev_second_charger_calculated_power correctly per-EV, and the
+    # main-fuse throttling block above correctly adjusts them per-field.
+    #
+    # This block checks whether any power field fell below its OWN charger's
+    # minimum operating power due to fuse throttling, and zeroes it if so.
+    # The energy contribution is reverse-engineered from the power field and
+    # subtracted from the combined slot energy totals so net consumption and
+    # cost remain consistent.
+    #
+    # IMPORTANT: This block MUST NOT recompute per-EV power from the combined
+    # ev_planned_load_kwh / ev_accounted_load_kwh totals.  Those fields are
+    # the SUM across both EVs; deriving a per-EV power from them would
+    # corrupt the per-EV output field with the combined total.
     _slot_hours = inp.interval_minutes / 60.0
-    _min_pwr_w = max(
-        inp.ev_planned_load_charger_min_power_w,
-        inp.ev_second_planned_load_charger_min_power_w,
-    )
-    for s in slots:
-        total_ev_ac = s.ev_planned_load_kwh + s.ev_accounted_load_kwh
-        if total_ev_ac < 1e-9:
-            continue
-        # For the current (partially elapsed) slot use remaining time.
-        s_end_tz = as_tz(s.end, now.tzinfo)
-        if as_tz(s.start, now.tzinfo) <= now < s_end_tz:
-            remaining_h = max((s_end_tz - now).total_seconds() / 3600.0, 1.0 / 3600.0)
-            ac_power_w = round((total_ev_ac / remaining_h) * 1000.0)
-            # Cap at the full-slot power — the charger physically
-            # cannot deliver more than its rated power, even if the
-            # MILP allocated a full slot's energy to a partial slot.
-            full_slot_power_w = round((total_ev_ac / _slot_hours) * 1000.0)
-            ac_power_w = min(ac_power_w, full_slot_power_w)
-            log_planner(
-                "debug",
-                "[core] EV power calc: slot=%s total_ev_ac=%.3f remaining_h=%.3f "
-                "ac_power_w=%d full_slot_power_w=%d",
-                s.start.isoformat(),
-                total_ev_ac,
-                remaining_h,
-                ac_power_w,
-                full_slot_power_w,
+    _ev_power_checks: list[tuple[str, float, bool]] = []
+    if inp.ev_planned_load_enabled:
+        _ev_power_checks.append(
+            (
+                "ev_charger_calculated_power",
+                inp.ev_planned_load_charger_min_power_w,
+                inp.ev_planned_load_base_load_includes_ev,
             )
-        else:
-            ac_power_w = round((total_ev_ac / _slot_hours) * 1000.0)
-            log_planner(
-                "debug",
-                "[core] EV power calc: slot=%s total_ev_ac=%.3f ac_power_w=%d (future slot)",
-                s.start.isoformat(),
-                total_ev_ac,
-                ac_power_w,
+        )
+    if inp.ev_second_planned_load_enabled:
+        _ev_power_checks.append(
+            (
+                "ev_second_charger_calculated_power",
+                inp.ev_second_planned_load_charger_min_power_w,
+                inp.ev_second_planned_load_base_load_includes_ev,
             )
+        )
 
-        if _min_pwr_w > 1e-9 and ac_power_w < _min_pwr_w:
-            # Below minimum — charger won't start.  Zero out power,
-            # load, and recommendation so net consumption and cost
-            # reflect reality.
-            log_planner(
-                "debug",
-                "[core] EV power below minimum (%d < %d), zeroing out",
-                ac_power_w,
-                _min_pwr_w,
-            )
-            s.ev_charger_calculated_power = 0
-            s.ev_second_charger_calculated_power = 0
-            s.ev_planned_load_kwh = 0.0
-            s.ev_accounted_load_kwh = 0.0
-            s.ev_total_planned_load_kwh = 0.0
-            s.estimated_net_consumption_kwh = (
-                s.avg_house_consumption_kwh - s.solcast_pv_estimate_kwh
-            )
-            net = s.estimated_net_consumption_kwh
-            if net > 0:
-                s.estimated_cost_currency = round(net * s.price.import_price, 4)
-            else:
-                s.estimated_cost_currency = round(net * s.price.export_price, 4)
-        else:
-            log_planner(
-                "debug",
-                "[core] EV power set to %d W for slot %s",
-                ac_power_w,
-                s.start.isoformat(),
-            )
-            s.ev_charger_calculated_power = ac_power_w
+    for s in slots:
+        for attr, min_pwr_w, base_includes in _ev_power_checks:
+            ev_w = round(getattr(s, attr))
+            if ev_w <= 0:
+                continue
+            if min_pwr_w > 1e-9 and ev_w < min_pwr_w:
+                # Below this EV's own minimum — charger won't start.
+                # Reverse-engineer the energy contribution from the
+                # power field to subtract from combined slot totals.
+                s_end_tz = as_tz(s.end, now.tzinfo)
+                if as_tz(s.start, now.tzinfo) <= now < s_end_tz:
+                    remaining_h = max(
+                        (s_end_tz - now).total_seconds() / 3600.0,
+                        1.0 / 3600.0,
+                    )
+                    ev_energy = round((ev_w / 1000.0) * remaining_h, 3)
+                else:
+                    ev_energy = round((ev_w / 1000.0) * _slot_hours, 3)
+
+                log_planner(
+                    "debug",
+                    "[core] EV power below %s minimum (%d < %d), "
+                    "zeroing field and subtracting %.3f kWh",
+                    attr,
+                    ev_w,
+                    min_pwr_w,
+                    ev_energy,
+                )
+
+                # Zero this EV's power field only (not the other EV's).
+                setattr(s, attr, 0)
+
+                # Remove this EV's energy contribution from the combined
+                # slot energy fields.  The energy bucket depends on whether
+                # base load already includes EV consumption.
+                if base_includes:
+                    s.ev_accounted_load_kwh = round(
+                        max(0.0, s.ev_accounted_load_kwh - ev_energy), 3
+                    )
+                else:
+                    s.ev_planned_load_kwh = round(
+                        max(0.0, s.ev_planned_load_kwh - ev_energy), 3
+                    )
+                s.ev_total_planned_load_kwh = round(
+                    s.ev_planned_load_kwh + s.ev_accounted_load_kwh, 3
+                )
+
+                # Recompute net consumption and cost with the reduced EV load.
+                s.estimated_net_consumption_kwh = (
+                    s.avg_house_consumption_kwh
+                    + s.ev_planned_load_kwh
+                    - s.solcast_pv_estimate_kwh
+                )
+                net = s.estimated_net_consumption_kwh
+                if net > 0:
+                    s.estimated_cost_currency = round(net * s.price.import_price, 4)
+                else:
+                    s.estimated_cost_currency = round(net * s.price.export_price, 4)
 
     _EV_KEEP = frozenset(
         {

--- a/docs/ev-charge-plan-setup.md
+++ b/docs/ev-charge-plan-setup.md
@@ -345,10 +345,13 @@ If you are on a version before this fix, update HSEM.
 
 ### EV charging slots show zero power
 
-The engine post-processing applies a **minimum power floor** (default 1380 W, configurable
-via `hsem_ev_planned_load_charger_min_power_w`). If the computed AC power for a slot is
-below this threshold, the slot's EV fields are zeroed out because the charger physically
-cannot operate below 6 A (230 V × 6 A = 1380 W).
+The engine post-processing applies a **per-EV minimum power floor** (default
+1380 W per EV, configurable via `hsem_ev_planned_load_charger_min_power_w` and
+`hsem_ev_second_planned_load_charger_min_power_w`).  If an EV's computed AC power
+for a slot falls below **its own** threshold, that EV's power field is zeroed
+because the charger physically cannot operate below 6 A (230 V × 6 A = 1380 W).
+Each EV is checked independently against its own minimum — a higher minimum on
+one EV does not affect the other.
 
 ### Deadline is in the past
 

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -1357,20 +1357,30 @@ The EV planner (`planner/ev_planner.py`) MUST satisfy these invariants:
 
     The MILP's decisions are authoritative for all EV charging.
 
-12. **EV charger power field**: `ev_charger_calculated_power` is computed
-    from the per-slot EV AC load (`ev_planned_load_kwh + ev_accounted_load_kwh`)
-    divided by the slot duration in hours.  For the **current** (partially
-    elapsed) slot the divisor is the remaining slot time (minimum 1 s).
+12. **EV charger power fields**: `ev_charger_calculated_power` (primary EV)
+    and `ev_second_charger_calculated_power` (second EV) are each computed
+    **per-EV** from that EV's own charging plan (`EVChargingPlan.charging_slots`)
+    by `_compute_ev_charger_power()` (for non-MILP candidates) or directly by
+    the MILP's EV power computation (for MILP candidates).
 
-    The computation runs **after** the winner is selected (MILP or baseline),
-    ensuring the power field is always consistent with the actual slot load.
-    If the computed power is below `charger_min_power_w` (default 1380 W),
-    the charger physically cannot start — the slot's EV fields are zeroed out
-    (power, load, recommendation, net consumption, cost).
+    The per-EV power fields are set **before** candidate selection and
+    correctly adjusted by the main-fuse throttling block (per-field loop).
 
-    The field is purely a planner output — the applier must read this value
-    to throttle the go-e charger; the planner does not control hardware
-    directly.
+    After candidate selection, a per-EV minimum-power floor check runs:
+    each EV's power field is compared against **its own**
+    `charger_min_power_w`.  If the power fell below that EV's own minimum
+    (due to fuse throttling), only that EV's power field is zeroed, and
+    its energy contribution is reverse-engineered from the power value and
+    subtracted from the combined slot energy totals.
+
+    **Important**: per-EV power fields MUST NOT be recomputed from the
+    combined `ev_planned_load_kwh + ev_accounted_load_kwh` totals, because
+    those fields are the sum across both EVs.  Deriving a per-EV power from
+    a combined total would corrupt the per-EV output with the sum of both
+    EVs' loads.
+
+    The fields are purely planner outputs — the applier must read them to
+    throttle the go-e charger; the planner does not control hardware directly.
 
 ### Invariants for tests
 

--- a/tests/planner/test_ev_planned_load.py
+++ b/tests/planner/test_ev_planned_load.py
@@ -1758,8 +1758,19 @@ class TestEvLoadSemantics:
             f"ev_accounted_load_kwh should be 0 (base excludes EV), got {total_ev_accounted:.3f}"
         )
         assert total_ev_total == pytest.approx(7.0, abs=0.1), (
-            f"ev_total_planned_load_kwh should be 7.0, got {total_ev_total:.3f}"
+            f"ev_total_planned_load_kwh total should be 7.0, got {total_ev_total:.3f}"
         )
+
+        # Per-EV power fields must not exceed each EV's own rated power.
+        for s in out.slots:
+            assert s.ev_charger_calculated_power <= 11000 + 1, (
+                f"Primary EV power {s.ev_charger_calculated_power} W "
+                f"exceeds its rated 11000 W"
+            )
+            assert s.ev_second_charger_calculated_power <= 11000 + 1, (
+                f"Second EV power {s.ev_second_charger_calculated_power} W "
+                f"exceeds its rated 11000 W"
+            )
 
     # ------------------------------------------------------------------
     # Test 3: Two EVs, same slot, base_load_includes_ev=True
@@ -1858,6 +1869,17 @@ class TestEvLoadSemantics:
             f"ev_total_planned_load_kwh total should be 7.0, got {total_ev_total:.3f}"
         )
 
+        # Per-EV power fields must not exceed each EV's own rated power.
+        for s in out.slots:
+            assert s.ev_charger_calculated_power <= 11000 + 1, (
+                f"Primary EV power {s.ev_charger_calculated_power} W "
+                f"exceeds its rated 11000 W"
+            )
+            assert s.ev_second_charger_calculated_power <= 11000 + 1, (
+                f"Second EV power {s.ev_second_charger_calculated_power} W "
+                f"exceeds its rated 11000 W"
+            )
+
         # net consumption must NOT include EV load (no double-count)
         for s in out.slots:
             expected_net = round(
@@ -1953,6 +1975,26 @@ class TestEvLoadSemantics:
         assert out.ev_charging_plan is not None
         assert out.ev_charging_plan.state == "fully_charged"
 
+        # Primary EV power must be 0 (fully charged, no charging allocated).
+        for s in out.slots:
+            assert s.ev_charger_calculated_power == pytest.approx(0.0, abs=1), (
+                f"Primary EV power should be 0 (fully charged), "
+                f"got {s.ev_charger_calculated_power} W"
+            )
+
+        # Second EV power must be positive in at least one slot.
+        second_power_slots = [
+            s for s in out.slots if s.ev_second_charger_calculated_power > 1
+        ]
+        assert second_power_slots, (
+            "Second EV should have non-zero power in at least one slot"
+        )
+        for s in second_power_slots:
+            assert s.ev_second_charger_calculated_power <= 11000 + 1, (
+                f"Second EV power {s.ev_second_charger_calculated_power} W "
+                f"exceeds its rated 11000 W"
+            )
+
     # ------------------------------------------------------------------
     # Test 5: Second EV zero load does not clear primary EV load
     # ------------------------------------------------------------------
@@ -2033,6 +2075,26 @@ class TestEvLoadSemantics:
             f"ev_total_planned_load_kwh should be 3.0 (primary only, second is zero), "
             f"got {total_ev_total:.3f}"
         )
+
+        # Primary EV power must not exceed its rated power.
+        primary_power_slots = [
+            s for s in out.slots if s.ev_charger_calculated_power > 1
+        ]
+        assert primary_power_slots, (
+            "Primary EV should have non-zero power in at least one slot"
+        )
+        for s in primary_power_slots:
+            assert s.ev_charger_calculated_power <= 11000 + 1, (
+                f"Primary EV power {s.ev_charger_calculated_power} W "
+                f"exceeds its rated 11000 W"
+            )
+
+        # Second EV power must be 0 (fully charged).
+        for s in out.slots:
+            assert s.ev_second_charger_calculated_power == pytest.approx(0.0, abs=1), (
+                f"Second EV power should be 0 (fully charged), "
+                f"got {s.ev_second_charger_calculated_power} W"
+            )
 
     # ------------------------------------------------------------------
     # Test 6: Net consumption does not double-count EV when base includes EV
@@ -3030,6 +3092,249 @@ class TestEvChargerCalculatedPower:
         plan = build_ev_charging_plan(inp, starts, ends, surplus, prices)
         assert plan.state == "fully_charged"
         assert len(plan.charging_slots) == 0
+
+
+# ---------------------------------------------------------------------------
+# TestEvChargerPowerFields — regression tests for issue #646
+#
+# These tests assert that per-EV power fields (ev_charger_calculated_power,
+# ev_second_charger_calculated_power) are never corrupted by the combined
+# EV energy totals or by a shared minimum-power threshold.
+# ---------------------------------------------------------------------------
+
+
+class TestEvChargerPowerFields:
+    """Per-EV charger power field correctness tests (issue #646)."""
+
+    def test_two_evs_different_ratings_power_not_corrupted(self):
+        """EV1 (2 kW, min 200 W) + EV2 (11 kW, min 1380 W) in same slot.
+
+        Each EV's ev_charger_calculated_power must not exceed its OWN
+        rated charger power.  Before the fix, the recompute block derived
+        power from the COMBINED energy total and wrote it to only the
+        primary EV's field, which could far exceed its rated 2 kW.
+        """
+        now_iso = "2024-06-15T06:00:00+00:00"
+        from datetime import datetime as _dt2
+
+        now = _dt2.fromisoformat(now_iso)
+        deadline = now + timedelta(hours=6)
+
+        prices = [
+            PricePoint(hour=h, import_price=0.20, export_price=0.05) for h in range(24)
+        ]
+        pv = [SolcastSlot(hour=h, pv_estimate=0.0) for h in range(24)]
+        avgs = [
+            HourlyConsumptionAverage(
+                hour=h, avg_1d=1.0, avg_3d=1.0, avg_7d=1.0, avg_14d=1.0
+            )
+            for h in range(24)
+        ]
+
+        inp = PlannerInput(
+            now_iso=now_iso,
+            interval_minutes=60,
+            interval_length_hours=24,
+            battery_soc_pct=50.0,
+            battery_rated_capacity_kwh=10.0,
+            battery_end_of_discharge_soc_pct=10.0,
+            battery_max_soc_pct=90.0,
+            battery_max_charge_power_w=5000.0,
+            battery_max_discharge_power_w=5000.0,
+            battery_charge_efficiency_pct=100.0,
+            battery_discharge_efficiency_pct=100.0,
+            weight_1d=25,
+            weight_3d=30,
+            weight_7d=30,
+            weight_14d=15,
+            consumption_averages=avgs,
+            price_points=prices,
+            solcast_slots=pv,
+            ev_planned_load_enabled=True,
+            ev_planned_load_connected=True,
+            ev_planned_load_smart_charging_enabled=True,
+            ev_planned_load_current_soc_pct=0.0,
+            ev_planned_load_target_soc_pct=5.0,
+            ev_planned_load_battery_capacity_kwh=100.0,
+            ev_planned_load_charger_power_kw=2.0,
+            ev_planned_load_charger_efficiency_pct=100.0,
+            ev_planned_load_charger_min_power_w=200.0,
+            ev_planned_load_deadline=deadline,
+            ev_planned_load_base_load_includes_ev=False,
+            ev_second_planned_load_enabled=True,
+            ev_second_planned_load_connected=True,
+            ev_second_planned_load_smart_charging_enabled=True,
+            ev_second_planned_load_current_soc_pct=0.0,
+            ev_second_planned_load_target_soc_pct=5.0,
+            ev_second_planned_load_battery_capacity_kwh=100.0,
+            ev_second_planned_load_charger_power_kw=11.0,
+            ev_second_planned_load_charger_efficiency_pct=100.0,
+            ev_second_planned_load_charger_min_power_w=1380.0,
+            ev_second_planned_load_deadline=deadline,
+            ev_second_planned_load_base_load_includes_ev=False,
+        )
+        out = run_planner(inp)
+
+        for s in out.slots:
+            msg_primary = (
+                f"Slot {s.start.hour}: primary EV power "
+                f"{s.ev_charger_calculated_power} W > 2000 W rated. "
+                f"Combined total may have been written to primary field."
+            )
+            assert s.ev_charger_calculated_power <= 2000 + 1, msg_primary
+
+            msg_second = (
+                f"Slot {s.start.hour}: second EV power "
+                f"{s.ev_second_charger_calculated_power} W > 11000 W rated."
+            )
+            assert s.ev_second_charger_calculated_power <= 11000 + 1, msg_second
+
+    def test_second_ev_not_zeroed_by_disabled_primary_min(self):
+        """Second EV with allocation above its own min (200 W) but below
+        the primary EV's min (1380 W).  Primary EV is disabled.
+
+        Before the fix, the shared _min_pwr_w = max(1380, 200) = 1380 W
+        would incorrectly zero the second EV's 500 W allocation.
+        """
+        now_iso = "2024-06-15T06:00:00+00:00"
+        from datetime import datetime as _dt2
+
+        now = _dt2.fromisoformat(now_iso)
+        deadline = now + timedelta(hours=6)
+
+        prices = [
+            PricePoint(hour=h, import_price=0.20, export_price=0.05) for h in range(24)
+        ]
+        pv = [SolcastSlot(hour=h, pv_estimate=0.0) for h in range(24)]
+        avgs = [
+            HourlyConsumptionAverage(
+                hour=h, avg_1d=1.0, avg_3d=1.0, avg_7d=1.0, avg_14d=1.0
+            )
+            for h in range(24)
+        ]
+
+        inp = PlannerInput(
+            now_iso=now_iso,
+            interval_minutes=60,
+            interval_length_hours=24,
+            battery_soc_pct=50.0,
+            battery_rated_capacity_kwh=10.0,
+            battery_end_of_discharge_soc_pct=10.0,
+            battery_max_soc_pct=90.0,
+            battery_max_charge_power_w=5000.0,
+            battery_max_discharge_power_w=5000.0,
+            battery_charge_efficiency_pct=100.0,
+            battery_discharge_efficiency_pct=100.0,
+            weight_1d=25,
+            weight_3d=30,
+            weight_7d=30,
+            weight_14d=15,
+            consumption_averages=avgs,
+            price_points=prices,
+            solcast_slots=pv,
+            ev_planned_load_enabled=False,
+            ev_planned_load_charger_min_power_w=1380.0,
+            ev_second_planned_load_enabled=True,
+            ev_second_planned_load_connected=True,
+            ev_second_planned_load_smart_charging_enabled=True,
+            ev_second_planned_load_current_soc_pct=0.0,
+            ev_second_planned_load_target_soc_pct=0.5,
+            ev_second_planned_load_battery_capacity_kwh=100.0,
+            ev_second_planned_load_charger_power_kw=2.0,
+            ev_second_planned_load_charger_efficiency_pct=100.0,
+            ev_second_planned_load_charger_min_power_w=200.0,
+            ev_second_planned_load_deadline=deadline,
+            ev_second_planned_load_base_load_includes_ev=False,
+        )
+        out = run_planner(inp)
+
+        second_power_slots = [
+            s for s in out.slots if s.ev_second_charger_calculated_power > 1
+        ]
+        assert second_power_slots, (
+            "Second EV should have non-zero power allocation. "
+            "It may have been incorrectly zeroed by the primary EV's "
+            "irrelevant min-power threshold."
+        )
+
+        for s in out.slots:
+            assert s.ev_charger_calculated_power == pytest.approx(0.0, abs=1), (
+                f"Primary EV is disabled but power is {s.ev_charger_calculated_power} W"
+            )
+
+    def test_primary_ev_not_zeroed_by_disabled_second_min(self):
+        """Primary EV with allocation above its own min (200 W) but below
+        the second EV's min (1380 W).  Second EV is disabled.
+
+        Before the fix, the shared _min_pwr_w = max(1380, 200) = 1380 W
+        would incorrectly zero the primary EV's 500 W allocation.
+        """
+        now_iso = "2024-06-15T06:00:00+00:00"
+        from datetime import datetime as _dt2
+
+        now = _dt2.fromisoformat(now_iso)
+        deadline = now + timedelta(hours=6)
+
+        prices = [
+            PricePoint(hour=h, import_price=0.20, export_price=0.05) for h in range(24)
+        ]
+        pv = [SolcastSlot(hour=h, pv_estimate=0.0) for h in range(24)]
+        avgs = [
+            HourlyConsumptionAverage(
+                hour=h, avg_1d=1.0, avg_3d=1.0, avg_7d=1.0, avg_14d=1.0
+            )
+            for h in range(24)
+        ]
+
+        inp = PlannerInput(
+            now_iso=now_iso,
+            interval_minutes=60,
+            interval_length_hours=24,
+            battery_soc_pct=50.0,
+            battery_rated_capacity_kwh=10.0,
+            battery_end_of_discharge_soc_pct=10.0,
+            battery_max_soc_pct=90.0,
+            battery_max_charge_power_w=5000.0,
+            battery_max_discharge_power_w=5000.0,
+            battery_charge_efficiency_pct=100.0,
+            battery_discharge_efficiency_pct=100.0,
+            weight_1d=25,
+            weight_3d=30,
+            weight_7d=30,
+            weight_14d=15,
+            consumption_averages=avgs,
+            price_points=prices,
+            solcast_slots=pv,
+            ev_planned_load_enabled=True,
+            ev_planned_load_connected=True,
+            ev_planned_load_smart_charging_enabled=True,
+            ev_planned_load_current_soc_pct=0.0,
+            ev_planned_load_target_soc_pct=0.5,
+            ev_planned_load_battery_capacity_kwh=100.0,
+            ev_planned_load_charger_power_kw=2.0,
+            ev_planned_load_charger_efficiency_pct=100.0,
+            ev_planned_load_charger_min_power_w=200.0,
+            ev_planned_load_deadline=deadline,
+            ev_planned_load_base_load_includes_ev=False,
+            ev_second_planned_load_enabled=False,
+            ev_second_planned_load_charger_min_power_w=1380.0,
+        )
+        out = run_planner(inp)
+
+        primary_power_slots = [
+            s for s in out.slots if s.ev_charger_calculated_power > 1
+        ]
+        assert primary_power_slots, (
+            "Primary EV should have non-zero power allocation. "
+            "It may have been incorrectly zeroed by the second EV's "
+            "irrelevant min-power threshold."
+        )
+
+        for s in out.slots:
+            assert s.ev_second_charger_calculated_power == pytest.approx(0.0, abs=1), (
+                f"Second EV is disabled but power is "
+                f"{s.ev_second_charger_calculated_power} W"
+            )
 
     def test_fully_charged_when_above_target_even_with_past_target_enabled(self):
         """When SoC is above target and allow_charge_past_target_soc=True,


### PR DESCRIPTION
## Summary

Fixes two bugs in `run_planner()`'s post-candidate recompute block:

1. **Power corruption**: The block derived per-EV charger power from the COMBINED energy total (`ev_planned_load_kwh + ev_accounted_load_kwh`, which is the sum across both EVs) and wrote it to only the primary EV's field (`ev_charger_calculated_power`). When both EVs were active, this caused the primary EV's power field to hold the sum of both EVs' loads, potentially far exceeding its own charger's rated power.

2. **Shared minimum-power floor**: The block used `max(min1, min2)` as a single shared threshold applied to both EVs. This meant one EV's legitimate allocation (above its own minimum) could be incorrectly zeroed because the other EV's minimum happened to be higher, even if that other EV was completely disabled.

## Fix

Replaced the recompute block with a per-EV minimum-power floor check that operates on the existing per-EV power fields (already correctly set by `_compute_ev_charger_power()` for non-MILP candidates, and by the MILP's per-EV power computation for MILP candidates). Each EV is now checked against its own `charger_min_power_w`, and only that EV's fields are zeroed if below its own minimum.

## Changes

- **`custom_components/hsem/planner/engine_core.py`**: Replaced the 80-line recompute block with a 92-line per-EV minimum-power floor check that iterates over active EVs and checks each against its own minimum threshold.

- **`tests/planner/test_ev_planned_load.py`**: 
  - Extended 4 existing two-EV tests to assert per-EV power field invariants
  - Added 3 new tests in `TestEvChargerPowerFields` class:
    - Two EVs with different ratings (2 kW vs 11 kW) and different min-power thresholds
    - Second EV not zeroed by disabled primary EV's higher min-power threshold
    - Primary EV not zeroed by disabled second EV's higher min-power threshold

- **`docs/planner-spec.md`**: Updated invariant #12 to describe the per-EV computation and the prohibition against deriving per-EV power from combined energy totals.

- **`docs/ev-charge-plan-setup.md`**: Updated the "EV charging slots show zero power" troubleshooting section to describe the per-EV floor and reference the second EV's config entity.

- **`.github/memories.md`**: Added canonical warning that per-EV output fields must always be derived from per-EV data.

## Validation

- `tox -e lint`: ✅ passes
- `tox -e typing`: ✅ passes  
- `tox -e quality`: ✅ passes (0 errors, only pre-existing warnings)
- `tox -e py314`: ⚠️ pre-existing bcrypt/PyO3 environment issue prevents test collection (unrelated to this change)
- Smoke tests: ✅ both bugs confirmed fixed via standalone scripts

Fixes #646