### PR TITLE
fix(planner): match cost_function.py pricing to milp_optimizer.py

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -263,6 +263,20 @@ The same principle applies to any valuation that affects the LP's decisions:
 if `cost_function.py` includes it in `score`, the MILP's `c_obj` must include
 it too.  Post-hoc adjustments are for diagnostics only.
 
+**Both sides now fixed and matching (issue #657):** `cost_function.py`'s
+`score_plan()` previously used the OLD flat, uncapped
+`(initial_kwh - final_kwh) * replacement_price_per_kwh` formula (a stale
+copy of the pre-#638 MILP formula) even after `milp_optimizer.py` was fixed
+in PR #656.  It now computes the identical per-slot capped-differential
+term shown above, summed across `batteries_charged_kwh[t]` /
+`batteries_discharged_kwh[t]`.  `score_plan()` also now clamps import price
+via `imp_price_obj = max(imp_price, 0.0)` before pricing `import_cost` and
+both conversion-loss terms — mirroring the MILP's `p_imp_obj` clamp — so a
+negative-price slot never scores as a synthetic profit that the LP itself
+never realises. Always grep both files together when touching any pricing
+term; a mismatch here is easy to introduce silently and hard to notice
+without side-by-side numeric verification using varying (non-flat) prices.
+
 ---
 
 ## EV Charge-Past-Target Valuation (issue #630)

--- a/custom_components/hsem/planner/cost_function.py
+++ b/custom_components/hsem/planner/cost_function.py
@@ -19,12 +19,15 @@ The cost function aggregates eight independently-tunable terms:
 
 Money terms (sum to ``total_cost``):
 
-1. **Import cost** — energy imported from the grid × import price.
+1. **Import cost** — energy imported from the grid × the sanitised
+   (non-negative) import price.  Negative spot prices are clamped to 0 for
+   this term — mirrors ``milp_optimizer.py``'s ``p_imp_obj`` clamp, so a
+   negative price is never scored as a profit for importing (issue #655).
 2. **Export revenue** — energy exported to the grid × export price
    (negative contribution, i.e. revenue reduces total cost).
 3. **Battery conversion loss** — energy lost during a charge/discharge cycle,
-   priced at the *average* of the import and export prices in each slot as a
-   proxy for its opportunity cost.
+   priced at the sanitised (non-negative) import price of its own slot —
+   the price of the energy that was lost.  Same clamp as import cost.
 4. **Battery cycle cost** — depreciation per kWh cycled, derived from the
    battery's purchase price, rated capacity, and expected lifetime cycles.
 
@@ -38,12 +41,19 @@ Selector-only terms (added on top of ``total_cost`` to produce ``score``):
 7. **Override penalty** — per-slot cost added for any slot whose recommendation
    was forced by an override (e.g. read-only mode, manual schedule).  Penalises
    plans that deviate from the hardware's natural optimal state.
-8. **Terminal SoC value** — opportunity cost of the change in battery energy
-   over the horizon, priced at ``replacement_price_per_kwh``.  A plan that
-   ends the horizon with *more* stored energy than it started with receives a
-   *credit* (negative term that reduces ``score``); a plan that empties the
-   battery pays a *penalty* (positive term that increases ``score``).
-   Computed as ``(initial_kwh − final_kwh) × replacement_price_per_kwh``.
+8. **Terminal SoC value** — per-slot opportunity cost of charging/discharging,
+   capped by the differential between ``replacement_price_per_kwh`` and that
+   slot's own sanitised import price:
+   ``terminal_premium[t] = max(0, replacement_price_per_kwh - imp_price_obj[t])``.
+   Discharging a slot incurs ``+terminal_premium[t]`` per kWh; charging earns
+   ``-terminal_premium[t]`` per kWh.  Summed across all slots.  This mirrors
+   ``milp_optimizer.py``'s ``c_obj`` terminal-SoC term exactly, so the
+   selector's score always matches what the LP actually optimised for
+   (issue #655) — when ``replacement_price_per_kwh <= imp_price_obj[t]`` for
+   every slot, this reduces to the same net effect as the old flat
+   ``(initial_kwh − final_kwh) × replacement_price_per_kwh`` formula, but it
+   no longer *over-penalises* discharge in slots where the replacement price
+   does not exceed that slot's own import price.
 
 All monetary values are in the caller's local currency (e.g. DKK or EUR).
 
@@ -225,11 +235,15 @@ class PlanCostBreakdown:
         override_penalty:
             Penalty for forced-override slots.  Selector-only.
         terminal_soc_value:
-            Opportunity cost of the change in stored battery energy across
-            the horizon, priced at ``replacement_price_per_kwh``.  Negative
-            (credit) when the plan ends with *more* stored energy than it
-            started with; positive (penalty) when the plan empties the
-            battery.  Selector-only — does not enter :attr:`total_cost`.
+            Per-slot opportunity cost of charging/discharging, summed across
+            the horizon.  Each slot's contribution is capped by the
+            differential between ``replacement_price_per_kwh`` and that
+            slot's own sanitised import price (mirrors
+            ``milp_optimizer.py``'s terminal-SoC objective term exactly,
+            issue #655).  Negative (credit) when the plan nets more
+            charging than discharging in slots where the differential is
+            positive; positive (penalty) when it nets more discharging.
+            Selector-only — does not enter :attr:`total_cost`.
         total_cost:
             Money outcome of the plan in the horizon.  Equal to
             ``import_cost − export_revenue + cycle_cost + conversion_loss_cost``.
@@ -363,54 +377,6 @@ def _resolve_cycle_cost(weights: CostWeights) -> float:
         return result
 
     log_planner("debug", "[cost] _resolve_cycle_cost  return 0 (insufficient data)")
-    return 0.0
-
-
-# ---------------------------------------------------------------------------
-# Terminal-SoC helper
-# ---------------------------------------------------------------------------
-
-
-def _final_battery_kwh(
-    slots: Sequence[PlannedSlot],
-    now: datetime | None,
-) -> float:
-    """Return the estimated stored battery energy (kWh) at end of horizon.
-
-    Scans *slots* in reverse and returns the ``estimated_battery_capacity``
-    value of the last slot that is still in the future.
-
-    The SoC simulator writes ``estimated_battery_capacity`` as the remaining
-    usable energy above the discharge floor at the *end* of each slot.  Past
-    slots have this field zeroed as a sentinel, so we must explicitly skip
-    them when picking the horizon's terminal SoC.
-
-    Args:
-        slots: Ordered list of planned slots.
-        now: Timezone-aware current datetime.  When provided, slots with
-            ``slot.end <= now`` are skipped.  When ``None``, slots whose
-            recommendation equals the ``TimePassed`` sentinel are skipped.
-
-    Returns:
-        Remaining battery energy above the discharge floor (kWh) at the end
-        of the last future slot, or ``0.0`` when no future slot exists.
-    """
-    _time_passed_value = Recommendations.TimePassed.value
-    for slot in reversed(slots):
-        if now is not None:
-            if slot.end <= now:
-                continue
-        elif slot.recommendation == _time_passed_value:
-            continue
-        result = slot.estimated_battery_capacity_kwh
-        log_planner(
-            "debug",
-            "[cost] _final_battery_kwh  result=%.3f  slot=%s",
-            result,
-            slot.start.isoformat(),
-        )
-        return result
-    log_planner("debug", "[cost] _final_battery_kwh  return 0.0 (no future slot)")
     return 0.0
 
 
@@ -564,6 +530,7 @@ def score_plan(
     soc_penalty = 0.0
     grid_limit_penalty = 0.0
     override_penalty = 0.0
+    terminal_soc_value = 0.0
 
     # Discounted versions for the selector score (total_cost stays raw).
     # time_discount_rate < 1.0 means future savings are worth less.
@@ -619,11 +586,22 @@ def score_plan(
         if math.isnan(exp_price):
             exp_price = 0.0
 
+        # Sanitised (non-negative) import price — mirrors milp_optimizer.py's
+        # p_imp_obj clamp.  A negative spot price must never be scored as a
+        # profit for importing or for lossy conversion: the MILP's own
+        # objective never rewards those events (its gi[t]/ec[t]/ed[t]
+        # coefficients use p_imp_obj = max(p_imp, 0)), so the selector must
+        # value the identical physical decisions the same way, or its score
+        # no longer matches what the LP actually optimised for (issue #655).
+        # The raw (possibly negative) imp_price is still used for export
+        # clamping logic elsewhere and is unaffected by this sanitisation.
+        imp_price_obj = max(imp_price, 0.0)
+
         # 1. Import cost — grid_import_kwh already reflects the extra grid draw
         #    needed to store energy through the charge efficiency (i.e. the
         #    simulation writes grid_import_kwh = charge_stored / charge_eff).
         if slot.grid_import_kwh > 1e-9:
-            cost = slot.grid_import_kwh * imp_price
+            cost = slot.grid_import_kwh * imp_price_obj
             import_cost += cost
             import_cost_disc += cost * discount
 
@@ -645,18 +623,21 @@ def score_plan(
         # 3. Conversion loss cost — opportunity cost of energy lost in the
         #    round-trip.  The loss occurred at purchase time (charge slot) and
         #    at delivery time (discharge slot).  Each side is priced at the
-        #    import price of its own slot — the price of the energy that was
-        #    lost.
+        #    sanitised (non-negative) import price of its own slot — the
+        #    price of the energy that was lost.  Using imp_price_obj here
+        #    (not the raw imp_price) keeps this term consistent with
+        #    milp_optimizer.py's c_obj[ec_off]/c_obj[ed_off], which price
+        #    conversion loss at p_imp_obj (issue #655).
         charge_loss_fraction = 1.0 - charge_eff
         discharge_loss_fraction = 1.0 - discharge_eff
         if slot.batteries_charged_kwh > 1e-9 and charge_loss_fraction > 1e-9:
             lost_kwh_charge = slot.batteries_charged_kwh * charge_loss_fraction
-            conv = lost_kwh_charge * imp_price
+            conv = lost_kwh_charge * imp_price_obj
             conversion_loss_cost += conv
             conversion_loss_cost_disc += conv * discount
         if slot.batteries_discharged_kwh > 1e-9 and discharge_loss_fraction > 1e-9:
             lost_kwh_discharge = slot.batteries_discharged_kwh * discharge_loss_fraction
-            conv = lost_kwh_discharge * imp_price
+            conv = lost_kwh_discharge * imp_price_obj
             conversion_loss_cost += conv
             conversion_loss_cost_disc += conv * discount
 
@@ -699,16 +680,32 @@ def score_plan(
         if _is_override_slot(slot) and abs(weights.override_penalty_per_slot) > 1e-9:
             override_penalty += weights.override_penalty_per_slot
 
-    # 8. Terminal-SoC opportunity cost (selector-only).
-    terminal_soc_value = 0.0
-    if (
-        initial_battery_kwh is not None
-        and replacement_price_per_kwh is not None
-        and abs(replacement_price_per_kwh) > 1e-9
-    ):
-        final_battery_kwh = _final_battery_kwh(slots, now)
-        delta_kwh = initial_battery_kwh - final_battery_kwh
-        terminal_soc_value = delta_kwh * replacement_price_per_kwh
+        # 8. Terminal-SoC opportunity cost (selector-only).
+        #
+        # Per-slot incentive capped by the opportunity-cost DIFFERENTIAL
+        # between the replacement price and this slot's own (sanitised)
+        # import price — mirrors milp_optimizer.py's terminal_premium term
+        # exactly, so the selector's score matches what the LP actually
+        # optimised for (issue #655).  When replacement_price <=
+        # imp_price_obj[t], the premium is zero: charging/discharging in
+        # that slot is not discouraged or encouraged by terminal-SoC alone.
+        # Charging (batteries_charged_kwh) earns a credit; discharging
+        # (batteries_discharged_kwh) incurs a penalty.  Undiscounted —
+        # matches milp_optimizer.py's treatment of this term.
+        #
+        # Gated on initial_battery_kwh as well (even though this per-slot
+        # formula no longer needs its value) to preserve the documented
+        # enablement contract: terminal-SoC accounting requires BOTH
+        # initial_battery_kwh and replacement_price_per_kwh to be provided.
+        if (
+            initial_battery_kwh is not None
+            and replacement_price_per_kwh is not None
+            and abs(replacement_price_per_kwh) > 1e-9
+        ):
+            terminal_premium = max(0.0, replacement_price_per_kwh - imp_price_obj)
+            terminal_soc_value += (
+                slot.batteries_discharged_kwh - slot.batteries_charged_kwh
+            ) * terminal_premium
 
     # ``total_cost`` is money only — never includes synthetic penalties.
     total_cost = import_cost - export_revenue + conversion_loss_cost + cycle_cost_total

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -766,31 +766,46 @@ Plans must not look better merely because they empty the battery before the
 horizon ends.
 
 The cost function implements this via a `terminal_soc_value` term that
-contributes to `score` (not to `total_cost`):
+contributes to `score` (not to `total_cost`).  It is computed **per slot**
+and summed across the horizon, mirroring `milp_optimizer.py`'s `c_obj`
+terminal-SoC term exactly (issue #655/#657) so the selector's score always
+matches what the LP actually optimised for:
 
 ```text
-initial_kwh = stored battery energy above the discharge floor at the start of the horizon
-final_kwh   = stored battery energy above the discharge floor at the end of the horizon
-            (taken from the last future slot's estimated_battery_capacity)
-delta_kwh   = initial_kwh - final_kwh
+imp_price_obj[t]     = max(slot.price.import_price, 0.0)
+terminal_premium[t]  = max(0, replacement_price_per_kwh - imp_price_obj[t])
 
-terminal_soc_value = delta_kwh * replacement_price_per_kwh
+terminal_soc_value = sum over all slots of:
+    (batteries_discharged_kwh[t] - batteries_charged_kwh[t]) * terminal_premium[t]
 ```
 
-Sign convention:
+Sign convention (per slot):
 
-- `delta_kwh < 0` (plan ends with **more** energy than it started with) →
-  `terminal_soc_value < 0` → **credit**, reduces `score`.
-- `delta_kwh > 0` (plan ends with **less** energy) →
-  `terminal_soc_value > 0` → **penalty**, increases `score`.
+- Charging (`batteries_charged_kwh[t] > 0`) contributes a **negative**
+  (credit) term, reducing `score`.
+- Discharging (`batteries_discharged_kwh[t] > 0`) contributes a **positive**
+  (penalty) term, increasing `score`.
+
+The per-slot premium is capped by the differential between
+`replacement_price_per_kwh` and that slot's own sanitised import price.  When
+`replacement_price_per_kwh <= imp_price_obj[t]`, the premium is zero for that
+slot - charging/discharging then has no terminal-SoC effect, because the LP
+saw no genuine opportunity cost either.  This prevents the selector from
+over-penalising discharge in cheap-import slots, matching the MILP exactly.
 
 The recommended `replacement_price_per_kwh` is the **minimum future import
 price across the planning horizon**.  This represents the marginal cost of
-re-purchasing one stored kWh at the cheapest available opportunity — the
+re-purchasing one stored kWh at the cheapest available opportunity - the
 economically correct proxy for the opportunity cost of consuming stored energy
 now rather than later.  Using the average over all future slots (including
 expensive peak prices) systematically over-values stored energy during
 high-price periods and biases the selector against discharging.
+
+Import prices are sanitised the same way as the MILP's own objective
+(`imp_price_obj = max(imp_price, 0.0)`) before being used anywhere in
+`score_plan` - including the import-cost term itself and the
+conversion-loss term - so a negative-price slot never scores as a synthetic
+profit when the LP itself never realises one.
 
 Terminal-SoC accounting is **only active** when both `initial_battery_kwh`
 and `replacement_price_per_kwh` are supplied to `score_plan`.  Unit tests

--- a/tests/planner/test_cost_function.py
+++ b/tests/planner/test_cost_function.py
@@ -169,13 +169,20 @@ class TestImportCost:
         bd = score_plan([slot], CostWeights())
         assert bd.import_cost == pytest.approx(0.0)
 
-    def test_negative_import_price_reduces_cost(self):
-        """Negative import price (surplus grid) reduces total cost."""
+    def test_negative_import_price_clamped_to_zero_cost(self):
+        """Negative import price is sanitised to zero, not treated as profit.
+
+        Mirrors ``milp_optimizer.py``'s ``p_imp_obj = max(p_imp, 0.0)``
+        clamp (issue #635/#657): the LP never earns a synthetic profit from
+        importing during a negative-price slot, so ``score_plan`` must not
+        either, or the selector's score would diverge from what the LP
+        actually optimised for.
+        """
         slot = _make_slot(import_price=-0.05, grid_import_kwh=2.0)
         bd = score_plan([slot], CostWeights())
-        # import_cost = 2.0 × −0.05 = −0.10
-        assert bd.import_cost == pytest.approx(-0.10)
-        assert bd.total < 0.0
+        # import_cost = 2.0 × max(−0.05, 0.0) = 0.0
+        assert bd.import_cost == pytest.approx(0.0)
+        assert bd.total == pytest.approx(0.0)
 
     def test_multiple_slots_summed(self):
         """Import cost is accumulated across all slots."""

--- a/tests/planner/test_cost_score_split.py
+++ b/tests/planner/test_cost_score_split.py
@@ -149,12 +149,26 @@ class TestTerminalSoCCredit:
     """A plan ending with more stored energy receives a credit (negative)."""
 
     def test_credit_when_battery_grows(self) -> None:
-        """Final capacity > initial → terminal_soc_value < 0 → reduces score."""
-        # Two slots; the second is "future" with estimated_battery_capacity_kwh=8.
-        # Initial energy above floor = 3 kWh; final = 8 kWh.
-        # delta = 3 − 8 = −5; with replacement 0.30 DKK/kWh → −1.50.
+        """Charging with a net capacity gain → terminal_soc_value < 0 → reduces score.
+
+        The terminal-SoC term is computed per-slot, capped by the
+        differential between ``replacement_price_per_kwh`` and that slot's
+        own import price (issue #655) — it must match
+        ``milp_optimizer.py``'s identical formula.  Using ``import_price=0.0``
+        makes the differential equal to the full replacement price, so the
+        expected numbers below match what the flat pre-#655 formula would
+        have produced for this scenario, while still exercising the new
+        per-slot, flow-based calculation (``batteries_charged_kwh``) rather
+        than an ungrounded ``estimated_battery_capacity_kwh`` that no real
+        SoC simulation would ever produce on its own.
+        """
+        # Battery charges 5 kWh this slot (3 -> 8 kWh); price 0.30 DKK/kWh.
+        # terminal_premium = max(0, 0.30 - 0.0) = 0.30.
+        # terminal_soc_value = (discharged - charged) * premium = (0 - 5) * 0.30 = -1.50.
         slot = _make_slot(
+            import_price=0.0,
             grid_import_kwh=1.0,
+            batteries_charged_kwh=5.0,
             estimated_battery_capacity_kwh=8.0,
             estimated_battery_soc_pct=80.0,
         )
@@ -166,18 +180,25 @@ class TestTerminalSoCCredit:
 
         assert bd.terminal_soc_value == pytest.approx(-1.50, abs=1e-9)
         # Money cost is unaffected.
-        assert bd.total_cost == pytest.approx(0.20, abs=1e-9)
+        assert bd.total_cost == pytest.approx(0.0, abs=1e-9)
         # Score includes the credit.
-        assert bd.score == pytest.approx(0.20 - 1.50, abs=1e-9)
+        assert bd.score == pytest.approx(0.0 - 1.50, abs=1e-9)
 
 
 class TestTerminalSoCPenalty:
     """A plan ending with less stored energy pays a penalty (positive)."""
 
     def test_penalty_when_battery_empties(self) -> None:
-        """Final capacity < initial → terminal_soc_value > 0 → increases score."""
-        # Initial 8 kWh; final 1 kWh → delta = 7; price 0.40 → penalty = 2.80.
+        """Discharging with a net capacity loss → terminal_soc_value > 0 → increases score.
+
+        Using ``import_price=0.0`` makes the per-slot differential equal to
+        the full replacement price, matching the pre-#655 flat formula's
+        numbers for this scenario while exercising the new per-slot
+        calculation.
+        """
+        # Initial 8 kWh; discharges 7 kWh -> final 1 kWh; price 0.40 -> penalty = 2.80.
         slot = _make_slot(
+            import_price=0.0,
             grid_import_kwh=0.0,
             batteries_discharged_kwh=7.0,
             estimated_battery_capacity_kwh=1.0,
@@ -264,18 +285,31 @@ class TestComparePlansUsesScore:
         76.5 DKK) but different end-of-horizon battery capacity.  Cycle and
         conversion-loss terms are disabled by setting the relevant weights
         to zero so the test isolates the terminal-SoC behaviour.
+
+        The terminal-SoC term is a per-slot ``batteries_charged_kwh`` /
+        ``batteries_discharged_kwh`` differential capped by
+        ``replacement_price_per_kwh - imp_price_obj`` (mirrors
+        ``milp_optimizer.py`` exactly, issue #655/#657).  ``import_price`` is
+        set to ``0.0`` on both slots so the cap never bites and the
+        differential equals the full ``replacement_price_per_kwh``, matching
+        the flat-formula expected values below.
         """
         # Both plans: same import cost; same SoC %.  Difference: final
-        # estimated_battery_capacity_kwh.
+        # estimated_battery_capacity_kwh, driven by the matching
+        # batteries_charged_kwh / batteries_discharged_kwh flow fields.
         discharge_only_last_slot = _make_slot(
             hour=23,
+            import_price=0.0,
             grid_import_kwh=76.5,
+            batteries_discharged_kwh=4.5,  # 5.0 -> 0.5
             estimated_battery_capacity_kwh=0.5,  # nearly empty
             estimated_battery_soc_pct=15.0,
         )
         solar_only_last_slot = _make_slot(
             hour=23,
+            import_price=0.0,
             grid_import_kwh=76.5,
+            batteries_charged_kwh=4.0,  # 5.0 -> 9.0
             estimated_battery_capacity_kwh=9.0,  # ends nearly full
             estimated_battery_soc_pct=95.0,
         )
@@ -311,9 +345,23 @@ class TestComparePlansUsesScore:
         )
 
     def test_score_strictly_lower_when_battery_preserved(self) -> None:
-        """A plan that preserves more battery energy must score strictly lower."""
-        slot_a = _make_slot(grid_import_kwh=1.0, estimated_battery_capacity_kwh=4.0)
-        slot_b = _make_slot(grid_import_kwh=1.0, estimated_battery_capacity_kwh=1.0)
+        """A plan that preserves more battery energy must score strictly lower.
+
+        ``import_price`` is set to ``0.0`` so the terminal-SoC differential
+        cap never bites and equals the full ``replacement_price_per_kwh``.
+        """
+        slot_a = _make_slot(
+            import_price=0.0,
+            grid_import_kwh=1.0,
+            batteries_charged_kwh=2.0,  # 2.0 -> 4.0
+            estimated_battery_capacity_kwh=4.0,
+        )
+        slot_b = _make_slot(
+            import_price=0.0,
+            grid_import_kwh=1.0,
+            batteries_discharged_kwh=1.0,  # 2.0 -> 1.0
+            estimated_battery_capacity_kwh=1.0,
+        )
         bd_a, bd_b, winner = compare_plans(
             [slot_a],
             [slot_b],
@@ -346,8 +394,13 @@ class TestTotalAlias:
         assert bd.total == pytest.approx(bd.score, abs=1e-9)
 
     def test_total_alias_includes_terminal_soc(self) -> None:
+        """``import_price`` stays at the default (0.20) here: the credit only
+        needs to be negative, not equal to the flat-formula value, so the
+        differential cap doesn't need to be avoided.
+        """
         slot = _make_slot(
             grid_import_kwh=1.0,
+            batteries_charged_kwh=6.0,  # 2.0 -> 8.0
             estimated_battery_capacity_kwh=8.0,
             estimated_battery_soc_pct=80.0,
         )

--- a/tests/planner/test_milp_optimizer.py
+++ b/tests/planner/test_milp_optimizer.py
@@ -409,6 +409,86 @@ def test_milp_cycle_cost_matches_score_plan():
     )
 
 
+@_scipy_skip()
+def test_milp_terminal_soc_matches_score_plan_with_varying_prices():
+    """Regression for issue #657.
+
+    score_plan()'s terminal-SoC term must use the SAME per-slot,
+    price-differential-capped formula as solve_milp()'s c_obj terminal-SoC
+    term. Flat/uniform prices cannot distinguish the old (buggy) flat
+    delta formula from the correct per-slot capped-differential formula --
+    both produce identical numbers when price is constant. This test uses
+    three DISTINCT, varying per-slot import prices spanning a range both
+    above and below the replacement price, which only the correct per-slot
+    formula reproduces exactly.
+    """
+    replacement_price = 1.00
+    # Slot 0: import price BELOW replacement price -> full premium applies.
+    # Slot 1: import price ABOVE replacement price -> premium capped to 0.
+    # Slot 2: import price EXACTLY at replacement price -> premium is 0.
+    slots = [
+        _make_slot(hour=0, import_price=0.20, consumption_kwh=0.0),
+        _make_slot(hour=1, import_price=2.00, consumption_kwh=0.0),
+        _make_slot(hour=2, import_price=1.00, consumption_kwh=0.0),
+    ]
+
+    milp_result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=5.0,
+        usable_kwh=9.0,
+        max_charge_per_slot=5.0,
+        max_discharge_per_slot=5.0,
+        cycle_cost_per_kwh=0.0,
+        charge_efficiency_pct=100.0,
+        discharge_efficiency_pct=100.0,
+        replacement_price_per_kwh=replacement_price,
+    )
+    assert milp_result is not None, "MILP must return a solution"
+    result, _diag = milp_result
+
+    simulate_soc(
+        result,
+        _NOW,
+        current_kwh=5.0,
+        usable_kwh=9.0,
+        max_capacity_kwh=9.0,
+        max_charge_per_slot=5.0,
+        max_discharge_per_slot=5.0,
+        rated_kwh=10.0,
+        end_of_discharge_soc_pct=0.0,
+    )
+
+    # Compute the expected terminal-SoC value directly from the MILP's own
+    # per-slot capped-differential formula, using the realised SoC-simulated
+    # charge/discharge flows.
+    expected_terminal_soc_value = 0.0
+    for s in result:
+        imp_price_obj = max(s.price.import_price, 0.0)
+        terminal_premium = max(0.0, replacement_price - imp_price_obj)
+        expected_terminal_soc_value += (
+            s.batteries_discharged_kwh - s.batteries_charged_kwh
+        ) * terminal_premium
+
+    bd = score_plan(
+        result,
+        CostWeights(cycle_cost_per_kwh=0.0),
+        slot_duration_hours=1.0,
+        now=_NOW,
+        initial_battery_kwh=5.0,
+        replacement_price_per_kwh=replacement_price,
+    )
+
+    assert bd.terminal_soc_value == pytest.approx(
+        expected_terminal_soc_value, abs=1e-6
+    ), (
+        f"score_plan terminal_soc_value {bd.terminal_soc_value:.6f} does not "
+        f"match the MILP's own per-slot capped-differential formula "
+        f"{expected_terminal_soc_value:.6f} -- cost_function.py and "
+        f"milp_optimizer.py have diverged (issue #657)."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Performance test
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`cost_function.py::score_plan()` (the selector's scoring function) used different pricing formulas than `milp_optimizer.py::solve_milp()` (the LP's objective) for the same physical decisions — violating this repo's documented invariant in `.github/memories.md`: *"if `cost_function.py` includes it in `score`, the MILP's `c_obj` must include it too."*

PR #656 fixed `milp_optimizer.py` for issues #635 and #638, but the matching fixes were never applied to `cost_function.py`, leaving the two functions silently mismatched.

Fixes #657

## What changed

- **`custom_components/hsem/planner/cost_function.py`**
  - Added `imp_price_obj = max(imp_price, 0.0)` per slot, mirroring the MILP's `p_imp_obj` clamp.
  - `import_cost` and both conversion-loss terms now use `imp_price_obj` instead of the raw (possibly negative) import price — a negative-price import now scores as zero cost, not a synthetic profit.
  - Replaced the flat, uncapped terminal-SoC formula `(initial_kwh - final_kwh) * replacement_price_per_kwh` with the per-slot, price-differential-capped formula computed inside the main per-slot loop:
    ```python
    terminal_premium = max(0.0, replacement_price_per_kwh - imp_price_obj)
    terminal_soc_value += (batteries_discharged_kwh - batteries_charged_kwh) * terminal_premium
    ```
    This exactly mirrors `milp_optimizer.py`'s `c_obj` terminal-SoC term.
  - Removed the now-unused `_final_battery_kwh()` helper (confirmed zero remaining callers).
  - Updated all docstrings describing the old formulas.
- **`docs/planner-spec.md`** — updated the "Terminal SoC value" section under "Cost function" to describe the corrected per-slot formula (the MILP section already described it correctly from PR #656; the two sections were inconsistent).
- **`.github/memories.md`** — documented that both `cost_function.py` and `milp_optimizer.py` are now fixed and matching.
- **Tests**:
  - `tests/planner/test_cost_function.py` — `test_negative_import_price_reduces_cost` asserted the buggy "negative price = profit" behavior; rewritten as `test_negative_import_price_clamped_to_zero_cost` asserting the corrected clamp.
  - `tests/planner/test_cost_score_split.py` — 3 tests asserted the old flat terminal-SoC formula's numeric expectations without setting `batteries_charged_kwh`/`batteries_discharged_kwh` consistently with the narrated capacity change (a state real `simulate_soc()` output never produces). Fixed by adding matching flow fields and pinning `import_price=0.0` where the test needs the differential to equal the full replacement price.
  - `tests/planner/test_milp_optimizer.py` — added `test_milp_terminal_soc_matches_score_plan_with_varying_prices`, a new regression test using **three distinct, varying per-slot import prices** (spanning both above and below the replacement price) that numerically proves `score_plan()` and `solve_milp()` now agree on terminal-SoC valuation for the same plan. A flat-price test would not catch this bug class, since the old and new formulas only coincide when price is uniform.

## Acceptance criteria

- [x] `score_plan()` clamps import price via `imp_price_obj = max(imp_price, 0.0)` before pricing `import_cost` and both conversion-loss terms.
- [x] `score_plan()`'s terminal-SoC term is computed per-slot using the capped differential formula, matching `milp_optimizer.py`'s `c_obj` term exactly.
- [x] `_final_battery_kwh()` helper removed.
- [x] Docstrings in `cost_function.py` updated.
- [x] `docs/planner-spec.md` updated and consistent with the MILP section.
- [x] `.github/memories.md` updated.
- [x] All existing tests pass with corrected expected values (not weakened assertions).
- [x] New regression test added using varying, non-flat import prices.
- [x] Full test suite: zero new failures beyond the documented pre-existing baseline (verified via stash/pop diff against clean `main`: 14 pre-existing failures before and after, +1 new passing test).
- [x] `tox -e lint`, `tox -e typing`, `tox -e quality` all pass with zero new warnings/errors.

## Validation

- `python -m pytest tests/ -o addopts=""` — **2369 passed**, 14 failed (all pre-existing/documented, confirmed identical via `git stash`/`pop` diff against clean `main`), 31 skipped, 10 xfailed.
- `tox -e lint` — pass (ruff format + ruff check).
- `tox -e typing` — pass (mypy, 0 issues in 252 source files).
- `tox -e quality` — pass (pyright: 0 errors, 26 pre-existing warnings unrelated to this change; vulture: pass).

Note: `cost_function.py` was already over the repo's 30 KB soft-limit guideline before this change (~34.5 KB) and grows slightly further here (~35.7 KB). It is not currently in the tracked oversized-files list (`engine.py` #441, `charge_scheduler.py` #442, `coordinator.py` #443); splitting it is out of scope for this bug fix per the "don't refactor unrelated code" rule, but may be worth a follow-up issue.
