### PR TITLE
fix(services): remove unused targets and clarify create_dashboard, sync dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@
 
 ### User Experience
 - **Quick setup wizard** — auto-detects Huawei Solar, Solcast, and price entities
-- **Bundled Lovelace dashboard** — 6-view dashboard with price charts, energy flow, savings, and accuracy
+- **Bundled Lovelace dashboard** — single-section dashboard with price charts, energy flow, savings, and accuracy
 - **Live-configurable** — all thresholds and settings editable from the dashboard without restart
-- **`hsem.create_dashboard` service** — install or update the bundled Lovelace dashboard from Developer Tools
+- **`hsem.create_dashboard` service** — logs the bundled dashboard YAML path for manual import from Developer Tools
 - **Bilingual** — English and Danish translations
 
 ---

--- a/custom_components/hsem/dashboards/dashboard_en.yaml
+++ b/custom_components/hsem/dashboards/dashboard_en.yaml
@@ -1,412 +1,1151 @@
-title: HSEM Energy Management
 views:
-  - title: Overview
-    icon: mdi:home-battery-outline
-    path: overview
-    cards:
-      - type: vertical-stack
+  - title: HSEM
+    type: sections
+    max_columns: 2
+    cards: []
+    badges: []
+    sections:
+      - type: grid
         cards:
-          # ── Master Status Row ──
-          - type: horizontal-stack
-            cards:
-              - type: custom:mushroom-template-card
-                primary: HSEM Status
-                secondary: "{{ states('sensor.hsem_workingmode_sensor') }}"
-                icon: mdi:robot
-                entity: sensor.hsem_workingmode_sensor
-                icon_color: |-
-                  {% if states('sensor.hsem_workingmode_sensor') in ['batteries_charge_grid','batteries_charge_solar'] %}
-                    green
-                  {% elif states('sensor.hsem_workingmode_sensor') in ['batteries_discharge_mode','force_batteries_discharge'] %}
-                    red
-                  {% else %}
-                    blue
-                  {% endif %}
-                multiline_secondary: false
-                layout: vertical
-                tap_action:
-                  action: more-info
-              - type: custom:mushroom-template-card
-                primary: System Health
-                secondary: "{{ states('sensor.hsem_degraded_mode_sensor') }}"
-                icon: mdi:heart-pulse
-                entity: sensor.hsem_degraded_mode_sensor
-                icon_color: |-
-                  {% if is_state('sensor.hsem_degraded_mode_sensor', 'ok') %}
-                    green
-                  {% else %}
-                    red
-                  {% endif %}
-                layout: vertical
-                tap_action:
-                  action: more-info
-              - type: custom:mushroom-template-card
-                primary: Read-Only
-                secondary: "{{ states('sensor.hsem_read_only_sensor') }}"
-                icon: mdi:lock
-                entity: sensor.hsem_read_only_sensor
-                icon_color: |-
-                  {% if is_state('sensor.hsem_read_only_sensor', 'off') %}
-                    green
-                  {% else %}
-                    orange
-                  {% endif %}
-                layout: vertical
-                tap_action:
-                  action: more-info
-              - type: custom:mushroom-template-card
-                primary: Next Update
-                secondary: "{{ states('sensor.hsem_next_update_sensor') }}"
-                icon: mdi:update
-                entity: sensor.hsem_next_update_sensor
-                icon_color: blue
-                layout: vertical
-                tap_action:
-                  action: more-info
-
-          # ── Plan Status Bar ──
-          - type: horizontal-stack
-            cards:
-              - type: custom:mushroom-entity-card
-                entity: sensor.hsem_plan_explanation_sensor
-                name: Plan Strategy
-                icon: mdi:strategy
-                secondary_info: last-changed
-              - type: custom:mushroom-entity-card
-                entity: sensor.hsem_force_mode_sensor
-                name: Force Mode
-                icon: mdi:hand-back-right
-              - type: custom:mushroom-entity-card
-                entity: sensor.hsem_applier_status_sensor
-                name: Inverter Apply
-                icon: mdi:transmission-tower
-              - type: custom:mushroom-entity-card
-                entity: sensor.hsem_hardware_writes_sensor
-                name: HW Writes
-                icon: mdi:pencil-off
-
-          # ── Diagnostics Row ──
-          - type: entities
-            title: Diagnostics
-            entities:
-              - entity: sensor.hsem_missing_entities_sensor
-                name: Missing Entities
-              - entity: sensor.hsem_update_interval_sensor
-                name: Update Interval
-              - entity: sensor.hsem_last_updated_sensor
-                name: Last Updated
-              - entity: sensor.hsem_net_consumption_sensor
-                name: Net Consumption
-              - entity: sensor.hsem_recommendation_interval_sensor
-                name: Recommendation Interval
-
-  - title: Energy
-    icon: mdi:flash
-    path: energy
-    cards:
-      - type: vertical-stack
+          - type: heading
+            heading: HSEM Status & Control
+            heading_style: title
+            grid_options:
+              columns: full
+              rows: 2
+          - type: tile
+            entity: sensor.hsem_workingmode_sensor
+            name: Working Mode
+            icon: mdi:robot
+            color: state
+            grid_options:
+              columns: 2
+          - type: tile
+            entity: sensor.hsem_degraded_mode_sensor
+            name: System Health
+            icon: mdi:heart-pulse
+            color: state
+            grid_options:
+              columns: 2
+          - type: tile
+            entity: switch.hsem_read_only
+            name: Read-Only
+            icon: mdi:lock
+            color: state
+            features:
+              - type: toggle
+            grid_options:
+              columns: 2
+          - type: tile
+            entity: sensor.hsem_plan_explanation_sensor
+            name: Plan Strategy
+            icon: mdi:strategy
+            color: state
+            grid_options:
+              columns: 2
+          - type: tile
+            entity: select.hsem_force_working_mode
+            name: Force Mode
+            icon: mdi:hand-back-right
+            color: state
+            features:
+              - type: select-options
+            grid_options:
+              columns: 2
+          - type: tile
+            entity: sensor.hsem_next_update_sensor
+            name: Next Update
+            icon: mdi:update
+            color: state
+            grid_options:
+              columns: 2
+          - type: tile
+            entity: sensor.hsem_applier_status_sensor
+            name: Inverter Apply
+            icon: mdi:transmission-tower
+            color: state
+            grid_options:
+              columns: 2
+          - type: tile
+            entity: sensor.hsem_hardware_writes_sensor
+            name: Hardware Writes
+            icon: mdi:pencil-off
+            color: state
+            grid_options:
+              columns: 2
+          - type: tile
+            entity: sensor.hsem_pv_curtailment_sensor
+            name: PV Curtailment
+            icon: mdi:solar-power
+            color: state
+            grid_options:
+              columns: 2
+      - type: grid
         cards:
-          # ── Price Chart (24h import/export) ──
-          - type: custom:apexcharts-card
-            graph_span: 24h
-            header:
-              show: true
-              title: Electricity Prices (24h)
-              show_states: true
-            series:
-              - entity: sensor.hsem_import_cost
-                name: Import Price
-                type: line
-                stroke_width: 2
-                color: "#e74c3c"
-                show:
-                  in_header: true
-              - entity: sensor.hsem_export_income
-                name: Export Price
-                type: line
-                stroke_width: 2
-                color: "#2ecc71"
-                show:
-                  in_header: true
-            yaxis:
-              - id: price
-                title: Price (currency/kWh)
-                decimals: 2
-            now:
-              show: true
-              label: Now
-
-          # ── Solar Section ──
-          - type: horizontal-stack
-            cards:
-              - type: custom:mushroom-entity-card
-                entity: sensor.solcast_pv_forecast_forecast_today
-                name: Solar Today
-                icon: mdi:solar-power
-                icon_color: yellow
-                secondary_info: last-updated
-              - type: custom:mushroom-entity-card
-                entity: sensor.solcast_pv_forecast_forecast_tomorrow
-                name: Solar Tomorrow
-                icon: mdi:solar-power-variant
-                icon_color: orange
-                secondary_info: last-updated
-              - type: custom:mushroom-entity-card
-                entity: sensor.hsem_solar_confidence_sensor
-                name: Solar Confidence
-                icon: mdi:weather-sunny-alert
-                icon_color: cyan
-
-          # ── Battery Section ──
-          - type: horizontal-stack
-            cards:
-              - type: custom:mushroom-entity-card
-                entity: sensor.hsem_battery_soc_sensor
-                name: Battery SoC
-                icon: mdi:battery-high
-                icon_color: |-
-                  {% set soc = states('sensor.hsem_battery_soc_sensor') | float(0) %}
-                  {% if soc > 80 %}green{% elif soc > 40 %}orange{% else %}red{% endif %}
-                layout: vertical
-              - type: custom:mushroom-entity-card
-                entity: select.hsem_force_working_mode
-                name: Working Mode
-                icon: mdi:list-status
-              - type: custom:mushroom-entity-card
-                entity: sensor.hsem_effective_discharge_floor_sensor
-                name: Discharge Floor
-                icon: mdi:arrow-collapse-down
-
-          - type: entities
-            title: Battery Settings
-            entities:
-              - entity: number.hsem_battery_charge_efficiency
-                name: Charge Efficiency
-              - entity: number.hsem_battery_discharge_efficiency
-                name: Discharge Efficiency
-              - entity: switch.hsem_dynamic_discharge_floor
-                name: Dynamic Discharge Floor
-
-  - title: EV Charging
-    icon: mdi:ev-station
-    path: ev
-    cards:
-      - type: vertical-stack
+          - type: heading
+            heading: Financial Insights
+            heading_style: title
+            grid_options:
+              columns: full
+              rows: 2
+          - type: tile
+            entity: sensor.hsem_export_income
+            name: Export Income
+            icon: mdi:cash-plus
+            color: state
+            grid_options:
+              columns: 2
+          - type: tile
+            entity: sensor.hsem_import_cost
+            name: Import Cost
+            icon: mdi:cash-minus
+            color: state
+            grid_options:
+              columns: 2
+          - type: tile
+            entity: sensor.hsem_net_grid_balance
+            name: Net Grid Balance
+            icon: mdi:scale-balance
+            color: state
+            grid_options:
+              columns: 2
+          - type: tile
+            entity: sensor.hsem_savings_tracker
+            name: Savings Tracker
+            icon: mdi:piggy-bank
+            color: state
+            grid_options:
+              columns: 2
+      - type: grid
         cards:
-          # ── EV Charger Status ──
-          - type: conditional
-            conditions:
-              - entity: sensor.hsem_ev_charging_sensor
-                state_not: "unavailable"
-            card:
-              type: horizontal-stack
-              cards:
-                - type: custom:mushroom-entity-card
-                  entity: sensor.hsem_ev_charging_sensor
-                  name: EV Charging
-                  icon: mdi:ev-station
-                  icon_color: |-
-                    {% if is_state('sensor.hsem_ev_charging_sensor', 'on') %}
-                      green
-                    {% else %}
-                      grey
-                    {% endif %}
-                - type: custom:mushroom-entity-card
-                  entity: sensor.hsem_ocpp_charger_power_sensor
-                  name: Charger Power
-                  icon: mdi:lightning-bolt
-                  icon_color: yellow
-                - type: custom:mushroom-entity-card
-                  entity: sensor.hsem_ocpp_charger_status_sensor
-                  name: Charger Status
-                  icon: mdi:information-outline
-
-          # ── Optimal Plan ──
+          - type: heading
+            heading: Forecast Quality
+            heading_style: title
+            grid_options:
+              columns: full
+              rows: 2
+          - type: tile
+            entity: sensor.hsem_forecast_accuracy_sensor
+            name: Forecast Accuracy
+            icon: mdi:chart-line
+            color: state
+            grid_options:
+              columns: 2
+          - type: tile
+            entity: sensor.hsem_prediction_accuracy_sensor
+            name: Prediction Accuracy
+            icon: mdi:target
+            color: state
+            grid_options:
+              columns: 2
+          - type: tile
+            entity: sensor.hsem_solar_confidence_sensor
+            name: Solar Confidence
+            icon: mdi:solar-power
+            color: state
+            grid_options:
+              columns: 2
+      - type: grid
+        cards:
+          - type: heading
+            heading: EV Charging
+            heading_style: title
+            grid_options:
+              columns: full
+              rows: 2
           - type: conditional
             conditions:
               - entity: sensor.hsem_ev_optimal_charging_plan
-                state_not: "unavailable"
+                state_not: unavailable
+            grid_options:
+              columns: 2
             card:
-              type: custom:mushroom-entity-card
+              type: tile
               entity: sensor.hsem_ev_optimal_charging_plan
-              name: Optimal Charging Plan
-              icon: mdi:calendar-clock
-              layout: vertical
-              secondary_info: last-updated
-
+              name: EV Plan
+              icon: mdi:ev-station
+              color: state
+          - type: conditional
+            conditions:
+              - entity: sensor.hsem_ev_charging_sensor
+                state_not: unavailable
+            grid_options:
+              columns: 2
+            card:
+              type: tile
+              entity: sensor.hsem_ev_charging_sensor
+              name: EV Charging Active
+              icon: mdi:lightning-bolt
+              color: state
+          - type: conditional
+            conditions:
+              - entity: switch.hsem_ev_smart_charging
+                state_not: unavailable
+            grid_options:
+              columns: 2
+            card:
+              type: tile
+              entity: switch.hsem_ev_smart_charging
+              name: EV Smart Charging
+              icon: mdi:brain
+              color: state
+              features:
+                - type: toggle
+          - type: conditional
+            conditions:
+              - entity: switch.hsem_ev_force_charge_now
+                state_not: unavailable
+            grid_options:
+              columns: 2
+            card:
+              type: tile
+              entity: switch.hsem_ev_force_charge_now
+              name: EV Force Charge
+              icon: mdi:lightning-bolt-outline
+              color: state
+              features:
+                - type: toggle
+          - type: conditional
+            conditions:
+              - entity: number.hsem_ev_target_soc
+                state_not: unavailable
+            grid_options:
+              columns: 2
+            card:
+              type: tile
+              entity: number.hsem_ev_target_soc
+              name: EV Target SoC
+              icon: mdi:battery-charging
+              color: state
+          - type: conditional
+            conditions:
+              - entity: time.hsem_ev_deadline_time
+                state_not: unavailable
+            grid_options:
+              columns: 2
+            card:
+              type: tile
+              entity: time.hsem_ev_deadline_time
+              name: EV Deadline
+              icon: mdi:clock-end
+              color: state
           - type: conditional
             conditions:
               - entity: sensor.hsem_ev_second_optimal_charging_plan
-                state_not: "unavailable"
+                state_not: unavailable
+            grid_options:
+              columns: 2
             card:
-              type: custom:mushroom-entity-card
+              type: tile
               entity: sensor.hsem_ev_second_optimal_charging_plan
-              name: EV 2 Optimal Charging Plan
-              icon: mdi:calendar-clock-outline
-              layout: vertical
-              secondary_info: last-updated
-
-          # ── EV Controls ──
-          - type: entities
-            title: EV Controls
-            entities:
-              - entity: switch.hsem_ev_smart_charging
-                name: EV Smart Charging
-              - entity: switch.hsem_ev_force_charge_now
-                name: EV Force Charge Now
-              - entity: number.hsem_ev_target_soc
-                name: EV Target SoC
-              - entity: time.hsem_ev_deadline_time
-                name: EV Charge Deadline
+              name: EV 2 Plan
+              icon: mdi:ev-station
+              color: state
+          - type: conditional
+            conditions:
               - entity: switch.hsem_ev_second_smart_charging
-                name: EV 2 Smart Charging
+                state_not: unavailable
+            grid_options:
+              columns: 2
+            card:
+              type: tile
+              entity: switch.hsem_ev_second_smart_charging
+              name: EV 2 Smart Charging
+              icon: mdi:brain
+              color: state
+              features:
+                - type: toggle
+          - type: conditional
+            conditions:
               - entity: switch.hsem_ev_second_force_charge_now
