### PR TITLE
feat(devcontainer): add YubiKey SSH/GPG support via TCP relay

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.14.2-alpine
+
+# Install GPG, smartcard support, and YubiKey manager
+# pyscard (ykman dep) needs gcc/musl-dev/pcsc-lite-dev/swig to build
+RUN apk add --no-cache \
+    gnupg \
+    gpg-agent \
+    pinentry \
+    pcsc-lite \
+    pcsc-lite-dev \
+    openssh-client \
+    git \
+    socat \
+    gcc \
+    musl-dev \
+    swig \
+    && pip install --no-cache-dir yubikey-manager \
+    && apk del pcsc-lite-dev gcc musl-dev swig
+
+# Copy the SSH agent bridge script
+COPY scripts/devcontainer-agent-bridge.sh /usr/local/bin/devcontainer-agent-bridge.sh
+RUN chmod +x /usr/local/bin/devcontainer-agent-bridge.sh

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -13,6 +13,42 @@ In the container you will have a dedicated Home Assistant core instance running 
 - [Visual Studio code](https://code.visualstudio.com/)
 - [Remote - Containers (VSC Extension)][extension-link]
 
+**YubiKey / GPG Support**
+
+The devcontainer is pre-configured to use your YubiKey for SSH authentication and GPG signing:
+
+- `gnupg`, `gpg-agent`, `pinentry`, `socat`, `openssh-client`, and `git` are installed in the container
+- Your host `~/.ssh`, `~/.gnupg`, and `~/.gitconfig` are mounted into the container
+- `yubikey-manager` CLI (`ykman`) is available for managing your YubiKey
+
+**macOS setup**: Docker Desktop runs inside a Linux VM and cannot forward Unix domain
+sockets (like `gpg-agent.ssh`) across the VM boundary. This devcontainer uses a TCP
+relay to bridge the SSH and GPG agents from host to container.
+
+1. **Install the relay as a macOS LaunchAgent** (runs at login, restarts automatically):
+   ```sh
+   sh .devcontainer/scripts/install-agent-relay.sh install
+   ```
+   This starts TCP relays on ports 9999 (SSH agent), 9998 (GPG agent), 9997 (scdaemon).
+
+2. **Check status**:
+   ```sh
+   sh .devcontainer/scripts/install-agent-relay.sh status
+   ```
+
+3. **Open the devcontainer** in VS Code (`F1` → `Remote-Containers: Reopen in Container`).
+   The `postCreateCommand` automatically starts the container-side socat bridge.
+
+4. **Verify**: run `ssh -T git@github.com` and `gpg --card-status` in the container terminal.
+
+To uninstall the relay:
+   ```sh
+   sh .devcontainer/scripts/install-agent-relay.sh uninstall
+   ```
+
+**Linux note**: On a native Linux Docker host, you can add `--privileged` and USB
+device mounts via `runArgs` in `devcontainer.json` for direct hardware access.
+
 [More info about requirements and devcontainer in general](https://code.visualstudio.com/docs/remote/containers#_getting-started)
 
 [extension-link]: https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,22 @@
 // See https://containers.dev/implementors/json_reference/ for format details.
-// Note that python:0-3.10-bullseye should be used for local arm64/Apple Silicon.
-// Depending on setup, "remoteUser": "vscode", might be preferred to add.
 {
   "name": "HSEM",
-  "image": "python:3.14.2-alpine",
-  "postCreateCommand": "scripts/setup",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "postCreateCommand": "devcontainer-agent-bridge.sh /bin/sh -c 'echo SSH agent ready in container || true'",
+  "remoteUser": "root",
   "forwardPorts": [8123],
   "mounts": [
     "type=bind,source=${localEnv:HOME}/.ssh,target=/root/.ssh,readonly",
-    "type=bind,source=${localEnv:HOME}/.gnupg,target=/root/.gnupg,readonly"
-  ]
+    "type=bind,source=${localEnv:HOME}/.gnupg,target=/root/.gnupg",
+    "type=bind,source=${localEnv:HOME}/.gitconfig,target=/root/.gitconfig,readonly"
+  ],
+  "containerEnv": {
+    "SSH_AUTH_SOCK": "/tmp/ssh-agent.sock",
+    "SSH_AGENT_PORT": "9999",
+    "GPG_AGENT_PORT": "9998",
+    "SCDAEMON_PORT": "9997",
+    "SSH_AGENT_HOST": "host.docker.internal"
+  }
 }

--- a/.devcontainer/scripts/com.hsem.agent-relay.plist.template
+++ b/.devcontainer/scripts/com.hsem.agent-relay.plist.template
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.hsem.agent-relay</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/python3</string>
+        <string>RELAY_SCRIPT_PATH</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>LOG_PATH</string>
+
+    <key>StandardErrorPath</key>
+    <string>LOG_PATH</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>SSH_AUTH_SOCK</key>
+        <string>SSH_AUTH_SOCK_PLACEHOLDER</string>
+    </dict>
+</dict>
+</plist>

--- a/.devcontainer/scripts/devcontainer-agent-bridge.sh
+++ b/.devcontainer/scripts/devcontainer-agent-bridge.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+# Bridges SSH and GPG agents from macOS host to container over TCP.
+#
+# Docker Desktop for Mac runs inside a Linux VM and cannot forward
+# Unix domain sockets. This script uses socat to relay the host-side
+# SSH agent (gpg-agent.ssh), GPG agent (gpg-agent), and scdaemon
+# sockets from the macOS host into the container over TCP.
+#
+# Sockets are created in /tmp (container-local) because Docker for Mac's
+# bind-mounted filesystems (osxfs) do not support Unix sockets.
+#
+# GPG needs a writable homedir for lock files and stub generation.
+# We copy the host's read-only gnupg data to a container-local directory.
+
+set -e
+
+SSH_PORT="${SSH_AGENT_PORT:-9999}"
+GPG_PORT="${GPG_AGENT_PORT:-9998}"
+SCDAEMON_PORT="${SCDAEMON_PORT:-9997}"
+AGENT_HOST="${SSH_AGENT_HOST:-host.docker.internal}"
+
+# Kill any stale relays
+pkill -f "socat.*${SSH_PORT}" 2>/dev/null || true
+pkill -f "socat.*${GPG_PORT}" 2>/dev/null || true
+pkill -f "socat.*${SCDAEMON_PORT}" 2>/dev/null || true
+
+# Create TCP→Unix relays in /tmp
+socat UNIX-LISTEN:/tmp/ssh-agent.sock,fork,mode=0600 \
+    TCP:"${AGENT_HOST}:${SSH_PORT}" &
+
+socat UNIX-LISTEN:/tmp/S.gpg-agent,fork,mode=0600 \
+    TCP:"${AGENT_HOST}:${GPG_PORT}" &
+
+socat UNIX-LISTEN:/tmp/S.scdaemon,fork,mode=0600 \
+    TCP:"${AGENT_HOST}:${SCDAEMON_PORT}" &
+
+# Wait for relays to be ready
+for i in $(seq 1 10); do
+    if [ -S /tmp/ssh-agent.sock ] && [ -S /tmp/S.gpg-agent ] && [ -S /tmp/S.scdaemon ]; then
+        break
+    fi
+    sleep 0.5
+done
+
+echo "SSH agent bridge ready:  /tmp/ssh-agent.sock -> ${AGENT_HOST}:${SSH_PORT}"
+echo "GPG agent bridge ready:   /tmp/S.gpg-agent -> ${AGENT_HOST}:${GPG_PORT}"
+echo "scdaemon bridge ready:    /tmp/S.scdaemon -> ${AGENT_HOST}:${SCDAEMON_PORT}"
+
+# Copy host gnupg data to container-local writable directory, then
+# replace the sockets with our relayed ones
+rm -rf /tmp/gpg-home
+cp -a /root/.gnupg /tmp/gpg-home
+rm -f /tmp/gpg-home/S.gpg-agent /tmp/gpg-home/S.scdaemon /tmp/gpg-home/S.gpg-agent.ssh
+ln -sf /tmp/S.gpg-agent /tmp/gpg-home/S.gpg-agent
+ln -sf /tmp/S.scdaemon /tmp/gpg-home/S.scdaemon
+ln -sf /tmp/ssh-agent.sock /tmp/gpg-home/S.gpg-agent.ssh
+
+export SSH_AUTH_SOCK=/tmp/ssh-agent.sock
+export GNUPGHOME=/tmp/gpg-home
+
+# Create writable global git config (host ~/.gitconfig is mounted read-only
+# and may point to /opt/homebrew/bin/gpg which doesn't exist in the container)
+cp /root/.gitconfig /tmp/gitconfig 2>/dev/null || true
+git config -f /tmp/gitconfig gpg.program /usr/bin/gpg 2>/dev/null || true
+export GIT_CONFIG_GLOBAL=/tmp/gitconfig
+
+echo "GPG homedir ready: /tmp/gpg-home"
+echo "Environment: SSH_AUTH_SOCK=$SSH_AUTH_SOCK GNUPGHOME=$GNUPGHOME"
+
+# Keep the relay alive
+exec "$@"

--- a/.devcontainer/scripts/install-agent-relay.sh
+++ b/.devcontainer/scripts/install-agent-relay.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+# Install/uninstall the HSEM agent relay as a macOS LaunchAgent.
+#
+# The relay bridges YubiKey GPG/SSH agent sockets over TCP so Docker
+# containers can access them. This installs it as a per-user service
+# that starts at login and restarts if it crashes.
+#
+# Usage:
+#   sh install-agent-relay.sh install    # Install and start
+#   sh install-agent-relay.sh uninstall  # Stop and remove
+#   sh install-agent-relay.sh status     # Check if running
+
+set -e
+
+LABEL="com.hsem.agent-relay"
+PLIST="$HOME/Library/LaunchAgents/${LABEL}.plist"
+LOG="$HOME/Library/Logs/${LABEL}.log"
+APP_SUPPORT="$HOME/Library/Application Support"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RELAY_SRC="$SCRIPT_DIR/start-agent-relay.py"
+RELAY_DST="$APP_SUPPORT/hsem-agent-relay.py"
+TEMPLATE="$SCRIPT_DIR/com.hsem.agent-relay.plist.template"
+
+install_service() {
+    echo "Installing HSEM agent relay as LaunchAgent..."
+
+    if [ ! -f "$RELAY_SRC" ]; then
+        echo "ERROR: Relay script not found at $RELAY_SRC"
+        exit 1
+    fi
+
+    # Copy relay to Application Support (launchd can't access arbitrary paths)
+    mkdir -p "$APP_SUPPORT"
+    cp "$RELAY_SRC" "$RELAY_DST"
+
+    # Create LaunchAgents dir if needed
+    mkdir -p "$HOME/Library/LaunchAgents"
+
+    # Generate plist from template
+    sed -e "s|RELAY_SCRIPT_PATH|$RELAY_DST|g" \
+        -e "s|LOG_PATH|$LOG|g" \
+        -e "s|SSH_AUTH_SOCK_PLACEHOLDER|${SSH_AUTH_SOCK:-$HOME/.gnupg/S.gpg-agent.ssh}|g" \
+        "$TEMPLATE" > "$PLIST"
+
+    # Unload old if running
+    launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || true
+
+    # Load and start
+    launchctl bootstrap "gui/$(id -u)" "$PLIST"
+
+    echo ""
+    echo "Installed. Service will start at login and run in the background."
+    echo "  Relay script: $RELAY_DST"
+    echo "  Plist:        $PLIST"
+    echo "  Logs:         $LOG"
+    echo ""
+    echo "Ports: 9999 (SSH agent), 9998 (GPG agent), 9997 (scdaemon)"
+}
+
+uninstall_service() {
+    echo "Uninstalling HSEM agent relay..."
+
+    launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || true
+    rm -f "$PLIST"
+    rm -f "$LOG"
+    rm -f "$RELAY_DST"
+
+    echo "Uninstalled."
+}
+
+status_service() {
+    if launchctl print "gui/$(id -u)/${LABEL}" > /dev/null 2>&1; then
+        echo "Service: RUNNING"
+        launchctl print "gui/$(id -u)/${LABEL}" 2>/dev/null | grep -E "state|last exit"
+        echo ""
+        lsof -iTCP -sTCP:LISTEN -P 2>/dev/null | grep -E "999[789]" || echo "No ports listening (may need a moment to start)"
+    else
+        echo "Service: NOT INSTALLED"
+    fi
+}
+
+case "${1:-}" in
+    install) install_service ;;
+    uninstall) uninstall_service ;;
+    status) status_service ;;
+    *)
+        echo "Usage: $0 {install|uninstall|status}"
+        exit 1
+        ;;
+esac

