### PR TITLE
fix(applier): cap max discharge power to 0W when EV is charging

### DIFF
--- a/custom_components/hsem/custom_sensors/applier.py
+++ b/custom_components/hsem/custom_sensors/applier.py
@@ -308,6 +308,47 @@ async def async_apply_battery_settings(
 
     recommendation = rec.recommendation
 
+    # When an EV is actively charging and we are NOT in a forced-discharge
+    # or forced-export recommendation, cap the battery discharge power at 0
+    # to prevent the Huawei inverter from physically discharging into the EV
+    # (issue #592).  The inverter's CT clamp sees the full EV load as demand
+    # and will offset it from the battery unless the discharge power is
+    # explicitly restricted.
+    #
+    # This applies regardless of whether the planner successfully capped the
+    # consumption forecast — the physical hardware must be told not to
+    # discharge.
+    ev_active = live.ev.is_charging or live.ev_second.is_charging
+    if (
+        ev_active
+        and recommendation
+        not in (
+            Recommendations.ForceBatteriesDischarge.value,
+            Recommendations.ForceExport.value,
+        )
+    ):
+        discharge_entity = cfg.huawei_solar_batteries_maximum_discharging_power
+        if discharge_entity is not None and live.huawei_batteries_max_discharge_power_w != 0:
+            _de3: str = discharge_entity  # narrowed for closure
+            ev_discharge_result = await async_write_and_verify(
+                entity_id=_de3,
+                desired=0,
+                writer=lambda: async_set_number_value(sensor, _de3, 0),
+                reader=lambda: _read_number_state(sensor, _de3),
+            )
+            summary.results.append(ev_discharge_result)
+            _LOGGER.debug(
+                "EV active — capped max discharge power to 0 W to prevent "
+                "battery from discharging into EV.",
+                "debug",
+            )
+            if ev_discharge_result.status == ApplyStatus.FAILED:
+                _LOGGER.debug(
+                    f"EV discharge cap write FAILED for {discharge_entity}.",
+                    "error",
+                )
+                return summary
+
     # If we're switching away from force discharge, explicitly stop any
     # active forcible charge/discharge before applying the new mode.
     if recommendation not in (


### PR DESCRIPTION
## Summary

The planner-level fixes (PR #680 + PR #681) correctly prevent the planner from recommending battery discharge during EV charging. But the Huawei inverter's CT clamp still sees the EV load as demand and physically discharges from the battery unless the hardware discharge limit is explicitly restricted.

## Problem

In `async_apply_battery_settings`, the code that sets `maximum_discharge_power` on the Huawei inverter is **skipped entirely** when an EV is charging:

```python
# Set maximum discharging power unless EV is charging
if not live.ev.is_charging and not live.ev_second.is_charging:
    ...
```

This means the inverter retains its previous (typically full 5000W) discharge limit. When a massive EV load (11 kW) hits the CT clamp, even in `batteries_charge_solar` / Self-Consumption mode, the inverter offsets the demand from the battery — draining it into the EV.

## Fix

When an EV is actively charging AND the planner is NOT in a forced-discharge or forced-export recommendation, set `maximum_discharge_power` to **0 W** on the Huawei inverter to physically block battery discharge.

Forced-discharge and forced-export modes are exempt — those are intentional user-requested discharge actions that should proceed.

## Files changed

| File | Change |
|---|---|
| `custom_components/hsem/custom_sensors/applier.py` | Cap `max_discharge_power` to 0W when EV charging + not forced-discharge/export |

## Related PRs

- PR #680 — MILP discharge guard for `ev_accounted_load_kwh`
- PR #681 — Strip EV power from live injection + 3× forecast cap
- This PR — Hardware-level enforcement on the Huawei inverter

#592