### PR TITLE
fix(prices): match sub-hourly price points to distinct recommendation slots

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -770,6 +770,29 @@ Regression tests: ``tests/test_coordinator_builder.py``,
 
 ---
 
+## Price/Solcast Slot Matching — Floor to Source Interval, Not Hour (issue #720)
+
+``hourly_data_populator/prices_solcast.py`` matches sensor data points to
+recommendation slots by timestamp.  The original code truncated both sides
+with ``.replace(minute=0, second=0)``, which collapsed all four 15-min
+price points of an hour onto one key — the last write won, and all
+quarter-hour slots showed the same (hourly) price even when EDS published
+96 distinct prices per day.
+
+Canonical rule: **floor data points to the start of their enclosing
+*source* window** (``electricity_price_update_interval`` for prices, 60 min
+for Solcast) via ``normalize_slot_start(dt, source_interval_minutes)``,
+then match a slot when its start lies inside that source window
+(``dt_key <= obj_start < dt_key + source_window``).  This preserves both
+fan-out directions:
+
+- 15-min prices + 15-min slots → each point lands on exactly one slot
+- 60-min prices + 15-min slots → the hourly point covers all four slots
+
+Regression tests: ``tests/test_15min_price_matching.py``.
+
+---
+
 ## File Organization — By Responsibility, Not By Theme
 
 AI agents naturally bucket related things together (e.g. "all planner inputs in one file").

--- a/custom_components/hsem/custom_sensors/hourly_data_populator/prices_solcast.py
+++ b/custom_components/hsem/custom_sensors/hourly_data_populator/prices_solcast.py
@@ -7,14 +7,17 @@ or from a pre-collected :class:`StateSnapshot` (snapshot).
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 
 from custom_components.hsem.models.hourly_recommendation import HourlyRecommendation
 from custom_components.hsem.models.sensor_config import SensorConfig
 from custom_components.hsem.models.state_snapshot import StateSnapshot
 from custom_components.hsem.utils.conversion import convert_to_float
-from custom_components.hsem.utils.datetime_utils import normalize_datetime
+from custom_components.hsem.utils.datetime_utils import (
+    normalize_datetime,
+    normalize_slot_start,
+)
 from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
 
 from . import _resolve_cached  # noqa: F401