-                name: EV 2 Force Charge Now
+                state_not: unavailable
+            grid_options:
+              columns: 2
+            card:
+              type: tile
+              entity: switch.hsem_ev_second_force_charge_now
+              name: EV 2 Force Charge
+              icon: mdi:lightning-bolt-outline
+              color: state
+              features:
+                - type: toggle
+          - type: conditional
+            conditions:
               - entity: number.hsem_ev_second_target_soc
-                name: EV 2 Target SoC
+                state_not: unavailable
+            grid_options:
+              columns: 2
+            card:
+              type: tile
+              entity: number.hsem_ev_second_target_soc
+              name: EV 2 Target SoC
+              icon: mdi:battery-charging
+              color: state
+          - type: conditional
+            conditions:
               - entity: time.hsem_ev_second_deadline_time
-                name: EV 2 Charge Deadline
-
-  - title: Savings
-    icon: mdi:cash
-    path: savings
-    cards:
-      - type: vertical-stack
+                state_not: unavailable
+            grid_options:
+              columns: 2
+            card:
+              type: tile
+              entity: time.hsem_ev_second_deadline_time
+              name: EV 2 Deadline
+              icon: mdi:clock-end
+              color: state
+      - type: grid
         cards:
-          # ── Financial Summary ──
-          - type: horizontal-stack
-            cards:
-              - type: custom:mushroom-entity-card
-                entity: sensor.hsem_export_income
-                name: Export Income
-                icon: mdi:cash-plus
-                icon_color: green
-                layout: vertical
-              - type: custom:mushroom-entity-card
-                entity: sensor.hsem_import_cost
-                name: Import Cost
-                icon: mdi:cash-minus
-                icon_color: red
-                layout: vertical
-              - type: custom:mushroom-entity-card
-                entity: sensor.hsem_net_grid_balance
-                name: Net Balance
-                icon: mdi:scale-balance
-                icon_color: |-
-                  {% set bal = states('sensor.hsem_net_grid_balance') | float(0) %}
-                  {% if bal > 0 %}green{% elif bal < 0 %}red{% else %}grey{% endif %}
-                layout: vertical
-
-          # ── Savings Tracker ──
-          - type: custom:mushroom-entity-card
-            entity: sensor.hsem_savings_tracker_sensor
-            name: Savings Tracker
-            icon: mdi:piggy-bank
-            icon_color: green
-            layout: vertical
-            secondary_info: last-updated
-
-          # ── Daily Plan vs Actual ──
-          - type: custom:mushroom-entity-card
-            entity: sensor.hsem_daily_plan_vs_actual
-            name: Daily Plan vs Actual
-            icon: mdi:chart-line
-            icon_color: cyan
-            layout: vertical
-            secondary_info: last-updated
-
-  - title: Accuracy
-    icon: mdi:target
-    path: accuracy
-    cards:
-      - type: vertical-stack
+          - type: heading
+            heading: HSEM Working Mode Recommendation
+            heading_style: title
+            grid_options:
+              columns: full
+              rows: 2
+          - type: custom:apexcharts-card
+            update_interval: 5m
+            experimental:
+              disable_config_validation: true
+            grid_options:
+              columns: full
+            layout_options:
+              grid_columns: 3
+              grid_rows: 1
+            header:
+              show: false
+            graph_span: 48h
+            span:
+              start: day
+            now:
+              show: true
+              color: red
+              label: Now
+            apex_config:
+              chart:
+                height: 120
+              stroke:
+                curve: stepline
+              xaxis:
+                labels:
+                  format: HH
+                  rotate: -45
+                  rotateAlways: true
+                  hideOverlappingLabels: true
+                  style:
+                    fontSize: 10
+                    fontWeight: 500
+              yaxis:
+                show: false
+                min: 0
+                max: 1
+                tickAmount: 1
+            series:
+              - name: Batteries Charge From Grid
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: area
+                opacity: 1
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end, recommendation })
+                  => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    const on = recommendation === 'batteries_charge_grid' ? 1 : null;
+                    out.push([s, on], [e, on]);
+                  }); return out;
+                color: "#ef4444"
+              - name: Batteries Charge From Solar
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: area
+                opacity: 1
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end, recommendation })
+                  => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    const on = recommendation === 'batteries_charge_solar' ? 1 : null;
+                    out.push([s, on], [e, on]);
+                  }); return out;
+                color: "#22c55e"
+              - name: Batteries Discharge Mode
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: area
+                opacity: 1
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end, recommendation })
+                  => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    const on = recommendation === 'batteries_discharge_mode' ? 1 : null;
+                    out.push([s, on], [e, on]);
+                  }); return out;
+                color: "#f97316"
+              - name: Batteries Wait Mode
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: area
+                opacity: 1
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end, recommendation })
+                  => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    const on = recommendation === 'batteries_wait_mode' ? 1 : null;
+                    out.push([s, on], [e, on]);
+                  }); return out;
+                color: "#8b5cf6"
+              - name: EV Smart Charging
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: area
+                opacity: 1
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end, recommendation })
+                  => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    const on = recommendation === 'ev_smart_charging' ? 1 : null;
+                    out.push([s, on], [e, on]);
+                  }); return out;
+                color: "#06b6d4"
+              - name: Time Passed
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: area
+                opacity: 1
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end, recommendation })
+                  => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    const on = recommendation === 'time_passed' ? 1 : null;
+                    out.push([s, on], [e, on]);
+                  }); return out;
+                color: "#64748b"
+              - name: Force Batteries Discharge
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: area
+                opacity: 1
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end, recommendation })
+                  => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    const on = recommendation === 'force_batteries_discharge' ? 1 : null;
+                    out.push([s, on], [e, on]);
+                  }); return out;
+                color: "#ec4899"
+          - type: tile
+            entity: sensor.hsem_workingmode_sensor
+            features_position: bottom
+            vertical: false
+            grid_options:
+              columns: 24
+              rows: 1
+          - type: heading
+            heading: Battery
+            heading_style: title
+          - type: custom:apexcharts-card
+            update_interval: 10m
+            apex_config:
+              chart:
+                height: 150px
+              legend:
+                show: false
+              xaxis:
+                labels:
+                  show: true
+                  format: HH
+                  rotate: -45
+                  rotateAlways: true
+                  hideOverlappingLabels: true
+                  style:
+                    fontSize: 10
+                    fontWeight: 10
+            header:
+              show: true
+              show_states: true
+              colorize_states: true
+            all_series_config:
+              type: area
+              opacity: 0.3
+              stroke_width: 1
+            series:
+              - entity: sensor.batteries_state_of_capacity
+                type: line
+                color: "#eab308"
+                yaxis_id: pct
+                opacity: 1
+                stroke_width: 2
+              - entity: sensor.power_import
+                color: "#ef4444"
+                yaxis_id: watt
+                group_by:
+                  func: avg
+                  duration: 5min
+            yaxis:
+              - id: pct
+                show: true
+                opposite: false
+                decimals: 0
+                max: 100
+                min: 0
+              - id: watt
+                show: true
+                opposite: true
+                decimals: 0
+                min: 0
+          - type: custom:apexcharts-card
+            update_interval: 5m
+            header:
+              show: true
+              title: batteries_charged_kwh
+            graph_span: 48h
+            span:
+              start: day
+            now:
+              show: true
+              color: red
+              label: Now
+            apex_config:
+              chart:
+                height: 180
+              stroke:
+                curve: stepline
+                width: 1
+              markers:
+                size: 0
+              xaxis:
+                labels:
+                  format: HH
+                  rotate: -45
+                  rotateAlways: true
+                  hideOverlappingLabels: true
+                  style:
+                    fontSize: 10
+                    fontWeight: 500
+              yaxis:
+                decimalsInFloat: 3
+                opposite: true
+            series:
+              - name: batteries_charged_kwh
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: line
+                color: "#22c55e"
+                float_precision: 3
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end,
+                  batteries_charged_kwh }) => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, batteries_charged_kwh], [e, batteries_charged_kwh]);
+                  }); return out;
+          - type: custom:apexcharts-card
+            update_interval: 1m
+            experimental:
+              disable_config_validation: true
+            grid_options:
+              columns: full
+            layout_options:
+              grid_columns: 3
+              grid_rows: 1
+            graph_span: 24h
+            span:
+              start: day
+            now:
+              show: true
+              color: red
+              label: Now
+            apex_config:
+              chart:
+                height: 500
+              stroke:
+                width: 2
+              xaxis:
+                labels:
+                  format: HH
+                  rotate: -45
+                  rotateAlways: true
+                  hideOverlappingLabels: true
+                  style:
+                    fontSize: 10
+                    fontWeight: 500
+              yaxis:
+                decimalsInFloat: 3
+            series:
+              - name: avg_house_consumption_kwh
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: area
+                color: "#f97316"
+                float_precision: 3
+                opacity: 0.3
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end,
+                  avg_house_consumption_kwh }) => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, avg_house_consumption_kwh], [e, avg_house_consumption_kwh]);
+                  }); return out;
+              - name: avg_house_consumption_1d_kwh
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: line
+                color: "#3b82f6"
+                float_precision: 3
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end,
+                  avg_house_consumption_1d_kwh }) => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, avg_house_consumption_1d_kwh], [e, avg_house_consumption_1d_kwh]);
+                  }); return out;
+              - name: avg_house_consumption_3d
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: line
+                color: "#eab308"
+                float_precision: 3
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end,
+                  avg_house_consumption_3d_kwh }) => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, avg_house_consumption_3d_kwh], [e, avg_house_consumption_3d_kwh]);
+                  }); return out;
+              - name: avg_house_consumption_7d_kwh
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: line
+                color: "#8b5cf6"
+                float_precision: 3
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end,
+                  avg_house_consumption_7d_kwh }) => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, avg_house_consumption_7d_kwh], [e, avg_house_consumption_7d_kwh]);
+                  }); return out;
+              - name: avg_house_consumption_14d_kwh
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: line
+                color: "#22c55e"
+                float_precision: 3
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end,
+                  avg_house_consumption_14d_kwh }) => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, avg_house_consumption_14d_kwh], [e, avg_house_consumption_14d_kwh]);
+                  }); return out;
+        column_span: 2
+      - type: grid
         cards:
-          # ── Forecast Accuracy ──
-          - type: custom:mushroom-entity-card
-            entity: sensor.hsem_forecast_accuracy_sensor
-            name: Forecast Accuracy
-            icon: mdi:crosshairs-gps
-            icon_color: |-
-              {% set acc = states('sensor.hsem_forecast_accuracy_sensor') | float(0) %}
-              {% if acc >= 90 %}green{% elif acc >= 70 %}orange{% else %}red{% endif %}
-            layout: vertical
-            secondary_info: last-updated
-
-          # ── Prediction Accuracy ──
-          - type: custom:mushroom-entity-card
-            entity: sensor.hsem_prediction_accuracy_sensor
-            name: Prediction Accuracy
-            icon: mdi:brain
-            icon_color: purple
-            layout: vertical
-            secondary_info: last-updated
-
-          # ── Accuracy Details ──
-          - type: entities
-            title: Accuracy Details
-            entities:
-              - entity: sensor.hsem_forecast_accuracy_sensor
-                name: SoC Forecast Accuracy
-              - entity: sensor.hsem_prediction_accuracy_sensor
-                name: Solar Prediction Accuracy
-              - entity: sensor.hsem_daily_plan_vs_actual
-                name: Plan-vs-Actual Tracking
-
-  - title: Controls
-    icon: mdi:tune
-    path: controls
-    cards:
-      - type: vertical-stack
+          - type: custom:apexcharts-card
+            update_interval: 5m
+            header:
+              show: true
+              title: estimated_net_consumption_kwh
+            graph_span: 48h
+            span:
+              start: day
+            now:
+              show: true
+              color: red
+              label: Now
+            apex_config:
+              chart:
+                height: 180
+              stroke:
+                curve: stepline
+                width: 1
+              markers:
+                size: 0
+              xaxis:
+                labels:
+                  format: HH
+                  rotate: -45
+                  rotateAlways: true
+                  hideOverlappingLabels: true
+                  style:
+                    fontSize: 10
+                    fontWeight: 500
+              yaxis:
+                decimalsInFloat: 3
+                opposite: true
+            series:
+              - name: estimated_net_consumption_kwh
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: line
+                color: "#06b6d4"
+                float_precision: 3
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end,
+                  estimated_net_consumption_kwh }) => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, estimated_net_consumption_kwh], [e, estimated_net_consumption_kwh]);
+                  }); return out;
+          - type: custom:apexcharts-card
+            update_interval: 5m
+            header:
+              show: true
+              title: estimated_cost
+            graph_span: 48h
+            span:
+              start: day
+            now:
+              show: true
+              color: red
+              label: Now
+            apex_config:
+              chart:
+                height: 180
+              stroke:
+                curve: stepline
+                width: 1
+              markers:
+                size: 0
+              xaxis:
+                labels:
+                  format: HH
+                  rotate: -45
+                  rotateAlways: true
+                  hideOverlappingLabels: true
+                  style:
+                    fontSize: 10
+                    fontWeight: 500
+              yaxis:
+                decimalsInFloat: 2
+                opposite: true
+            series:
+              - name: estimated_cost_currency
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: line
+                color: "#22c55e"
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end,
+                  estimated_cost_currency }) => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, estimated_cost_currency], [e, estimated_cost_currency]);
+                  }); return out;
+          - type: custom:apexcharts-card
+            update_interval: 5m
+            header:
+              show: true
+              title: avg_house_consumption_kwh
+            graph_span: 48h
+            span:
+              start: day
+            now:
+              show: true
+              color: red
+              label: Now
+            apex_config:
+              chart:
+                height: 180
+              stroke:
+                curve: stepline
+                width: 1
+              markers:
+                size: 0
+              xaxis:
+                labels:
+                  format: HH
+                  rotate: -45
+                  rotateAlways: true
+                  hideOverlappingLabels: true
+                  style:
+                    fontSize: 10
+                    fontWeight: 500
+              yaxis:
+                decimalsInFloat: 3
+                opposite: true
+            series:
+              - name: Estimated consumption
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: line
+                float_precision: 3
+                color: "#ef4444"
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end,
+                  avg_house_consumption_kwh }) => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, avg_house_consumption_kwh], [e, avg_house_consumption_kwh]);
+                  }); return out;
+          - type: custom:apexcharts-card
+            update_interval: 5m
+            header:
+              show: true
+              title: export_price
+            graph_span: 48h
+            span:
+              start: day
+            now:
+              show: true
+              color: red
+              label: Now
+            apex_config:
+              chart:
+                height: 180
+              stroke:
+                curve: stepline
+                width: 1
+              markers:
+                size: 0
+              xaxis:
+                labels:
+                  format: HH
+                  rotate: -45
+                  rotateAlways: true
+                  hideOverlappingLabels: true
+                  style:
+                    fontSize: 10
+                    fontWeight: 500
+              yaxis:
+                decimalsInFloat: 3
+                opposite: true
+            series:
+              - name: export_price
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: line
+                color: "#22c55e"
+                float_precision: 3
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end, export_price }) =>
+                  {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, export_price], [e, export_price]);
+                  }); return out;
+      - type: grid
         cards:
