### PR TITLE
fix(milp): merge energy-flow write-out loops and guard degenerate-vertex resolution

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -446,15 +446,21 @@ formulation itself, not a downstream patch.
 When the LP write-out path resolves a degenerate/ambiguous solution (the
 mutex / "Bug J" simultaneous charge+discharge resolution), **every**
 downstream field derived from that slot's energy flow — charge, discharge,
-grid import, grid export — must come from the **same resolved decision**.
+grid import, grid export — must come from the **same resolved decision**
+and must be written in the same loop iteration.
 
 **Never** re-read from raw, pre-resolution LP arrays (``ed_sol``,
 ``gi_sol``, ``ge_sol``) in a separate pass.  The raw LP values were
 computed under the original (possibly now-invalid) ec/ed combination and
 will not satisfy the energy balance once ec/ed are adjusted.
 
-All four energy-flow fields must be written in the same loop iteration
-that performs the resolution.
+**Penalty-guarded net preservation**: When collapsing a degenerate vertex
+to its net direction (ec − ed), the LP's SoC penalty variables
+(``s_max_pen[t]``, ``s_min_pen[t]``) must be checked first.  If either
+penalty is active (``> 1e-6``), the vertex sits at a SoC bound where
+ec≈ed is solver noise — both ec and ed must be zeroed.  Preserving the
+net residual at a penalty-bound slot would inject a spurious charge or
+discharge into a battery that is already at its capacity limit.
 
 ---
 

--- a/.github/memories.md
+++ b/.github/memories.md
@@ -417,10 +417,13 @@ Always check `docs/huawei_entities.md` before looking elsewhere.
 
 ## MILP Energy Flow Source-of-Truth Rule (issue #637)
 
-`solve_milp()` now writes **every** per-slot energy flow field directly from
-the LP solution: `batteries_discharged_kwh`, `grid_import_kwh`, and
-`grid_export_kwh`.  These are the **source of truth** for MILP-sourced
-candidates.
+`solve_milp()` writes **every** per-slot energy flow field
+(`batteries_charged_kwh`, `batteries_discharged_kwh`, `grid_import_kwh`,
+`grid_export_kwh`) from a **single merged write-out pass** that first
+resolves degenerate LP vertices (simultaneous charge+discharge) and then
+derives grid import/export from the slot's energy balance equation using
+the **same resolved** ec/ed values.  There is no second pass that reads
+raw LP arrays independently.
 
 - `simulate_soc()` accepts an optional `milp_prepopulated=True` parameter.
   When ``True``, it preserves the LP's pre-populated energy flow values
@@ -437,6 +440,21 @@ LP-derived per-slot energy flows (``batteries_discharged_kwh``,
 ``grid_import_kwh``, ``grid_export_kwh``) on MILP-sourced slots.
 If a step needs to adjust these values, it must be part of the LP
 formulation itself, not a downstream patch.
+
+### Degenerate-Vertex Consistency Rule (issue #659)
+
+When the LP write-out path resolves a degenerate/ambiguous solution (the
+mutex / "Bug J" simultaneous charge+discharge resolution), **every**
+downstream field derived from that slot's energy flow — charge, discharge,
+grid import, grid export — must come from the **same resolved decision**.
+
+**Never** re-read from raw, pre-resolution LP arrays (``ed_sol``,
+``gi_sol``, ``ge_sol``) in a separate pass.  The raw LP values were
+computed under the original (possibly now-invalid) ec/ed combination and
+will not satisfy the energy balance once ec/ed are adjusted.
+
+All four energy-flow fields must be written in the same loop iteration
+that performs the resolution.
 
 ---
 

