### PR TITLE
fix(milp): guard EV pre-deadline benefit against charge_past_target

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -328,6 +328,27 @@ b_ub[ev_row] = shortfall
   in `ev_total_rows` alongside `ev_soc_rows`, `ev_deadline_rows`,
   `ev_post_deadline_rows`, and `ev_surplus_rows`.
 
+## EV Pre-Deadline Benefit / Charge-Past-Target Mutual Exclusivity (Issue #643)
+
+In `milp_optimizer.py`, the pre-deadline benefit block and the
+charge-past-target benefit block both add benefit coefficients to the same
+`ev_c[t]` LP variable.  Today `engine_core.py`'s `_build_ev_configs_for_milp()`
+sets `EVConfig` fields such that they are never both true in practice, but
+`milp_optimizer.py` itself does not enforce this.  If any future caller or test
+constructs an `EVConfig` where both are true, the two benefit blocks would
+stack, double-counting the reward on the same variable.
+
+**Invariant**: The LP construction must guard the pre-deadline benefit block
+with `and not ev.charge_past_target`, mirroring the existing
+post-deadline zero-charge and target-cap constraint guards.  This makes the
+LP itself robust regardless of what any caller does.
+
+- The guard is a one-line addition to the outer condition of the pre-deadline
+  benefit block (search for `ev_penalty_cost = max(p_imp_max, 0.1) *
+  max(energy_needed, 1.0) * 10.0`).
+- This follows the exact same pattern already used by the post-deadline
+  zero-charge constraint and the target-cap constraint in the same file.
+
 ---
 
 ## Discharge Concentration — Per-Day Budget Pools