-          # ── Switches ──
-          - type: entities
-            title: System Controls
-            entities:
-              - entity: switch.hsem_read_only
-                name: Read-Only Mode
-              - entity: switch.hsem_extended_attributes
-                name: Extended Attributes
-              - entity: switch.hsem_verbose_logging
-                name: Verbose Logging
-              - entity: switch.hsem_ml_consumption_enabled
-                name: ML Consumption
-              - entity: switch.hsem_ml_consumption_sequential
-                name: ML Sequential
-              - entity: switch.hsem_ev_charger_force_max_discharge_power
-                name: EV Force Max Discharge
-              - entity: switch.hsem_dynamic_discharge_floor
-                name: Dynamic Discharge Floor
-
-          # ── Discharge Schedules ──
-          - type: entities
-            title: Discharge Schedules
-            entities:
-              - entity: switch.hsem_batteries_enable_batteries_schedule_1
-                name: Schedule 1
-              - entity: time.hsem_batteries_enable_batteries_schedule_1_start
-                name: Schedule 1 Start
-              - entity: time.hsem_batteries_enable_batteries_schedule_1_end
-                name: Schedule 1 End
-              - entity: switch.hsem_batteries_enable_batteries_schedule_2
-                name: Schedule 2
-              - entity: time.hsem_batteries_enable_batteries_schedule_2_start
-                name: Schedule 2 Start
-              - entity: time.hsem_batteries_enable_batteries_schedule_2_end
-                name: Schedule 2 End
-              - entity: switch.hsem_batteries_enable_batteries_schedule_3
-                name: Schedule 3
-              - entity: time.hsem_batteries_enable_batteries_schedule_3_start
-                name: Schedule 3 Start
-              - entity: time.hsem_batteries_enable_batteries_schedule_3_end
-                name: Schedule 3 End
-
-          # ── Solcast ──
-          - type: entities
-            title: Solar Forecast
-            entities:
-              - entity: select.hsem_solcast_likelihood
-                name: Solcast Likelihood
-              - entity: sensor.solcast_pv_forecast_forecast_today
-                name: Solcast Today
-              - entity: sensor.solcast_pv_forecast_forecast_tomorrow
-                name: Solcast Tomorrow
+          - type: custom:apexcharts-card
+            update_interval: 5m
+            header:
+              show: true
+              title: estimated_battery_capacity_kwh
+            graph_span: 48h
+            span:
+              start: day
+            now:
+              show: true
+              color: red
+              label: Now
+            apex_config:
+              chart:
+                height: 180
+              stroke:
+                curve: stepline
+                width: 1
+              markers:
+                size: 0
+              xaxis:
+                labels:
+                  format: HH
+                  rotate: -45
+                  rotateAlways: true
+                  hideOverlappingLabels: true
+                  style:
+                    fontSize: 10
+                    fontWeight: 500
+              yaxis:
+                decimalsInFloat: 0
+                opposite: true
+            series:
+              - name: estimated_battery_capacity_kwh
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: line
+                color: "#06b6d4"
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end,
+                  estimated_battery_capacity_kwh }) => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, estimated_battery_capacity_kwh], [e, estimated_battery_capacity_kwh]);
+                  }); return out;
+          - type: custom:apexcharts-card
+            update_interval: 5m
+            header:
+              show: true
+              title: estimated_battery_soc_pct
+            graph_span: 48h
+            span:
+              start: day
+            now:
+              show: true
+              color: red
+              label: Now
+            apex_config:
+              chart:
+                height: 180
+              stroke:
+                curve: stepline
+                width: 1
+              markers:
+                size: 0
+              xaxis:
+                labels:
+                  format: HH
+                  rotate: -45
+                  rotateAlways: true
+                  hideOverlappingLabels: true
+                  style:
+                    fontSize: 10
+                    fontWeight: 500
+              yaxis:
+                decimalsInFloat: 0
+                opposite: true
+            series:
+              - name: estimated_battery_soc_pct
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: line
+                color: "#eab308"
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end,
+                  estimated_battery_soc_pct }) => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, estimated_battery_soc_pct], [e, estimated_battery_soc_pct]);
+                  }); return out;
+          - type: custom:apexcharts-card
+            update_interval: 5m
+            header:
+              show: true
+              title: solcast_pv_estimate_kwh
+            graph_span: 48h
+            span:
+              start: day
+            now:
+              show: true
+              color: red
+              label: Now
+            apex_config:
+              chart:
+                height: 180
+              stroke:
+                curve: stepline
+                width: 1
+              markers:
+                size: 0
+              xaxis:
+                labels:
+                  format: HH
+                  rotate: -45
+                  rotateAlways: true
+                  hideOverlappingLabels: true
+                  style:
+                    fontSize: 10
+                    fontWeight: 500
+              yaxis:
+                decimalsInFloat: 3
+                opposite: true
+            series:
+              - name: solcast_pv_estimate_kwh
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: line
+                color: "#f59e0b"
+                float_precision: 3
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end,
+                  solcast_pv_estimate_kwh }) => {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, solcast_pv_estimate_kwh], [e, solcast_pv_estimate_kwh]);
+                  }); return out;
+          - type: custom:apexcharts-card
+            update_interval: 5m
+            header:
+              show: true
+              title: import_price
+            graph_span: 48h
+            span:
+              start: day
+            now:
+              show: true
+              color: red
+              label: Now
+            apex_config:
+              chart:
+                height: 180
+              stroke:
+                curve: stepline
+                width: 1
+              markers:
+                size: 0
+              xaxis:
+                labels:
+                  format: HH
+                  rotate: -45
+                  rotateAlways: true
+                  hideOverlappingLabels: true
+                  style:
+                    fontSize: 10
+                    fontWeight: 500
+              yaxis:
+                decimalsInFloat: 3
+                opposite: true
+            series:
+              - name: import_price
+                entity: sensor.hsem_workingmode_sensor
+                attribute: hourly_recommendations
+                type: line
+                color: "#ef4444"
+                float_precision: 3
+                show:
+                  legend_value: false
+                data_generator: >
+                  const rows =
+                  (Array.isArray(entity.attributes.hourly_recommendations) ?
+                  entity.attributes.hourly_recommendations : [])
+                    .slice()
+                    .sort((a,b) => new Date(a.start) - new Date(b.start));
+                  const out = []; rows.forEach(({ start, end, import_price }) =>
+                  {
+                    const s = new Date(start).getTime();
+                    const e = new Date(end).getTime();
+                    out.push([s, import_price], [e, import_price]);
+                  }); return out;

--- a/custom_components/hsem/services.py
+++ b/custom_components/hsem/services.py
@@ -1,15 +1,15 @@
 """Service handlers for the HSEM integration.
 
-This module implements the four HSEM services:
+This module implements the five HSEM services:
 
 - ``force_recalculation`` — Re-run the full planning pipeline immediately.
 - ``set_temporary_override`` — Force a specific working mode on the select entity.
 - ``clear_override`` — Reset the force-mode select to ``"auto"``.
 - ``export_diagnostics`` — Return a structured diagnostics dump as service response.
+- ``create_dashboard`` — Log the path to the bundled dashboard YAML.
 
-All services expect the caller to provide the config-entry device ID (or the
-coordinator is looked up from the only configured HSEM entry).  Service schemas
-are defined in ``services.yaml``.
+All services are integration-level actions; the coordinator is looked up from
+the only configured HSEM entry.  Service schemas are defined in ``services.yaml``.
 """
 
 from __future__ import annotations
@@ -75,7 +75,7 @@ SCHEMA_CLEAR_OVERRIDE = vol.Schema({})
 
 SCHEMA_EXPORT_DIAGNOSTICS = vol.Schema({})
 
