### PR TITLE
fix(applier,planner): stop EV cap ratchet and close flicker feedback path

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -732,12 +732,29 @@ cover evening house load.
 
 Canonical rule: **planner inputs must reflect physical capability, not
 commanded entity state.**  Use
-``coordinator_builder._resolve_max_discharge_power_w(live)`` — during an
-active EV session it derives the max from the rated capacity via
-``get_max_discharge_power()``; otherwise it uses the live read-back (rated
-maximum or genuine user override).
+``coordinator_builder._resolve_max_discharge_power_w(live)`` — it always
+derives the max from the rated capacity via
+``get_max_discharge_power()``; the live entity read-back is only a
+degraded fallback when the rated capacity is unknown.  (Beta8 gated the
+substitution on ``any_ev_charging``, but a single EV-status flicker let
+the still-capped entity poison an off-schedule run — the substitution is
+now unconditional.)
 
-Regression tests: ``tests/test_coordinator_builder.py``.
+## EV Discharge Cap Must Never Ratchet Down (issue #592, beta8)
+
+``applier.compute_ev_discharge_cap_w()`` is the single place that computes
+the cap.  The live reading (``house_w − ev_w``) drifts below the true
+house baseline whenever the CT clamp and the EV power sensor disagree —
+and the battery's own discharge shrinks the CT reading further, so
+``min(live, history)`` ratcheted the cap 363→40 W over one night.  Rules:
+
+- live below baseline → hold the historical baseline (never ratchet down)
+- live above baseline → raise, bounded at 3× baseline (EV under-read guard)
+- no EV power sensor → minimum positive sub-window average
+- no history → trust live
+
+Regression tests: ``tests/test_coordinator_builder.py``,
+``tests/sensors/test_applier.py::TestComputeEvDischargeCapW``.
 
 ---
 

--- a/custom_components/hsem/coordinator_builder.py
+++ b/custom_components/hsem/coordinator_builder.py
@@ -68,26 +68,31 @@ def _resolve_max_discharge_power_w(live: LiveState) -> float | None:
     value into the planner as the horizon-wide discharge limit — the
     classic feedback loop observed in the beta7 logs where every slot was
     limited to ``discharge=0.073 kWh`` (321 W × 15 min) and the battery
-    could never cover evening house load.
+    could never cover evening house load.  Beta8 narrowed the substitution
+    to ``any_ev_charging`` cycles only, but a single EV-status flicker let
+    the capped value slip through on an off-schedule run.
 
-    When an EV is actively charging, the physical capability is derived
-    from the rated capacity instead (same formula the applier uses for the
-    uncapped write).  When no EV is charging, the live read-back is used
-    unchanged — at that point it always reflects the rated maximum (or a
-    genuine user override, which should be respected).
+    The physical capability is therefore **always** derived from the rated
+    capacity (same formula the applier uses for the uncapped write) — never
+    from the live entity read-back.  The read-back is a *commanded* value,
+    not a capability: besides the EV cap, a brief EV-status flicker (boolean
+    sensor bouncing off for one cycle) would otherwise let a still-capped
+    entity poison an off-schedule planner run (observed in beta8: one
+    irregular cycle planned the whole horizon at ``max_discharge/slot
+    =0.010`` after the EV boolean dropped out for a single poll).
 
     Args:
         live: Live state snapshot.
 
     Returns:
-        Max discharge power in Watts, or ``None`` when unavailable.
+        Max discharge power in Watts, or ``None`` when the rated capacity
+        is unavailable.
     """
-    live_w = convert_to_float(live.huawei_batteries_max_discharge_power_w)
-    if live.any_ev_charging:
-        rated_wh = convert_to_int(live.huawei_batteries_rated_capacity_wh)
-        if rated_wh is not None and rated_wh > 0:
-            return float(get_max_discharge_power(rated_wh))
-    return live_w or None
+    rated_wh = convert_to_int(live.huawei_batteries_rated_capacity_wh)
+    if rated_wh is not None and rated_wh > 0:
+        return float(get_max_discharge_power(rated_wh))
+    # Degraded fallback: no rated capacity known — use the live read-back.
+    return convert_to_float(live.huawei_batteries_max_discharge_power_w) or None
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/hsem/custom_sensors/applier.py
+++ b/custom_components/hsem/custom_sensors/applier.py
@@ -81,6 +81,61 @@ def _fmt_live_power_w(power_w: float | None) -> str:
     return f"{int(power_w)}W"
 
 
+def compute_ev_discharge_cap_w(
+    *,
+    live_net_w: float | None,
+    ev_power_available: bool,
+    historical_w: int,
+    sub_window_ws: list[int],
+) -> int:
+    """Compute the EV discharge cap in Watts (pure function, unit-testable).
+
+    The cap limits battery discharge to the house-only load while an EV is
+    charging, so 100 % of the EV load goes to the grid.
+
+    Selection rules:
+
+    - **Live reading available** (EV power sensor present): the historical
+      baseline is the stable reference.  The live reading
+      (``house_w − ev_w``) drifts below the true house baseline whenever
+      the CT clamp and the EV power sensor disagree slightly — and because
+      the battery's own discharge reduces the CT reading, the error
+      compounds cycle over cycle.  Taking ``min(live, history)`` ratchets
+      the cap toward zero (observed in beta8: 363→289→241→…→40 W over one
+      night while the true house load stayed ~400 W).  The cap therefore
+      never drops below the historical baseline; the live reading may only
+      RAISE it (bounded at 3× baseline) when genuine extra house demand
+      appears (e.g. cooking while the EV charges).
+    - **No live reading** (boolean-only EV sensor): fall back to the
+      smallest positive sub-window average — the 1d window recalibrates
+      fastest after an upgrade or sensor configuration change.
+    - **No history at all** (fresh install): trust the live reading.
+
+    Args:
+        live_net_w: ``net_consumption_w`` from the live state (EV power
+            already subtracted), or ``None``.
+        ev_power_available: Whether at least one EV power sensor reported
+            a positive reading this cycle.
+        historical_w: House baseline in Watts from the current slot's
+            weighted average (0 when unavailable).
+        sub_window_ws: Sub-window averages (1d/3d/7d/14d/weighted)
+            converted to Watts.
+
+    Returns:
+        The discharge cap in Watts (≥ 0).
+    """
+    if live_net_w is not None and ev_power_available:
+        live_abs = max(live_net_w, 0.0)
+        if historical_w > 0:
+            return int(max(historical_w, min(live_abs, historical_w * 3)))
+        return int(live_abs)
+    best_w = 0
+    for w in sub_window_ws:
+        if w > 0 and (best_w == 0 or w < best_w):
+            best_w = w
+    return best_w
+
+
 def _should_force_export_for_ev(
     ev: Any,
     ev_cfg: Any,
@@ -358,38 +413,26 @@ async def async_apply_battery_settings(
             # provided a value.  When ev.power_w is 0/None but is_charging
             # is True (e.g. boolean-only sensor, or sensor unavailable),
             # net_consumption_w == house_w (no EV subtraction happened).
-            # In that case fall back to the minimum sub-window average.
             ev_power_available = (
                 live.ev.power_w is not None and live.ev.power_w > 1e-9
             ) or (live.ev_second.power_w is not None and live.ev_second.power_w > 1e-9)
-            if live_net_w is not None and ev_power_available:
-                live_abs = max(live_net_w, 0.0)
-                if historical_w > 0:
-                    # Take the more conservative of live and historical so a
-                    # single polluted source cannot inflate the cap.
-                    cap_w = int(min(live_abs, historical_w))
-                else:
-                    # No history yet (fresh install) — trust the live reading.
-                    cap_w = int(live_abs)
-            else:
-                # No reliable live reading or no EV power sensor.
-                # Fall back to the most conservative (smallest) of the
-                # sub-window averages.  The 1d window recalibrates
-                # fastest after an upgrade or sensor configuration change.
-                sub_windows = [
+            sub_window_ws = [
+                int(sw / slot_hours * 1000.0)
+                for sw in (
                     rec.avg_house_consumption_1d_kwh,
                     rec.avg_house_consumption_3d_kwh,
                     rec.avg_house_consumption_7d_kwh,
                     rec.avg_house_consumption_14d_kwh,
                     rec.avg_house_consumption_kwh,
-                ]
-                best_w = 0
-                for sw in sub_windows:
-                    if sw > 1e-9:
-                        w = int(sw / slot_hours * 1000.0) if slot_hours > 1e-9 else 0
-                        if best_w == 0 or (w > 0 and w < best_w):
-                            best_w = w
-                cap_w = best_w
+                )
+                if sw > 1e-9 and slot_hours > 1e-9
+            ]
+            cap_w = compute_ev_discharge_cap_w(
+                live_net_w=live_net_w,
+                ev_power_available=ev_power_available,
+                historical_w=historical_w,
+                sub_window_ws=sub_window_ws,
+            )
             cap_reason = "EV active" if hsem_planned_ev else "EV active (unplanned)"
 
             if live.huawei_batteries_max_discharge_power_w != cap_w:

--- a/tests/sensors/test_applier.py
+++ b/tests/sensors/test_applier.py
@@ -69,3 +69,91 @@ class TestParsePowerControlPct:
     def test_fractional_localized(self):
         """Localized percentage with decimal rounds correctly."""
         assert _parse_power_control_pct("Begrenzt auf 79.6 %") == 80
+
+
+# ---------------------------------------------------------------------------
+# compute_ev_discharge_cap_w — EV discharge cap selection (issue #592, beta8)
+# ---------------------------------------------------------------------------
+
+
+class TestComputeEvDischargeCapW:
+    """The cap must hold the historical baseline and never ratchet down."""
+
+    @staticmethod
+    def _cap(**kwargs):
+        from custom_components.hsem.custom_sensors.applier import (
+            compute_ev_discharge_cap_w,
+        )
+
+        return compute_ev_discharge_cap_w(**kwargs)
+
+    def test_live_below_history_holds_baseline(self):
+        """Sensor drift pulling live below the baseline must NOT lower the
+        cap (beta8 ratchet: 363→289→…→40 W over one night)."""
+        cap = self._cap(
+            live_net_w=200.0,  # drifted below the true 400 W baseline
+            ev_power_available=True,
+            historical_w=400,
+            sub_window_ws=[400],
+        )
+        assert cap == 400
+
+    def test_live_above_history_raises_cap_bounded(self):
+        """Genuine extra house demand (cooking) raises the cap, bounded at
+        3× the baseline to limit EV-sensor under-read leakage."""
+        cap = self._cap(
+            live_net_w=900.0,
+            ev_power_available=True,
+            historical_w=400,
+            sub_window_ws=[400],
+        )
+        assert cap == 900
+
+    def test_live_spike_capped_at_3x_baseline(self):
+        """A huge live spike (EV sensor severely under-reading) is bounded."""
+        cap = self._cap(
+            live_net_w=5000.0,
+            ev_power_available=True,
+            historical_w=400,
+            sub_window_ws=[400],
+        )
+        assert cap == 1200
+
+    def test_no_history_trusts_live(self):
+        cap = self._cap(
+            live_net_w=350.0,
+            ev_power_available=True,
+            historical_w=0,
+            sub_window_ws=[],
+        )
+        assert cap == 350
+
+    def test_no_ev_power_sensor_uses_min_sub_window(self):
+        """Boolean-only EV sensor: fall back to the smallest sub-window."""
+        cap = self._cap(
+            live_net_w=None,
+            ev_power_available=False,
+            historical_w=400,
+            sub_window_ws=[280, 520, 480, 400],
+        )
+        assert cap == 280
+
+    def test_negative_live_treated_as_zero(self):
+        """CT clamp < EV sensor (slight over-read) → live is negative;
+        cap still holds the historical baseline."""
+        cap = self._cap(
+            live_net_w=-150.0,
+            ev_power_available=True,
+            historical_w=400,
+            sub_window_ws=[400],
+        )
+        assert cap == 400
+
+    def test_everything_missing_returns_zero(self):
+        cap = self._cap(
+            live_net_w=None,
+            ev_power_available=False,
+            historical_w=0,
+            sub_window_ws=[],
+        )
+        assert cap == 0

--- a/tests/test_coordinator_builder.py
+++ b/tests/test_coordinator_builder.py
@@ -29,11 +29,12 @@ class TestResolveMaxDischargePowerW:
         live.huawei_batteries_rated_capacity_wh = rated_wh
         return live
 
-    def test_no_ev_charging_uses_live_value(self) -> None:
-        """Without an active EV session the live read-back reflects the
-        rated maximum (or a genuine user override) and is used unchanged."""
+    def test_no_ev_charging_uses_rated_capability(self) -> None:
+        """The planner always gets the physical capability derived from the
+        rated capacity — the live entity is a commanded value, never a
+        capability (issue #592)."""
         live = self._live(ev_charging=False, max_discharge_w=321.0)
-        assert _resolve_max_discharge_power_w(live) == pytest.approx(321.0)
+        assert _resolve_max_discharge_power_w(live) == pytest.approx(5000.0)
 
     def test_ev_charging_uses_rated_capability(self) -> None:
         """During an EV session the applier caps the entity (e.g. 321 W).
@@ -43,11 +44,17 @@ class TestResolveMaxDischargePowerW:
         live = self._live(ev_charging=True, max_discharge_w=321.0)
         assert _resolve_max_discharge_power_w(live) == pytest.approx(5000.0)
 
-    def test_ev_charging_without_rated_capacity_falls_back_to_live(self) -> None:
+    def test_ev_status_flicker_does_not_leak_cap(self) -> None:
+        """A single-cycle EV boolean flicker must not let the still-capped
+        entity poison an off-schedule planner run (beta8 regression)."""
+        live = self._live(ev_charging=False, max_discharge_w=40.0)
+        assert _resolve_max_discharge_power_w(live) == pytest.approx(5000.0)
+
+    def test_missing_rated_capacity_falls_back_to_live(self) -> None:
         """Missing rated capacity → keep the live value (degraded but safe)."""
         live = self._live(ev_charging=True, max_discharge_w=321.0, rated_wh=0)
         assert _resolve_max_discharge_power_w(live) == pytest.approx(321.0)
 
-    def test_no_ev_charging_missing_live_value_returns_none(self) -> None:
-        live = self._live(ev_charging=False, max_discharge_w=0.0)
+    def test_missing_rated_capacity_and_live_value_returns_none(self) -> None:
+        live = self._live(ev_charging=False, max_discharge_w=0.0, rated_wh=0)
         assert _resolve_max_discharge_power_w(live) is None


### PR DESCRIPTION
## Summary

Two bugs from @Extati's beta8 night test in #592:

### 1. EV discharge cap ratcheted to zero (363→289→241→…→40 W)

The cap used `min(live, history)`. The live reading (`house_w − ev_w`) drifts below the true house baseline whenever the CT clamp and the EV power sensor disagree slightly — and the battery's own capped discharge shrinks the CT reading further each cycle, so the error **compounded downward** all night while the true house load stayed ~400 W.

**Fix:** extracted `compute_ev_discharge_cap_w()` (pure, unit-testable):
- live below baseline → **hold the historical baseline** (never ratchet down)
- live above baseline → raise, **bounded at 3× baseline** (guards against EV-sensor under-read leakage)
- no EV power sensor → minimum positive sub-window average (unchanged)
- no history → trust live (unchanged)

### 2. EV-status flicker let the capped entity poison an off-schedule planner run

Beta8 gated the rated-capacity substitution in `_resolve_max_discharge_power_w` on `any_ev_charging`. At 01:00:16 the EV boolean dropped out for a single poll → the next (off-schedule) planner run read back the still-capped **40 W** entity and planned the whole horizon at `max_discharge/slot=0.010`.

**Fix:** `_resolve_max_discharge_power_w()` now **always** derives the physical capability from the rated capacity via `get_max_discharge_power()`. The live entity is a *commanded* value, never a capability. Live read-back remains only as a degraded fallback when rated capacity is unknown.

## Regression tests

- `TestComputeEvDischargeCapW` — 7 cases (ratchet hold, bounded raise, 3× spike cap, no-history, min sub-window, negative live, all-missing)
- `TestResolveMaxDischargePowerW` — 5 cases incl. the exact flicker scenario (EV off + 40 W capped entity → still 5000 W)

## Quality gates

- ✅ `lint` — all checks passed
- ✅ `typing` — 0 errors (276 files)
- ✅ `quality` — 0 errors, 0 warnings
- ✅ `test` — **2392 passed**

Refs #592