@@ -68,6 +71,10 @@ async def async_populate_price_and_solcast(
     # Solcast forecasts are always given as hourly totals (Wh/h), so the share
     # factor is always relative to 60 minutes regardless of price configuration.
     solcast_share = 60.0 / cfg.recommendation_interval_minutes
+    # Source-side window used to floor data-point timestamps before matching:
+    # price sources publish at the configured price cadence, Solcast hourly.
+    price_source_minutes = cfg.electricity_price_update_interval
+    solcast_source_minutes = 60
 
     # Import price — read from primary sensor (may embed forecast attributes)
     await _async_update_hourly_field(
@@ -77,6 +84,7 @@ async def async_populate_price_and_solcast(
         "import_price",
         price_share,
         cfg.solcast_pv_forecast_forecast_likelihood,
+        price_source_minutes,
     )
     # Import price — fallback to dedicated forecast sensor if configured
     if cfg.import_electricity_price_forecast_sensor:
@@ -87,6 +95,7 @@ async def async_populate_price_and_solcast(
             "import_price",
             price_share,
             cfg.solcast_pv_forecast_forecast_likelihood,
+            price_source_minutes,
         )
     # Export price — read from primary sensor
     await _async_update_hourly_field(
@@ -96,8 +105,9 @@ async def async_populate_price_and_solcast(
         "export_price",
         price_share,
         cfg.solcast_pv_forecast_forecast_likelihood,
+        price_source_minutes,
     )
-    # Export price — fallback to dedicated forecast sensor if configured
+    # Export price — fallback to dedicated forecast sensor
     if cfg.export_electricity_price_forecast_sensor:
         await _async_update_hourly_field(
             sensor,
@@ -106,6 +116,7 @@ async def async_populate_price_and_solcast(
             "export_price",
             price_share,
             cfg.solcast_pv_forecast_forecast_likelihood,
+            price_source_minutes,
         )
     # Solcast today
     await _async_update_hourly_field(
@@ -115,6 +126,7 @@ async def async_populate_price_and_solcast(
         "solcast_pv_estimate_kwh",
         solcast_share,
         cfg.solcast_pv_forecast_forecast_likelihood,
+        solcast_source_minutes,
     )
     # Solcast tomorrow
     await _async_update_hourly_field(
@@ -124,6 +136,7 @@ async def async_populate_price_and_solcast(
         "solcast_pv_estimate_kwh",
         solcast_share,
         cfg.solcast_pv_forecast_forecast_likelihood,
+        solcast_source_minutes,
     )
 
 
@@ -139,6 +152,7 @@ async def _async_update_hourly_field(
     field_name: str,
     share: float,
     solcast_likelihood_key: str,
+    source_interval_minutes: int,
 ) -> None:
     """Match sensor attribute data to recommendation slots and write one field.
 
@@ -152,6 +166,8 @@ async def _async_update_hourly_field(
     """
     if sensor_id is None:
         return
+
+    source_window = timedelta(minutes=source_interval_minutes)
 
     sensor_state = sensor.hass.states.get(sensor_id)
     if not sensor_state:
@@ -198,8 +214,13 @@ async def _async_update_hourly_field(
                     dt_key = datetime.fromisoformat(str(raw_time))
 
                 try:
-                    # Normalize to HA-local timezone, strip sub-minute precision
-                    dt_key = normalize_datetime(dt_key).replace(minute=0, second=0)
+                    # Floor the data point to the start of its enclosing source
+                    # interval (e.g. 15 min for quarter-hourly prices, 60 min for
+                    # hourly Solcast forecasts).  Flooring to the *hour* here
+                    # would collapse sub-hourly price points onto the same key
+                    # and overwrite all quarter-hour slots of the hour with the
+                    # last hourly value (issue #720).
+                    dt_key = normalize_slot_start(dt_key, source_interval_minutes)
                 except ValueError, OSError:  # noqa: TRY302
                     # Skip data points with unparseable or non-local timestamps
                     continue
@@ -226,8 +247,15 @@ async def _async_update_hourly_field(
                 value = value / share
 
                 for obj in recommendations:
-                    obj_hour = normalize_datetime(obj.start).replace(minute=0, second=0)
-                    if obj.start.date() == dt_key.date() and obj_hour == dt_key:
+                    # A data point covers every slot whose start falls inside
+                    # the source window that begins at dt_key:
+                    #   - 15-min prices + 15-min slots → one point per slot
+                    #   - hourly prices + 15-min slots → one point fans out
+                    #     to all four quarter-hour slots of the hour
+                    # Flooring dt_key to the *hour* (old behavior) collapsed
+                    # all four quarter-hour prices onto one key (issue #720).
+                    obj_start = normalize_datetime(obj.start)
+                    if dt_key <= obj_start < dt_key + source_window:
                         setattr(obj, field_name, round(value, 5))
 
 
@@ -255,6 +283,8 @@ def populate_price_and_solcast_from_snapshot(
         cfg.electricity_price_update_interval / cfg.recommendation_interval_minutes
     )
     solcast_share = 60.0 / cfg.recommendation_interval_minutes
+    price_source_minutes = cfg.electricity_price_update_interval
+    solcast_source_minutes = 60
 
     _update_hourly_field_from_attrs(
         recommendations,
@@ -262,6 +292,7 @@ def populate_price_and_solcast_from_snapshot(
         "import_price",
         price_share,
         cfg.solcast_pv_forecast_forecast_likelihood,
+        price_source_minutes,
     )
     if cfg.import_electricity_price_forecast_sensor:
         _update_hourly_field_from_attrs(
@@ -272,6 +303,7 @@ def populate_price_and_solcast_from_snapshot(
             "import_price",
             price_share,
             cfg.solcast_pv_forecast_forecast_likelihood,
+            price_source_minutes,
         )
     _update_hourly_field_from_attrs(
         recommendations,
@@ -279,6 +311,7 @@ def populate_price_and_solcast_from_snapshot(
         "export_price",
         price_share,
         cfg.solcast_pv_forecast_forecast_likelihood,
+        price_source_minutes,
     )
     if cfg.export_electricity_price_forecast_sensor:
         _update_hourly_field_from_attrs(
@@ -289,6 +322,7 @@ def populate_price_and_solcast_from_snapshot(
             "export_price",
             price_share,
             cfg.solcast_pv_forecast_forecast_likelihood,
+            price_source_minutes,
         )
     _update_hourly_field_from_attrs(
         recommendations,
@@ -296,6 +330,7 @@ def populate_price_and_solcast_from_snapshot(
         "solcast_pv_estimate_kwh",
         solcast_share,
         cfg.solcast_pv_forecast_forecast_likelihood,
+        solcast_source_minutes,
     )
     _update_hourly_field_from_attrs(
         recommendations,
@@ -303,6 +338,7 @@ def populate_price_and_solcast_from_snapshot(
         "solcast_pv_estimate_kwh",
         solcast_share,
         cfg.solcast_pv_forecast_forecast_likelihood,
+        solcast_source_minutes,
     )
 
 
@@ -312,6 +348,7 @@ def _update_hourly_field_from_attrs(
     field_name: str,
     share: float,
     solcast_likelihood_key: str,
+    source_interval_minutes: int,
 ) -> None:
     """Match pre-read sensor attribute data to recommendation slots.
 
@@ -328,6 +365,8 @@ def _update_hourly_field_from_attrs(
     """
     if attributes is None:
         return
+
+    source_window = timedelta(minutes=source_interval_minutes)
 
     data_sources: dict[str, list[dict[str, str]]] = {
         "forecast": [{"k": "hour", "v": "price"}],
@@ -369,7 +408,8 @@ def _update_hourly_field_from_attrs(
                         continue
 
                 try:
-                    dt_key = normalize_datetime(dt_key).replace(minute=0, second=0)
+                    # Same source-interval flooring as the async path (issue #720).
+                    dt_key = normalize_slot_start(dt_key, source_interval_minutes)
                 except ValueError, OSError:
                     continue
 
@@ -380,6 +420,6 @@ def _update_hourly_field_from_attrs(
                 value = value / share
 
                 for obj in recommendations:
-                    obj_hour = normalize_datetime(obj.start).replace(minute=0, second=0)
-                    if obj.start.date() == dt_key.date() and obj_hour == dt_key:
+                    obj_start = normalize_datetime(obj.start)
+                    if dt_key <= obj_start < dt_key + source_window:
                         setattr(obj, field_name, round(value, 5))

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -1100,6 +1100,12 @@ Common configurations:
    per-slot `HourlyRecommendation` object.
    This gives each slot its proportional share of the price-rate value so
    slot boundaries align correctly.
+   Data-point timestamps are floored to the start of their enclosing *source*
+   interval (the EDS update interval for prices, 60 min for Solcast), never
+   to the hour: a 15-min price point covers only the slots whose start lies
+   inside that 15-min window, so quarter-hourly prices land on distinct
+   slots (issue #720).  With hourly price data and 15-min slots the single
+   hourly point fans out to all four quarter-hour slots of the hour.
 
 2. **Planner input** (`coordinator._build_planner_input`):
    When assembling `PricePoint` objects for the planner engine, each stored
@@ -1125,6 +1131,9 @@ planner always receives the original price rate regardless of configuration.
 - Changing `energi_data_service_update_interval` from 60 to 15 with the same
   price input must not change the price seen by the planner engine.
 - Negative prices must survive the full pipeline unchanged.
+- With 15-min price data and 15-min slots, each quarter-hour price must land
+  on exactly its own slot — four distinct prices within an hour must produce
+  four distinct slot prices (issue #720).
 
 ## Candidate plans
 

--- a/tests/test_15min_price_matching.py
+++ b/tests/test_15min_price_matching.py
@@ -1,0 +1,214 @@
+"""Regression tests for issue #720 — 15-minute prices collapsed to hourly.
+
+Bug
+---
+``custom_sensors/hourly_data_populator/prices_solcast.py`` normalised every
+price timestamp with ``.replace(minute=0, second=0)`` on both the sensor data
+points and the recommendation slots before matching.  With 15-minute
+recommendation slots and 15-minute price data (e.g. Energi Data Service on
+Nord Pool 15-min MTUs), all four quarter-hour price points within an hour
+collapsed onto the same key and the *last* one was written to all four
+recommendation slots of that hour.
+
+Fix
+---
+Both sides of the match are now floored to the enclosing recommendation slot
+via ``normalize_slot_start(dt, interval_minutes)`` so each sub-hourly price
+lands on exactly one slot.
+
+These tests exercise the snapshot-based path
+(``populate_price_and_solcast_from_snapshot``), which shares the matching
+helper logic with the async path.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from custom_components.hsem.custom_sensors.hourly_data_populator.prices_solcast import (
+    populate_price_and_solcast_from_snapshot,
+)
+from custom_components.hsem.models.hourly_recommendation import HourlyRecommendation
+from custom_components.hsem.models.live_state import LiveState
+from custom_components.hsem.models.sensor_config import SensorConfig
+from custom_components.hsem.models.state_snapshot import StateSnapshot
+
+
+def _make_rec(start: datetime, end: datetime) -> HourlyRecommendation:
+    return HourlyRecommendation(
+        start=start,
+        end=end,
+        recommendation="idle",
+        avg_house_consumption_kwh=0.0,
+        avg_house_consumption_1d_kwh=0.0,
+        avg_house_consumption_3d_kwh=0.0,
+        avg_house_consumption_7d_kwh=0.0,
+        avg_house_consumption_14d_kwh=0.0,
+        batteries_charged_kwh=0.0,
+        batteries_discharged_kwh=0.0,
+        estimated_battery_capacity_kwh=0.0,
+        estimated_battery_soc_pct=0.0,
+        estimated_cost_currency=0.0,
+        estimated_net_consumption_kwh=0.0,
+        export_price=0.0,
+        grid_export_kwh=0.0,
+        grid_import_kwh=0.0,
+        import_price=0.0,
+        solcast_pv_estimate_kwh=0.0,
+    )
+
+
+class _Cfg(SensorConfig):
+    """SensorConfig with only the fields the price populator reads overridden."""
+
+    def __init__(self, price_interval: int, slot_interval: int) -> None:
+        super().__init__()
+        self.electricity_price_update_interval = price_interval
+        self.recommendation_interval_minutes = slot_interval
+        self.import_electricity_price_sensor = "sensor.eds_import"
+        self.import_electricity_price_forecast_sensor = None
+        self.export_electricity_price_sensor = "sensor.eds_export"
+        self.export_electricity_price_forecast_sensor = None
+        self.solcast_pv_forecast_forecast_today = None
+        self.solcast_pv_forecast_forecast_tomorrow = None
+        self.solcast_pv_forecast_forecast_likelihood = "pv_estimate"
+
+
+def _populate(recs: list[HourlyRecommendation], attrs: dict, cfg: _Cfg) -> None:
+    snapshot = StateSnapshot(
+        live=LiveState(), energy_average_values={}, sensor_attributes=attrs
+    )
+    populate_price_and_solcast_from_snapshot(recs, snapshot, cfg)
+
+
+class TestQuarterHourlyPriceMatching:
+    """96 distinct 15-min prices must land on 96 distinct 15-min slots."""
+
+    def setup_method(self) -> None:
+        self.base = datetime(2026, 8, 7, 0, 0, 0, tzinfo=UTC)
+
+    def _quarter_hour_prices(self, count: int = 96) -> list[dict[str, str]]:
+        return [
+            {
+                "start": (self.base + timedelta(minutes=15 * i)).isoformat(),
+                "price": f"{1.0 + i * 0.01:.5f}",
+            }
+            for i in range(count)
+        ]
+
+    def test_15min_prices_land_on_distinct_slots(self) -> None:
+        """Each 15-min price point must reach exactly its own slot (issue #720)."""
+        cfg = _Cfg(price_interval=15, slot_interval=15)
+        recs = [
+            _make_rec(
+                self.base + timedelta(minutes=15 * i),
+                self.base + timedelta(minutes=15 * (i + 1)),
+            )
+            for i in range(96)
+        ]
+        raw = self._quarter_hour_prices()
+        attrs = {
+            "sensor.eds_import": {"prices_today": raw},
+            "sensor.eds_export": {"prices_today": raw},
+        }
+        _populate(recs, attrs, cfg)
+
+        for i, rec in enumerate(recs):
+            expected = 1.0 + i * 0.01
+            assert rec.import_price == pytest.approx(expected, abs=1e-5), (
+                f"Slot {i} ({rec.start}): expected {expected}, got {rec.import_price}"
+            )
+            assert rec.export_price == pytest.approx(expected, abs=1e-5)
+
+    def test_quarter_hour_prices_not_overwritten_within_hour(self) -> None:
+        """Prices inside one hour must differ when the source differs.
+
+        Mirrors the exact scenario from issue #720: 20:00-20:45 all showed
+        the same price even though the source had 0.097/0.098/0.170/0.188.
+        """
+        cfg = _Cfg(price_interval=15, slot_interval=15)
+        hour20 = self.base.replace(hour=20)
+        recs = [
+            _make_rec(
+                hour20 + timedelta(minutes=15 * i),
+                hour20 + timedelta(minutes=15 * (i + 1)),
+            )
+            for i in range(4)
+        ]
+        prices = [0.097, 0.098, 0.170, 0.188]
+        raw = [
+            {
+                "start": (hour20 + timedelta(minutes=15 * i)).isoformat(),
+                "price": f"{p:.5f}",
+            }
+            for i, p in enumerate(prices)
+        ]
+        attrs = {
+            "sensor.eds_import": {"prices_today": raw},
+            "sensor.eds_export": {"prices_today": raw},
+        }
+        _populate(recs, attrs, cfg)
+
+        for rec, expected in zip(recs, prices, strict=True):
+            assert rec.import_price == pytest.approx(expected, abs=1e-5), (
+                f"{rec.start}: expected {expected}, got {rec.import_price}"
+            )
+
+    def test_hourly_prices_still_fan_out_to_15min_slots(self) -> None:
+        """60-min price config must still replicate the hourly value to all
+        four quarter-hour slots (existing behavior preserved)."""
+        cfg = _Cfg(price_interval=60, slot_interval=15)
+        recs = [
+            _make_rec(
+                self.base + timedelta(minutes=15 * i),
+                self.base + timedelta(minutes=15 * (i + 1)),
+            )
+            for i in range(8)
+        ]
+        raw = [
+            {
+                "start": (self.base + timedelta(hours=h)).isoformat(),
+                "price": f"{0.10 + h * 0.05:.5f}",
+            }
+            for h in range(2)
+        ]
+        attrs = {
+            "sensor.eds_import": {"prices_today": raw},
+            "sensor.eds_export": {"prices_today": raw},
+        }
+        _populate(recs, attrs, cfg)
+
+        share = 60 / 15  # stored value is raw / share
+        for i, rec in enumerate(recs):
+            hour = i // 4
+            expected = (0.10 + hour * 0.05) / share
+            assert rec.import_price == pytest.approx(expected, abs=1e-5), (
+                f"Slot {i}: expected {expected}, got {rec.import_price}"
+            )
+
+    def test_15min_prices_into_60min_slots_use_slot_start(self) -> None:
+        """With 60-min slots and 15-min price data, the price at the slot
+        start is used (matching the planner's hourly-equivalent resolution)."""
+        cfg = _Cfg(price_interval=15, slot_interval=60)
+        recs = [
+            _make_rec(
+                self.base + timedelta(hours=h), self.base + timedelta(hours=h + 1)
+            )
+            for h in range(2)
+        ]
+        raw = self._quarter_hour_prices(count=8)
+        attrs = {
+            "sensor.eds_import": {"prices_today": raw},
+            "sensor.eds_export": {"prices_today": raw},
+        }
+        _populate(recs, attrs, cfg)
+
+        # share = 15/60 = 0.25 → stored = raw / 0.25
+        for h, rec in enumerate(recs):
+            expected_raw = 1.0 + (h * 4) * 0.01  # price at the hour boundary
+            expected = expected_raw / 0.25
+            assert rec.import_price == pytest.approx(expected, abs=1e-4), (
+                f"Hour {h}: expected {expected}, got {rec.import_price}"
+            )


### PR DESCRIPTION
## Problem

With a 15-minute electricity price interval and 15-minute recommendation slots, HSEM collapsed all quarter-hourly prices to a single hourly value. In `hourly_data_populator/prices_solcast.py`, both the sensor data-point timestamps and the recommendation slot starts were truncated with `.replace(minute=0, second=0)` before matching, so all four 15-min price points within an hour mapped to the same key — the last write won, and all four slots of the hour showed identical prices.

The MILP optimizer therefore saw the whole hour as one flat price and scheduled max-power discharge across all four quarter-hour slots, even when the actual 15-min prices varied significantly (e.g. 0.097 / 0.098 / 0.170 / 0.188 in the 20:00 hour from the issue).

## Fix

In both the async (`_async_update_hourly_field`) and snapshot (`_update_hourly_field_from_attrs`) paths:

- Data-point timestamps are now floored to the start of their enclosing **source interval** via `normalize_slot_start(dt, source_interval_minutes)` — the configured `electricity_price_update_interval` for prices, 60 min for Solcast — instead of the hour.
- A slot matches when its start lies inside that source window (`dt_key <= obj_start < dt_key + source_window`).

This preserves both fan-out directions:
- 15-min prices + 15-min slots → each price point lands on exactly its own slot ✅
- 60-min prices + 15-min slots → the hourly point still covers all four quarter-hour slots (unchanged behavior) ✅
- 60-min Solcast + 15-min slots → unchanged ✅

## Changes

- `custom_components/hsem/custom_sensors/hourly_data_populator/prices_solcast.py` — source-interval flooring + window matching in both population paths
- `tests/test_15min_price_matching.py` — new regression tests: 96 distinct 15-min prices land on 96 distinct slots, the exact 20:00-hour scenario from the issue, hourly fan-out preserved, and 15-min prices into 60-min slots
- `docs/planner-spec.md` — price interval semantics section updated with the matching rule and a new invariant
- `.github/memories.md` — canonical rule documented (floor to source interval, not hour)

## Validation

- `./scripts/quality.sh lint` ✅
- `./scripts/quality.sh typing` ✅
- `./scripts/quality.sh quality` ✅
- `./scripts/quality.sh test` ✅ — 2402 passed
- File size: `prices_solcast.py` 17 KB (< 30 KB limit)

Refs #720