--- a/custom_components/hsem/planner/milp_optimizer.py
+++ b/custom_components/hsem/planner/milp_optimizer.py
@@ -146,10 +146,12 @@ def solve_milp(
       ``ForceBatteriesDischarge``, or ``None`` (idle).
     - ``batteries_charged_kwh`` — energy entering the battery this slot (kWh).
     - ``batteries_discharged_kwh`` — energy discharged from the battery this slot
-      (kWh).  Populated directly from the LP's ``ed[t]`` solution — this is the
-      source of truth and must not be re-derived by :func:`~soc_simulation.simulate_soc`.
-    - ``grid_import_kwh`` — grid import this slot (kWh), from the LP's ``gi[t]``.
-    - ``grid_export_kwh`` — grid export this slot (kWh), from the LP's ``ge[t]``.
+      (kWh).  Derived from the **resolved** ed after mutex resolution — this is the
+      source of truth and must not be re-derived by the SoC simulation.
+    - ``grid_import_kwh`` — grid import this slot (kWh), derived from the energy
+      balance equation using the resolved ec/ed values.
+    - ``grid_export_kwh`` — grid export this slot (kWh), derived from the energy
+      balance equation using the resolved ec/ed values.
     - ``ev_planned_load_kwh`` — EV AC load that must be added to base consumption
       (when ``ev_configs`` is provided and ``base_load_includes_ev`` is False).
     - ``ev_accounted_load_kwh`` — EV AC load already captured in house consumption
@@ -1092,18 +1094,60 @@ def solve_milp(
                 if float(ev_c_sol[lp_t]) >= _MIN_ACTION_KWH:
                     ev_charging_slots.add(lp_t)
 
+    # Pre-compute per-slot total EV AC load from the LP solution.
+    # Needed for deriving grid import/export from the energy balance
+    # equation when mutex resolution alters ec/ed (issue #659):
+    #   gi + pv + ed·η_dis = base_load + ec/η_chg + ge + curt + Σ ev_c/eff
+    ev_ac_load_by_slot: dict[int, float] = {}
+    if active_evs:
+        for ev_idx, ev in enumerate(active_evs):
+            ev_off = ev_var_offsets[ev_idx]
+            ev_c_sol = result.x[ev_off : ev_off + m]
+            for lp_t in range(m):
+                ev_dc = float(ev_c_sol[lp_t])
+                if ev_dc >= _MIN_ACTION_KWH:
+                    ev_ac_load_by_slot[lp_t] = (
+                        ev_ac_load_by_slot.get(lp_t, 0.0)
+                        + ev_dc / ev.charger_efficiency
+                    )
+
+    # Extract curtailment solution early — needed for the energy balance
+    # derivation in the merged write-out loop below.
+    curt_sol_full = result.x[curt_off : curt_off + m]
+
+    # ------------------------------------------------------------------
+    # Single merged energy-flow write-out pass (issue #659).
+    #
+    # Resolves degenerate LP vertices (simultaneous charge+discharge),
+    # sets recommendation, and populates ALL per-slot energy-flow fields
+    # (charge, discharge, grid import, grid export) consistently from
+    # the SAME resolved ec/ed decision.  Grid import/export are derived
+    # from the slot's energy balance equation rather than read from the
+    # raw LP arrays, so they remain correct even when ec/ed are adjusted
+    # by the mutex resolution.
+    #
+    # The SoC simulation (simulate_soc) must use these verbatim when
+    # milp_prepopulated=True — never re-derive a different (greedy)
+    # value from the recommendation label and net_demand.
+    # ------------------------------------------------------------------
     for lp_t, slot_i in enumerate(future_idx):
         ec_kwh = float(ec_sol[lp_t])
         ed_kwh = float(ed_sol[lp_t])
-        ge_kwh = float(result.x[ge_off + lp_t])  # grid export from LP
+        ge_kwh = float(result.x[ge_off + lp_t])  # raw LP export (for recommendation)
 
         if ec_kwh > _MIN_ACTION_KWH and ed_kwh > _MIN_ACTION_KWH:
             # Mutual exclusion is guaranteed by the LP constraint
             # (ec/max_charge + ed/max_dis <= 1).  If we reach here,
-            # it is due to numerical tolerance.  Resolve by checking
-            # whether the round-trip is net profitable (Bug J fix).
-            # The value of discharging is avoided import (p_imp),
-            # not export revenue (p_exp).
+            # it is due to numerical tolerance at a degenerate LP
+            # vertex.  Resolve by checking whether the round-trip is
+            # net profitable (Bug J fix).  The value of discharging is
+            # avoided import (p_imp), not export revenue (p_exp).
+            #
+            # When the round-trip is NOT profitable, collapse the
+            # degenerate vertex to its net direction instead of
+            # zeroing both — the LP expressed a net charge or
+            # discharge through the vertex and that net effect must
+            # be preserved (issue #659).
             net_charge_profit = (
                 p_imp[lp_t] * discharge_eff
                 - p_imp[lp_t] / charge_eff
@@ -1111,9 +1155,14 @@ def solve_milp(
             )
             if net_charge_profit > 0:
                 ed_kwh = 0.0
-            else:
-                ec_kwh = 0.0
+            elif ec_kwh > ed_kwh:
+                # Net charge: keep the delta, zero the discharge
+                ec_kwh = ec_kwh - ed_kwh
                 ed_kwh = 0.0
+            else:
+                # Net discharge (or equal): keep the delta, zero the charge
+                ed_kwh = ed_kwh - ec_kwh
+                ec_kwh = 0.0
 
         if ec_kwh > _MIN_ACTION_KWH:
             # Use BatteriesChargeSolar when PV surplus is available,
@@ -1139,7 +1188,6 @@ def solve_milp(
                     out_slots[
                         slot_i
                     ].recommendation = Recommendations.BatteriesChargeGrid.value
-            out_slots[slot_i].batteries_charged_kwh = round(ec_kwh, 3)
         elif ed_kwh > _MIN_ACTION_KWH:
             # If the LP is exporting (ge > 0) in this slot, use
             # ForceBatteriesDischarge to signal that the battery should
@@ -1153,22 +1201,37 @@ def solve_milp(
                     slot_i
                 ].recommendation = Recommendations.BatteriesDischargeMode.value
 
-    # ------------------------------------------------------------------
-    # Write LP-derived energy flow fields to ALL future slots.
-    #
-    # These are the source of truth for batteries_discharged_kwh,
-    # grid_import_kwh, and grid_export_kwh.  The SoC simulation
-    # (simulate_soc) must use these verbatim when milp_prepopulated=True
-    # — never re-derive a different (greedy) value from the
-    # recommendation label and net_demand.
-    # ------------------------------------------------------------------
-    for lp_t, slot_i in enumerate(future_idx):
-        ed_val = float(ed_sol[lp_t])
-        gi_val = float(result.x[gi_off + lp_t])
-        ge_val = float(result.x[ge_off + lp_t])
-        out_slots[slot_i].batteries_discharged_kwh = round(max(ed_val, 0.0), 3)
-        out_slots[slot_i].grid_import_kwh = round(max(gi_val, 0.0), 3)
-        out_slots[slot_i].grid_export_kwh = round(max(ge_val, 0.0), 3)
+        # Write resolved charge/discharge kWh fields consistently.
+        resolved_charge = round(max(ec_kwh, 0.0), 3)
+        resolved_discharge = round(max(ed_kwh, 0.0), 3)
+        out_slots[slot_i].batteries_charged_kwh = resolved_charge
+        out_slots[slot_i].batteries_discharged_kwh = resolved_discharge
+
+        # Derive grid import/export from the slot's energy balance using
+        # the SAME resolved (rounded) charge/discharge values stored in
+        # the slot fields.  This guarantees the equality
+        #   gi + pv + ed·η_dis = house_load + ec/η_chg + ge
+        # holds exactly at 3-decimal precision.
+        #
+        # LP energy balance:  gi + pv + ed·η_dis
+        #     = base_load + ec/η_chg + ge + curt + Σ ev_c/eff
+        # ⇒ gi − ge = base_load + ec/η_chg − ed·η_dis + curt + Σ ev_c/eff − pv
+        curt_kwh = float(curt_sol_full[lp_t])
+        ev_ac_kwh = ev_ac_load_by_slot.get(lp_t, 0.0)
+        net_flow = (
+            base_load[lp_t]
+            + resolved_charge / charge_eff
+            - resolved_discharge * discharge_eff
+            + curt_kwh
+            + ev_ac_kwh
+            - pv_avail[lp_t]
+        )
+        if net_flow > 0:
+            out_slots[slot_i].grid_import_kwh = round(net_flow, 3)
+            out_slots[slot_i].grid_export_kwh = 0.0
+        else:
+            out_slots[slot_i].grid_import_kwh = 0.0
+            out_slots[slot_i].grid_export_kwh = round(-net_flow, 3)
 
     # ------------------------------------------------------------------
     # Write MILP-derived EV charging decisions to output slots
@@ -1346,9 +1409,7 @@ def solve_milp(
                 total_fuse_violation_kwh,
             )
 
-    # Extract curtailment solution
-    curt_sol = result.x[curt_off : curt_off + m]
-    total_curtailment_kwh = float(np.sum(curt_sol))
+    total_curtailment_kwh = float(np.sum(curt_sol_full))
 
     log_planner(
         "debug",

--- a/custom_components/hsem/planner/milp_optimizer.py
+++ b/custom_components/hsem/planner/milp_optimizer.py
@@ -1114,6 +1114,8 @@ def solve_milp(
     # Extract curtailment solution early — needed for the energy balance
     # derivation in the merged write-out loop below.
     curt_sol_full = result.x[curt_off : curt_off + m]
+    s_max_pen_vals = [float(v) for v in result.x[s_max_off : s_max_off + m]]
+    s_min_pen_vals = [float(v) for v in result.x[s_min_off : s_min_off + m]]
 
     # ------------------------------------------------------------------
     # Single merged energy-flow write-out pass (issue #659).
@@ -1144,16 +1146,23 @@ def solve_milp(
             # avoided import (p_imp), not export revenue (p_exp).
             #
             # When the round-trip is NOT profitable, collapse the
-            # degenerate vertex to its net direction instead of
-            # zeroing both — the LP expressed a net charge or
-            # discharge through the vertex and that net effect must
-            # be preserved (issue #659).
+            # degenerate vertex to its net direction — but ONLY when
+            # the LP's SoC penalty variables indicate the net residual
+            # is a genuine economic signal rather than noise at a SoC
+            # bound (issue #659).  If either s_max_pen[t] or
+            # s_min_pen[t] is active, the vertex sits at a bound where
+            # ec~ed is solver noise — zero both.
             net_charge_profit = (
                 p_imp[lp_t] * discharge_eff
                 - p_imp[lp_t] / charge_eff
                 - 2.0 * cycle_cost_per_kwh
             )
-            if net_charge_profit > 0:
+            has_penalty = s_max_pen_vals[lp_t] > 1e-6 or s_min_pen_vals[lp_t] > 1e-6
+            if net_charge_profit > 0 and not has_penalty:
+                ed_kwh = 0.0
+            elif has_penalty:
+                # Degenerate vertex at a SoC bound — noise, not signal.
+                ec_kwh = 0.0
                 ed_kwh = 0.0
             elif ec_kwh > ed_kwh:
                 # Net charge: keep the delta, zero the discharge
@@ -1331,13 +1340,10 @@ def solve_milp(
                 s.estimated_cost_currency = round(net * s.price.export_price, 4)
 
     # ------------------------------------------------------------------
-    # Extract penalty variable values and compute violation diagnostics
+    # Compute violation diagnostics from early-extracted penalty values
     # ------------------------------------------------------------------
-    s_max_pen_sol = result.x[s_max_off : s_max_off + m]
-    s_min_pen_sol = result.x[s_min_off : s_min_off + m]
-
-    s_max_pen_list = [float(v) for v in s_max_pen_sol]
-    s_min_pen_list = [float(v) for v in s_min_pen_sol]
+    s_max_pen_list = list(s_max_pen_vals)
+    s_min_pen_list = list(s_min_pen_vals)
     total_violation = sum(s_max_pen_list) + sum(s_min_pen_list)
     has_violations = total_violation > 1e-6
 

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -297,11 +297,22 @@ simulation uses the slot's **existing** `batteries_discharged_kwh`,
 `grid_import_kwh`, and `grid_export_kwh` values verbatim — it does **not**
 re-derive them from the recommendation label and net demand.
 
-This mode is used for MILP-sourced candidates, where `solve_milp()` has
-already populated these fields from the LP's `ed[t]`, `gi[t]`, and
-`ge[t]` solutions.  The LP values are the source of truth; the SoC
-simulation must never silently overwrite them with a greedy
-re-derivation.
+This mode is used for MILP-sourced candidates.  `solve_milp()` populates
+these fields in a **single merged write-out pass** (issue #659) that:
+
+1. Resolves degenerate LP vertices (simultaneous charge+discharge) by
+   collapsing to the net direction.
+2. Writes `batteries_charged_kwh` and `batteries_discharged_kwh` from the
+   **resolved** ec/ed (not the raw LP arrays).
+3. Derives `grid_import_kwh` and `grid_export_kwh` from the slot's energy
+   balance equation using the **same resolved** ec/ed values — they are
+   **not** read directly from the raw LP `gi[t]`/`ge[t]` arrays, because
+   the raw arrays assume the original (potentially now-invalid) ec/ed
+   combination.
+
+All four energy-flow fields are consistent with each other and with the
+recommendation label for every slot.  The resolved values are the source
+of truth; the SoC simulation must never silently overwrite them.
 
 For non-MILP candidates (`milp_prepopulated=False`, the default),
 the simulation continues to derive discharge and grid flows greedily

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -301,7 +301,10 @@ This mode is used for MILP-sourced candidates.  `solve_milp()` populates
 these fields in a **single merged write-out pass** (issue #659) that:
 
 1. Resolves degenerate LP vertices (simultaneous charge+discharge) by
-   collapsing to the net direction.
+   collapsing to the net direction — but only when the LP's SoC penalty
+   variables indicate the net residual is a genuine economic signal
+   rather than noise at a SoC bound.  At a bound (penalty active),
+   both ec and ed are zeroed.
 2. Writes `batteries_charged_kwh` and `batteries_discharged_kwh` from the
    **resolved** ec/ed (not the raw LP arrays).
 3. Derives `grid_import_kwh` and `grid_export_kwh` from the slot's energy

--- a/tests/planner/test_arbitrage_grid_charge.py
+++ b/tests/planner/test_arbitrage_grid_charge.py
@@ -299,6 +299,43 @@ class TestArbitrageNegatives:
 # ===========================================================================
 
 
+class TestArbitrageDegenerateVertexRegression:
+    """Regression: degenerate LP vertex must not charge a full battery.
+
+    Issue #659 fixed energy-flow write-out inconsistency, but
+    introduced a regression where collapsing a degenerate vertex to
+    its net direction at a SoC-bound slot would inject a spurious
+    charge into a full battery.  The fix checks SoC penalty variables
+    to distinguish genuine economic signals from solver noise at
+    SoC bounds.
+    """
+
+    def test_no_net_charge_from_degenerate_vertex_at_soc_ceiling(self):
+        """Battery at 100% SoC, cheap noon, 100% efficiency, zero cycle cost.
+
+        The LP solver can produce a degenerate vertex at the cheap slot
+        with both ec and ed positive (a wash cycle).  The mutex
+        resolution must NOT collapse this to a net charge into an
+        already-full battery.
+
+        Uses the same fixture as test_no_charge_when_battery_full:
+        battery_soc_pct=100.0, rated 10 kWh, cheap noon 0.66, 100%
+        efficiency, zero cycle cost.
+        """
+        result = run_planner(
+            _make_arbitrage_input(
+                battery_soc_pct=100.0,
+                battery_rated_capacity_kwh=10.0,
+            )
+        )
+        for s in result.slots:
+            if s.recommendation == _CHARGE_GRID:
+                raise AssertionError(
+                    f"unexpected grid charge at {s.start.isoformat()} "
+                    f"(battery full — degenerate vertex should have been zeroed)"
+                )
+
+
 class TestArbitrageVsSeasonalFallback:
     @pytest.mark.skip(
         reason="MILP-only mode: schedule-based arbitrage not applied on winner"

--- a/tests/planner/test_milp_optimizer.py
+++ b/tests/planner/test_milp_optimizer.py
@@ -2415,3 +2415,81 @@ def test_ev_primary_only_routes_to_primary_field():
         f"Primary EV power must go to ev_charger_calculated_power. "
         f"Got primary={primary_used}, second={second_used}"
     )
+
+
+@_scipy_skip()
+def test_milp_energy_fields_consistent_after_mutex_resolution():
+    """Regression test for issue #659: energy-flow fields must be consistent.
+
+    When the LP returns a degenerate vertex with simultaneous charge and
+    discharge for the same slot, the mutex resolution (Bug J fix) zeroes
+    or adjusts ec/ed.  All per-slot energy-flow fields —
+    batteries_charged_kwh, batteries_discharged_kwh, grid_import_kwh,
+    grid_export_kwh — must reflect the SAME resolved decision, and the
+    slot energy balance must hold within floating-point tolerance.
+
+    The test constructs a scenario where a cheap slot (import 0.01)
+    followed by neutral slots (import 0.50) with 100 % efficiency and
+    zero cycle cost reliably triggers a degenerate LP vertex.
+    """
+    slots = [
+        _make_slot(
+            hour=h,
+            import_price=(0.01 if h == 0 else 0.50),
+            export_price=0.01,
+            consumption_kwh=0.3,
+        )
+        for h in range(4)
+    ]
+    for s in slots:
+        s.solcast_pv_estimate_kwh = 0.0
+        s.estimated_net_consumption_kwh = (
+            s.avg_house_consumption_kwh - s.solcast_pv_estimate_kwh
+        )
+
+    milp_result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=0.0,
+        usable_kwh=9.0,
+        max_charge_per_slot=5.0,
+        max_discharge_per_slot=None,
+        cycle_cost_per_kwh=0.0,
+        charge_efficiency_pct=100.0,
+        discharge_efficiency_pct=100.0,
+    )
+    assert milp_result is not None, "MILP must solve the 4-slot problem"
+    milp_slots, _diag = milp_result
+
+    charge_eff = 1.0  # 100 %
+    discharge_eff = 1.0
+
+    for i, s in enumerate(milp_slots):
+        # Invariant 1: a None recommendation must not coexist with
+        # nonzero charge or discharge.
+        if s.recommendation is None:
+            assert s.batteries_charged_kwh == pytest.approx(0.0, abs=1e-4), (
+                f"Slot {i}: recommendation=None but batteries_charged_kwh="
+                f"{s.batteries_charged_kwh}"
+            )
+            assert s.batteries_discharged_kwh == pytest.approx(0.0, abs=1e-4), (
+                f"Slot {i}: recommendation=None but batteries_discharged_kwh="
+                f"{s.batteries_discharged_kwh}"
+            )
+
+        # Invariant 2: energy balance must hold.
+        # gi + pv + ed·η_dis == house_load + ec/η_chg + ge
+        lhs = (
+            s.grid_import_kwh
+            + s.solcast_pv_estimate_kwh
+            + s.batteries_discharged_kwh * discharge_eff
+        )
+        rhs = (
+            s.avg_house_consumption_kwh
+            + s.batteries_charged_kwh / charge_eff
+            + s.grid_export_kwh
+        )
+        assert lhs == pytest.approx(rhs, abs=1e-6), (
+            f"Slot {i}: energy balance violation. "
+            f"LHS={lhs:.6f} RHS={rhs:.6f} delta={abs(lhs - rhs):.6f}"
+        )


### PR DESCRIPTION
## Summary

Merge two separate post-LP loops in `solve_milp()` into a single pass that writes all four energy-flow fields consistently from the same resolved ec/ed values.

### Problem (issue #659)

`solve_milp()` contained two separate loops processing the same raw LP solution:

1. **Loop 1** (the mutex/"Bug J" resolution): detected degenerate LP vertices where both ec[t] > 0 and ed[t] > 0 for the same slot, resolved them by zeroing local ec_kwh/ed_kwh variables, and set `recommendation` and `batteries_charged_kwh`.

2. **Loop 2** (added in PR #650 for issue #637): wrote `batteries_discharged_kwh`, `grid_import_kwh`, and `grid_export_kwh` directly from the **raw, unresolved** `ed_sol`/`gi_sol`/`ge_sol` arrays — completely bypassing loop 1's resolution.

This produced internally contradictory slots: e.g. `recommendation=None` and `batteries_charged_kwh=0.0` (correctly resolved by loop 1) alongside `batteries_discharged_kwh=2.636` (incorrectly left as the raw LP vertex value by loop 2).

### Fix

- **Single merged write-out pass** writes `batteries_charged_kwh`, `batteries_discharged_kwh`, `grid_import_kwh`, and `grid_export_kwh` in the same loop iteration.
- **Grid import/export** are derived from the slot's energy balance equation using the **same resolved** (rounded) charge/discharge values, not read from raw `gi_sol`/`ge_sol` arrays.
- **Mutex resolution improved**: when the round-trip is not profitable, the degenerate vertex is collapsed to its **net direction** (ec − ed preserved) rather than zeroing both — but **only when no SoC penalty is active**. If `s_max_pen[t] > 1e-6` or `s_min_pen[t] > 1e-6`, the vertex sits at a SoC bound and both ec/ed are zeroed (the net residual is solver noise, not economic signal).

### Regression fixed (second commit)

The initial mutex net-preservation change introduced a regression where a full battery (100% SoC) would receive a spurious charge from a degenerate LP vertex at the cheap-noon slot. The root cause was that collapsing to net direction fired unconditionally without checking whether the SoC was at a bound. Fixed by the penalty-guarded check described above.

### Tests

- **New regression test in `test_milp_optimizer.py`**: `test_milp_energy_fields_consistent_after_mutex_resolution` — verifies no contradictory slot fields, energy balance holds, and the issue #659 reproduction case is fixed.
- **New regression test in `test_arbitrage_grid_charge.py`**: `TestArbitrageDegenerateVertexRegression::test_no_net_charge_from_degenerate_vertex_at_soc_ceiling` — verifies a full battery is never grid-charged from a degenerate vertex at a SoC bound.
- **`test_milp_soc_rises_after_cheap_charge_slot`** passes (genuine net charge is preserved when no SoC penalty is active).

### Pre-existing failures (out of scope, unchanged)

- `test_main_fuse_house_load_exceeds_fuse_penalty_fires` — test-authoring bug (fixture house load never exceeds the configured fuse limit)
- `test_main_fuse_has_violations_flag` — same root cause
- Failures in `test_ev_planned_load.py`, `test_roundtrip_efficiency.py`, `test_session_ev.py` are pre-existing on main and unrelated to this code path

### Quality

- `tox -e lint` — passes
- `tox -e typing` — passes (0 issues)
- `tox -e quality` — passes (0 errors, 26 pre-existing warnings)

Fixes #659