### PR TITLE
fix(migration): migrate entity unique_ids in place on v1->v2

### DIFF
--- a/custom_components/hsem/config_flow.py
+++ b/custom_components/hsem/config_flow.py
@@ -8,6 +8,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 
 from custom_components.hsem.const import DEFAULT_CONFIG_VALUES, DOMAIN, NAME
 from custom_components.hsem.flows.batteries_excess_export import (
@@ -175,6 +176,26 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
         if config_entry.version == 1:
             data = _migrate_v1_to_v2(dict(config_entry.data))
             hass.config_entries.async_update_entry(config_entry, data=data, version=2)
+            # v6.0.0 (#523) prefixed every entity unique_id with the config
+            # entry id, but shipped no entity-registry migration -- so existing
+            # v5 entities were orphaned and re-created with a "_2" suffix (losing
+            # their entity_id and long-term statistics). Rename the registry
+            # entries IN PLACE so entity_id + history are preserved.
+            _prefix = f"{DOMAIN}_{config_entry.entry_id}_"
+
+            @callback
+            def _migrate_unique_id(
+                entity_entry: er.RegistryEntry,
+            ) -> dict[str, str] | None:
+                uid = entity_entry.unique_id
+                if not uid.startswith(f"{DOMAIN}_") or uid.startswith(_prefix):
+                    return None
+                return {"new_unique_id": f"{_prefix}{uid[len(DOMAIN) + 1 :]}"}
+
+            await er.async_migrate_entries(
+                hass, config_entry.entry_id, _migrate_unique_id
+            )
+
             _LOGGER.info(
                 "Config entry %s migrated from v1 to v2",
                 config_entry.entry_id,

--- a/tests/test_config_flow_migrate_unique_ids.py
+++ b/tests/test_config_flow_migrate_unique_ids.py
@@ -1,0 +1,82 @@
+"""Regression tests for the v1->v2 entity ``unique_id`` migration.
+
+v6.0.0 (#523) prefixed every entity ``unique_id`` with the config entry id but
+shipped no entity-registry migration, so existing v5 entities were orphaned and
+re-created with a ``_2`` suffix -- losing their ``entity_id`` and long-term
+statistics. ``async_migrate_entry`` must hand a remap callback to
+``entity_registry.async_migrate_entries`` that renames the ids in place.
+
+These tests use plain mocks (matching the rest of the suite) and exercise the
+remap callback directly, so they need no running Home Assistant.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.hsem.config_flow import HSEMConfigFlow
+
+ENTRY_ID = "01JHBRS16N1VQM58YSEB88AC90"
+
+
+def _make_entry() -> MagicMock:
+    entry = MagicMock()
+    entry.version = 1
+    entry.entry_id = ENTRY_ID
+    entry.data = {}
+    return entry
+
+
+@pytest.mark.asyncio
+async def test_migrate_v1_to_v2_registers_unique_id_remap() -> None:
+    """v1->v2 migrates config data AND rewrites entity unique_ids in place."""
+    hass = MagicMock()
+    entry = _make_entry()
+
+    with patch(
+        "custom_components.hsem.config_flow.er.async_migrate_entries",
+        new=AsyncMock(),
+    ) as migrate_entries:
+        result = await HSEMConfigFlow().async_migrate_entry(hass, entry)
+
+    assert result is True
+
+    # Config data was migrated to version 2.
+    hass.config_entries.async_update_entry.assert_called_once()
+    assert hass.config_entries.async_update_entry.call_args.kwargs["version"] == 2
+
+    # The entity-registry remap was invoked for this entry.
+    migrate_entries.assert_awaited_once()
+    assert migrate_entries.await_args is not None
+    hass_arg, entry_id_arg, update_func = migrate_entries.await_args.args
+    assert hass_arg is hass
+    assert entry_id_arg == ENTRY_ID
+
+    # Old (unprefixed) id -> prefixed in place (entity_id/history preserved).
+    old = SimpleNamespace(unique_id="hsem_workingmode_sensor")
+    assert update_func(old) == {"new_unique_id": f"hsem_{ENTRY_ID}_workingmode_sensor"}
+
+
+@pytest.mark.asyncio
+async def test_remap_callback_is_idempotent_and_scoped() -> None:
+    """Already-prefixed and foreign unique_ids are left untouched."""
+    hass = MagicMock()
+    entry = _make_entry()
+
+    with patch(
+        "custom_components.hsem.config_flow.er.async_migrate_entries",
+        new=AsyncMock(),
+    ) as migrate_entries:
+        await HSEMConfigFlow().async_migrate_entry(hass, entry)
+
+    assert migrate_entries.await_args is not None
+    update_func = migrate_entries.await_args.args[2]
+
+    already = SimpleNamespace(unique_id=f"hsem_{ENTRY_ID}_workingmode_sensor")
+    assert update_func(already) is None  # no double prefix
+
+    foreign = SimpleNamespace(unique_id="other_integration_sensor")
+    assert update_func(foreign) is None  # only hsem_ ids are touched


### PR DESCRIPTION
Problem

v6.0.0 (#523) prefixed every entity unique_id with the config entry id
(hsem_workingmode_sensor → hsem_<entry_id>_workingmode_sensor), but the
async_migrate_entry v1→v2 migration only migrates the config data — it
never migrates the entity registry.

So on the first load after upgrading from v5.x, Home Assistant does not
recognise the new unique_ids as belonging to the existing entities. Each
entity is re-created fresh:

the old entity is orphaned ("no longer provided by the hsem integration"), and
the live entity is registered with a _2 suffix (sensor.hsem_..._2), because
the original entity_id is still taken by the orphan.

This contradicts the release notes' own guarantees:

"Entity IDs are unchanged" — false; live entities become *_2.
"State history is preserved" — the old long-term statistics stay stranded on
the orphan; the live _2 entity starts from zero.

Any automations/dashboards/templates referencing sensor.hsem_* then point at the
dead orphan.

Reproduced on a real v5.1.0 → v6.0.0 upgrade: 243 orphaned + 170 _2 entities.

Fix

Add the missing entity-registry migration to async_migrate_entry: rename each
existing entry's unique_id from hsem_<key> to hsem_<entry_id>_<key> in
place via entity_registry.async_migrate_entries. The same registry entry is
reused, so entity_id and long-term statistics are preserved and no _2
duplicates are created. The guard skips already-prefixed ids → idempotent and
safe for genuinely new v6 entities.

Verification

Applied to a live v5.1.0 → v6.0.0 upgrade:

0 _2 duplicates, 0 orphans
migrated entity keeps its entity_id; unique_id is the new hsem_<entry_id>_…
form; history intact
HSEM healthy afterwards (workingmode live, read_only honoured, apply_status
ok, data_quality complete)

Adds tests/test_config_flow_migrate_unique_ids.py covering the in-place remap and
idempotency.