--- a/custom_components/hsem/planner/milp_optimizer.py
+++ b/custom_components/hsem/planner/milp_optimizer.py
@@ -630,7 +630,11 @@ def solve_milp(
     # Must be high enough that the MILP always prefers meeting the target
     # when it is physically possible within the available slots.
     for ev_idx, ev in enumerate(active_evs):
-        if ev.deadline_slot is not None and ev.target_kwh > ev.initial_soc_kwh + 1e-9:
+        if (
+            ev.deadline_slot is not None
+            and ev.target_kwh > ev.initial_soc_kwh + 1e-9
+            and not ev.charge_past_target
+        ):
             # Penalty per kWh shortfall: proportional to energy needed,
             # not full capacity. This ensures the MILP prioritizes the EV
             # when it needs significant energy, but doesn't force EV charging

--- a/docs/milp-optimization.md
+++ b/docs/milp-optimization.md
@@ -85,7 +85,7 @@ When an EV's `charge_past_target` flag is `True` (EV already at user-configured 
 - An **avoided-future-import-cost benefit** (`future_value_per_kwh`, issue #630) is added to the objective, falling back to a tiny fixed tiebreaker when no future price data is available (see Objective function below)
 
 When an EV has a deadline and `charge_past_target=False` (normal mode):
-- **Pre-deadline slots** (`t ≤ D`): direct benefit `-ev_penalty_cost` on `ev_c[t]` forces charging
+- **Pre-deadline slots** (`t \u2264 D`): direct benefit `-ev_penalty_cost` on `ev_c[t]` forces charging.  This benefit is **mutually exclusive** with `charge_past_target` — the LP guards the pre-deadline benefit block with `and not ev.charge_past_target`, mirroring the post-deadline zero-charge and target-cap constraint guards.
 - **Post-deadline slots** (`t > D`): hard constraint `ev_c[t] = 0` — charging is forbidden
 
 ### Fuse constraint extension (issue #567)
@@ -168,6 +168,8 @@ $$
 $$
 
 This direct benefit on pre-deadline slots ensures the LP always prefers charging over paying the deadline penalty. Post-deadline slots ($t > D_v$) have zero coefficient unless `charge_past_target=True`.
+
+The pre-deadline benefit block and the charge-past-target benefit block are **mutually exclusive** by design. The LP construction guards the pre-deadline block with `and not ev.charge_past_target`, mirroring the post-deadline zero-charge constraint's guard. An EV in charge-past-target mode never receives the large penalty-driven benefit — only the `future_value_per_kwh` benefit (or its tiebreaker fallback) applies. This exclusion is enforced directly in the LP construction rather than relying on caller discipline in `engine_core.py`.
 
 Plus EV charge-past-target benefit (discounted, per charge-past-target EV $v$):
 

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -412,6 +412,14 @@ coefficient of `-ev_penalty_cost`, creating a direct benefit that forces the LP
 to charge the EV. The LP will use PV surplus first (free), then grid import
 (costs `p_imp[t]`) when PV alone is insufficient.
 
+This pre-deadline benefit is **mutually exclusive** with `charge_past_target`.
+The LP construction guards the pre-deadline benefit block with
+`and not ev.charge_past_target` (mirroring the post-deadline zero-charge and
+target-cap constraints), so an EV in charge-past-target mode never receives the
+large penalty-driven benefit. The LP enforces this exclusion directly — it does
+not rely on caller discipline in `engine_core.py` to prevent both conditions
+from being true simultaneously.
+
 **Post-deadline slots** (`t > D`):
 - When `charge_past_target=False`: `ev_c[t]` is hard-constrained to zero —
   no charging allowed after the deadline.

--- a/tests/planner/test_milp_ev.py
+++ b/tests/planner/test_milp_ev.py
@@ -868,6 +868,60 @@ def test_charge_past_target_unaffected_by_target_cap():
 
 
 @_pytestmark_scipy
+def test_pre_deadline_benefit_mutually_exclusive_with_charge_past_target():
+    """Pre-deadline benefit block must not fire when charge_past_target=True.
+
+    When both charge_past_target and a pre-deadline benefit condition
+    (deadline_slot set, target_kwh > initial_soc_kwh) are true for the
+    same EVConfig, only the charge-past-target benefit should apply.
+    The MILP itself must enforce this mutual exclusion rather than
+    relying on caller discipline in engine_core.py.
+
+    Verification: set future_value_per_kwh below export price so that
+    the charge-past-target benefit alone would lose to export.  If the
+    pre-deadline benefit block also fired, its large penalty-driven
+    benefit (~20/kWh) would override export and force EV charging.
+    """
+    slots = [
+        _make_slot(hour=14, day=15, import_price=1.50, export_price=0.89, pv_kwh=5.0)
+    ]
+
+    ev = EVConfig(
+        enabled=True,
+        initial_soc_kwh=0.0,  # far below target — pre-deadline condition applies
+        target_kwh=10.0,  # needs 10 kWh — pre-deadline condition applies
+        capacity_kwh=50.0,
+        max_charge_per_slot=10.0,
+        charger_efficiency=1.0,
+        deadline_slot=0,  # deadline set — pre-deadline condition applies
+        charge_past_target=True,  # but charge-past-target is also enabled!
+        future_value_per_kwh=0.40,  # below export price of 0.89
+    )
+
+    result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=0.0,
+        usable_kwh=0.001,
+        max_charge_per_slot=0.001,
+        max_discharge_per_slot=None,
+        ev_configs=[ev],
+    )
+
+    assert result is not None
+    out_slots, _diag = result
+
+    # When only charge-past-target benefit applies (0.40/kWh), export
+    # (0.89/kWh) is more valuable — surplus should be exported, not
+    # diverted to the EV.  If the pre-deadline benefit had also fired,
+    # the combined benefit (~20/kWh) would force EV charging here.
+    assert out_slots[0].ev_total_planned_load_kwh == pytest.approx(0.0, abs=1e-6), (
+        "EV should not charge from surplus when future_value_per_kwh < export, "
+        "proving the pre-deadline benefit block did not also fire"
+    )
+
+
+@_pytestmark_scipy
 def test_full_planner_with_ev_integration():
     """Full planner run with EV enabled produces valid output.
 


### PR DESCRIPTION
## Summary

Make the MILP EV pre-deadline benefit block explicitly mutually exclusive with `charge_past_target`, so the LP construction itself enforces the exclusion rather than relying on caller discipline in `engine_core.py`.

## What changed

- **`milp_optimizer.py`** — Added `and not ev.charge_past_target` guard to the pre-deadline benefit block's outer condition, mirroring the existing post-deadline zero-charge and target-cap constraint guards in the same file.
- **`tests/planner/test_milp_ev.py`** — Added `test_pre_deadline_benefit_mutually_exclusive_with_charge_past_target()`: constructs an EVConfig with both conditions true and verifies only the charge-past-target benefit applies.
- **`docs/planner-spec.md`** — Documented the mutual exclusivity in the EV co-optimisation section.
- **`docs/milp-optimization.md`** — Documented the mutual exclusivity in the objective function and EV co-optimization extension sections.
- **`.github/memories.md`** — Added canonical invariant section.

## Why

Today `engine_core.py`'s `_build_ev_configs_for_milp()` sets EVConfig fields such that `charge_past_target` and the pre-deadline condition are never both true in practice. But `milp_optimizer.py` itself had no enforcement — if any future caller or test constructed an EVConfig where both are true, the two benefit blocks would stack on `ev_c[t]`, double-counting the reward. The fix follows the exact same pattern already used by the post-deadline zero-charge constraint and target-cap constraint in the same file.

## Checklist

- [x] Lint passes (`tox -e lint`)
- [x] Type checking passes (`tox -e typing`)
- [x] Quality checks pass (`tox -e quality`)
- [x] Regression test added
- [x] Documentation updated
- [x] No unrelated code changes

Fixes #643