### PR TITLE
fix(applier): prefer live net_consumption_w for EV discharge cap

### DIFF
--- a/custom_components/hsem/custom_sensors/applier.py
+++ b/custom_components/hsem/custom_sensors/applier.py
@@ -342,17 +342,25 @@ async def async_apply_battery_settings(
             )
 
             if hsem_planned_ev:
-                # HSEM planned this — cap to house average as before.
-                # Use the weighted average house consumption from the
-                # current recommendation slot (already capped by the
-                # planner's 3× forecast guard in PR #681).  Convert kWh
-                # to Watts using the slot duration.
+                # HSEM planned this — cap to house average.
+                # Prefer the live net_consumption_w (house - solar - ev)
+                # which already has EV power subtracted.  This avoids
+                # using polluted v5 upgrade history that contains EV load
+                # in the rolling average (issue #592).
+                # Falls back to historical average when live is unavailable.
                 slot_hours = slot_duration_hours(rec.start, rec.end)
-                cap_w = (
+                historical_w = (
                     int(rec.avg_house_consumption_kwh / slot_hours * 1000.0)
                     if slot_hours > 1e-9 and rec.avg_house_consumption_kwh > 1e-9
                     else 0
                 )
+                live_net_w = live.net_consumption_w
+                if live_net_w is not None and live_net_w > 0:
+                    # Live reading available — use the more conservative
+                    # of the two sources to protect against polluted history.
+                    cap_w = int(min(live_net_w, max(historical_w, 1)))
+                else:
+                    cap_w = historical_w
                 cap_reason = "EV active — HSEM planned"
             else:
                 # EV is charging without HSEM's permission (ghost


### PR DESCRIPTION
## Summary

When upgrading from v5 with `house_power_includes_ev=True` but no EV power sensor, the 14-day rolling consumption averages are polluted with EV load — inflating the discharge cap during EV charging (issue #592).

## Root Cause

The applier uses `rec.avg_house_consumption_kwh` (planner's historical weighted average) for the EV discharge cap. When upgrading from v5, this history contains full EV+house load because the old system had no EV power sensor to subtract EV load. It takes up to 14 days for the rolling average to recalibrate to the real ~400W house baseline.

## Fix

When an EV power sensor is available (e.g., a Boleen template sensor), use `live.net_consumption_w` as the primary source for the discharge cap. This value is computed fresh every cycle as `house_w - solar_w - ev_w` in `state_collector.py` — it already has EV power subtracted and is never affected by polluted history.

The logic:
- **Both live and historical available**: take the minimum of the two (conservative)
- **Only historical available**: fall back to historical
- **Ghost charging** (unplanned EV, `hsem_planned_ev = False`): still caps at 0 W (unchanged)

## Files changed

| File | Change |
|---|---|
| `custom_components/hsem/custom_sensors/applier.py` | Use `live.net_consumption_w` for discharge cap, fall back to historical |

## Related

- #684 — Dynamic house-average cap
- #689 — Ghost-charging 0W cap
- #592 — Original issue

#592