### PR TITLE
fix(sensor): pass hass to IntegrationSensor/UtilityMeterSensor only when accepted

### DIFF
--- a/custom_components/hsem/custom_sensors/integration_sensor.py
+++ b/custom_components/hsem/custom_sensors/integration_sensor.py
@@ -6,6 +6,7 @@ metadata so that all derived energy sensors appear on the HSEM device page.
 
 from __future__ import annotations
 
+import inspect
 from typing import Any, override
 
 from homeassistant.components.integration.sensor import IntegrationSensor
@@ -42,6 +43,14 @@ class HSEMIntegrationSensor(IntegrationSensor, HSEMEntity):
             config_entry: The HSEM config entry (required).
             **kwargs: Keyword arguments forwarded to :class:`IntegrationSensor`.
         """
+        # Home Assistant core removed the `hass` parameter from
+        # IntegrationSensor.__init__ in 2026.8 (home-assistant/core#177596)
+        # without listing it as a breaking change, since the class is
+        # considered internal API. Only pass `hass` through when the
+        # installed HA version still accepts it, so this works on both
+        # sides of that change.
+        if "hass" not in inspect.signature(IntegrationSensor.__init__).parameters:
+            kwargs.pop("hass", None)
         IntegrationSensor.__init__(self, *args, **kwargs)
         assert config_entry is not None, (
             "config_entry is required for HSEMIntegrationSensor"

--- a/custom_components/hsem/custom_sensors/utility_meter_sensor.py
+++ b/custom_components/hsem/custom_sensors/utility_meter_sensor.py
@@ -6,6 +6,7 @@ per-hour energy meters appear on the HSEM device page.
 
 from __future__ import annotations
 
+import inspect
 from typing import Any, override
 
 from homeassistant.components.sensor.const import SensorDeviceClass, SensorStateClass
@@ -43,6 +44,14 @@ class HSEMUtilityMeterSensor(UtilityMeterSensor, HSEMEntity):
             config_entry: The HSEM config entry (required).
             **kwargs: Keyword arguments forwarded to :class:`UtilityMeterSensor`.
         """
