### PR TITLE
fix(applier): use live net_consumption_w for EV discharge cap

### DIFF
--- a/custom_components/hsem/custom_sensors/applier.py
+++ b/custom_components/hsem/custom_sensors/applier.py
@@ -309,15 +309,16 @@ async def async_apply_battery_settings(
     recommendation = rec.recommendation
 
     # When an EV is actively charging and we are NOT in a forced-discharge
-    # or forced-export recommendation, cap the battery discharge power at 0
-    # to prevent the Huawei inverter from physically discharging into the EV
-    # (issue #592).  The inverter's CT clamp sees the full EV load as demand
-    # and will offset it from the battery unless the discharge power is
-    # explicitly restricted.
+    # or forced-export recommendation, cap the battery discharge power to
+    # the historical weighted average house consumption to prevent the
+    # Huawei inverter from physically discharging into the EV (issue #592).
     #
-    # This applies regardless of whether the planner successfully capped the
-    # consumption forecast — the physical hardware must be told not to
-    # discharge.
+    # The inverter's CT clamp sees the full EV load as demand and will
+    # offset it from the battery unless the discharge power is explicitly
+    # restricted.  Instead of a hard 0 W cap, we set the limit to the
+    # historical average house consumption (converted to Watts) so that
+    # the battery still covers normal house load while 100% of the EV
+    # load goes to the grid.
     ev_active = live.ev.is_charging or live.ev_second.is_charging
     if (
         ev_active
@@ -328,26 +329,40 @@ async def async_apply_battery_settings(
         )
     ):
         discharge_entity = cfg.huawei_solar_batteries_maximum_discharging_power
-        if discharge_entity is not None and live.huawei_batteries_max_discharge_power_w != 0:
-            _de3: str = discharge_entity  # narrowed for closure
-            ev_discharge_result = await async_write_and_verify(
-                entity_id=_de3,
-                desired=0,
-                writer=lambda: async_set_number_value(sensor, _de3, 0),
-                reader=lambda: _read_number_state(sensor, _de3),
+        if discharge_entity is not None:
+            # Use the weighted average house consumption from the current
+            # recommendation slot (already capped by the planner's 3×
+            # forecast guard in PR #681).  Convert kWh to Watts using the
+            # slot duration.
+            slot_hours = (rec.end - rec.start).total_seconds() / 3600.0
+            house_avg_w = (
+                int(rec.avg_house_consumption_kwh / slot_hours * 1000.0)
+                if slot_hours > 1e-9
+                and rec.avg_house_consumption_kwh > 1e-9
+                else 0
             )
-            summary.results.append(ev_discharge_result)
-            _LOGGER.debug(
-                "EV active — capped max discharge power to 0 W to prevent "
-                "battery from discharging into EV.",
-                "debug",
-            )
-            if ev_discharge_result.status == ApplyStatus.FAILED:
-                _LOGGER.debug(
-                    f"EV discharge cap write FAILED for {discharge_entity}.",
-                    "error",
+            if live.huawei_batteries_max_discharge_power_w != house_avg_w:
+                _de3: str = discharge_entity  # narrowed for closure
+                ev_discharge_result = await async_write_and_verify(
+                    entity_id=_de3,
+                    desired=house_avg_w,
+                    writer=lambda: async_set_number_value(sensor, _de3, house_avg_w),
+                    reader=lambda: _read_number_state(sensor, _de3),
                 )
-                return summary
+                summary.results.append(ev_discharge_result)
+                _LOGGER.debug(
+                    "EV active — capped max discharge power to %d W "
+                    "(house avg %.3f kWh/slot) to prevent battery from "
+                    "discharging into EV.",
+                    house_avg_w,
+                    rec.avg_house_consumption_kwh,
+                )
+                if ev_discharge_result.status == ApplyStatus.FAILED:
+                    _LOGGER.debug(
+                        f"EV discharge cap write FAILED for {discharge_entity}.",
+                        "error",
+                    )
+                    return summary
 
     # If we're switching away from force discharge, explicitly stop any
     # active forcible charge/discharge before applying the new mode.

--- a/custom_components/hsem/custom_sensors/applier.py
+++ b/custom_components/hsem/custom_sensors/applier.py
@@ -310,15 +310,21 @@ async def async_apply_battery_settings(
 
     # When an EV is actively charging and we are NOT in a forced-discharge
     # or forced-export recommendation, cap the battery discharge power to
-    # the historical weighted average house consumption to prevent the
-    # Huawei inverter from physically discharging into the EV (issue #592).
+    # the house-only consumption to prevent the Huawei inverter from
+    # physically discharging into the EV (issue #592).
     #
     # The inverter's CT clamp sees the full EV load as demand and will
     # offset it from the battery unless the discharge power is explicitly
-    # restricted.  Instead of a hard 0 W cap, we set the limit to the
-    # historical average house consumption (converted to Watts) so that
-    # the battery still covers normal house load while 100% of the EV
-    # load goes to the grid.
+    # restricted.  We cap at the estimated house-only load so the battery
+    # still covers normal house demand while 100% of the EV load goes to
+    # the grid.
+    #
+    # Two sources, in order of preference:
+    # 1. Live net_consumption_w (house - solar - ev) — directly measured,
+    #    already has EV power subtracted when a power sensor is available.
+    #    Not affected by polluted v5 upgrade history.
+    # 2. Historical avg_house_consumption_kwh from the planner slot —
+    #    fallback when live data is unavailable or less conservative.
     ev_active = live.ev.is_charging or live.ev_second.is_charging
     if (
         ev_active
@@ -330,17 +336,25 @@ async def async_apply_battery_settings(
     ):
         discharge_entity = cfg.huawei_solar_batteries_maximum_discharging_power
         if discharge_entity is not None:
-            # Use the weighted average house consumption from the current
-            # recommendation slot (already capped by the planner's 3×
-            # forecast guard in PR #681).  Convert kWh to Watts using the
-            # slot duration.
+            # Prefer the live net consumption reading (house minus solar
+            # minus EV) — it's always current and unaffected by polluted
+            # v5 upgrade history.  Falls back to the planner's historical
+            # average when live data is unavailable or less conservative.
             slot_hours = (rec.end - rec.start).total_seconds() / 3600.0
-            house_avg_w = (
+            live_net_w = live.net_consumption_w
+            historical_w = (
                 int(rec.avg_house_consumption_kwh / slot_hours * 1000.0)
                 if slot_hours > 1e-9
                 and rec.avg_house_consumption_kwh > 1e-9
                 else 0
             )
+            if live_net_w is not None and live_net_w > 0:
+                # Live reading is available.  Use it if it's more
+                # conservative than the historical average (protects
+                # against polluted v5 upgrade data).
+                house_avg_w = int(min(live_net_w, max(historical_w, 1)))
+            else:
+                house_avg_w = historical_w
             if live.huawei_batteries_max_discharge_power_w != house_avg_w:
                 _de3: str = discharge_entity  # narrowed for closure
                 ev_discharge_result = await async_write_and_verify(
@@ -352,9 +366,10 @@ async def async_apply_battery_settings(
                 summary.results.append(ev_discharge_result)
                 _LOGGER.debug(
                     "EV active — capped max discharge power to %d W "
-                    "(house avg %.3f kWh/slot) to prevent battery from "
-                    "discharging into EV.",
+                    "(live_net=%s W, hist_avg=%.3f kWh/slot) to prevent "
+                    "battery from discharging into EV.",
                     house_avg_w,
+                    f"{live_net_w:.0f}" if live_net_w is not None else "N/A",
                     rec.avg_house_consumption_kwh,
                 )
                 if ev_discharge_result.status == ApplyStatus.FAILED:


### PR DESCRIPTION
## Summary

When upgrading from v5 with `house_power_includes_ev=True` but no EV power sensor, the 14-day rolling consumption averages are polluted with EV load. This inflates the discharge cap during EV charging — causing the battery to discharge at kW levels instead of the actual ~400W house baseline.

## Root Cause

The v6.1.0 beta4 applier uses `rec.avg_house_consumption_kwh` (planner's historical weighted average) to set the discharge cap. When upgrading from v5, this history contains full EV+house load because the old system had no way to subtract EV power. It takes up to 14 days for the rolling average to recalibrate.

## Fix

Instead of relying solely on potentially-polluted history, the applier now:

1. **Prefers** `live.net_consumption_w` — the live measurement computed every cycle as `house_w - solar_w - ev_w` in `state_collector.py`. This already has EV power subtracted when a power sensor is available.
2. Takes the **minimum** of live and historical to be conservative
3. Falls back to historical only when live data is unavailable

This means the cap immediately uses the correct house-only value as soon as a user adds an EV power sensor — no 14-day wait.

## Files changed

| File | Change |
|---|---|
| `custom_components/hsem/custom_sensors/applier.py` | Use `live.net_consumption_w` for discharge cap, fall back to historical average |

## Related

- #684 — Dynamic house-average cap (this PR builds on it)
- #592 — Original issue

Fixes #592