### PR TITLE
fix(planner): validation follow-ups from issue #592 review + re-merge lost #695 fix

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -94,9 +94,10 @@ assert result == pytest.approx(expected, rel=1e-6)
 
 ## MILP Variable Vector
 
-The MILP in `milp_optimizer.py` uses **8*n** LP variables for battery-only (n = number of
+The MILP in `milp_optimizer.py` uses **9*n** LP variables for battery-only (n = number of
 future slots).  When EV co-optimisation is active (one or more `EVConfig` objects passed),
-the vector grows to **8n + 2n·E + E** where E is the number of active EVs.
+the vector grows by **n·E + E** where E is the number of active EVs.  When the main-fuse
+soft constraint is active, a further **n** `gi_pen[t]` variables are appended.
 
 ```
 Index range      Variable     Meaning
@@ -108,11 +109,14 @@ Index range      Variable     Meaning
 [5n .. 6n-1]     m[t]         max(ec[t], ed[t]) auxiliary variable for cycle cost
 [6n .. 7n-1]     s_max_pen[t] Penalty: kWh SoC exceeds usable_kwh
 [7n .. 8n-1]     s_min_pen[t] Penalty: kWh SoC drops below 0
+[8n .. 9n-1]     curt[t]      PV curtailment in slot t (kWh)
 --- EV co-optimisation (when ev_configs is provided) ---
-[8n .. 9n-1]     ev0_c[t]     EV0 DC-side charge per slot (kWh)
-[9n .. 10n-1]    ev1_c[t]     EV1 DC-side charge per slot (kWh) (if second EV active)
-[10n]            ev0_pen      EV0 deadline target slack (kWh shortfall)
-[10n+1]          ev1_pen      EV1 deadline target slack (if second EV active)
+[9n .. 10n-1]    ev0_c[t]     EV0 DC-side charge per slot (kWh)
+[10n .. 11n-1]   ev1_c[t]     EV1 DC-side charge per slot (kWh) (if second EV active)
+[11n]            ev0_pen      EV0 deadline target slack (kWh shortfall)
+[11n+1]          ev1_pen      EV1 deadline target slack (if second EV active)
+--- Main-fuse soft constraint (when main_fuse_amps > 0) ---
+[... .. +n-1]    gi_pen[t]    Grid-import excess above fuse limit per slot (kWh)
 ```
 
 Cycle cost is counted as `α * m[t]` — **not** `α * (ec[t] + ed[t])`.
@@ -124,8 +128,8 @@ The `m[t]` constraints are: `m[t] >= ec[t]` and `m[t] >= ed[t]`.
 
 - **Hard limit: 30 KB per file** in the planner and utils layers.
 - If a file exceeds 30 KB, split it before adding more features.
-- Current oversized planner files: `milp_optimizer.py` (75 KB), `engine_core.py` (50 KB),
-  `cost_function.py` (39 KB), `candidate_generator.py` (36 KB), `charge_scheduler.py` (35 KB).
+- Current oversized planner files: `ev_planner.py` (31.8 KB).
+- Check before every PR: `wc -c custom_components/hsem/planner/*.py`.
 
 ---
 

--- a/.github/memories.md
+++ b/.github/memories.md
@@ -544,6 +544,38 @@ incorrectly write the second EV's power into the primary field.
 
 ---
 
+## MILP Solar Export Priority (issue #694)
+
+The MILP objective function naturally prioritises exporting solar surplus
+during expensive hours over charging the battery, because:
+
+- Export revenue: ``-p_exp[t]`` — negative coefficient = profit, large
+  when prices are high.
+- Battery charge cost: ``charge_loss × p_imp_obj[t]`` — small positive
+  cost, proportional to the import price (conversion loss).
+
+The LP is a global optimiser — it sees all future slots and will defer
+battery charging to cheap slots when future solar is sufficient.
+
+**When the LP may charge during expensive hours:** only when future cheap
+slots lack enough solar surplus to fill the battery before it is needed
+(e.g., a discharge window starts before cheap solar arrives).  In that
+case the LP correctly prioritises meeting the discharge commitment over
+export revenue.
+
+**Regression tests** in ``tests/planner/test_milp_optimizer.py``:
+
+- ``test_milp_exports_solar_in_expensive_slots_charges_in_cheap`` —
+  basic 4-slot setup from the acceptance criteria.
+- ``test_milp_exports_solar_when_future_cheap_solar_sufficient`` —
+  battery starts partially full, replacement price active.
+- ``test_milp_charges_early_only_when_future_solar_insufficient`` —
+  verifies the LP only charges early when necessary.
+- ``test_milp_solar_export_with_house_load_and_replacement_price`` —
+  realistic scenario with house load and terminal-SoC incentive.
+
+---
+
 ## File Organization — By Responsibility, Not By Theme
 
 AI agents naturally bucket related things together (e.g. "all planner inputs in one file").

--- a/custom_components/hsem/custom_sensors/applier.py
+++ b/custom_components/hsem/custom_sensors/applier.py
@@ -315,17 +315,11 @@ async def async_apply_battery_settings(
     #
     # The inverter's CT clamp sees the full EV load as demand and will
     # offset it from the battery unless the discharge power is explicitly
-    # restricted.  The cap depends on whether HSEM actually planned the EV
-    # charging for this slot:
-    #
-    # - HSEM-planned (issue #592): cap to the historical average house
-    #   consumption so the battery still covers normal house load while
-    #   100 % of the EV load goes to the grid.
-    #
-    # - Unplanned / ghost charging: the EV is charging without HSEM's
-    #   permission (e.g. go-e's own PV-surplus latch while calc = 0).
-    #   Cap to 0 W so the battery does not feed the EV at all.
-    ev_active = live.ev.is_charging or live.ev_second.is_charging
+    # restricted.  The cap is the house-only consumption — the battery
+    # still covers normal house load while 100 % of the EV load goes to
+    # the grid.  This applies identically to HSEM-planned and unplanned
+    # ("ghost") EV charging (issue #592).
+    ev_active = live.any_ev_charging
     if ev_active and recommendation not in (
         Recommendations.ForceBatteriesDischarge.value,
         Recommendations.ForceExport.value,
@@ -359,16 +353,17 @@ async def async_apply_battery_settings(
             # net_consumption_w == house_w (no EV subtraction happened).
             # In that case fall back to the minimum sub-window average.
             ev_power_available = (
-                (live.ev.power_w is not None and live.ev.power_w > 1e-9)
-                or (live.ev_second.power_w is not None
-                    and live.ev_second.power_w > 1e-9)
-            )
+                live.ev.power_w is not None and live.ev.power_w > 1e-9
+            ) or (live.ev_second.power_w is not None and live.ev_second.power_w > 1e-9)
             if live_net_w is not None and ev_power_available:
                 live_abs = max(live_net_w, 0.0)
-                if live_abs > 0:
-                    cap_w = int(min(live_abs, max(historical_w, 1)))
+                if historical_w > 0:
+                    # Take the more conservative of live and historical so a
+                    # single polluted source cannot inflate the cap.
+                    cap_w = int(min(live_abs, historical_w))
                 else:
-                    cap_w = historical_w
+                    # No history yet (fresh install) — trust the live reading.
+                    cap_w = int(live_abs)
             else:
                 # No reliable live reading or no EV power sensor.
                 # Fall back to the most conservative (smallest) of the

--- a/custom_components/hsem/flows/ev_helpers.py
+++ b/custom_components/hsem/flows/ev_helpers.py
@@ -41,7 +41,7 @@ _CONNECTED_DOMAINS = ["sensor", "switch", "input_boolean", "button", "binary_sen
 _DISCHARGE_POWER_SELECTOR = selector(
     {
         "number": {
-            "min": 50,
+            "min": 0,
             "max": 5000,
             "step": 1,
             "unit_of_measurement": UnitOfPower.WATT,

--- a/custom_components/hsem/planner/cost_function.py
+++ b/custom_components/hsem/planner/cost_function.py
@@ -449,6 +449,10 @@ def score_plan(
         # (batteries_discharged_kwh) incurs a penalty.  Undiscounted —
         # matches milp_optimizer.py's treatment of this term.
         #
+        # SECOND CAP (issue #694): the terminal premium must never make
+        # battery charging more attractive than grid export.  Mirrors the
+        # identical cap in milp_optimizer.py's _build_objective().
+        #
         # Gated on initial_battery_kwh as well (even though this per-slot
         # formula no longer needs its value) to preserve the documented
         # enablement contract: terminal-SoC accounting requires BOTH
@@ -459,9 +463,28 @@ def score_plan(
             and abs(replacement_price_per_kwh) > 1e-9
         ):
             terminal_premium = max(0.0, replacement_price_per_kwh - imp_price_obj)
+            # Cap the CHARGE credit only: the terminal premium for
+            # charging is reduced by the opportunity cost of not
+            # exporting the same PV surplus (issue #694).
+            #
+            #   charge_premium = repl - p_imp - p_exp / η_chg
+            #
+            # Mirrors the identical formula in milp_optimizer.py's
+            # _build_objective().  The discharge penalty is NOT capped.
+            if charge_eff > 1e-9:
+                _charge_premium = max(
+                    0.0,
+                    replacement_price_per_kwh
+                    - imp_price_obj
+                    - slot.price.export_price / charge_eff,
+                )
+            else:
+                _charge_premium = terminal_premium
+            # Charge earns the capped credit; discharge incurs the full penalty
             terminal_soc_value += (
-                slot.batteries_discharged_kwh - slot.batteries_charged_kwh
-            ) * terminal_premium
+                -slot.batteries_charged_kwh * _charge_premium
+                + slot.batteries_discharged_kwh * terminal_premium
+            )
 
     # ``total_cost`` is money only — never includes synthetic penalties.
     total_cost = import_cost - export_revenue + conversion_loss_cost + cycle_cost_total

--- a/custom_components/hsem/planner/engine_population.py
+++ b/custom_components/hsem/planner/engine_population.py
@@ -206,23 +206,23 @@ def _inject_live_data_into_current_slot(
                 # If the live reading (after subtracting known EV power) still
                 # exceeds the forecast by >3×, it likely contains unmeasured EV
                 # load.  Cap at the forecast to prevent the battery from
-                # serving unknown EV demand.
+                # serving unknown EV demand.  When the forecast is ~0 (e.g. a
+                # night slot), the ratio test is degenerate — use an absolute
+                # floor instead so a multi-kW EV spike is still capped.
                 forecast = slot.avg_house_consumption_kwh
-                if (
-                    inp.house_power_includes_ev
-                    and live_load_kwh > forecast * 3.0
-                    and forecast > 1e-9
-                ):
+                cap_kwh = max(forecast * 3.0, 0.05)
+                if inp.house_power_includes_ev and live_load_kwh > cap_kwh:
                     log_planner(
                         "debug",
                         "[core] _inject_live_data  slot=%s  "
-                        "live %.3f kWh > 3× forecast %.3f kWh — "
-                        "capping at forecast (probable unmeasured EV load)",
+                        "live %.3f kWh > cap %.3f kWh (3× forecast %.3f kWh) — "
+                        "capping (probable unmeasured EV load)",
                         slot.start.isoformat(),
                         live_load_kwh,
+                        cap_kwh,
                         forecast,
                     )
-                    live_load_kwh = forecast
+                    live_load_kwh = forecast if forecast > 1e-9 else cap_kwh
 
                 log_planner(
                     "debug",

--- a/custom_components/hsem/planner/milp/_objective.py
+++ b/custom_components/hsem/planner/milp/_objective.py
@@ -112,13 +112,59 @@ def _build_objective(
         # The differential is computed against the sanitised import price
         # (p_imp_obj, non-negative) so that negative import prices cannot
         # artificially inflate the terminal premium.
+        #
+        # SECOND CAP (issue #694): the terminal premium must never make
+        # battery charging more attractive than grid export for the same
+        # slot.  Without this cap, a high replacement_price can cause the
+        # LP to charge from solar during expensive hours instead of
+        # exporting at peak prices — a "tunnel-vision" effect where the
+        # LP rushes to satisfy the terminal-SoC target immediately rather
+        # than deferring charging to cheaper slots with ample solar.
+        #
+        #   Export benefit:  -p_exp[t]
+        #   Charge cost:     (charge_loss·p_imp[t] - premium + cycle_cost) · η_chg
+        #
+        # Requiring export ≤ charge (both negative = both beneficial):
+        #   -p_exp[t] ≤ (charge_loss·p_imp[t] - premium + cycle_cost) · η_chg
+        #   → premium ≤ charge_loss·p_imp[t] + cycle_cost + p_exp[t] / η_chg
+        #
+        # The cap only reduces the terminal premium — it can never increase
+        # it.  When p_exp[t] is high the cap is large and rarely binds;
+        # when p_exp[t] is low (cheap slots) the cap is small, but the LP
+        # still charges in those slots because the global optimum values
+        # stored energy for future discharge windows.
         if (
             replacement_price_per_kwh is not None
             and abs(replacement_price_per_kwh) > 1e-9
         ):
             terminal_premium = max(0.0, replacement_price_per_kwh - p_imp_obj[t])
-            c_obj[ec_off + t] -= terminal_premium
-            c_obj[ed_off + t] += terminal_premium
+            # Cap the CHARGE credit only: the terminal premium for
+            # charging is reduced by the opportunity cost of not
+            # exporting the same PV surplus (issue #694).
+            #
+            #   charge_premium = repl - p_imp - p_exp / η_chg
+            #
+            # This ensures that when export prices are high (expensive
+            # slots), the charge credit is small and the LP exports.
+            # When export prices are low (cheap slots), the charge
+            # credit is close to the full terminal premium and the
+            # LP charges to store energy for future discharge windows.
+            #
+            # The discharge penalty is NOT capped — it remains at the
+            # full terminal_premium to prevent unnecessary discharging
+            # (issue #638).
+            _charge_eff = 1.0 - charge_loss
+            if _charge_eff > 1e-9:
+                _charge_premium = max(
+                    0.0,
+                    replacement_price_per_kwh
+                    - p_imp_obj[t]
+                    - p_exp[t] / _charge_eff,
+                )
+            else:
+                _charge_premium = terminal_premium
+            c_obj[ec_off + t] -= _charge_premium  # capped credit for charging
+            c_obj[ed_off + t] += terminal_premium  # full penalty for discharging
 
         # Penalty costs: high enough that penalties are zero when SoC is
         # within bounds, but absorb violations when the initial SoC is

--- a/custom_components/hsem/planner/milp/_objective.py
+++ b/custom_components/hsem/planner/milp/_objective.py
@@ -157,9 +157,7 @@ def _build_objective(
             if _charge_eff > 1e-9:
                 _charge_premium = max(
                     0.0,
-                    replacement_price_per_kwh
-                    - p_imp_obj[t]
-                    - p_exp[t] / _charge_eff,
+                    replacement_price_per_kwh - p_imp_obj[t] - p_exp[t] / _charge_eff,
                 )
             else:
                 _charge_premium = terminal_premium

--- a/custom_components/hsem/planner/milp_optimizer.py
+++ b/custom_components/hsem/planner/milp_optimizer.py
@@ -145,7 +145,6 @@ def solve_milp(
             - Deciding between ``ForceBatteriesDischarge`` and
               ``BatteriesDischargeMode`` in post-processing.
             Defaults to 0.0.
-        evalue passed to ``_build_constraints.no_export``.
         ev_configs:
             Optional list of :class:`EVConfig` objects (one per EV).  When
             provided, the MILP co-optimises EV charging alongside the battery.

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -595,6 +595,28 @@ dominated per-slot import-saving benefits in flat/near-flat price scenarios,
 causing zero discharge even when a full battery could cover house load
 (issue #638 regression).
 
+**Charge-credit cap (issue #694):** the terminal premium is applied
+**asymmetrically**.  The charge credit is further reduced by the export
+opportunity cost — the revenue foregone by not exporting the same PV
+surplus:
+
+```
+charge_premium[t] = max(0, replacement_price_per_kwh − p_imp[t] − p_exp[t] / η_chg)
+
+c_obj[ec[t]] −= charge_premium[t]   (capped credit for charging)
+c_obj[ed[t]] += terminal_premium[t] (full penalty for discharging)
+```
+
+Without this cap, a high `replacement_price` can make the charge credit
+larger than the export benefit (`−p_exp[t]`), causing the LP to charge the
+battery from solar during expensive hours instead of exporting at peak
+prices and deferring charging to cheaper slots — a "tunnel-vision" effect.
+When `p_exp[t]` is high (expensive slots) the capped credit is small and
+the LP exports; when `p_exp[t]` is low (cheap slots) the credit is close
+to the full premium and the LP charges to store energy for future
+discharge windows.  The discharge penalty is deliberately **not** capped,
+preserving the issue #638 protection against unnecessary discharging.
+
 - **Undiscounted** — terminal SoC is a single point-in-time valuation at
   horizon end, matching `cost_function.py`'s `terminal_soc_value` treatment.
 - The differential uses the sanitised import price (`max(p_imp, 0)`) so
@@ -857,10 +879,19 @@ matches what the LP actually optimised for:
 ```text
 imp_price_obj[t]     = max(slot.price.import_price, 0.0)
 terminal_premium[t]  = max(0, replacement_price_per_kwh - imp_price_obj[t])
+charge_premium[t]    = max(0, replacement_price_per_kwh - imp_price_obj[t]
+                             - slot.price.export_price / charge_eff)
 
 terminal_soc_value = sum over all slots of:
-    (batteries_discharged_kwh[t] - batteries_charged_kwh[t]) * terminal_premium[t]
+    batteries_discharged_kwh[t] * terminal_premium[t]
+    - batteries_charged_kwh[t] * charge_premium[t]
 ```
+
+The formula is **asymmetric** (issue #694): the charge credit is reduced
+by the export opportunity cost (`p_exp / η_chg`) so that charging never
+beats exporting in the same slot, while the discharge penalty uses the
+full `terminal_premium[t]`.  This mirrors the MILP's `c_obj` terminal-SoC
+term exactly.
 
 Sign convention (per slot):
 

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -301,6 +301,32 @@ the finished plan with full information.
 - A house-load discharge slot (grid_export_kwh == 0) must have the SAME
   loss cost as before the fix (import-price valuation, regression guard).
 
+## Live data injection (current slot)
+
+Before scoring, the engine replaces the current (partially elapsed) slot's
+forecast PV and consumption with live measurements
+(`engine_population.py::_inject_live_data_into_current_slot`).  Live Watts
+are converted to a projected full-slot kWh by multiplying by the slot's full
+duration.
+
+When `house_power_includes_ev = True`, the live house reading may contain EV
+charging power that the battery must not serve (issue #592).  Two layers
+protect against this:
+
+1. **Known EV power subtraction** — when `ev_session_charge_kw` (and/or the
+   second charger's) is available, it is subtracted from the live reading
+   (floored at 0) before injection.
+2. **Spike cap** — if the remaining live reading still exceeds
+   `max(3 × forecast, 0.05 kWh)`, it is capped at the forecast (or at the
+   0.05 kWh floor when the forecast is ~0, where the ratio test would be
+   degenerate).  A spike of that magnitude is unambiguous unmetered load
+   (e.g. a boolean-only EV status sensor); normal house load does not
+   triple between slots.
+
+The sub-window averages (`avg_house_consumption_1d/3d/7d/14d_kwh`) of the
+current slot are updated to match the injected value so spike detection in
+`populate_consumption` stays consistent.
+
 ## SoC simulation
 
 SoC must be simulated forward through the full horizon.
@@ -407,6 +433,42 @@ never uses penalties unless forced by an out-of-bounds initial SoC.
 - Violations are logged at WARNING level.
 - The diagnostics dict (returned alongside the slot list) captures penalty
   values for the engine to surface.
+
+### Battery discharge upper bounds (hard)
+
+In addition to the soft SoC penalties, the MILP applies **hard per-slot upper
+bounds** on the discharge variable `ed[t]` (implemented as variable bounds in
+`_build_constraints`):
+
+1. **EV discharge guard (issue #592)** — when EV co-optimisation is **not**
+   active and a slot has `ev_accounted_load_kwh > 0` (EV load already included
+   in the house consumption sensor):
+
+   ```text
+   ed[t] <= max(0, base_load[t] - ev_accounted_load_kwh[t]) / discharge_eff
+   ```
+
+   The battery may only serve the non-EV portion of demand; the EV load is
+   served by grid import or PV.  When co-optimisation **is** active the guard
+   is skipped — `base_load` is rebuilt without EV load, so the battery can
+   never serve it.
+
+2. **No-export cap (issue #592)** — when `excess_export_enabled = False`
+   (`no_export=True`):
+
+   ```text
+   ed[t] <= base_load[t] / discharge_eff
+   ```
+
+   The battery can never discharge more than the slot's house load, so it
+   cannot export energy to the grid.  When `base_load[t] = 0` (PV-surplus
+   slot) the cap is 0 and the battery sits idle.  PV export is unaffected.
+   Note this also suppresses battery-driven grid arbitrage — intentional:
+   "excess export disabled" means the battery never feeds the grid.
+
+When both apply, the tighter cap wins.  Because the battery cannot export
+under `no_export`, the MILP labels discharge slots `BatteriesDischargeMode`
+(self-consumption) rather than `ForceBatteriesDischarge` in post-processing.
 
 ### EV co-optimisation (MILP)
 

--- a/tests/planner/test_cost_score_split.py
+++ b/tests/planner/test_cost_score_split.py
@@ -167,6 +167,7 @@ class TestTerminalSoCCredit:
         # terminal_soc_value = (discharged - charged) * premium = (0 - 5) * 0.30 = -1.50.
         slot = _make_slot(
             import_price=0.0,
+            export_price=0.0,
             grid_import_kwh=1.0,
             batteries_charged_kwh=5.0,
             estimated_battery_capacity_kwh=8.0,
@@ -300,6 +301,7 @@ class TestComparePlansUsesScore:
         discharge_only_last_slot = _make_slot(
             hour=23,
             import_price=0.0,
+            export_price=0.0,
             grid_import_kwh=76.5,
             batteries_discharged_kwh=4.5,  # 5.0 -> 0.5
             estimated_battery_capacity_kwh=0.5,  # nearly empty
@@ -308,6 +310,7 @@ class TestComparePlansUsesScore:
         solar_only_last_slot = _make_slot(
             hour=23,
             import_price=0.0,
+            export_price=0.0,
             grid_import_kwh=76.5,
             batteries_charged_kwh=4.0,  # 5.0 -> 9.0
             estimated_battery_capacity_kwh=9.0,  # ends nearly full

--- a/tests/planner/test_milp_optimizer.py
+++ b/tests/planner/test_milp_optimizer.py
@@ -464,13 +464,23 @@ def test_milp_terminal_soc_matches_score_plan_with_varying_prices():
     # Compute the expected terminal-SoC value directly from the MILP's own
     # per-slot capped-differential formula, using the realised SoC-simulated
     # charge/discharge flows.
+    #
+    # The formula is asymmetric (issue #694): the charge credit is reduced
+    # by the export opportunity cost (p_exp / η_chg), while the discharge
+    # penalty uses the full terminal premium.
+    charge_eff = 1.0  # 100 % efficiency in this test
     expected_terminal_soc_value = 0.0
     for s in result:
         imp_price_obj = max(s.price.import_price, 0.0)
         terminal_premium = max(0.0, replacement_price - imp_price_obj)
+        charge_premium = max(
+            0.0,
+            replacement_price - imp_price_obj - s.price.export_price / charge_eff,
+        )
         expected_terminal_soc_value += (
-            s.batteries_discharged_kwh - s.batteries_charged_kwh
-        ) * terminal_premium
+            s.batteries_discharged_kwh * terminal_premium
+            - s.batteries_charged_kwh * charge_premium
+        )
 
     bd = score_plan(
         result,
@@ -2629,4 +2639,303 @@ def test_milp_lp_coefficient_uses_import_price():
     ), (
         "Expected destination-aware discharge loss cost 0.12, "
         f"got {diag['discharge_loss_cost_destination_aware']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Issue #694 — MILP solar export priority during expensive hours
+# ---------------------------------------------------------------------------
+
+
+@_scipy_skip()
+def test_milp_exports_solar_in_expensive_slots_charges_in_cheap():
+    """MILP must export solar surplus during expensive hours and charge during cheap.
+
+    Acceptance criteria from issue #694:
+    Setup with 4 slots — first two expensive (p_imp=3.0), last two cheap (p_imp=0.1),
+    enough solar in cheap slots to fill battery. Battery should export in expensive
+    slots and charge in cheap slots.
+    """
+    slots = [
+        _make_slot(
+            hour=0,
+            import_price=3.0,
+            export_price=2.4,
+            pv_kwh=5.0,
+            consumption_kwh=0.0,
+        ),
+        _make_slot(
+            hour=1,
+            import_price=3.0,
+            export_price=2.4,
+            pv_kwh=5.0,
+            consumption_kwh=0.0,
+        ),
+        _make_slot(
+            hour=2,
+            import_price=0.1,
+            export_price=0.08,
+            pv_kwh=5.0,
+            consumption_kwh=0.0,
+        ),
+        _make_slot(
+            hour=3,
+            import_price=0.1,
+            export_price=0.08,
+            pv_kwh=5.0,
+            consumption_kwh=0.0,
+        ),
+    ]
+
+    milp_result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=0.0,
+        usable_kwh=10.0,
+        max_charge_per_slot=5.0,
+        max_discharge_per_slot=5.0,
+        cycle_cost_per_kwh=0.0,
+        charge_efficiency_pct=100.0,
+        discharge_efficiency_pct=100.0,
+    )
+
+    assert milp_result is not None, "MILP must return a solution"
+    result, _diag = milp_result
+
+    # Expensive slots (0-1): must export solar, must NOT charge battery
+    for i in range(2):
+        s = result[i]
+        assert s.grid_export_kwh > 0.1, (
+            f"Slot {i} (expensive): expected grid export > 0, "
+            f"got ge={s.grid_export_kwh:.3f}"
+        )
+        assert s.batteries_charged_kwh < 0.01, (
+            f"Slot {i} (expensive): expected no battery charging, "
+            f"got ec={s.batteries_charged_kwh:.3f}"
+        )
+
+    # Cheap slots (2-3): must charge battery from solar
+    total_charged = sum(result[i].batteries_charged_kwh for i in range(2, 4))
+    assert total_charged > 1.0, (
+        f"Cheap slots (2-3): expected battery charging > 1 kWh, "
+        f"got {total_charged:.3f}"
+    )
+
+
+@_scipy_skip()
+def test_milp_exports_solar_when_future_cheap_solar_sufficient():
+    """MILP must export now when future cheap slots have enough solar to fill battery.
+
+    Battery starts partially full (5 kWh of 10 kWh usable). Morning expensive
+    slots have solar surplus; afternoon cheap slots also have enough solar to
+    fill the remaining 5 kWh. The MILP should export morning solar rather than
+    charging the battery, because the battery can be filled later at lower cost.
+    """
+    slots = [
+        _make_slot(
+            hour=0,
+            import_price=3.0,
+            export_price=2.4,
+            pv_kwh=5.0,
+            consumption_kwh=0.0,
+        ),
+        _make_slot(
+            hour=1,
+            import_price=3.0,
+            export_price=2.4,
+            pv_kwh=5.0,
+            consumption_kwh=0.0,
+        ),
+        _make_slot(
+            hour=2,
+            import_price=0.1,
+            export_price=0.08,
+            pv_kwh=5.0,
+            consumption_kwh=0.0,
+        ),
+        _make_slot(
+            hour=3,
+            import_price=0.1,
+            export_price=0.08,
+            pv_kwh=5.0,
+            consumption_kwh=0.0,
+        ),
+    ]
+
+    milp_result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=5.0,
+        usable_kwh=10.0,
+        max_charge_per_slot=5.0,
+        max_discharge_per_slot=5.0,
+        cycle_cost_per_kwh=0.05,
+        charge_efficiency_pct=97.0,
+        discharge_efficiency_pct=97.0,
+        replacement_price_per_kwh=1.5,
+    )
+
+    assert milp_result is not None, "MILP must return a solution"
+    result, _diag = milp_result
+
+    # Expensive slots (0-1): must export solar, must NOT charge battery
+    for i in range(2):
+        s = result[i]
+        assert s.grid_export_kwh > 0.1, (
+            f"Slot {i} (expensive): expected grid export > 0, "
+            f"got ge={s.grid_export_kwh:.3f}"
+        )
+        assert s.batteries_charged_kwh < 0.01, (
+            f"Slot {i} (expensive): expected no battery charging, "
+            f"got ec={s.batteries_charged_kwh:.3f}"
+        )
+
+    # Cheap slots (2-3): must charge battery from solar
+    total_charged = sum(result[i].batteries_charged_kwh for i in range(2, 4))
+    assert total_charged > 1.0, (
+        f"Cheap slots (2-3): expected battery charging > 1 kWh, "
+        f"got {total_charged:.3f}"
+    )
+
+
+@_scipy_skip()
+def test_milp_charges_early_only_when_future_solar_insufficient():
+    """MILP should only charge during expensive hours if future solar is insufficient.
+
+    When future cheap slots do NOT have enough solar to fill the battery,
+    the MILP may need to charge during expensive hours to meet energy needs.
+    This test verifies that the MILP correctly identifies when early charging
+    is necessary.
+    """
+    # Only 1 kWh of solar in cheap slots — not enough to fill a 10 kWh battery
+    slots = [
+        _make_slot(
+            hour=0,
+            import_price=3.0,
+            export_price=2.4,
+            pv_kwh=5.0,
+            consumption_kwh=0.0,
+        ),
+        _make_slot(
+            hour=1,
+            import_price=3.0,
+            export_price=2.4,
+            pv_kwh=5.0,
+            consumption_kwh=0.0,
+        ),
+        _make_slot(
+            hour=2,
+            import_price=0.1,
+            export_price=0.08,
+            pv_kwh=1.0,
+            consumption_kwh=0.0,
+        ),
+        _make_slot(
+            hour=3,
+            import_price=0.1,
+            export_price=0.08,
+            pv_kwh=1.0,
+            consumption_kwh=0.0,
+        ),
+    ]
+
+    milp_result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=0.0,
+        usable_kwh=10.0,
+        max_charge_per_slot=5.0,
+        max_discharge_per_slot=5.0,
+        cycle_cost_per_kwh=0.05,
+        charge_efficiency_pct=97.0,
+        discharge_efficiency_pct=97.0,
+        replacement_price_per_kwh=1.5,
+    )
+
+    assert milp_result is not None, "MILP must return a solution"
+    result, _diag = milp_result
+
+    # With insufficient future solar, the MILP may charge during expensive
+    # hours. We just verify the solution is valid (no crash).
+    # The LP should still prefer exporting expensive solar, but may also
+    # charge some to meet terminal-SoC targets.
+    total_charged = sum(s.batteries_charged_kwh for s in result)
+    total_exported = sum(s.grid_export_kwh for s in result)
+    assert total_charged >= 0.0, "Battery charging must be non-negative"
+    assert total_exported >= 0.0, "Grid export must be non-negative"
+
+
+@_scipy_skip()
+def test_milp_solar_export_with_house_load_and_replacement_price():
+    """MILP exports solar in expensive slots even with house load and replacement price.
+
+    More realistic scenario: house load consumes some solar, replacement price
+    creates terminal-SoC incentive. The MILP must still prefer exporting during
+    expensive hours over charging the battery.
+    """
+    slots = [
+        _make_slot(
+            hour=0,
+            import_price=3.0,
+            export_price=2.4,
+            pv_kwh=5.0,
+            consumption_kwh=0.5,
+        ),
+        _make_slot(
+            hour=1,
+            import_price=3.0,
+            export_price=2.4,
+            pv_kwh=5.0,
+            consumption_kwh=0.5,
+        ),
+        _make_slot(
+            hour=2,
+            import_price=0.1,
+            export_price=0.08,
+            pv_kwh=5.0,
+            consumption_kwh=0.5,
+        ),
+        _make_slot(
+            hour=3,
+            import_price=0.1,
+            export_price=0.08,
+            pv_kwh=5.0,
+            consumption_kwh=0.5,
+        ),
+    ]
+
+    milp_result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=0.0,
+        usable_kwh=10.0,
+        max_charge_per_slot=5.0,
+        max_discharge_per_slot=5.0,
+        cycle_cost_per_kwh=0.05,
+        charge_efficiency_pct=97.0,
+        discharge_efficiency_pct=97.0,
+        replacement_price_per_kwh=2.0,
+    )
+
+    assert milp_result is not None, "MILP must return a solution"
+    result, _diag = milp_result
+
+    # Expensive slots (0-1): must export solar surplus, must NOT charge battery
+    for i in range(2):
+        s = result[i]
+        # After house load (0.5 kWh), remaining solar is 4.5 kWh
+        assert s.grid_export_kwh > 0.1, (
+            f"Slot {i} (expensive): expected grid export > 0, "
+            f"got ge={s.grid_export_kwh:.3f}"
+        )
+        assert s.batteries_charged_kwh < 0.01, (
+            f"Slot {i} (expensive): expected no battery charging, "
+            f"got ec={s.batteries_charged_kwh:.3f}"
+        )
+
+    # Cheap slots (2-3): must charge battery from solar
+    total_charged = sum(result[i].batteries_charged_kwh for i in range(2, 4))
+    assert total_charged > 1.0, (
+        f"Cheap slots (2-3): expected battery charging > 1 kWh, "
+        f"got {total_charged:.3f}"
     )

--- a/tests/planner/test_milp_optimizer.py
+++ b/tests/planner/test_milp_optimizer.py
@@ -2717,8 +2717,7 @@ def test_milp_exports_solar_in_expensive_slots_charges_in_cheap():
     # Cheap slots (2-3): must charge battery from solar
     total_charged = sum(result[i].batteries_charged_kwh for i in range(2, 4))
     assert total_charged > 1.0, (
-        f"Cheap slots (2-3): expected battery charging > 1 kWh, "
-        f"got {total_charged:.3f}"
+        f"Cheap slots (2-3): expected battery charging > 1 kWh, got {total_charged:.3f}"
     )
 
 
@@ -2793,8 +2792,7 @@ def test_milp_exports_solar_when_future_cheap_solar_sufficient():
     # Cheap slots (2-3): must charge battery from solar
     total_charged = sum(result[i].batteries_charged_kwh for i in range(2, 4))
     assert total_charged > 1.0, (
-        f"Cheap slots (2-3): expected battery charging > 1 kWh, "
-        f"got {total_charged:.3f}"
+        f"Cheap slots (2-3): expected battery charging > 1 kWh, got {total_charged:.3f}"
     )
 
 
@@ -2936,6 +2934,5 @@ def test_milp_solar_export_with_house_load_and_replacement_price():
     # Cheap slots (2-3): must charge battery from solar
     total_charged = sum(result[i].batteries_charged_kwh for i in range(2, 4))
     assert total_charged > 1.0, (
-        f"Cheap slots (2-3): expected battery charging > 1 kWh, "
-        f"got {total_charged:.3f}"
+        f"Cheap slots (2-3): expected battery charging > 1 kWh, got {total_charged:.3f}"
     )

--- a/tests/planner/test_no_export_and_live_injection.py
+++ b/tests/planner/test_no_export_and_live_injection.py
@@ -1,0 +1,202 @@
+"""Regression tests for issue #592 follow-up fixes.
+
+Covers:
+- The MILP ``no_export`` constraint (battery must never export to the grid
+  when excess export is disabled).
+- The live-injection spike cap in ``_inject_live_data_into_current_slot``
+  (unmetered EV load must not inflate the current slot's house consumption).
+"""
+
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from custom_components.hsem.models.planned_slot import PlannedSlot
+from custom_components.hsem.planner.engine_population import (
+    _inject_live_data_into_current_slot,
+)
+from custom_components.hsem.planner.milp_optimizer import (
+    is_scipy_available,
+    solve_milp,
+)
+from custom_components.hsem.utils.prices import SlotPrice
+
+_TZ = ZoneInfo("Europe/Copenhagen")
+_NOW = datetime(2024, 6, 15, 12, 0, tzinfo=_TZ)
+
+
+def _make_slot(
+    *,
+    hour: int,
+    import_price: float = 0.50,
+    export_price: float = 0.40,
+    pv_kwh: float = 0.0,
+    consumption_kwh: float = 0.3,
+) -> PlannedSlot:
+    start = datetime(2024, 6, 15, hour, 0, tzinfo=_TZ)
+    s = PlannedSlot(
+        start=start,
+        end=start + timedelta(hours=1),
+        price=SlotPrice(import_price=import_price, export_price=export_price),
+    )
+    s.avg_house_consumption_kwh = consumption_kwh
+    s.solcast_pv_estimate_kwh = pv_kwh
+    s.ev_planned_load_kwh = 0.0
+    s.estimated_net_consumption_kwh = consumption_kwh - pv_kwh
+    return s
+
+
+# ---------------------------------------------------------------------------
+# no_export constraint (issue #592 — battery dumped 5 kW into the grid
+# while excess export was disabled)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not is_scipy_available(), reason="scipy not available")
+def test_no_export_caps_discharge_at_house_load():
+    """With no_export=True the battery covers house load but cannot export."""
+    # Fully charged battery, expensive prices, export price nearly as high —
+    # without the constraint the LP would dump the battery into the grid.
+    slots = [
+        _make_slot(hour=h, import_price=3.0, export_price=2.9, consumption_kwh=0.4)
+        for h in range(12, 16)
+    ]
+
+    milp_result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=9.0,
+        usable_kwh=9.0,
+        max_charge_per_slot=5.0,
+        max_discharge_per_slot=5.0,
+        no_export=True,
+    )
+    assert milp_result is not None
+    result, _diag = milp_result
+
+    for s in result:
+        # Discharge may at most cover the slot's house load (0.4 kWh AC,
+        # divided by discharge efficiency on the DC side).
+        assert s.batteries_discharged_kwh <= 0.4 / 0.97 + 1e-6
+        # The battery must not contribute to grid export.
+        assert s.grid_export_kwh <= 1e-6
+
+
+@pytest.mark.skipif(not is_scipy_available(), reason="scipy not available")
+def test_no_export_blocks_discharge_in_pv_surplus_slot():
+    """With no_export=True and base_load=0 (PV surplus), discharge cap is 0."""
+    slots = [
+        _make_slot(hour=12, pv_kwh=3.0, consumption_kwh=0.4),
+        _make_slot(hour=13, pv_kwh=3.0, consumption_kwh=0.4),
+    ]
+
+    milp_result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=9.0,
+        usable_kwh=9.0,
+        max_charge_per_slot=5.0,
+        max_discharge_per_slot=5.0,
+        no_export=True,
+    )
+    assert milp_result is not None
+    result, _diag = milp_result
+
+    for s in result:
+        assert s.batteries_discharged_kwh <= 1e-6
+
+
+@pytest.mark.skipif(not is_scipy_available(), reason="scipy not available")
+def test_export_allowed_when_no_export_false():
+    """Sanity check: with no_export=False the LP may export battery energy."""
+    slots = [
+        _make_slot(hour=h, import_price=3.0, export_price=2.9, consumption_kwh=0.4)
+        for h in range(12, 16)
+    ]
+
+    milp_result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=9.0,
+        usable_kwh=9.0,
+        max_charge_per_slot=5.0,
+        max_discharge_per_slot=5.0,
+        no_export=False,
+    )
+    assert milp_result is not None
+    result, _diag = milp_result
+
+    total_export = sum(float(s.grid_export_kwh) for s in result)
+    assert total_export > 0.1, "LP should export battery energy when allowed"
+
+
+# ---------------------------------------------------------------------------
+# Live injection spike cap (issue #592 — unmetered EV load inflating the
+# current slot; zero-forecast edge case where the 3x ratio test is degenerate)
+# ---------------------------------------------------------------------------
+
+
+class _Inp:
+    """Minimal planner-input stand-in for live injection tests."""
+
+    def __init__(
+        self,
+        *,
+        live_house_w: float,
+        live_solar_w: float = 0.0,
+        includes_ev: bool = True,
+        ev_kw: float | None = None,
+    ) -> None:
+        self.interval_minutes = 60
+        self.live_solar_production_w = live_solar_w
+        self.live_house_consumption_w = live_house_w
+        self.house_power_includes_ev = includes_ev
+        self.ev_session_charge_kw = ev_kw
+        self.ev_second_session_charge_kw = None
+
+
+def _current_slot(forecast_kwh: float) -> PlannedSlot:
+    start = datetime(2024, 6, 15, 12, 0, tzinfo=_TZ)
+    s = PlannedSlot(
+        start=start,
+        end=start + timedelta(hours=1),
+        price=SlotPrice(import_price=0.5, export_price=0.4),
+    )
+    s.avg_house_consumption_kwh = forecast_kwh
+    s.solcast_pv_estimate_kwh = 0.0
+    return s
+
+
+def test_live_injection_caps_spike_at_forecast():
+    """A >3x live spike is capped at the forecast (unmetered EV load)."""
+    slot = _current_slot(forecast_kwh=0.4)
+    inp = _Inp(live_house_w=4000.0)  # 4 kW — 10x the 0.4 kWh forecast
+    _inject_live_data_into_current_slot([slot], inp, _NOW)  # type: ignore[arg-type]
+    assert slot.avg_house_consumption_kwh == pytest.approx(0.4)
+
+
+def test_live_injection_caps_spike_when_forecast_zero():
+    """With a ~0 forecast the ratio test is degenerate; an absolute floor
+    must still cap a multi-kW EV spike."""
+    slot = _current_slot(forecast_kwh=0.0)
+    inp = _Inp(live_house_w=3600.0)  # 3.6 kW EV spike, no forecast
+    _inject_live_data_into_current_slot([slot], inp, _NOW)  # type: ignore[arg-type]
+    assert slot.avg_house_consumption_kwh <= 0.05 + 1e-9
+
+
+def test_live_injection_subtracts_known_ev_power():
+    """Known EV power is subtracted before injection (Layer 1)."""
+    slot = _current_slot(forecast_kwh=0.4)
+    # House CT reads 4.0 kW total, EV sensor reports 3.6 kW → 0.4 kW house.
+    inp = _Inp(live_house_w=4000.0, ev_kw=3.6)
+    _inject_live_data_into_current_slot([slot], inp, _NOW)  # type: ignore[arg-type]
+    assert slot.avg_house_consumption_kwh == pytest.approx(0.4)
+
+
+def test_live_injection_normal_load_passes_through():
+    """A normal live reading within 3x of forecast is injected unchanged."""
+    slot = _current_slot(forecast_kwh=0.4)
+    inp = _Inp(live_house_w=600.0)  # 0.6 kWh — 1.5x forecast, fine
+    _inject_live_data_into_current_slot([slot], inp, _NOW)  # type: ignore[arg-type]
+    assert slot.avg_house_consumption_kwh == pytest.approx(0.6)


### PR DESCRIPTION
## Summary

Validation follow-up for the v6.0.0 feedback thread (#592). Every comment and associated PR was re-validated against `main`. Most fixes verified correct — this PR re-merges one lost fix and resolves the residual bugs found during validation.

**Critical finding:** PR #695 (fix for #694 — MILP solar export priority) was merged to a stale base and is **not present in `main`**, even though v6.1.1-beta6 release notes claim it is. This PR re-merges it (clean merge, zero test regressions — verified via clean worktree comparison against plain `main`).

## Branch

`validation/592-fixes`

## Files Changed

| File | Change |
|---|---|
| `planner/milp/_objective.py`, `cost_function.py`, `docs/planner-spec.md`, `.github/memories.md`, `tests/planner/test_milp_optimizer.py`, `test_cost_score_split.py` | Re-merge of PR #695 (asymmetric terminal-SoC charge credit, `charge_premium = max(0, repl − p_imp − p_exp/η_chg)`) — Fixes #694 |
| `custom_sensors/applier.py` | EV discharge cap: when live net ≤ 0 (PV covers house), cap no longer falls back to polluted history; fresh-install (no history) trusts live reading instead of collapsing cap to ≤1 W; use canonical `live.any_ev_charging`; fix stale docstring |
| `planner/engine_population.py` | 3× spike cap no-oped when forecast ≈ 0 (ratio test degenerate) — added 0.05 kWh absolute floor so unmetered EV spikes in night slots are still capped |
| `flows/ev_helpers.py` | Manual EV discharge power selector min 50 → 0 W (was forcing a dummy value when the toggle is disabled) |
| `planner/milp_optimizer.py` | Remove orphaned docstring line |
| `.github/memories.md` | MILP variable layout updated 8·n → 9·n (`curt` block); stale oversized-file list refreshed |
| `docs/planner-spec.md` | Document `no_export` constraint, EV discharge guard, and live data injection semantics (previously undocumented — spec/implementation divergence) |
| `tests/planner/test_no_export_and_live_injection.py` | **New** — 7 regression tests |

## Validation results per #592 sub-issue

| # | Issue | Verdict |
|---|---|---|
| 1 | HACS 404 | ✅ Deployment, resolved |
| 2 | `_2` duplicate entities | ✅ PR #673 correct (idempotent unique_id migration + tests) |
| 3 | Missing Huawei entities | ✅ Graceful, self-heals each cycle |
| 4 | Battery → EV discharge chain (#680–#699) | ✅ Correct; 2 residual bugs fixed here |
| 5a | EV setup forced values | ✅ Fixed (min 0.0 selectors, skip-when-disabled) |
| 5b | ML data loss | ✅ Not reproducible; data persisted correctly |
| 6 | Battery dumped to grid w/ export disabled | ✅ `no_export` constraint + centralized `resolve_cycle_cost()` verified correct |
| 7 | MILP solar export priority | ❌ **#695 missing from main — re-merged here** |
| 8 | Manual EV Watt field rejects 0 | ❌ Still broken — fixed here |

## Tests

- New: `tests/planner/test_no_export_and_live_injection.py` — 7 tests covering the `no_export` constraint (caps discharge at house load, blocks discharge in PV-surplus slots, export still allowed when enabled) and the live-injection spike cap (cap at forecast, zero-forecast floor, Layer-1 EV subtraction, normal pass-through). **All pass.**
- Full suite: `14 failed, 2396 passed` — all 14 failures verified **pre-existing on plain `main`** (identical failure set via clean worktree run); zero regressions from this PR. Tracked separately in the issue filed alongside this PR.

## Quality gates

- `quality.sh lint` — same 6 pre-existing `T201 print` errors in `scripts/validate-*.py` as plain `main` (untouched by this PR); all changed files clean
- `quality.sh typing` — ✅ 0 errors (274 files)
- `quality.sh quality` — ✅ 0 errors (26 pre-existing warnings)
- `quality.sh test` — ✅ no new failures (see above)

## Known limitations (not addressed here)

- During EV charging + force-discharge/export recommendation, a previously written discharge cap stays latched until the EV stops (forcible discharge passes power explicitly, so impact is minimal).
- The min-of-subwindows fallback can remain polluted for ~24 h after a config change (bounded, mitigated — not eliminable without a power sensor).
- The coordinator warning "EV is physically charging but no slot has ev_total_planned_load_kwh > 0" now fires in the expected unplanned-EV steady state — rewording left for a follow-up.

Refs #592, Fixes #694