### PR TITLE
fix(applier): EV discharge cap follows baseline only + SoC reserve guard

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -740,18 +740,30 @@ substitution on ``any_ev_charging``, but a single EV-status flicker let
 the still-capped entity poison an off-schedule run — the substitution is
 now unconditional.)
 
-## EV Discharge Cap Must Never Ratchet Down (issue #592, beta8)
+## EV Discharge Cap Is the Historical Baseline — Live Never Moves It (issue #592)
 
 ``applier.compute_ev_discharge_cap_w()`` is the single place that computes
-the cap.  The live reading (``house_w − ev_w``) drifts below the true
-house baseline whenever the CT clamp and the EV power sensor disagree —
-and the battery's own discharge shrinks the CT reading further, so
-``min(live, history)`` ratcheted the cap 363→40 W over one night.  Rules:
+the cap.  Two opposite failures proved the live reading must not move the
+cap at all when history exists:
 
-- live below baseline → hold the historical baseline (never ratchet down)
-- live above baseline → raise, bounded at 3× baseline (EV under-read guard)
+- **beta8 ratchet:** ``min(live, history)`` let CT-clamp/EV-sensor drift
+  pull the cap 363→40 W over one night (the battery's own capped
+  discharge shrinks the CT reading further — a self-poisoning input).
+- **v6.2.0-beta1 swings:** ``max(history, min(live, 3×history))`` let
+  ordinary house noise (cooking, heat pump) swing the cap 652→1968→928 W
+  for 5+ hours, draining the battery before the 06:00 scheduled plan.
+
+Rules:
+
+- history available → cap = historical baseline, live is ignored
 - no EV power sensor → minimum positive sub-window average
 - no history → trust live
