### PR TITLE
fix(ci): move read permissions from workflow to job level

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions: {}
+
 jobs:
   lint:
     name: Lint with tox

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -7,13 +7,12 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-permissions:
-  contents: read
-
 jobs:
   lint:
     name: Lint with tox
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7.0.0
 
@@ -44,6 +43,8 @@ jobs:
   type-check:
     name: Type check with tox
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7.0.0
 
@@ -69,6 +70,8 @@ jobs:
   quality:
     name: Static quality checks with tox
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7.0.0
 
@@ -94,6 +97,8 @@ jobs:
   tests:
     name: Tests with tox
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7.0.0
 


### PR DESCRIPTION
Fixes two SAST warnings:

- **SonarCloud S8264:** Moved `permissions: contents: read` from workflow level to job level for the four jobs that run `actions/checkout` (`lint`, `type-check`, `quality`, `tests`). The `codecov` job is intentionally left without `contents: read` since it only downloads an artifact and uploads to Codecov.

- **Checkov CKV2_GHA_1:** Added `permissions: {}` at the workflow level to prevent the implicit `write-all` default, while each job explicitly requests only `contents: read`.