### PR TITLE
fix(i18n): remove hardcoded EUR currency from user-facing labels

### DIFF
--- a/custom_components/hsem/flows/ev_planned_load_helpers.py
+++ b/custom_components/hsem/flows/ev_planned_load_helpers.py
@@ -32,7 +32,7 @@ from custom_components.hsem.utils.misc import get_config_value
 _CAPACITY_SELECTOR = selector(
     {
         "number": {
-            "min": 1.0,
+            "min": 0.0,
             "max": 200.0,
             "step": 0.5,
             "unit_of_measurement": UnitOfEnergy.KILO_WATT_HOUR,
@@ -44,7 +44,7 @@ _CAPACITY_SELECTOR = selector(
 _POWER_KW_SELECTOR = selector(
     {
         "number": {
-            "min": 0.1,
+            "min": 0.0,
             "max": 50.0,
             "step": 0.1,
             "unit_of_measurement": UnitOfPower.KILO_WATT,

--- a/custom_components/hsem/models/sensor_config.py
+++ b/custom_components/hsem/models/sensor_config.py
@@ -113,7 +113,7 @@ class SensorConfig:
             Defaults to 97 % (3 % discharge-side loss).
         batteries_purchase_price: Battery pack purchase price for depreciation calc.
         batteries_expected_cycles: Expected total cycle life of the battery.
-        batteries_cycle_cost: User-configured extra per-kWh cycle cost (EUR/kWh).
+        batteries_cycle_cost: User-configured extra per-kWh cycle cost.
             Added to the auto-derived depreciation threshold.  0.0 = disabled.
 
         batteries_schedule_1: First discharge-window schedule config.

--- a/custom_components/hsem/planner/cost_function.py
+++ b/custom_components/hsem/planner/cost_function.py
@@ -55,7 +55,7 @@ Selector-only terms (added on top of ``total_cost`` to produce ``score``):
    no longer *over-penalises* discharge in slots where the replacement price
    does not exceed that slot's own import price.
 
-All monetary values are in the caller's local currency (e.g. DKK or EUR).
+All monetary values are in the caller's local currency.
 
 Design constraints
 ------------------

--- a/custom_components/hsem/translations/da.json
+++ b/custom_components/hsem/translations/da.json
@@ -178,10 +178,10 @@
       "huawei_solar": {
         "data": {
           "hsem_batteries_charge_efficiency": "Batteri-opladningseffektivitet (%)",
-          "hsem_batteries_cycle_cost": "Batteri-cyklusomkostning (EUR/kWh)",
+          "hsem_batteries_cycle_cost": "Batteri-cyklusomkostning (pr. kWh)",
           "hsem_batteries_discharge_efficiency": "Batteri-afladningseffektivitet (%)",
           "hsem_batteries_expected_cycles": "Forventede battericyklusser",
-          "hsem_batteries_purchase_price": "Batteri-købspris (EUR)",
+          "hsem_batteries_purchase_price": "Batteri-købspris",
           "hsem_huawei_solar_batteries_excess_pv_energy_use_in_tou": "Huawei-batterier overskydende PV-energianvendelse i TOU",
           "hsem_huawei_solar_batteries_end_of_discharge_soc": "Huawei-batterier afladningsstop SOC (%)",
           "hsem_huawei_solar_batteries_charging_cutoff_capacity": "Huawei-batterier opladningsstopkapacitet (maks. SoC %)",
@@ -201,9 +201,9 @@
         "data_description": {
           "hsem_batteries_charge_efficiency": "Angiv batteriets opladningseffektivitet som en procentdel (0-100). Energi lagret i batteriet = inputenergi Å— denne faktor. Typiske lithium-batterier opnår 95-98%. Standard: 98%.",
           "hsem_batteries_discharge_efficiency": "Angiv batteriets afladningseffektivitet som en procentdel (0-100). Energi leveret til huset = fjernet batterienergi Å— denne faktor. Typiske lithium-batterier opnår 95-98%. Standard: 98%.",
-          "hsem_batteries_cycle_cost": "Valgfri ekstra per-kWh-omkostning ved at cykle batteriet (EUR/kWh). Tilføjes oven på den automatisk beregnede afskrivningstærskel. Sæt til 0 for kun at stole på afskrivningsbeskyttelsen.",
+          "hsem_batteries_cycle_cost": "Valgfri ekstra per-kWh-omkostning ved at cykle batteriet (pr. kWh). Tilføjes oven på den automatisk beregnede afskrivningstærskel. Sæt til 0 for kun at stole på afskrivningsbeskyttelsen.",
           "hsem_batteries_expected_cycles": "Indtast det forventede antal fulde opladnings-/afladningscyklusser i batteriets levetid. Bruges til at beregne afskrivningsomkostning pr. kWh. Typiske LiFePO4-batterier understøtter 4000-8000 cyklusser.",
-          "hsem_batteries_purchase_price": "Indtast den samlede købspris for dit batterisystem i EUR. Bruges sammen med forventede cyklusser og brugbar kapacitet til at beregne afskrivningsomkostning pr. kWh.",
+          "hsem_batteries_purchase_price": "Indtast den samlede købspris for dit batterisystem. Bruges sammen med forventede cyklusser og brugbar kapacitet til at beregne afskrivningsomkostning pr. kWh.",
           "hsem_huawei_solar_batteries_excess_pv_energy_use_in_tou": "Vælg den sensor, der giver indstilling for overskydende PV-energianvendelse i TOU-perioder.",
           "hsem_huawei_solar_batteries_end_of_discharge_soc": "Angiv afladningsstop SOC-procent for dine Huawei-batterier. Når batteriet når dette SOC-niveau, stopper det afladning for at forhindre dybdeafladning.",
           "hsem_huawei_solar_batteries_charging_cutoff_capacity": "Vælg den enhed, der definerer den maksimale ladetilstand (SoC), batteriet må nå under opladning. Typisk 90-100%. Bruges af SoC-simuleringen som den øvre SoC-grænse.",
@@ -225,17 +225,17 @@
       },
       "battery_economics": {
         "data": {
-          "hsem_batteries_purchase_price": "Batteri-købspris (EUR)",
+          "hsem_batteries_purchase_price": "Batteri-købspris",
           "hsem_batteries_expected_cycles": "Forventede battericyklusser",
-          "hsem_batteries_cycle_cost": "Batteri-cyklusomkostning (EUR/kWh)",
+          "hsem_batteries_cycle_cost": "Batteri-cyklusomkostning (pr. kWh)",
           "hsem_batteries_charge_efficiency": "Batteri-opladningseffektivitet (%)",
           "hsem_batteries_discharge_efficiency": "Batteri-afladningseffektivitet (%)",
           "hsem_batteries_capacity_loss_pct": "Kapacitetstab (%)"
         },
         "data_description": {
-          "hsem_batteries_purchase_price": "Indtast den samlede købspris for dit batterisystem i EUR. Bruges sammen med forventede cyklusser og brugbar kapacitet til at beregne afskrivningsomkostning pr. kWh.",
+          "hsem_batteries_purchase_price": "Indtast den samlede købspris for dit batterisystem. Bruges sammen med forventede cyklusser og brugbar kapacitet til at beregne afskrivningsomkostning pr. kWh.",
           "hsem_batteries_expected_cycles": "Indtast det forventede antal fulde opladnings-/afladningscyklusser i batteriets levetid. Bruges til at beregne afskrivningsomkostning pr. kWh. Typiske LiFePO4-batterier understøtter 4000-8000 cyklusser.",
-          "hsem_batteries_cycle_cost": "Valgfri ekstra per-kWh-omkostning ved at cykle batteriet (EUR/kWh). Tilføjes oven på den automatisk beregnede afskrivningstærskel. Sæt til 0 for kun at stole på afskrivningsbeskyttelsen.",
+          "hsem_batteries_cycle_cost": "Valgfri ekstra per-kWh-omkostning ved at cykle batteriet (pr. kWh). Tilføjes oven på den automatisk beregnede afskrivningstærskel. Sæt til 0 for kun at stole på afskrivningsbeskyttelsen.",
           "hsem_batteries_charge_efficiency": "Angiv batteriets opladningseffektivitet som en procentdel (0-100). Energi lagret i batteriet = inputenergi Å— denne faktor. Typiske lithium-batterier opnår 95-98%. Standard: 98%.",
           "hsem_batteries_discharge_efficiency": "Angiv batteriets afladningseffektivitet som en procentdel (0-100). Energi leveret til huset = fjernet batterienergi Å— denne faktor. Typiske lithium-batterier opnår 95-98%. Standard: 98%.",
           "hsem_batteries_capacity_loss_pct": "Forventet kapacitetstab ved end-of-life for batteriet (0-100%)."
@@ -644,10 +644,10 @@
       "huawei_solar": {
         "data": {
           "hsem_batteries_charge_efficiency": "Battery Charge Efficiency (%)",
-          "hsem_batteries_cycle_cost": "Battery Cycle Cost (EUR/kWh)",
+          "hsem_batteries_cycle_cost": "Battery Cycle Cost (pr. kWh)",
           "hsem_batteries_discharge_efficiency": "Battery Discharge Efficiency (%)",
           "hsem_batteries_expected_cycles": "Expected Battery Cycles",
-          "hsem_batteries_purchase_price": "Battery Purchase Price (EUR)",
+          "hsem_batteries_purchase_price": "Battery Purchase Price",
           "hsem_huawei_solar_batteries_excess_pv_energy_use_in_tou": "Huawei Batteries Excess PV energy use in TOU",
           "hsem_huawei_solar_batteries_forcible_charge": "Battery Forcible Charge State",
           "hsem_huawei_solar_batteries_end_of_discharge_soc": "Huawei Batteries End of Discharge SOC (%)",
@@ -667,9 +667,9 @@
         "data_description": {
           "hsem_batteries_charge_efficiency": "Specify the charge-side efficiency of your battery as a percentage (0–100). Energy stored in the battery equals the input energy multiplied by this factor. Typical lithium batteries achieve 95–98 %. Defaults to 98 %.",
           "hsem_batteries_discharge_efficiency": "Specify the discharge-side efficiency of your battery as a percentage (0–100). Energy delivered to the house equals the battery energy removed multiplied by this factor. Typical lithium batteries achieve 95–98 %. Defaults to 98 %.",
-          "hsem_batteries_cycle_cost": "Optional extra per-kWh cost of cycling the battery (EUR/kWh). Added on top of the auto-calculated depreciation threshold. Set to 0 to rely solely on the depreciation guard. Example: 0.02 means the planner requires 2 cent extra spread per kWh cycled before approving grid charging.",
+          "hsem_batteries_cycle_cost": "Optional extra per-kWh cost of cycling the battery (pr. kWh). Added on top of the auto-calculated depreciation threshold. Set to 0 to rely solely on the depreciation guard. Example: 0.02 means the planner requires 2 cent extra spread per kWh cycled before approving grid charging.",
           "hsem_batteries_expected_cycles": "Enter the expected number of full charge/discharge cycles over the battery's lifetime. Used to calculate depreciation cost per kWh and the recommended minimum export price threshold. Typical LiFePO4 batteries support 4000–8000 cycles.",
-          "hsem_batteries_purchase_price": "Enter the total purchase price of your battery system in EUR. Used together with expected cycles and usable capacity to calculate the depreciation cost per kWh and the recommended minimum export price threshold.",
+          "hsem_batteries_purchase_price": "Enter the total purchase price of your battery system in your local currency. Used together with expected cycles and usable capacity to calculate the depreciation cost per kWh and the recommended minimum export price threshold.",
           "hsem_huawei_solar_batteries_excess_pv_energy_use_in_tou": "Select the sensor that provides setting for excess PV energy use in TOU periods.",
           "hsem_huawei_solar_batteries_forcible_charge": "Sensor showing current forcible charge/discharge state (e.g. Stopped, Discharging at 5000W for 60 minutes)",
           "hsem_huawei_solar_batteries_end_of_discharge_soc": "Specify the end of discharge SOC percentage for your Huawei batteries. When the battery reaches this SOC level, it will stop discharging to prevent deep discharge and potential damage to the battery.",

--- a/custom_components/hsem/translations/en.json
+++ b/custom_components/hsem/translations/en.json
@@ -212,10 +212,10 @@
       "huawei_solar": {
         "data": {
           "hsem_batteries_charge_efficiency": "Battery Charge Efficiency (%)",
-          "hsem_batteries_cycle_cost": "Battery Cycle Cost (EUR/kWh)",
+          "hsem_batteries_cycle_cost": "Battery Cycle Cost (per kWh)",
           "hsem_batteries_discharge_efficiency": "Battery Discharge Efficiency (%)",
           "hsem_batteries_expected_cycles": "Expected Battery Cycles",
-          "hsem_batteries_purchase_price": "Battery Purchase Price (EUR)",
+          "hsem_batteries_purchase_price": "Battery Purchase Price",
           "hsem_huawei_solar_batteries_excess_pv_energy_use_in_tou": "Huawei Batteries Excess PV energy use in TOU",
           "hsem_huawei_solar_batteries_forcible_charge": "Battery Forcible Charge State",
           "hsem_huawei_solar_batteries_end_of_discharge_soc": "Huawei Batteries End of Discharge SOC (%)",
@@ -235,9 +235,9 @@
         "data_description": {
           "hsem_batteries_charge_efficiency": "Specify the charge-side efficiency of your battery as a percentage (0â€“100). Energy stored in the battery equals the input energy multiplied by this factor. Typical lithium batteries achieve 95â€“98 %. Defaults to 98 %.",
           "hsem_batteries_discharge_efficiency": "Specify the discharge-side efficiency of your battery as a percentage (0â€“100). Energy delivered to the house equals the battery energy removed multiplied by this factor. Typical lithium batteries achieve 95â€“98 %. Defaults to 98 %.",
-          "hsem_batteries_cycle_cost": "Optional extra per-kWh cost of cycling the battery (EUR/kWh). Added on top of the auto-calculated depreciation threshold. Set to 0 to rely solely on the depreciation guard. Example: 0.02 means the planner requires 2 cent extra spread per kWh cycled before approving grid charging.",
+          "hsem_batteries_cycle_cost": "Optional extra per-kWh cost of cycling the battery (per kWh). Added on top of the auto-calculated depreciation threshold. Set to 0 to rely solely on the depreciation guard. Example: 0.02 means the planner requires 2 cent extra spread per kWh cycled before approving grid charging.",
           "hsem_batteries_expected_cycles": "Enter the expected number of full charge/discharge cycles over the battery's lifetime. Used to calculate depreciation cost per kWh and the recommended minimum export price threshold. Typical LiFePO4 batteries support 4000â€“8000 cycles.",
-          "hsem_batteries_purchase_price": "Enter the total purchase price of your battery system in EUR. Used together with expected cycles and usable capacity to calculate the depreciation cost per kWh and the recommended minimum export price threshold.",
+          "hsem_batteries_purchase_price": "Enter the total purchase price of your battery system in your local currency. Used together with expected cycles and usable capacity to calculate the depreciation cost per kWh and the recommended minimum export price threshold.",
           "hsem_huawei_solar_batteries_excess_pv_energy_use_in_tou": "Select the sensor that provides setting for excess PV energy use in TOU periods.",
           "hsem_huawei_solar_batteries_forcible_charge": "Sensor showing current forcible charge/discharge state (e.g. Stopped, Discharging at 5000W for 60 minutes)",
           "hsem_huawei_solar_batteries_end_of_discharge_soc": "Specify the end of discharge SOC percentage for your Huawei batteries. When the battery reaches this SOC level, it will stop discharging to prevent deep discharge and potential damage to the battery.",
@@ -259,9 +259,9 @@
       },
       "battery_economics": {
         "data": {
-          "hsem_batteries_purchase_price": "Battery Purchase Price (EUR)",
+          "hsem_batteries_purchase_price": "Battery Purchase Price",
           "hsem_batteries_expected_cycles": "Expected Battery Cycles",
-          "hsem_batteries_cycle_cost": "Battery Cycle Cost (EUR/kWh)",
+          "hsem_batteries_cycle_cost": "Battery Cycle Cost (per kWh)",
           "hsem_batteries_capacity_loss_pct": "Battery Capacity Loss at End-of-Life (%)",
           "hsem_batteries_charge_efficiency": "Battery Charge Efficiency (%)",
           "hsem_batteries_discharge_efficiency": "Battery Discharge Efficiency (%)",
@@ -271,9 +271,9 @@
           "hsem_planner_window_hysteresis_minutes": "Window Hysteresis Hold Time (minutes)"
         },
         "data_description": {
-          "hsem_batteries_purchase_price": "Enter the total purchase price of your battery system in EUR. Used together with expected cycles and usable capacity to calculate the depreciation cost per kWh and the recommended minimum export price threshold.",
+          "hsem_batteries_purchase_price": "Enter the total purchase price of your battery system in your local currency. Used together with expected cycles and usable capacity to calculate the depreciation cost per kWh and the recommended minimum export price threshold.",
           "hsem_batteries_expected_cycles": "Enter the expected number of full charge/discharge cycles over the battery's lifetime. Used to calculate depreciation cost per kWh and the recommended minimum export price threshold. Typical LiFePO4 batteries support 4000â€“8000 cycles.",
-          "hsem_batteries_cycle_cost": "Optional extra per-kWh cost of cycling the battery (EUR/kWh). Added on top of the auto-calculated depreciation threshold. Set to 0 to rely solely on the depreciation guard. Example: 0.02 means the planner requires 2 cent extra spread per kWh cycled before approving grid charging.",
+          "hsem_batteries_cycle_cost": "Optional extra per-kWh cost of cycling the battery (per kWh). Added on top of the auto-calculated depreciation threshold. Set to 0 to rely solely on the depreciation guard. Example: 0.02 means the planner requires 2 cent extra spread per kWh cycled before approving grid charging.",
           "hsem_batteries_capacity_loss_pct": "Expected capacity loss at end-of-life as a percentage. LiFePO4 typically reaches 80% capacity after ~6000 cycles (20% loss). Default 30% adds margin for calendar ageing.",
           "hsem_batteries_charge_efficiency": "Specify the charge-side efficiency of your battery as a percentage (0â€“100). Energy stored in the battery equals the input energy multiplied by this factor. Typical lithium batteries achieve 95â€“98 %. Defaults to 98 %.",
           "hsem_batteries_discharge_efficiency": "Specify the discharge-side efficiency of your battery as a percentage (0â€“100). Energy delivered to the house equals the battery energy removed multiplied by this factor. Typical lithium batteries achieve 95â€“98 %. Defaults to 98 %.",
@@ -686,10 +686,10 @@
       "huawei_solar": {
         "data": {
           "hsem_batteries_charge_efficiency": "Battery Charge Efficiency (%)",
-          "hsem_batteries_cycle_cost": "Battery Cycle Cost (EUR/kWh)",
+          "hsem_batteries_cycle_cost": "Battery Cycle Cost (per kWh)",
           "hsem_batteries_discharge_efficiency": "Battery Discharge Efficiency (%)",
           "hsem_batteries_expected_cycles": "Expected Battery Cycles",
-          "hsem_batteries_purchase_price": "Battery Purchase Price (EUR)",
+          "hsem_batteries_purchase_price": "Battery Purchase Price",
           "hsem_huawei_solar_batteries_excess_pv_energy_use_in_tou": "Huawei Batteries Excess PV energy use in TOU",
           "hsem_huawei_solar_batteries_forcible_charge": "Battery Forcible Charge State",
           "hsem_huawei_solar_batteries_end_of_discharge_soc": "Huawei Batteries End of Discharge SOC (%)",
@@ -709,9 +709,9 @@
         "data_description": {
           "hsem_batteries_charge_efficiency": "Specify the charge-side efficiency of your battery as a percentage (0â€“100). Energy stored in the battery equals the input energy multiplied by this factor. Typical lithium batteries achieve 95â€“98 %. Defaults to 98 %.",
           "hsem_batteries_discharge_efficiency": "Specify the discharge-side efficiency of your battery as a percentage (0â€“100). Energy delivered to the house equals the battery energy removed multiplied by this factor. Typical lithium batteries achieve 95â€“98 %. Defaults to 98 %.",
-          "hsem_batteries_cycle_cost": "Optional extra per-kWh cost of cycling the battery (EUR/kWh). Added on top of the auto-calculated depreciation threshold. Set to 0 to rely solely on the depreciation guard. Example: 0.02 means the planner requires 2 cent extra spread per kWh cycled before approving grid charging.",
+          "hsem_batteries_cycle_cost": "Optional extra per-kWh cost of cycling the battery (per kWh). Added on top of the auto-calculated depreciation threshold. Set to 0 to rely solely on the depreciation guard. Example: 0.02 means the planner requires 2 cent extra spread per kWh cycled before approving grid charging.",
           "hsem_batteries_expected_cycles": "Enter the expected number of full charge/discharge cycles over the battery's lifetime. Used to calculate depreciation cost per kWh and the recommended minimum export price threshold. Typical LiFePO4 batteries support 4000â€“8000 cycles.",
-          "hsem_batteries_purchase_price": "Enter the total purchase price of your battery system in EUR. Used together with expected cycles and usable capacity to calculate the depreciation cost per kWh and the recommended minimum export price threshold.",
+          "hsem_batteries_purchase_price": "Enter the total purchase price of your battery system in your local currency. Used together with expected cycles and usable capacity to calculate the depreciation cost per kWh and the recommended minimum export price threshold.",
           "hsem_huawei_solar_batteries_excess_pv_energy_use_in_tou": "Select the sensor that provides setting for excess PV energy use in TOU periods.",
           "hsem_huawei_solar_batteries_forcible_charge": "Sensor showing current forcible charge/discharge state (e.g. Stopped, Discharging at 5000W for 60 minutes)",
           "hsem_huawei_solar_batteries_end_of_discharge_soc": "Specify the end of discharge SOC percentage for your Huawei batteries. When the battery reaches this SOC level, it will stop discharging to prevent deep discharge and potential damage to the battery.",
@@ -733,9 +733,9 @@
       },
       "battery_economics": {
         "data": {
-          "hsem_batteries_purchase_price": "Battery Purchase Price (EUR)",
+          "hsem_batteries_purchase_price": "Battery Purchase Price",
           "hsem_batteries_expected_cycles": "Expected Battery Cycles",
-          "hsem_batteries_cycle_cost": "Battery Cycle Cost (EUR/kWh)",
+          "hsem_batteries_cycle_cost": "Battery Cycle Cost (per kWh)",
           "hsem_batteries_capacity_loss_pct": "Battery Capacity Loss at End-of-Life (%)",
           "hsem_batteries_charge_efficiency": "Battery Charge Efficiency (%)",
           "hsem_batteries_discharge_efficiency": "Battery Discharge Efficiency (%)",
@@ -745,9 +745,9 @@
           "hsem_planner_window_hysteresis_minutes": "Window Hysteresis Hold Time (minutes)"
         },
         "data_description": {
-          "hsem_batteries_purchase_price": "Enter the total purchase price of your battery system in EUR. Used together with expected cycles and usable capacity to calculate the depreciation cost per kWh and the recommended minimum export price threshold.",
+          "hsem_batteries_purchase_price": "Enter the total purchase price of your battery system in your local currency. Used together with expected cycles and usable capacity to calculate the depreciation cost per kWh and the recommended minimum export price threshold.",
           "hsem_batteries_expected_cycles": "Enter the expected number of full charge/discharge cycles over the battery's lifetime. Used to calculate depreciation cost per kWh and the recommended minimum export price threshold. Typical LiFePO4 batteries support 4000â€“8000 cycles.",
-          "hsem_batteries_cycle_cost": "Optional extra per-kWh cost of cycling the battery (EUR/kWh). Added on top of the auto-calculated depreciation threshold. Set to 0 to rely solely on the depreciation guard. Example: 0.02 means the planner requires 2 cent extra spread per kWh cycled before approving grid charging.",
+          "hsem_batteries_cycle_cost": "Optional extra per-kWh cost of cycling the battery (per kWh). Added on top of the auto-calculated depreciation threshold. Set to 0 to rely solely on the depreciation guard. Example: 0.02 means the planner requires 2 cent extra spread per kWh cycled before approving grid charging.",
           "hsem_batteries_capacity_loss_pct": "Expected capacity loss at end-of-life as a percentage. LiFePO4 typically reaches 80% capacity after ~6000 cycles (20% loss). Default 30% adds margin for calendar ageing.",
           "hsem_batteries_charge_efficiency": "Specify the charge-side efficiency of your battery as a percentage (0â€“100). Energy stored in the battery equals the input energy multiplied by this factor. Typical lithium batteries achieve 95â€“98 %. Defaults to 98 %.",
           "hsem_batteries_discharge_efficiency": "Specify the discharge-side efficiency of your battery as a percentage (0â€“100). Energy delivered to the house equals the battery energy removed multiplied by this factor. Typical lithium batteries achieve 95â€“98 %. Defaults to 98 %.",

--- a/docs/config-flow-reference.md
+++ b/docs/config-flow-reference.md
@@ -100,9 +100,9 @@ Battery depreciation and efficiency parameters.
 
 | Field | Key | Default | Description |
 |---|---|---|---|
-| Purchase price | `hsem_batteries_purchase_price` | 0 | Battery system cost (EUR) |
+| Purchase price | `hsem_batteries_purchase_price` | 0 | Battery system cost |
 | Expected cycles | `hsem_batteries_expected_cycles` | 6000 | Total expected lifetime cycles |
-| Cycle cost | `hsem_batteries_cycle_cost` | 0 | Extra per-kWh wear margin (EUR/kWh) |
+| Cycle cost | `hsem_batteries_cycle_cost` | 0 | Extra per-kWh wear margin |
 | Capacity loss at EOL | `hsem_batteries_capacity_loss_pct` | 30 % | Expected capacity loss at end-of-life (%) |
 | Charge efficiency | `hsem_batteries_charge_efficiency` | 98 % | Charge-side efficiency |
 | Discharge efficiency | `hsem_batteries_discharge_efficiency` | 98 % | Discharge-side efficiency |

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -686,7 +686,7 @@ The cost function returns **two distinct aggregates** for every plan
 (issue #413):
 
 - `total_cost` — the **money outcome** of the plan within the horizon.
-  Pure DKK / EUR.  Auditable; directly comparable to a real electricity bill.
+  Pure monetary value.  Auditable; directly comparable to a real electricity bill.
 - `score` — the **selector objective**.  Equals `total_cost` plus every
   synthetic penalty plus the terminal-SoC opportunity cost.  The candidate
   selector picks the plan with the **lowest score** — not the lowest money

--- a/tests/planner/fixtures.py
+++ b/tests/planner/fixtures.py
@@ -32,7 +32,7 @@ _DEFAULT_SUMMER_ISO = "2024-06-15T00:00:00+02:00"
 # Base 24-hour time-series helpers
 # ---------------------------------------------------------------------------
 
-# Danish-style spot prices (EUR/kWh, roughly realistic day-ahead pattern)
+# Danish-style spot prices (roughly realistic day-ahead pattern)
 # Index 0 = 00:00-01:00, index 23 = 23:00-24:00
 _SPOT_PRICES_SUMMER = [
     # 00-06: cheap overnight

--- a/tests/planner/test_ev_planned_load.py
+++ b/tests/planner/test_ev_planned_load.py
@@ -679,7 +679,7 @@ class TestPlannerEngineEVIntegration:
     def test_cheap_grid_can_still_charge_battery_while_ev_charging(self):
         """When grid price is cheap, home battery may grid-charge even during EV charging.
 
-        Set up cheapest grid price at 02:00 (0.01 EUR/kWh) with EV also charging.
+        Set up cheapest grid price at 02:00 (0.01 /kWh) with EV also charging.
         The planner may still assign BatteriesChargeGrid to cheap slots even
         when EV is scheduled there.
         """

--- a/tests/planner/test_invariants.py
+++ b/tests/planner/test_invariants.py
@@ -576,7 +576,7 @@ class TestForceExport:
             soc_high_penalty_weight=0.0,
         )
         bd = score_plan([slot], weights)
-        # 2.0 kWh × 0.15 EUR/kWh = 0.30 revenue
+        # 2.0 kWh × 0.15/kWh = 0.30 revenue
         assert bd.export_revenue == pytest.approx(0.30, abs=1e-6)
         assert bd.import_cost == pytest.approx(0.0, abs=1e-6)
         # total = 0 - 0.30 = -0.30 (net revenue)

--- a/tests/test_hourly_price_expansion.py
+++ b/tests/test_hourly_price_expansion.py
@@ -538,7 +538,7 @@ class TestVatCurrencyTransparency:
             assert sp.export_price == pytest.approx(0.987654, rel=1e-6)
 
     def test_large_price_values_preserved(self):
-        # Extreme price spike (e.g. 10 EUR/kWh = 74 DKK/kWh during energy crisis).
+        # Extreme price spike (e.g. 10/kWh = 74/kWh during energy crisis).
         imp = dict.fromkeys(range(24), 74.0)
         exp = dict.fromkeys(range(24), 55.0)
         slots = expand_hourly_prices_to_slots(self.now, imp, exp)


### PR DESCRIPTION
## Summary

Removes hardcoded "EUR" currency references from all user-facing labels, docstrings, and documentation. HSEM works with any currency — the labels should reflect that. Also relaxes EV planned-load selector minimums to allow zero (disabling the input when not needed).

## Changes

### Currency-neutral labels
- **Translations** (`en.json`, `da.json`): Replace labels like `"Battery Cycle Cost (EUR/kWh)"` → `"Battery Cycle Cost (per kWh)"` and `"Battery Purchase Price (EUR)"` → `"Battery Purchase Price"` across all config flow steps (huawei_solar, battery_economics, options).
- **Docstrings** (`sensor_config.py`, `cost_function.py`): Remove `EUR` and `DKK` references in parameter docs.
- **Documentation** (`config-flow-reference.md`, `planner-spec.md`): Remove currency-specific references.
- **Tests** (`fixtures.py`, `test_ev_planned_load.py`, `test_invariants.py`, `test_hourly_price_expansion.py`): Update comments to match.

### EV planned-load selector minimums
- **`ev_planned_load_helpers.py`**: Lower `_CAPACITY_SELECTOR` min from `1.0` → `0.0` and `_POWER_KW_SELECTOR` min from `0.1` → `0.0`, allowing users to disable these inputs by setting them to zero.

## Checklist

- [x] Translations updated (en, da)
- [x] Docstrings updated
- [x] Documentation updated
- [ ] CI passes (lint, typing, quality, py314)