### PR TITLE
fix(planner): strip EV power from live house consumption injection

### DIFF
--- a/custom_components/hsem/planner/engine_core.py
+++ b/custom_components/hsem/planner/engine_core.py
@@ -228,7 +228,54 @@ def _inject_live_data_into_current_slot(
                 slot.solcast_pv_estimate_kwh = round(live_pv_kwh, 3)
 
             if inp.live_house_consumption_w > 1e-9:
-                live_load_kwh = (inp.live_house_consumption_w / 1000.0) * slot_hours
+                # When house power includes EV charger load, the live reading
+                # may include EV power that the battery must not serve.
+                #
+                # Layer 1: if ev_session_charge_kw is available (EV actively
+                # charging with a known power reading), subtract it directly.
+                #
+                # Layer 2: otherwise, if the live reading is dramatically
+                # higher than the forecast (>3×), cap the injection at the
+                # forecast value.  A 3× spike is unambiguous EV load — normal
+                # house load does not triple between slots (issue #592).
+                live_house_w = inp.live_house_consumption_w
+                if inp.house_power_includes_ev:
+                    ev_ac_w = 0.0
+                    if (
+                        inp.ev_session_charge_kw is not None
+                        and inp.ev_session_charge_kw > 1e-9
+                    ):
+                        ev_ac_w += inp.ev_session_charge_kw * 1000.0
+                    if (
+                        inp.ev_second_session_charge_kw is not None
+                        and inp.ev_second_session_charge_kw > 1e-9
+                    ):
+                        ev_ac_w += inp.ev_second_session_charge_kw * 1000.0
+                    live_house_w = max(live_house_w - ev_ac_w, 0.0)
+
+                live_load_kwh = (live_house_w / 1000.0) * slot_hours
+
+                # If the live reading (after subtracting known EV power) still
+                # exceeds the forecast by >3×, it likely contains unmeasured EV
+                # load.  Cap at the forecast to prevent the battery from
+                # serving unknown EV demand.
+                forecast = slot.avg_house_consumption_kwh
+                if (
+                    inp.house_power_includes_ev
+                    and live_load_kwh > forecast * 3.0
+                    and forecast > 1e-9
+                ):
+                    log_planner(
+                        "debug",
+                        "[core] _inject_live_data  slot=%s  "
+                        "live %.3f kWh > 3× forecast %.3f kWh — "
+                        "capping at forecast (probable unmeasured EV load)",
+                        slot.start.isoformat(),
+                        live_load_kwh,
+                        forecast,
+                    )
+                    live_load_kwh = forecast
+
                 log_planner(
                     "debug",
                     "[core] _inject_live_data  slot=%s  "


### PR DESCRIPTION
## Summary

Follow-up to PR #680. Strips EV power from the live house consumption injection in `_inject_live_data_into_current_slot` — the root cause of the battery discharging into the EV.

PR #680 added a MILP-level guard for `ev_accounted_load_kwh`, but that only covers the case where the EV planner has populated planned load into slots. It doesn't cover @Extati's Clever scenario (boolean EV sensor only, no smart charging, no power reading) where `ev_accounted_load_kwh` and `ev_session_charge_kw` are both 0/None.

## Fix — Two safeguards in `_inject_live_data_into_current_slot`

When `house_power_includes_ev=True`:

1. **If `ev_session_charge_kw` is available** — subtract the known EV AC power directly from the live house consumption before injecting into the slot.

2. **If the live reading still exceeds 3× the forecast** after layer 1 — cap it at the forecast value. A 3× spike (e.g., 11 kW EV vs 0.5 kW house load) is unambiguous unmeasured EV load from an unmetered charger like a boolean-only sensor.

## Files changed

| File | Change |
|---|---|
| `custom_components/hsem/planner/engine_core.py` | Strip EV power from live injection + 3× forecast cap |

## Test results

- **685 passed**, 12 pre-existing failures (unchanged)
- Zero new failures

## Related

- PR #680 — MILP discharge guard for `ev_accounted_load_kwh` path (already merged)

Fixes #592