--- a/.devcontainer/scripts/start-agent-relay.py
+++ b/.devcontainer/scripts/start-agent-relay.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Start TCP relays for SSH agent, GPG agent, and scdaemon on macOS host.
+
+Docker Desktop for Mac cannot forward Unix domain sockets across the VM boundary.
+This script listens on TCP ports and forwards traffic to the Unix sockets,
+allowing the devcontainer to reach the YubiKey-backed agents.
+
+Usage:
+    python3 start-agent-relay.py
+"""
+
+import argparse
+import os
+import socket
+import select
+import sys
+import threading
+
+
+def relay(client_sock: socket.socket, agent_path: str) -> None:
+    """Bidirectional relay between a client socket and the Unix agent socket."""
+    agent_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        agent_sock.connect(agent_path)
+    except OSError as e:
+        print(f"Failed to connect to agent at {agent_path}: {e}", file=sys.stderr)
+        client_sock.close()
+        return
+
+    sockets = [client_sock, agent_sock]
+    try:
+        while True:
+            readable, _, _ = select.select(sockets, [], [], 30)
+            if not readable:
+                break
+            for sock in readable:
+                data = sock.recv(65536)
+                if not data:
+                    return
+                target = agent_sock if sock is client_sock else client_sock
+                target.sendall(data)
+    finally:
+        client_sock.close()
+        agent_sock.close()
+
+
+def start_listener(port: int, socket_path: str, label: str) -> None:
+    """Start a TCP listener that relays to a Unix socket."""
+    if not os.path.exists(socket_path):
+        print(f"ERROR: {label} socket not found: {socket_path}", file=sys.stderr)
+        return
+
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(("127.0.0.1", port))
+    server.listen(5)
+
+    print(f"{label} relay: 127.0.0.1:{port} -> {socket_path}")
+
+    def accept_loop():
+        try:
+            while True:
+                client, addr = server.accept()
+                t = threading.Thread(target=relay, args=(client, socket_path), daemon=True)
+                t.start()
+        except OSError:
+            pass
+
+    threading.Thread(target=accept_loop, daemon=True).start()
+
+
+def main() -> None:
+    gnupg_dir = os.path.expanduser("~/.gnupg")
+
+    parser = argparse.ArgumentParser(description="SSH + GPG + scdaemon agent TCP relays")
+    parser.add_argument("--ssh-port", type=int, default=9999, help="TCP port for SSH agent relay")
+    parser.add_argument("--gpg-port", type=int, default=9998, help="TCP port for GPG agent relay")
+    parser.add_argument("--scdaemon-port", type=int, default=9997, help="TCP port for scdaemon relay")
+    parser.add_argument(
+        "--ssh-socket",
+        default=os.environ.get("SSH_AUTH_SOCK", os.path.join(gnupg_dir, "S.gpg-agent.ssh")),
+        help="Path to SSH agent Unix socket",
+    )
+    parser.add_argument(
+        "--gpg-socket",
+        default=os.path.join(gnupg_dir, "S.gpg-agent"),
+        help="Path to GPG agent Unix socket",
+    )
+    parser.add_argument(
+        "--scdaemon-socket",
+        default=os.path.join(gnupg_dir, "S.scdaemon"),
+        help="Path to scdaemon Unix socket",
+    )
+    args = parser.parse_args()
+
+    start_listener(args.ssh_port, args.ssh_socket, "SSH agent")
+    start_listener(args.gpg_port, args.gpg_socket, "GPG agent")
+    start_listener(args.scdaemon_port, args.scdaemon_socket, "scdaemon")
+
+    print("")
+    print("Container can connect to:")
+    print(f"  SSH agent: host.docker.internal:{args.ssh_port}")
+    print(f"  GPG agent: host.docker.internal:{args.gpg_port}")
+    print(f"  scdaemon:  host.docker.internal:{args.scdaemon_port}")
+    print("Press Ctrl+C to stop.")
+
+    try:
+        threading.Event().wait()
+    except KeyboardInterrupt:
+        print("\nShutting down.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.devcontainer/scripts/start-agent-relay.sh
+++ b/.devcontainer/scripts/start-agent-relay.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Starts the SSH agent TCP relay on the macOS host.
+# Run this before starting the devcontainer.
+# Uses Python 3 (ships with macOS) - no external dependencies needed.
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+exec python3 "$DIR/start-agent-relay.py" "$@"


### PR DESCRIPTION
## Summary

Add YubiKey SSH and GPG agent support to the devcontainer for macOS Docker Desktop users.

Docker Desktop for Mac cannot forward Unix domain sockets across the VM boundary, making YubiKey-backed SSH and GPG agents inaccessible inside containers. This PR adds a TCP relay system that bridges host agent sockets into the devcontainer.

### Architecture

```
macOS host                                    Docker VM / container
──────────                                    ─────────────────────
S.gpg-agent.ssh ───TCP:9999──► host.docker.internal:9999 ──socat──► /tmp/ssh-agent.sock
S.gpg-agent     ───TCP:9998──► host.docker.internal:9998 ──socat──► /tmp/S.gpg-agent
S.scdaemon      ───TCP:9997──► host.docker.internal:9997 ──socat──► /tmp/S.scdaemon
                                                       │
                                              cp -a /root/.gnupg → /tmp/gpg-home
                                              symlink sockets in
                                              GNUPGHOME=/tmp/gpg-home
```

### Files changed

| File | Change |
|------|--------|
| `.devcontainer/Dockerfile` | **New** — builds from `python:3.14.2-alpine`, adds gnupg, gpg-agent, pcsc-lite, openssh-client, git, socat, ykman |
| `.devcontainer/devcontainer.json` | Switched from `"image"` to `"build"`, sets env vars for relay ports, runs bridge in `postCreateCommand`, changed gnupg mount to read-write |
| `.devcontainer/scripts/start-agent-relay.py` | **New** — Python TCP relay that bridges SSH, GPG, and scdaemon sockets on macOS host |
| `.devcontainer/scripts/start-agent-relay.sh` | **New** — Shell wrapper for the relay |
| `.devcontainer/scripts/devcontainer-agent-bridge.sh` | **New** — Container-side socat bridge + GPG homedir setup + git config fixup |
| `.devcontainer/scripts/install-agent-relay.sh` | **New** — Install/uninstall as macOS LaunchAgent (auto-start at login) |
| `.devcontainer/scripts/com.hsem.agent-relay.plist.template` | **New** — LaunchAgent plist template |
| `.devcontainer/README.md` | Updated setup instructions with LaunchAgent and relay documentation |

### Verified

- [x] `ssh -T git@github.com` works from container → "Hi woopstar!"
- [x] `gpg --card-status` works from container → YubiKey detected
- [x] LaunchAgent starts at login and restarts on crash
- [x] Docker image builds successfully

### Known limitation

GPG signing (`gpg --clearsign`) fails with "No secret key" because the signing subkey stub file is missing from `~/.gnupg/private-keys-v1.d/` on the host. This is a host-side GPG configuration issue — the stub needs to be regenerated via `gpg --card-edit` → `fetch`. Once that's done on the host, the container will pick it up automatically.

### Usage

```sh
# Install the relay as a macOS LaunchAgent (auto-start at login)
sh .devcontainer/scripts/install-agent-relay.sh install

# Open in VS Code → F1 → Remote-Containers: Reopen in Container
# Inside the container:
ssh -T git@github.com
gpg --card-status
```