### PR TITLE
fix(applier): use minimum sub-window average as EV discharge cap fallback

### DIFF
--- a/custom_components/hsem/custom_sensors/applier.py
+++ b/custom_components/hsem/custom_sensors/applier.py
@@ -353,12 +353,41 @@ async def async_apply_battery_settings(
                 else 0
             )
             live_net_w = live.net_consumption_w
-            if live_net_w is not None and live_net_w > 0:
-                # Live reading available — use the more conservative
-                # of the two sources to protect against polluted history.
-                cap_w = int(min(live_net_w, max(historical_w, 1)))
+            # Only trust net_consumption_w if the EV power sensor actually
+            # provided a value.  When ev.power_w is 0/None but is_charging
+            # is True (e.g. boolean-only sensor, or sensor unavailable),
+            # net_consumption_w == house_w (no EV subtraction happened).
+            # In that case fall back to the minimum sub-window average.
+            ev_power_available = (
+                (live.ev.power_w is not None and live.ev.power_w > 1e-9)
+                or (live.ev_second.power_w is not None
+                    and live.ev_second.power_w > 1e-9)
+            )
+            if live_net_w is not None and ev_power_available:
+                live_abs = max(live_net_w, 0.0)
+                if live_abs > 0:
+                    cap_w = int(min(live_abs, max(historical_w, 1)))
+                else:
+                    cap_w = historical_w
             else:
-                cap_w = historical_w
+                # No reliable live reading or no EV power sensor.
+                # Fall back to the most conservative (smallest) of the
+                # sub-window averages.  The 1d window recalibrates
+                # fastest after an upgrade or sensor configuration change.
+                sub_windows = [
+                    rec.avg_house_consumption_1d_kwh,
+                    rec.avg_house_consumption_3d_kwh,
+                    rec.avg_house_consumption_7d_kwh,
+                    rec.avg_house_consumption_14d_kwh,
+                    rec.avg_house_consumption_kwh,
+                ]
+                best_w = 0
+                for sw in sub_windows:
+                    if sw > 1e-9:
+                        w = int(sw / slot_hours * 1000.0) if slot_hours > 1e-9 else 0
+                        if best_w == 0 or (w > 0 and w < best_w):
+                            best_w = w
+                cap_w = best_w
             cap_reason = "EV active" if hsem_planned_ev else "EV active (unplanned)"
 
             if live.huawei_batteries_max_discharge_power_w != cap_w:


### PR DESCRIPTION
## Summary

Two complementary fixes for the EV discharge cap fallback logic:

### Fix 1: Only trust `net_consumption_w` when EV power sensor provides data

`net_consumption_w = house_w - solar_w - ev_w`. When `ev.power_w` is 0 or None but `ev.is_charging` is True (boolean-only sensor, or sensor temporarily unavailable), no EV subtraction happens. `net_consumption_w` equals `house_w` which includes the full EV draw.

Now the applier checks `ev.power_w` before using `net_consumption_w`. If the EV is charging but no power reading is available, it falls through to the sub-window fallback.

### Fix 2: Fall back to minimum sub-window average

When live data is unreliable, instead of using only the single polluted weighted average (`avg_house_consumption_kwh`), the fallback scans all sub-window averages (1d, 3d, 7d, 14d, weighted) and picks the **smallest** one.

The 1d window recalibrates fastest — within 24 hours of having an EV power sensor active, it reflects real house-only consumption.

### Why this is needed

@Extati's setup: Clever charger, boolean status sensor, Boleen template sensor for power. The boolean sensor correctly reports `is_charging=True`, but if the template sensor is not configured as `hsem_ev_charger_power` in the HSEM EV charger step, `ev.power_w` stays at 0. `net_consumption_w = house_w - 0 = house_w` (full EV draw). The cap uses this + polluted v5 history → battery discharges at 3.6kW into the EV.

## Files changed

| File | Change |
|---|---|
| `custom_components/hsem/custom_sensors/applier.py` | Check `ev.power_w` availability + minimum sub-window fallback |

Fixes #592