-SCHEMA_CREATE_DASHBOARD = vol.Schema({vol.Optional("force", default=False): bool})
+SCHEMA_CREATE_DASHBOARD = vol.Schema({})
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -303,7 +303,7 @@ async def async_handle_export_diagnostics(  # NOSONAR
 
 async def async_handle_create_dashboard(
     hass: HomeAssistant,
-    call: ServiceCall,
+    call: ServiceCall,  # noqa: ARG001
 ) -> None:
     """Log the path to the bundled HSEM dashboard YAML for manual import.
 

--- a/custom_components/hsem/services.yaml
+++ b/custom_components/hsem/services.yaml
@@ -8,8 +8,6 @@ force_recalculation:
     All entity states are re-read and the planner is re-run. Useful for
     testing or when you need the most up-to-date recommendation without
     waiting for the next scheduled update.
-  target:
-    entity: {}
   fields: {}
 
 set_temporary_override:
@@ -19,8 +17,6 @@ set_temporary_override:
     mode. While the override is active the planner output is bypassed and the
     chosen mode is sent directly to the inverter. Set the working mode to
     "auto" via the clear_override service to resume normal planner control.
-  target:
-    entity: {}
   fields:
     working_mode:
       required: true
@@ -54,8 +50,6 @@ clear_override:
   description: >-
     Clear any active temporary working-mode override and return to automatic
     planner control. Has no effect when no override is currently active.
-  target:
-    entity: {}
   fields: {}
 
 export_diagnostics:
@@ -65,23 +59,14 @@ export_diagnostics:
     response contains the most recent planner input, planner output, hardware
     write status, and integration version — with all entity IDs redacted for
     safe sharing. Useful for debugging and issue reports.
-  target:
-    entity:
-      integration: hsem
   fields: {}
 
 create_dashboard:
   name: Create dashboard
   description: >-
-    Create or update the HSEM Lovelace dashboard at /hsem-dashboard.
-    The dashboard includes status cards, price charts, battery SoC,
-    EV status, savings, and accuracy views. Set force: true to
-    overwrite an existing dashboard.
-  target:
-    entity: {}
-  fields:
-    force:
-      required: false
-      selector:
-        boolean: {}
-      description: "Overwrite the dashboard if it already exists."
+    Log the path to the bundled HSEM Lovelace dashboard YAML and provide
+    import instructions. The dashboard includes status cards, price charts,
+    battery SoC, EV status, savings, and accuracy views. Import the YAML
+    manually via Settings → Dashboards → Add Dashboard → New dashboard from
+    scratch → Raw configuration editor.
+  fields: {}

--- a/docs/dashboard-setup.md
+++ b/docs/dashboard-setup.md
@@ -29,8 +29,299 @@ Step-by-step guide for setting up the HSEM ApexCharts dashboard in Home Assistan
 ```yaml
 views:
   - title: HSEM
+    type: sections
+    max_columns: 2
+    cards: []
     badges: []
     sections:
+      - type: grid
+        cards:
+          - type: heading
+            heading: HSEM Status & Control
+            heading_style: title
+            grid_options:
+              columns: full
+              rows: 2
+          - type: tile
+            entity: sensor.hsem_workingmode_sensor
+            name: Working Mode
+            icon: mdi:robot
+            color: state
+            grid_options:
+              columns: 2
+          - type: tile
+            entity: sensor.hsem_degraded_mode_sensor
+            name: System Health
+            icon: mdi:heart-pulse
+            color: state
+            grid_options:
+              columns: 2
+          - type: tile
+            entity: switch.hsem_read_only
+            name: Read-Only
+            icon: mdi:lock
+            color: state
+            features:
+              - type: toggle
+            grid_options:
+              columns: 2
+          - type: tile
+            entity: sensor.hsem_plan_explanation_sensor
+            name: Plan Strategy
+            icon: mdi:strategy
+            color: state
+            grid_options:
+              columns: 2
+          - type: tile
+            entity: select.hsem_force_working_mode
+            name: Force Mode
+            icon: mdi:hand-back-right
+            color: state
+            features:
+              - type: select-options
+            grid_options:
+              columns: 2
+          - type: tile
+            entity: sensor.hsem_next_update_sensor
+            name: Next Update
+            icon: mdi:update
+            color: state
+            grid_options:
+              columns: 2
+          - type: tile
+            entity: sensor.hsem_applier_status_sensor
+            name: Inverter Apply
+            icon: mdi:transmission-tower
+            color: state
+            grid_options:
+              columns: 2
+          - type: tile
+            entity: sensor.hsem_hardware_writes_sensor
+            name: Hardware Writes
+            icon: mdi:pencil-off
+            color: state
+            grid_options:
+              columns: 2
+          - type: tile
+            entity: sensor.hsem_pv_curtailment_sensor
+            name: PV Curtailment
+            icon: mdi:solar-power
+            color: state
+            grid_options:
+              columns: 2
+      - type: grid
+        cards:
+          - type: heading
+            heading: Financial Insights
+            heading_style: title
+            grid_options:
+              columns: full
+              rows: 2
+          - type: tile
+            entity: sensor.hsem_export_income
+            name: Export Income
+            icon: mdi:cash-plus
+            color: state
+            grid_options:
+              columns: 2
+          - type: tile
+            entity: sensor.hsem_import_cost
+            name: Import Cost
+            icon: mdi:cash-minus
+            color: state
+            grid_options:
+              columns: 2
+          - type: tile
+            entity: sensor.hsem_net_grid_balance
+            name: Net Grid Balance
+            icon: mdi:scale-balance
+            color: state
+            grid_options:
+              columns: 2
+          - type: tile
+            entity: sensor.hsem_savings_tracker
+            name: Savings Tracker
+            icon: mdi:piggy-bank
+            color: state
+            grid_options:
+              columns: 2
+      - type: grid
+        cards:
+          - type: heading
+            heading: Forecast Quality
+            heading_style: title
+            grid_options:
+              columns: full
+              rows: 2
+          - type: tile
+            entity: sensor.hsem_forecast_accuracy_sensor
+            name: Forecast Accuracy
+            icon: mdi:chart-line
+            color: state
+            grid_options:
+              columns: 2
+          - type: tile
+            entity: sensor.hsem_prediction_accuracy_sensor
+            name: Prediction Accuracy
+            icon: mdi:target
+            color: state
+            grid_options:
+              columns: 2
+          - type: tile
+            entity: sensor.hsem_solar_confidence_sensor
+            name: Solar Confidence
+            icon: mdi:solar-power
+            color: state
+            grid_options:
+              columns: 2
+      - type: grid
+        cards:
+          - type: heading
+            heading: EV Charging
+            heading_style: title
+            grid_options:
+              columns: full
+              rows: 2
+          - type: conditional
+            conditions:
+              - entity: sensor.hsem_ev_optimal_charging_plan
+                state_not: unavailable
+            grid_options:
+              columns: 2
+            card:
+              type: tile
+              entity: sensor.hsem_ev_optimal_charging_plan
+              name: EV Plan
+              icon: mdi:ev-station
+              color: state
+          - type: conditional
+            conditions:
+              - entity: sensor.hsem_ev_charging_sensor
+                state_not: unavailable
+            grid_options:
+              columns: 2
+            card:
+              type: tile
+              entity: sensor.hsem_ev_charging_sensor
+              name: EV Charging Active
+              icon: mdi:lightning-bolt
+              color: state
+          - type: conditional
+            conditions:
+              - entity: switch.hsem_ev_smart_charging
+                state_not: unavailable
+            grid_options:
+              columns: 2
+            card:
+              type: tile
+              entity: switch.hsem_ev_smart_charging
+              name: EV Smart Charging
+              icon: mdi:brain
+              color: state
+              features:
+                - type: toggle
+          - type: conditional
+            conditions:
+              - entity: switch.hsem_ev_force_charge_now
+                state_not: unavailable
+            grid_options:
+              columns: 2
+            card:
+              type: tile
+              entity: switch.hsem_ev_force_charge_now
+              name: EV Force Charge
+              icon: mdi:lightning-bolt-outline
+              color: state
+              features:
+                - type: toggle
+          - type: conditional
+            conditions:
+              - entity: number.hsem_ev_target_soc
+                state_not: unavailable
+            grid_options:
+              columns: 2
+            card:
+              type: tile
+              entity: number.hsem_ev_target_soc
+              name: EV Target SoC
+              icon: mdi:battery-charging
+              color: state
+          - type: conditional
+            conditions:
+              - entity: time.hsem_ev_deadline_time
+                state_not: unavailable
+            grid_options:
+              columns: 2
+            card:
+              type: tile
+              entity: time.hsem_ev_deadline_time
+              name: EV Deadline
+              icon: mdi:clock-end
+              color: state
+          - type: conditional
+            conditions:
+              - entity: sensor.hsem_ev_second_optimal_charging_plan
+                state_not: unavailable
+            grid_options:
+              columns: 2
+            card:
+              type: tile
+              entity: sensor.hsem_ev_second_optimal_charging_plan
+              name: EV 2 Plan
+              icon: mdi:ev-station
+              color: state
+          - type: conditional
+            conditions:
+              - entity: switch.hsem_ev_second_smart_charging
+                state_not: unavailable
+            grid_options:
+              columns: 2
+            card:
+              type: tile
+              entity: switch.hsem_ev_second_smart_charging
+              name: EV 2 Smart Charging
+              icon: mdi:brain
+              color: state
+              features:
+                - type: toggle
+          - type: conditional
+            conditions:
+              - entity: switch.hsem_ev_second_force_charge_now
+                state_not: unavailable
+            grid_options:
+              columns: 2
+            card:
+              type: tile
+              entity: switch.hsem_ev_second_force_charge_now
+              name: EV 2 Force Charge
+              icon: mdi:lightning-bolt-outline
+              color: state
+              features:
+                - type: toggle
+          - type: conditional
+            conditions:
+              - entity: number.hsem_ev_second_target_soc
+                state_not: unavailable
+            grid_options:
+              columns: 2
+            card:
+              type: tile
+              entity: number.hsem_ev_second_target_soc
+              name: EV 2 Target SoC
+              icon: mdi:battery-charging
+              color: state
+          - type: conditional
+            conditions:
+              - entity: time.hsem_ev_second_deadline_time
+                state_not: unavailable
+            grid_options:
+              columns: 2
+            card:
+              type: tile
+              entity: time.hsem_ev_second_deadline_time
+              name: EV 2 Deadline
+              icon: mdi:clock-end
+              color: state
       - type: grid
         cards:
           - type: heading
@@ -887,26 +1178,86 @@ views:
                     const e = new Date(end).getTime();
                     out.push([s, import_price], [e, import_price]);
                   }); return out;
-    type: sections
-    max_columns: 2
-    cards: []
+
 ```
 
 ---
 
 ## Dashboard layout
 
-The dashboard uses a three-section layout within one view:
+The dashboard uses a seven-section layout within one view:
 
 | Section | Column span | Cards | Description |
 |---|---|---|---|
-| **Main** | 2 columns | 7 | Recommendation timeline, battery status, charged kWh, consumption breakdown |
-| **Middle** | 1 column | 4 | Net consumption, estimated cost, consumption, export price |
-| **Right** | 1 column | 4 | Battery capacity, simulated SoC, PV forecast, import price |
+| **Status & Control** | 1 column | 10 | Working mode, system health, read-only toggle, plan strategy, force mode, next update, inverter apply, hardware writes, PV curtailment |
+| **Financial Insights** | 1 column | 5 | Export income, import cost, net grid balance, savings tracker |
+| **Forecast Quality** | 1 column | 4 | Forecast accuracy, prediction accuracy, solar confidence |
+| **EV Charging** | 1 column | 12 | EV plan, active status, smart charging, force charge, target SoC, deadline (primary + secondary, conditional) |
+| **Working Mode Recommendation** | 2 columns | 7 | Recommendation timeline, battery status, charged kWh, consumption breakdown |
+| **Planner Output (left)** | 1 column | 4 | Net consumption, estimated cost, consumption, export price |
+| **Planner Output (right)** | 1 column | 4 | Battery capacity, simulated SoC, PV forecast, import price |
 
 ---
 
 ## Cards reference
+
+### Status & Control tiles
+
+The top section uses built-in `tile` cards to surface the most important HSEM
+state at a glance and to provide quick controls:
+
+| Card | Entity | Purpose |
+|---|---|---|
+| Working Mode | `sensor.hsem_workingmode_sensor` | Current planner recommendation |
+| System Health | `sensor.hsem_degraded_mode_sensor` | `ok` / `degraded` / `error` state |
+| Read-Only | `switch.hsem_read_only` | Toggle hardware write protection |
+| Plan Strategy | `sensor.hsem_plan_explanation_sensor` | Why the planner chose the current plan |
+| Force Mode | `select.hsem_force_working_mode` | Override the planner working mode |
+| Next Update | `sensor.hsem_next_update_sensor` | Countdown to the next planner cycle |
+| Inverter Apply | `sensor.hsem_applier_status_sensor` | Last hardware write result |
+| Hardware Writes | `sensor.hsem_hardware_writes_sensor` | Whether writes are currently blocked |
+| PV Curtailment | `sensor.hsem_pv_curtailment_sensor` | `curtailed` when PV is being throttled |
+
+### Financial Insights tiles
+
+Quick visibility into the financial impact of the planner:
+
+| Card | Entity | Purpose |
+|---|---|---|
+| Export Income | `sensor.hsem_export_income` | Cumulative revenue from grid exports |
+| Import Cost | `sensor.hsem_import_cost` | Cumulative cost of grid imports |
+| Net Grid Balance | `sensor.hsem_net_grid_balance` | Export income minus import cost |
+| Savings Tracker | `sensor.hsem_savings_tracker` | Actual savings vs missed savings |
+
+### Forecast Quality tiles
+
+Visibility into how well the planner's forecasts match reality:
+
+| Card | Entity | Purpose |
+|---|---|---|
+| Forecast Accuracy | `sensor.hsem_forecast_accuracy_sensor` | PV and load forecast MAE |
+| Prediction Accuracy | `sensor.hsem_prediction_accuracy_sensor` | SoC prediction MAE over 7/30 days |
+| Solar Confidence | `sensor.hsem_solar_confidence_sensor` | Learned per-hour solar correction factors |
+
+### EV Charging tiles
+
+All EV cards are wrapped in `conditional` cards so they only appear when the
+corresponding EV entity is available. The section covers the primary EV and a
+secondary EV when configured:
+
+| Card | Entity | Purpose |
+|---|---|---|
+| EV Plan | `sensor.hsem_ev_optimal_charging_plan` | Current EV charging plan state |
+| EV Charging Active | `sensor.hsem_ev_charging_sensor` | Whether an EV is currently charging |
+| EV Smart Charging | `switch.hsem_ev_smart_charging` | Enable/disable smart EV charging |
+| EV Force Charge | `switch.hsem_ev_force_charge_now` | Override and start charging now |
+| EV Target SoC | `number.hsem_ev_target_soc` | Target state of charge for smart charging |
+| EV Deadline | `time.hsem_ev_deadline_time` | Deadline by which the EV must reach target SoC |
+| EV 2 Plan | `sensor.hsem_ev_second_optimal_charging_plan` | Second EV charging plan state |
+| EV 2 Smart Charging | `switch.hsem_ev_second_smart_charging` | Enable/disable smart charging for second EV |
+| EV 2 Force Charge | `switch.hsem_ev_second_force_charge_now` | Override and start second EV charging now |
+| EV 2 Target SoC | `number.hsem_ev_second_target_soc` | Target SoC for second EV |
+| EV 2 Deadline | `time.hsem_ev_second_deadline_time` | Deadline for second EV |
 
 ### Recommendation timeline chart
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@
 | [Consumption Prediction](consumption-prediction.md) | Weighted-average model, IQR outlier detection, spike suppression |
 | [Safety Modes](safety-modes.md) | Degraded mode, read-only gate, write-verify applier, runtime resolver |
 | [Price Scaling](price-scaling.md) | EDS price scaling, eds_share conversion factor |
-| [Services Reference](services-reference.md) | All 4 HSEM services with examples |
+| [Services Reference](services-reference.md) | All 5 HSEM services with examples |
 | [Sensors Reference](sensors-reference.md) | Complete entity reference: all sensor, select, switch, number, and time entities |
 | [Dashboard Setup](dashboard-setup.md) | Step-by-step ApexCharts dashboard with full YAML, layout reference, and troubleshooting |
 | [Config Flow Reference](config-flow-reference.md) | Every config/options flow step and field |

--- a/docs/sensors-reference.md
+++ b/docs/sensors-reference.md
@@ -16,7 +16,6 @@ HSEM exposes these entity types:
 | **Switch** | ~15 | Toggle entities for schedules, EV settings, features, and ML options |
 | **Time** | 8 | Start/end time inputs for battery schedules and EV deadlines |
 | **Number** | ~12 | Charge/discharge efficiency, EV target SoC, temperature charge rates |
-| **Binary sensor** | 1 | PV curtailment detection |
 
 ---
 
@@ -485,18 +484,18 @@ Missed: {{ state_attr('sensor.hsem_savings_tracker', 'missed_savings') }}
 
 Detects when the inverter is actively curtailing PV production.
 
-**Entity:** `binary_sensor.hsem_pv_curtailment`
+**Entity:** `sensor.hsem_pv_curtailment_sensor`
 
 | Property | Value |
 |---|---|
-| **Type** | `binary_sensor` |
+| **Type** | `sensor` |
 | **State** | `curtailed` (PV being limited) or `normal` (no curtailment) |
-| **Device class** | `problem` |
+| **Entity category** | `diagnostic` |
 
 **Template example:**
 
 ```jinja2
-{% if is_state('binary_sensor.hsem_pv_curtailment', 'curtailed') %}
+{% if is_state('sensor.hsem_pv_curtailment_sensor', 'curtailed') %}
   PV is being curtailed
 {% endif %}
 ```
@@ -522,8 +521,9 @@ Detects when the inverter is actively curtailing PV production.
 | `sensor.hsem_last_updated_sensor` | Last Updated | Last coordinator cycle timestamp | ISO-8601 timestamp |
 | `sensor.hsem_next_update_sensor` | Next Update | Next scheduled coordinator cycle | ISO-8601 timestamp |
 | `sensor.hsem_missing_entities_sensor` | Missing Input Entities | Count of missing input entities | Integer |
-| `sensor.hsem_plan_explanation` | Plan Explanation | Planner strategy and cost breakdown | Winning candidate name |
+| `sensor.hsem_plan_explanation_sensor` | Plan Explanation | Planner strategy and cost breakdown | Winning candidate name |
 | `sensor.hsem_prediction_accuracy` | Prediction Accuracy | Multi-horizon forecast accuracy | `soc_mae_7d` |
+| `sensor.hsem_forecast_accuracy_sensor` | Forecast Accuracy | PV and load forecast MAE | kWh |
 | `sensor.hsem_recommendation_interval_sensor` | Recommendation Interval | Slot width and horizon info | Minutes |
 | `sensor.hsem_update_interval_sensor` | Update Interval | Current polling interval | Minutes |
 | `sensor.hsem_working_mode` | Working Mode | Active battery recommendation | Working mode state |
@@ -536,7 +536,7 @@ Detects when the inverter is actively curtailing PV production.
 | `sensor.hsem_ocpp_charger_info` | OCPP Charger Info | Vendor, model, firmware, serial | String |
 | `sensor.hsem_ocpp_charger_sessions` | OCPP Charger Sessions | Completed session log | Integer |
 | `sensor.hsem_savings_tracker` | Savings Tracker | Actual vs missed savings (90-day) | Monetary |
-| `binary_sensor.hsem_pv_curtailment` | PV Curtailment | PV curtailment detection | `curtailed` / `normal` |
+| `sensor.hsem_pv_curtailment_sensor` | PV Curtailment | PV curtailment detection | `curtailed` / `normal` |
 
 ---
 
@@ -650,9 +650,13 @@ OCPP configuration is exposed through the config flow with these keys:
 
 ### `hsem.create_dashboard`
 
-Creates a pre-configured HSEM dashboard in Home Assistant with cards for
-working mode, battery SoC, financial sensors, EV status, and plan explanation.
-Available in **Developer Tools → Services**.
+Logs the path to the bundled HSEM dashboard YAML and provides import
+instructions. The dashboard includes cards for working mode, battery SoC,
+financial sensors, EV status, and plan explanation. Import the YAML manually
+via **Developer Tools → Services** or **Settings → Dashboards**.
+
+> The service does **not** create or modify Home Assistant dashboards
+> automatically; it only surfaces the bundled YAML path for manual import.
 
 ---
 

--- a/docs/services-reference.md
+++ b/docs/services-reference.md
@@ -1,7 +1,12 @@
 # HSEM Services Reference
 
-HSEM exposes four Home Assistant services that allow automation, script, and
+HSEM exposes five Home Assistant services that allow automation, script, and
 manual control over the planner and hardware writes.
+
+These services are **integration-level actions**: they operate on the single
+configured HSEM instance and do not require a `target` (entity, device, or
+area). The UI and YAML calls should only provide the `data` fields shown
+below.
 
 ---
 
@@ -32,8 +37,6 @@ All entity states are re-read and the planner is re-run.
 **Example:**
 ```yaml
 service: hsem.force_recalculation
-target:
-  entity_id: sensor.hsem_working_mode
 ```
 
 ---
@@ -114,35 +117,29 @@ service: hsem.clear_override
 
 ## 4. `hsem.create_dashboard`
 
-Creates or updates the bundled HSEM Lovelace dashboard in Home Assistant.
-The dashboard YAML is bundled with the integration at
-`custom_components/hsem/dashboards/dashboard_en.yaml` and includes 6 views:
-price charts, energy flow, savings, accuracy, EV status, and battery health.
+Logs the path to the bundled HSEM Lovelace dashboard YAML and provides import
+instructions. The dashboard YAML is bundled with the integration at
+`custom_components/hsem/dashboards/dashboard_en.yaml` and uses a single
+sections-based view with cards for status, recommendation timeline, battery
+SoC, price charts, and planner output.
 
-**Schema:**
-
-| Field | Required | Type | Default | Description |
-|---|---|---|---|---|
-| `force` | No | Boolean | `false` | When `true`, overwrites an existing HSEM dashboard. When `false` (default), skips if a dashboard named "HSEM" already exists. |
+**Schema:** No fields.
 
 **Use cases:**
-- First-time dashboard installation after HSEM setup
-- Updating the bundled dashboard to a newer version after an HSEM upgrade
+- Find the bundled dashboard path when setting up HSEM for the first time
+- Check that the bundled dashboard YAML is present after an HSEM upgrade
 
 **Implementation notes:**
-- The service logs the path to the bundled dashboard YAML with import instructions.
-- Does not use HA internal storage or Lovelace APIs — relies on the user
-  importing the dashboard via the raw configuration editor or YAML mode.
+- The service does **not** create or modify any Home Assistant dashboard
+  automatically.
+- Import the YAML manually via **Settings → Dashboards → Add Dashboard →
+  New dashboard from scratch → Raw configuration editor**.
+- Replace `sensor.batteries_state_of_capacity` and `sensor.power_import` with
+  your own battery SoC and grid import power entities.
 
-**Examples:**
+**Example:**
 ```yaml
-# Create dashboard, skip if already exists
 service: hsem.create_dashboard
-
-# Force-overwrite an existing dashboard
-service: hsem.create_dashboard
-data:
-  force: true
 ```
 
 ---


### PR DESCRIPTION
## Summary

Fixes #707.

This PR addresses the confusion around HSEM service targets and improves the bundled dashboard so it surfaces all the valuable insights HSEM exposes.

### Services
- Removed the `target:` requirement from all services in `services.yaml`. The handlers are integration-level actions and never used the target.
- Removed the unused `force` field from `hsem.create_dashboard` and updated the service description.
- Updated `services.py` docstring to accurately describe the five services and the coordinator lookup behavior.

### Dashboard
- Re-synced `custom_components/hsem/dashboards/dashboard_en.yaml` with `docs/dashboard-setup.md`.
- Added new sections:
  - **Status & Control** — working mode, system health, read-only toggle, plan strategy, force mode, next update, inverter apply, hardware writes, PV curtailment.
  - **Financial Insights** — export income, import cost, net grid balance, savings tracker.
  - **Forecast Quality** — forecast accuracy, prediction accuracy, solar confidence.
  - **EV Charging** — conditional cards for primary and secondary EV plan, active status, smart charging toggle, force charge toggle, target SoC, and deadline.

### Documentation
- Updated `docs/services-reference.md` to remove the misleading target example and clarify `create_dashboard`.
- Updated `docs/sensors-reference.md` to fix the PV curtailment entity type (`binary_sensor` → `sensor`) and correct the plan explanation entity ID.
- Updated `docs/index.md` and `README.md` to reflect the five services and the true dashboard behavior.

### Quality gates
All four quality gates pass locally:
- `./scripts/quality.sh lint` ✅
- `./scripts/quality.sh typing` ✅
- `./scripts/quality.sh quality` ✅
- `./scripts/quality.sh test` ✅ (2403 passed)

### Notes
The `hsem.create_dashboard` service still only logs the bundled YAML path; automatic Lovelace dashboard creation via the service was not implemented because it touches Home Assistant internal storage.