+        # Home Assistant core removed the `hass` parameter from
+        # UtilityMeterSensor.__init__ in 2026.8 (home-assistant/core#177603)
+        # without listing it as a breaking change, since the class is
+        # considered internal API. Only pass `hass` through when the
+        # installed HA version still accepts it, so this works on both
+        # sides of that change.
+        if "hass" not in inspect.signature(UtilityMeterSensor.__init__).parameters:
+            kwargs.pop("hass", None)
         UtilityMeterSensor.__init__(self, *args, **kwargs)
         assert config_entry is not None, (
             "config_entry is required for HSEMUtilityMeterSensor"

--- a/tests/test_integration_utility_meter_sensor_init.py
+++ b/tests/test_integration_utility_meter_sensor_init.py
@@ -1,0 +1,288 @@
+"""Regression tests for HSEMIntegrationSensor / HSEMUtilityMeterSensor construction
+against both the pre-2026.8 and 2026.8+ Home Assistant core signatures.
+
+home-assistant/core PR #177596 ("Do not set a device on YAML integration
+entities", merged 2026-07-30) removed the `hass` parameter from
+``IntegrationSensor.__init__``, and PR #177603 ("Do not set a device on YAML
+utility_meter entities", merged the same day) made the identical change to
+``UtilityMeterSensor.__init__``. Neither change was listed in HA's official
+breaking-changes documentation, because both classes are considered internal
+API by core maintainers. HSEM instantiates both classes via keyword-only
+``hass=self.hass`` in
+``custom_components/hsem/custom_sensors/house_consumption_power_sensor.py``,
+so on HA 2026.8+ this raised ``TypeError: __init__() got an unexpected
+keyword argument 'hass'`` at entity-creation time.
+
+The fix (in ``integration_sensor.py`` and ``utility_meter_sensor.py``)
+inspects the installed parent class's ``__init__`` signature at runtime and
+only forwards ``hass`` when the signature still accepts it.
+
+IMPORTANT: unlike ``tests/test_house_consumption_sensor_lifecycle.py``, the
+tests below do NOT monkeypatch ``HSEMIntegrationSensor.__init__`` or
+``HSEMUtilityMeterSensor.__init__`` themselves — that would bypass the real
+constructor logic entirely and could never catch this class of bug. Instead:
+
+* ``TestRealConstructor`` calls the real wrapper constructors against
+  whatever ``homeassistant`` version is actually installed in this
+  environment (unpatched parent classes).
+* ``TestSimulatedHa2026_8Signature`` patches only the *parent* HA class's
+  ``__init__`` (``IntegrationSensor.__init__`` / ``UtilityMeterSensor.__init__``)
+  with a stand-in that mirrors the real 2026.8+ signature (no ``hass``
+  parameter). This exercises the real HSEM wrapper code deterministically,
+  regardless of which ``homeassistant`` version happens to be pinned in
+  ``requirements.txt`` at test time.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from homeassistant.components.integration.sensor import IntegrationSensor
+from homeassistant.components.utility_meter.sensor import UtilityMeterSensor
+from homeassistant.const import UnitOfTime
+
+from custom_components.hsem.custom_sensors.integration_sensor import (
+    HSEMIntegrationSensor,
+)
+from custom_components.hsem.custom_sensors.utility_meter_sensor import (
+    HSEMUtilityMeterSensor,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_config_entry() -> MagicMock:
+    entry = MagicMock()
+    entry.entry_id = "test_entry_id"
+    return entry
+
+
+def _integration_sensor_kwargs(hass: Any, config_entry: Any) -> dict[str, Any]:
+    """Mirror the real call site in house_consumption_power_sensor.py."""
+    return {
+        "integration_method": "left",
+        "name": "integral test sensor",
+        "round_digits": 2,
+        "source_entity": "sensor.house_power",
+        "unique_id": "integral_unique_id",
+        "unit_prefix": "k",
+        "unit_time": UnitOfTime.HOURS,
+        "max_sub_interval": timedelta(minutes=0),
+        "hass": hass,
+        "e_id": "sensor.integral_test",
+        "id": "integral_unique_id",
+        "config_entry": config_entry,
+    }
+
+
+def _utility_meter_sensor_kwargs(hass: Any, config_entry: Any) -> dict[str, Any]:
+    """Mirror the real call site in house_consumption_power_sensor.py."""
+    return {
+        "cron_pattern": None,
+        "delta_values": False,
+        "meter_offset": timedelta(hours=14),
+        "meter_type": "daily",
+        "name": "utility meter test sensor",
+        "net_consumption": True,
+        "parent_meter": "sensor.house_power",
+        "periodically_resetting": True,
+        "source_entity": "sensor.integral_test",
+        "tariff_entity": None,
+        "tariff": None,
+        "unique_id": "utility_unique_id",
+        "hass": hass,
+        "sensor_always_available": True,
+        "id": "utility_unique_id",
+        "e_id": "sensor.utility_test",
+        "config_entry": config_entry,
+    }
+
+
+def _fake_2026_8_integration_init(
+    self: Any,
+    *,
+    integration_method: str,
+    name: str | None,
+    round_digits: int | None,
+    source_entity: str,
+    unique_id: str | None,
+    unit_prefix: str | None,
+    unit_time: Any,
+    max_sub_interval: timedelta | None,
+    device: Any = None,
+) -> None:
+    """Stand-in for HA 2026.8+ ``IntegrationSensor.__init__`` (no ``hass``).
+
+    Records the kwargs it actually received so the test can assert that
+    ``hass`` was stripped before reaching this point, without needing HA
+    2026.8 installed.
+    """
+    self._attr_unique_id = unique_id
+    self._received_kwargs = {
+        "integration_method": integration_method,
+        "name": name,
+        "round_digits": round_digits,
+        "source_entity": source_entity,
+        "unique_id": unique_id,
+        "unit_prefix": unit_prefix,
+        "unit_time": unit_time,
+        "max_sub_interval": max_sub_interval,
+        "device": device,
+    }
+
+
+def _fake_2026_8_utility_init(
+    self: Any,
+    *,
+    cron_pattern: str | None,
+    delta_values: bool,
+    meter_offset: timedelta,
+    meter_type: str | None,
+    name: str | None,
+    net_consumption: bool,
+    parent_meter: str,
+    periodically_resetting: bool,
+    source_entity: str,
+    tariff_entity: str | None,
+    tariff: str | None,
+    unique_id: str | None,
+    sensor_always_available: bool = False,
+    suggested_entity_id: str | None = None,
+    device: Any = None,
+) -> None:
+    """Stand-in for HA 2026.8+ ``UtilityMeterSensor.__init__`` (no ``hass``)."""
+    self._attr_unique_id = unique_id
+    self._received_kwargs = {
+        "cron_pattern": cron_pattern,
+        "delta_values": delta_values,
+        "meter_offset": meter_offset,
+        "meter_type": meter_type,
+        "name": name,
+        "net_consumption": net_consumption,
+        "parent_meter": parent_meter,
+        "periodically_resetting": periodically_resetting,
+        "source_entity": source_entity,
+        "tariff_entity": tariff_entity,
+        "tariff": tariff,
+        "unique_id": unique_id,
+        "sensor_always_available": sensor_always_available,
+        "suggested_entity_id": suggested_entity_id,
+        "device": device,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Real constructor, unpatched — proves no regression against whichever
+# homeassistant version is actually installed (pinned in requirements.txt).
+# ---------------------------------------------------------------------------
+
+
+class TestRealConstructor:
+    """Construct the real HSEM wrapper classes with no __init__ patching."""
+
+    def test_integration_sensor_constructs_without_typeerror(self) -> None:
+        hass = MagicMock()
+        config_entry = _mock_config_entry()
+
+        sensor = HSEMIntegrationSensor(**_integration_sensor_kwargs(hass, config_entry))
+
+        assert sensor.unique_id == "integral_unique_id"
+        assert sensor.entity_id == "sensor.integral_test"
+
+    def test_utility_meter_sensor_constructs_without_typeerror(self) -> None:
+        hass = MagicMock()
+        config_entry = _mock_config_entry()
+
+        sensor = HSEMUtilityMeterSensor(
+            **_utility_meter_sensor_kwargs(hass, config_entry)
+        )
+
+        assert sensor.unique_id == "utility_unique_id"
+        assert sensor.entity_id == "sensor.utility_test"
+
+
+# ---------------------------------------------------------------------------
+# Simulated HA 2026.8+ signature — deterministic, independent of the
+# installed homeassistant version. Patches only the parent HA class's
+# __init__, so the real HSEM wrapper __init__ (including the fix) still runs.
+# ---------------------------------------------------------------------------
+
+
+class TestSimulatedHa2026_8Signature:
+    """HSEM wrapper must not forward `hass` when the parent HA class rejects it."""
+
+    def test_integration_sensor_drops_hass_when_parent_rejects_it(self) -> None:
+        hass = MagicMock()
+        config_entry = _mock_config_entry()
+
+        with patch.object(IntegrationSensor, "__init__", _fake_2026_8_integration_init):
+            sensor = HSEMIntegrationSensor(
+                **_integration_sensor_kwargs(hass, config_entry)
+            )
+
+        assert sensor.unique_id == "integral_unique_id"
+        assert sensor.entity_id == "sensor.integral_test"
+        assert "hass" not in sensor._received_kwargs  # type: ignore[attr-defined]  # set by fake init in test
+
+    def test_utility_meter_sensor_drops_hass_when_parent_rejects_it(self) -> None:
+        hass = MagicMock()
+        config_entry = _mock_config_entry()
+
+        with patch.object(UtilityMeterSensor, "__init__", _fake_2026_8_utility_init):
+            sensor = HSEMUtilityMeterSensor(
+                **_utility_meter_sensor_kwargs(hass, config_entry)
+            )
+
+        assert sensor.unique_id == "utility_unique_id"
+        assert sensor.entity_id == "sensor.utility_test"
+        assert "hass" not in sensor._received_kwargs  # type: ignore[attr-defined]  # set by fake init in test
+
+    def test_integration_sensor_still_passes_hass_when_parent_accepts_it(
+        self,
+    ) -> None:
+        """Backward-compat guard: pre-2026.8 HA still requires `hass`.
+
+        The fake's parameter must literally be named ``hass`` — that name is
+        exactly what ``inspect.signature(...).parameters`` is checked against
+        in the fix, so this pins down that detail too.
+        """
+        hass_mock = MagicMock()
+        config_entry = _mock_config_entry()
+        received: dict[str, Any] = {}
+
+        def fake_pre_2026_8_init(self: Any, hass: Any, **kwargs: Any) -> None:  # noqa: ANN001 - test stand-in
+            received["hass"] = hass
+            self._attr_unique_id = kwargs["unique_id"]
+
+        with patch.object(IntegrationSensor, "__init__", fake_pre_2026_8_init):
+            HSEMIntegrationSensor(**_integration_sensor_kwargs(hass_mock, config_entry))
+
+        assert received["hass"] is hass_mock
+
+    def test_utility_meter_sensor_still_passes_hass_when_parent_accepts_it(
+        self,
+    ) -> None:
+        """Backward-compat guard: pre-2026.8 HA still requires `hass`.
+
+        The fake's parameter must literally be named ``hass`` — that name is
+        exactly what ``inspect.signature(...).parameters`` is checked against
+        in the fix, so this pins down that detail too.
+        """
+        hass_mock = MagicMock()
+        config_entry = _mock_config_entry()
+        received: dict[str, Any] = {}
+
+        def fake_pre_2026_8_init(self: Any, hass: Any, **kwargs: Any) -> None:  # noqa: ANN001 - test stand-in
+            received["hass"] = hass
+            self._attr_unique_id = kwargs["unique_id"]
+
+        with patch.object(UtilityMeterSensor, "__init__", fake_pre_2026_8_init):
+            HSEMUtilityMeterSensor(
+                **_utility_meter_sensor_kwargs(hass_mock, config_entry)
+            )
+
+        assert received["hass"] is hass_mock


### PR DESCRIPTION
## What broke

`home-assistant/core` merged two PRs on 2026-07-30 that removed the `hass` parameter from two helper-entity `__init__` methods, shipping in **HA 2026.8.0** (released 2026-08-05):

- [home-assistant/core#177596](https://github.com/home-assistant/core/pull/177596) — "Do not set a device on YAML integration entities" (merged 2026-07-30T06:49:24Z): `IntegrationSensor.__init__` went from `def __init__(self, hass: HomeAssistant, *, integration_method, name, round_digits, source_entity, unique_id, unit_prefix, unit_time, max_sub_interval) -> None:` to `def __init__(self, *, integration_method, name, round_digits, source_entity, unique_id, unit_prefix, unit_time, max_sub_interval, device=None) -> None:` — `hass` removed entirely.
- [home-assistant/core#177603](https://github.com/home-assistant/core/pull/177603) — "Do not set a device on YAML utility_meter entities" (merged 2026-07-30T06:46:52Z): same change to `UtilityMeterSensor.__init__`.

**Neither change is listed in HA's official breaking-changes documentation** — both classes are considered internal API by core maintainers, so integrations that build on them got no warning.

`custom_components/hsem/custom_sensors/house_consumption_power_sensor.py` instantiates `HSEMIntegrationSensor` and `HSEMUtilityMeterSensor` with `hass=self.hass` as a keyword argument at both call sites (~line 477 and ~line 540). Both wrapper classes blindly forward `**kwargs` (including `hass`) straight into the parent HA class's `__init__`:

- `custom_components/hsem/custom_sensors/integration_sensor.py` → `IntegrationSensor.__init__(self, *args, **kwargs)`
- `custom_components/hsem/custom_sensors/utility_meter_sensor.py` → `UtilityMeterSensor.__init__(self, *args, **kwargs)`

On HA 2026.8+, this raises `TypeError: __init__() got an unexpected keyword argument 'hass'` at entity-creation time — every derived integral/utility-meter sensor HSEM creates would fail to instantiate on upgrade.

I independently confirmed this by installing `homeassistant==2026.8.0` in an isolated venv and reproducing the exact `TypeError` by calling `IntegrationSensor(hass=..., ...)` directly.

## The fix

Rather than pinning `homeassistant` to an older version, detect at runtime whether the installed parent `__init__` still accepts `hass` via `inspect.signature(...)`, and only forward it when it does. This way the same code works on both pre-2026.8 (which requires `hass`) and 2026.8+ (which rejects it) — no dependency pin change needed.

```python
if "hass" not in inspect.signature(IntegrationSensor.__init__).parameters:
    kwargs.pop("hass", None)
IntegrationSensor.__init__(self, *args, **kwargs)
```

...and the mirror in `utility_meter_sensor.py` checking `UtilityMeterSensor.__init__`'s own signature independently (they happened to change identically in this HA release, but the two checks are not assumed to be coupled).

`house_consumption_power_sensor.py` (the call sites) is untouched — the fix is entirely in the two wrapper `__init__` methods, keeping the diff minimal.

### Precedent

This is the same pattern already used successfully elsewhere for this exact upstream change:

- [jseidl/magic-areas#627](https://github.com/jseidl/magic-areas/pull/627) — "Keep AreaThresholdSensor working on HA 2026.8", same `inspect.signature` technique for `ThresholdSensor`.
- `bramstroker/homeassistant-powercalc` — has used runtime signature detection for HA helper-entity compatibility for years.
- `nathanmarlor/foxess_modbus` — explicit `inspect.signature` usage for the same class of problem.
- `Olen/homeassistant-plant#500` — same fix pattern.

## Testing

**Important existing-test caveat found during this work:** `tests/test_house_consumption_sensor_lifecycle.py` tests `HSEMHouseConsumptionPowerSensor` by monkeypatching `HSEMIntegrationSensor.__init__` and `HSEMUtilityMeterSensor.__init__` themselves with fakes (`patch.object(HSEMIntegrationSensor, "__init__", _fake_integration_init)`). That means it never exercises the real constructor path and would not have caught this bug, nor would it prove this fix works.

Added `tests/test_integration_utility_meter_sensor_init.py` with 6 new tests that do **not** patch the HSEM wrapper `__init__` methods:

- `TestRealConstructor` — constructs the real, unpatched `HSEMIntegrationSensor`/`HSEMUtilityMeterSensor` against whatever `homeassistant` is actually installed.
- `TestSimulatedHa2026_8Signature` — patches only the *parent* HA class's `__init__` (`IntegrationSensor.__init__` / `UtilityMeterSensor.__init__`) with a stand-in mirroring the real 2026.8+ signature (no `hass` param), so the real HSEM wrapper logic (including this fix) is genuinely exercised and the test is deterministic regardless of which `homeassistant` version happens to be pinned at test time. Also includes a backward-compat test confirming `hass` is still forwarded when the parent signature accepts it.

**Discrepancy worth flagging:** `requirements.txt`/`pyproject.toml` currently pin `homeassistant==2026.7.4`, which still accepts `hass` — so this specific `TypeError` does not reproduce today against the pinned test environment (only the `TestSimulatedHa2026_8Signature` tests actually prove the fix works). I independently confirmed the real bug and the real fix by installing `homeassistant==2026.8.0` in a separate throwaway venv, reproducing `TypeError: IntegrationSensor.__init__() got an unexpected keyword argument 'hass'`, and confirming `UtilityMeterSensor.__init__` dropped `hass` in the same way. I deliberately did **not** bump the `homeassistant` pin in this PR — that's outside the minimal-diff scope of this fix and is a separate decision for the maintainer; the runtime-detection fix is correct regardless of which version is installed.

I removed and re-applied the fix locally (`git stash`) to confirm the two `TestSimulatedHa2026_8Signature` "drops_hass" tests genuinely fail with the exact real-world `TypeError` on pre-fix code and pass after the fix.

### Quality gates (per `AGENTS.md`/`CLAUDE.md`)

All run with Python 3.14.2 via `uv sync --all-groups`:

| Gate | Before (baseline, `main`) | After (this branch) |
|---|---|---|
| `./scripts/quality.sh lint` | pass (ruff format + check) | pass |
| `./scripts/quality.sh typing` | pass (mypy, 276 files) | pass (mypy, 277 files) |
| `./scripts/quality.sh quality` | pass (pyright + vulture, 0/0/0) | pass (pyright + vulture, 0/0/0) |
| `./scripts/quality.sh test` | 2384 passed | 2390 passed (6 new) |

No pre-existing failures were encountered; nothing needed to be worked around.

## Disclosure

This PR was implemented with [Claude Code](https://claude.com/claude-code). I have no real Huawei solar hardware and validated this change entirely via unit tests and mocks (including a manual, isolated-venv reproduction of the upstream `TypeError` against `homeassistant==2026.8.0`) — no manual/hardware testing was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
