### PR TITLE
fix(planner): stop EV discharge cap from feeding back into the planner

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -721,6 +721,26 @@ and ``test_milp_charges_now_when_no_future_surplus_exceeds_headroom`` in
 
 ---
 
+## EV Discharge Cap Must Not Feed Back Into the Planner (issue #592, beta7)
+
+The applier's EV discharge cap writes a small value (e.g. 321 W) to the
+``maximum_discharging_power`` number entity.  Reading that entity back as
+``battery_max_discharge_power_w`` in ``coordinator_builder.build_planner_input``
+created a feedback loop: the entire planning horizon was limited to the EV
+cap (``discharge=0.073 kWh`` per 15-min slot) and the battery could never
+cover evening house load.
+
+Canonical rule: **planner inputs must reflect physical capability, not
+commanded entity state.**  Use
+``coordinator_builder._resolve_max_discharge_power_w(live)`` — during an
+active EV session it derives the max from the rated capacity via
+``get_max_discharge_power()``; otherwise it uses the live read-back (rated
+maximum or genuine user override).
+
+Regression tests: ``tests/test_coordinator_builder.py``.
+
+---
+
 ## File Organization — By Responsibility, Not By Theme
 
 AI agents naturally bucket related things together (e.g. "all planner inputs in one file").

--- a/custom_components/hsem/coordinator_builder.py
+++ b/custom_components/hsem/coordinator_builder.py
@@ -32,7 +32,10 @@ from custom_components.hsem.utils.capacity_learner import CapacityLearner
 from custom_components.hsem.utils.charge_rate_learner import CHARGE_RATE_LEARNER
 from custom_components.hsem.utils.conversion import convert_to_float, convert_to_int
 from custom_components.hsem.utils.datetime_utils import now as hsem_now
-from custom_components.hsem.utils.misc import calculate_recommended_threshold
+from custom_components.hsem.utils.misc import (
+    calculate_recommended_threshold,
+    get_max_discharge_power,
+)
 
 
 def _clamp_charge_rate(configured_w: float) -> float:
@@ -48,6 +51,43 @@ def _clamp_charge_rate(configured_w: float) -> float:
         cell_temp_c=None, fallback_w=configured_w
     )
     return min(configured_w, learned)
+
+
+def _resolve_max_discharge_power_w(live: LiveState) -> float | None:
+    """Return the battery's physical max discharge power for the planner.
+
+    The planner input must reflect the battery's *capability*, not the
+    currently commanded value of the ``maximum_discharging_power`` number
+    entity.  The applier writes that entity in two situations:
+
+    - the rated-capacity maximum (normal operation), and
+    - the EV discharge cap (issue #592) — a much smaller value (e.g. ~321 W)
+      that protects the battery from feeding an actively charging EV.
+
+    Reading the entity back while the EV cap is active feeds the capped
+    value into the planner as the horizon-wide discharge limit — the
+    classic feedback loop observed in the beta7 logs where every slot was
+    limited to ``discharge=0.073 kWh`` (321 W × 15 min) and the battery
+    could never cover evening house load.
+
+    When an EV is actively charging, the physical capability is derived
+    from the rated capacity instead (same formula the applier uses for the
+    uncapped write).  When no EV is charging, the live read-back is used
+    unchanged — at that point it always reflects the rated maximum (or a
+    genuine user override, which should be respected).
+
+    Args:
+        live: Live state snapshot.
+
+    Returns:
+        Max discharge power in Watts, or ``None`` when unavailable.
+    """
+    live_w = convert_to_float(live.huawei_batteries_max_discharge_power_w)
+    if live.any_ev_charging:
+        rated_wh = convert_to_int(live.huawei_batteries_rated_capacity_wh)
+        if rated_wh is not None and rated_wh > 0:
+            return float(get_max_discharge_power(rated_wh))
+    return live_w or None
 
 
 # ---------------------------------------------------------------------------