+
+**SoC guard (v6.2.0-beta1):** after computing the cap, if
+``battery_current_capacity_kwh <= current_required_battery_kwh`` (the
+planner's reserve until the next solar surplus), the cap is forced to
+0 W — the battery is preserved for its schedule and the house load is
+served from the grid until the battery recovers.
 
 Regression tests: ``tests/test_coordinator_builder.py``,
 ``tests/sensors/test_applier.py::TestComputeEvDischargeCapW``.

--- a/custom_components/hsem/custom_sensors/applier.py
+++ b/custom_components/hsem/custom_sensors/applier.py
@@ -96,16 +96,16 @@ def compute_ev_discharge_cap_w(
     Selection rules:
 
     - **Live reading available** (EV power sensor present): the historical
-      baseline is the stable reference.  The live reading
-      (``house_w − ev_w``) drifts below the true house baseline whenever
-      the CT clamp and the EV power sensor disagree slightly — and because
-      the battery's own discharge reduces the CT reading, the error
-      compounds cycle over cycle.  Taking ``min(live, history)`` ratchets
-      the cap toward zero (observed in beta8: 363→289→241→…→40 W over one
-      night while the true house load stayed ~400 W).  The cap therefore
-      never drops below the historical baseline; the live reading may only
-      RAISE it (bounded at 3× baseline) when genuine extra house demand
-      appears (e.g. cooking while the EV charges).
+      baseline is the stable reference — the cap **is** the baseline.  The
+      live reading (``house_w − ev_w``) must not move the cap in either
+      direction: downward it ratchets toward zero when the CT clamp and the
+      EV sensor disagree (beta8: 363→40 W staircase), and upward it swings
+      with ordinary house noise (cooking, heat pump cycles), slowly
+      draining the battery into what is supposed to be a grid-served EV
+      session (v6.2.0-beta1: 652→1968→928 W swings emptied the battery
+      before the 06:00 scheduled plan).  A short house spike covered from
+      the grid costs a few øre; an empty battery at 06:00 costs the whole
+      morning peak.
     - **No live reading** (boolean-only EV sensor): fall back to the
       smallest positive sub-window average — the 1d window recalibrates
       fastest after an upgrade or sensor configuration change.
@@ -125,10 +125,9 @@ def compute_ev_discharge_cap_w(
         The discharge cap in Watts (≥ 0).
     """
     if live_net_w is not None and ev_power_available:
-        live_abs = max(live_net_w, 0.0)
         if historical_w > 0:
-            return int(max(historical_w, min(live_abs, historical_w * 3)))
-        return int(live_abs)
+            return historical_w
+        return int(max(live_net_w, 0.0))
     best_w = 0
     for w in sub_window_ws:
         if w > 0 and (best_w == 0 or w < best_w):
@@ -434,6 +433,29 @@ async def async_apply_battery_settings(
                 sub_window_ws=sub_window_ws,
             )
             cap_reason = "EV active" if hsem_planned_ev else "EV active (unplanned)"
+
+            # SoC guard (issue #592, v6.2.0-beta1): never let the EV cap
+            # drain the battery below the energy the planner has reserved
+            # for upcoming scheduled discharge windows.  When the remaining
+            # usable energy is at or below the required reserve, force the
+            # cap to 0 — the battery is preserved for its schedule and the
+            # house load (like the EV) is served from the grid until the
+            # battery recovers above the reserve.
+            if (
+                cap_w > 0
+                and current_required_battery_kwh > 1e-9
+                and live.battery_current_capacity_kwh > 1e-9
+                and live.battery_current_capacity_kwh <= current_required_battery_kwh
+            ):
+                _LOGGER.debug(
+                    "%s — battery reserve reached (%.2f kWh left, %.2f kWh "
+                    "reserved for scheduled plans) — forcing EV discharge "
+                    "cap to 0 W to protect the schedule",
+                    cap_reason,
+                    live.battery_current_capacity_kwh,
+                    current_required_battery_kwh,
+                )
+                cap_w = 0
 
             if live.huawei_batteries_max_discharge_power_w != cap_w:
                 _de3: str = discharge_entity  # narrowed for closure

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -1267,6 +1267,30 @@ The applier must not write to hardware when:
 - required data is missing
 - config entry is unloading
 
+### EV discharge cap semantics (issue #592)
+
+When an EV is actively charging and the current recommendation is not a
+forced-discharge/export mode, the applier caps the inverter's
+`maximum_discharging_power` so the battery covers only house load while
+100 % of the EV load goes to the grid.  The cap is computed by
+`applier.compute_ev_discharge_cap_w()`:
+
+- **History available** → the cap IS the historical house baseline (the
+  current slot's weighted average).  The live `net_consumption_w` reading
+  is deliberately ignored: downward it ratchets the cap toward zero when
+  the CT clamp and the EV sensor disagree (the battery's own capped
+  discharge shrinks the CT reading further — a self-poisoning input);
+  upward it swings with ordinary house noise and drains the battery into
+  what is supposed to be a grid-served EV session.
+- **No EV power sensor** → the minimum positive sub-window average
+  (1d/3d/7d/14d/weighted).
+- **No history** (fresh install) → the live reading.
+
+**SoC guard:** when the battery's remaining usable energy is at or below
+the planner's required reserve (`current_required_battery_kwh` — energy
+needed until the next solar surplus), the cap is forced to 0 W so the
+battery is preserved for its scheduled plans.
+
 ## Invariants for tests
 
 Add tests for these invariants:

--- a/tests/sensors/test_applier.py
+++ b/tests/sensors/test_applier.py
@@ -77,7 +77,8 @@ class TestParsePowerControlPct:
 
 
 class TestComputeEvDischargeCapW:
-    """The cap must hold the historical baseline and never ratchet down."""
+    """With history present, the cap IS the historical baseline — the live
+    reading must not move it in either direction (issue #592)."""
 
     @staticmethod
     def _cap(**kwargs):
@@ -98,26 +99,27 @@ class TestComputeEvDischargeCapW:
         )
         assert cap == 400
 
-    def test_live_above_history_raises_cap_bounded(self):
-        """Genuine extra house demand (cooking) raises the cap, bounded at
-        3× the baseline to limit EV-sensor under-read leakage."""
+    def test_live_above_history_does_not_raise_cap(self):
+        """House noise (cooking, heat pump) must NOT raise the cap —
+        swinging with live demand for hours drains the battery into a
+        grid-served EV session (v6.2.0-beta1: 652→1968→928 W swings)."""
         cap = self._cap(
             live_net_w=900.0,
             ev_power_available=True,
             historical_w=400,
             sub_window_ws=[400],
         )
-        assert cap == 900
+        assert cap == 400
 
-    def test_live_spike_capped_at_3x_baseline(self):
-        """A huge live spike (EV sensor severely under-reading) is bounded."""
+    def test_live_spike_does_not_raise_cap(self):
+        """Even a huge live spike leaves the cap at the baseline."""
         cap = self._cap(
             live_net_w=5000.0,
             ev_power_available=True,
             historical_w=400,
             sub_window_ws=[400],
         )
-        assert cap == 1200
+        assert cap == 400
 
     def test_no_history_trusts_live(self):
         cap = self._cap(


### PR DESCRIPTION
## Summary

v6.2.0-beta1 testing by @Extati in #592 showed the #718 "raise cap up to 3× baseline on live demand" rule **over-correcting**: ordinary house noise (cooking, heat pump cycles) swung the cap 652→1968→928 W on and off for 5+ hours, draining the battery before his 06:00 scheduled discharge plan.

## The lesson from two opposite failures

| Version | Rule | Failure |
|---|---|---|
| beta8 | `min(live, history)` | CT/EV-sensor drift ratcheted the cap **down** 363→40 W overnight |
| beta1 | `max(history, min(live, 3×history))` | house noise swung the cap **up** 652→1968 W for hours, draining the battery |

Both directions prove the same point: **the live reading must not move the cap at all when history exists.** The cap's only job is to block EV load while covering the house baseline — the historical baseline already does exactly that. A 20-minute cooking spike covered from the grid costs a few øre; an empty battery at 06:00 costs the whole morning peak.

## Changes

### 1. `compute_ev_discharge_cap_w()` — cap IS the baseline

With history present, the cap is the historical house baseline; the live reading is ignored in both directions. Sub-window fallback (no EV power sensor) and fresh-install (trust live) behaviour unchanged. The cap will now sit rock-stable at ~400 W all night.

### 2. SoC reserve guard (proposed by @Extati)

After computing the cap: when the battery's remaining usable energy is at or below the planner's required reserve (`current_required_battery_kwh` — the energy needed until the next solar surplus), the cap is forced to **0 W**. The battery is preserved for its scheduled plans; house load is grid-served until the battery recovers above the reserve.

> "The most important thing for us is that the battery should never be allowed to run out before a plan it's supposed to feed." — @Extati

## Spec & tests

- New **"EV discharge cap semantics"** section in `docs/planner-spec.md` (Safety gates)
- `TestComputeEvDischargeCapW` updated: live-above-baseline now asserts the cap **holds** the baseline (was: raises bounded at 3×)
- memories.md updated with both failure modes and the SoC guard rule

## Quality gates

- ✅ `lint` — all checks passed
- ✅ `typing` — 0 errors (277 files)
- ✅ `quality` — 0 errors, 0 warnings
- ✅ `test` — **2398 passed**

Refs #592