@@ -201,10 +241,7 @@ def build_planner_input(
         battery_max_charge_power_w=_clamp_charge_rate(
             convert_to_float(live.huawei_batteries_max_charge_power_w) or 5000.0
         ),
-        battery_max_discharge_power_w=convert_to_float(
-            live.huawei_batteries_max_discharge_power_w
-        )
-        or None,
+        battery_max_discharge_power_w=_resolve_max_discharge_power_w(live),
         battery_charge_efficiency_pct=convert_to_float(cfg.batteries_charge_efficiency)
         or 95.0,
         battery_discharge_efficiency_pct=convert_to_float(

--- a/custom_components/hsem/custom_sensors/applier.py
+++ b/custom_components/hsem/custom_sensors/applier.py
@@ -74,6 +74,13 @@ from custom_components.hsem.utils.units import slot_duration_hours
 from custom_components.hsem.utils.workingmodes import WorkingModes
 
 
+def _fmt_live_power_w(power_w: float | None) -> str:
+    """Format a live power reading for log lines (``None`` → ``n/a``)."""
+    if power_w is None:
+        return "n/a"
+    return f"{int(power_w)}W"
+
+
 def _should_force_export_for_ev(
     ev: Any,
     ev_cfg: Any,
@@ -396,13 +403,16 @@ async def async_apply_battery_settings(
                 summary.results.append(ev_discharge_result)
                 _LOGGER.debug(
                     "%s — capped max discharge power to %d W "
-                    "(ev_power=%dW ev2_power=%dW ev_total_load=%.3fkWh "
+                    "(planned_ev_power=%dW planned_ev2_power=%dW "
+                    "ev_total_load=%.3fkWh live_ev_power=%s live_ev2_power=%s "
                     "house_avg=%.3f kWh/slot)",
                     cap_reason,
                     cap_w,
                     rec.ev_charger_calculated_power,
                     rec.ev_second_charger_calculated_power,
                     rec.ev_total_planned_load_kwh,
+                    _fmt_live_power_w(live.ev.power_w),
+                    _fmt_live_power_w(live.ev_second.power_w),
                     rec.avg_house_consumption_kwh,
                 )
                 if ev_discharge_result.status == ApplyStatus.FAILED:

--- a/custom_components/hsem/custom_sensors/recommendation_resolver.py
+++ b/custom_components/hsem/custom_sensors/recommendation_resolver.py
@@ -17,6 +17,13 @@ from custom_components.hsem.utils.logger import HSEM_LOGGER
 from custom_components.hsem.utils.recommendations import Recommendations
 
 
+def _fmt_live_w(power_w: float | None) -> str:
+    """Format a live power reading for log lines (``None`` → ``n/a``)."""
+    if power_w is None:
+        return "n/a"
+    return f"{int(power_w)}W"
+
+
 def resolve_current_recommendation(
     rec: HourlyRecommendation,
     live: LiveState,
@@ -87,11 +94,14 @@ def resolve_current_recommendation(
         rec.recommendation = Recommendations.EVSmartCharging.value
         HSEM_LOGGER.debug(
             "[resolver] EV actively charging + planner_allocated_ev=True "
-            "(ev_power=%dW ev2_power=%dW ev_total_load=%.3fkWh) "
+            "(planned_ev_power=%dW planned_ev2_power=%dW ev_total_load=%.3fkWh "
+            "live_ev_power=%s live_ev2_power=%s) "
             "→ overriding %s to ev_smart_charging",
             rec.ev_charger_calculated_power,
             rec.ev_second_charger_calculated_power,
             rec.ev_total_planned_load_kwh,
+            _fmt_live_w(live.ev.power_w),
+            _fmt_live_w(live.ev_second.power_w),
             original_recommendation,
         )
         return
@@ -99,11 +109,14 @@ def resolve_current_recommendation(
     if ev_actively_charging and not planner_allocated_ev:
         HSEM_LOGGER.debug(
             "[resolver] EV actively charging but planner_allocated_ev=False "
-            "(ev_power=%dW ev2_power=%dW ev_total_load=%.3fkWh) "
+            "(planned_ev_power=%dW planned_ev2_power=%dW ev_total_load=%.3fkWh "
+            "live_ev_power=%s live_ev2_power=%s) "
             "→ keeping original recommendation %s",
             rec.ev_charger_calculated_power,
             rec.ev_second_charger_calculated_power,
             rec.ev_total_planned_load_kwh,
+            _fmt_live_w(live.ev.power_w),
+            _fmt_live_w(live.ev_second.power_w),
             original_recommendation,
         )
 

--- a/tests/test_coordinator_builder.py
+++ b/tests/test_coordinator_builder.py
@@ -1,0 +1,53 @@
+"""Tests for coordinator_builder helper functions.
+
+Covers ``_resolve_max_discharge_power_w`` — the guard against the EV
+discharge-cap feedback loop (issue #592, beta7).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.hsem.coordinator_builder import _resolve_max_discharge_power_w
+from custom_components.hsem.models.live_state import LiveState
+
+
+class TestResolveMaxDischargePowerW:
+    """The planner must see the battery's physical capability, not the
+    applier's EV-capped write-back value."""
+
+    @staticmethod
+    def _live(
+        *,
+        ev_charging: bool,
+        max_discharge_w: float,
+        rated_wh: int = 10000,
+    ) -> LiveState:
+        live = LiveState()
+        live.ev.is_charging = ev_charging
+        live.huawei_batteries_max_discharge_power_w = max_discharge_w
+        live.huawei_batteries_rated_capacity_wh = rated_wh
+        return live
+
+    def test_no_ev_charging_uses_live_value(self) -> None:
+        """Without an active EV session the live read-back reflects the
+        rated maximum (or a genuine user override) and is used unchanged."""
+        live = self._live(ev_charging=False, max_discharge_w=321.0)
+        assert _resolve_max_discharge_power_w(live) == pytest.approx(321.0)
+
+    def test_ev_charging_uses_rated_capability(self) -> None:
+        """During an EV session the applier caps the entity (e.g. 321 W).
+        The planner must get the physical capability (5000 W for a
+        10 kWh battery), not the capped value — otherwise the entire
+        planning horizon is limited to the EV cap (issue #592)."""
+        live = self._live(ev_charging=True, max_discharge_w=321.0)
+        assert _resolve_max_discharge_power_w(live) == pytest.approx(5000.0)
+
+    def test_ev_charging_without_rated_capacity_falls_back_to_live(self) -> None:
+        """Missing rated capacity → keep the live value (degraded but safe)."""
+        live = self._live(ev_charging=True, max_discharge_w=321.0, rated_wh=0)
+        assert _resolve_max_discharge_power_w(live) == pytest.approx(321.0)
+
+    def test_no_ev_charging_missing_live_value_returns_none(self) -> None:
+        live = self._live(ev_charging=False, max_discharge_w=0.0)
+        assert _resolve_max_discharge_power_w(live) is None


### PR DESCRIPTION
## Summary

Beta7 testing by @Extati in #592 revealed a **feedback loop**: the EV discharge cap contaminated the planner input.

### Root cause

The applier's EV discharge guard writes a small cap (e.g. **321 W**) to the `maximum_discharging_power` number entity to protect the battery from feeding an actively charging EV. `build_planner_input` then read that entity back as `battery_max_discharge_power_w`.

The planner treated the EV cap as the battery's **horizon-wide physical limit**:
- `max_discharge/slot = 0.073 kWh` (321 W × 15 min) in every slot
- Every soc_sim slot showed `discharge=0.073` regardless of house load
- The battery stayed at ~86–100% and could never cover evening consumption
- Net effect: the house ran on grid import all night even with a charged battery

### Fix

New `coordinator_builder._resolve_max_discharge_power_w(live)`:
- **EV actively charging** → derive the max from the rated capacity via `get_max_discharge_power()` (the physical capability — the same formula the applier uses for its uncapped write). The EV cap no longer leaks into the planner.
- **No EV charging** → use the live read-back unchanged (rated maximum or a genuine user override, which must be respected).

Canonical rule added to `memories.md`: **planner inputs must reflect physical capability, not commanded entity state.**

### Log clarity (the "ev_power=0W" confusion)

The resolver and applier log lines printed `rec.ev_charger_calculated_power` — the planner's *commanded* charge power — labelled as `ev_power=`. For unmanaged chargers (Clever) this is always 0, which repeatedly looked like a broken sensor in #592 diagnostics. The log lines now show both:

```
planned_ev_power=0W planned_ev2_power=0W ev_total_load=0.000kWh
live_ev_power=3600W live_ev2_power=n/a
```

This makes the live sensor reading directly visible and ends the ambiguity.

### Regression tests

`tests/test_coordinator_builder.py` — 4 cases:
- no EV → live value used unchanged
- EV charging → rated capability (5000 W for 10 kWh) instead of the 321 W cap
- EV charging without rated capacity → safe fallback to live value
- missing live value → None

## Quality gates

- ✅ `lint` — all checks passed
- ✅ `typing` — 0 errors (275 files)
- ✅ `quality` — 0 errors
- ✅ `test` — **2335 passed**, 130 skipped, 10 xfailed

Refs #592