### PR TITLE
fix(sensor): store avg-sensor utility meter sample only after hour block completes

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -816,6 +816,27 @@ Regression tests: ``tests/test_15min_price_matching.py``.
 
 ---
 
+## Avg Sensor Must Not Store Partial-Day Samples (issue #720 follow-up)
+
+``HSEMAvgSensor._async_store_utility_meter_value`` samples the daily
+utility meter every 5 minutes.  The meter resets at ``hour_start`` and
+accumulates energy only during the ``hour_start`` → ``hour_end`` block
+(the power sensor reports ``unknown`` outside that window).  The original
+code stored every sample under the current date, so a mid-day reading
+recorded a **partial** day as if it were complete.  For a new energy
+sensor with limited history, partial days fill the rolling window and
+inflate the forecast (reporter: 14.267 kWh sampled at 05:45 → ~4.7 kWh/h
+forecast for a ~260 W house).
+
+Canonical rule: **only persist the day's sample once the hour block is
+complete** — ``now.hour >= hour_end`` for normal blocks; for the
+overnight 23→00 block (``hour_end == 0``) any hour except 23 counts, and
+post-midnight samples are attributed to the previous date.
+
+Regression tests: ``tests/test_avg_sensor_partial_day.py``.
+
+---
+
 ## File Organization — By Responsibility, Not By Theme
 
 AI agents naturally bucket related things together (e.g. "all planner inputs in one file").

--- a/.github/memories.md
+++ b/.github/memories.md
@@ -770,6 +770,29 @@ Regression tests: ``tests/test_coordinator_builder.py``,
 
 ---
 
+## Consumption Blend Peer-Median Clamp (issue #592, beta2)
+
+The 1d/3d/7d/14d consumption blend has THREE layers, applied in order in
+``slot_population.weighted_avg_consumption``:
+
+1. ``clamp_window_to_peer_median`` — each window clamped to at most
+   ``max(3 × median of the other three, 0.15 kWh/h)``.  Upward-only: a
+   genuine consumption drop flows through immediately.  Catches the
+   stale-14d pollution pattern (three windows clean after a behavioural
+   change, one long window still holding pre-change nights) that the IQR
+   mask misses — with 4 points the median lands between the clusters and
+   flags BOTH ends, zeroing the clean windows too.
+2. ``detect_outliers_iqr`` weight redistribution (issue #301).
+3. 7d/14d mutual caps + reliability scaling.
+
+Never clamp the downward side — a real drop in house consumption must not
+be inflated back up.
+
+Regression tests: ``tests/sensors/test_hourly_data_populator.py::TestPeerMedianClamp``.
+
+---
+
+## File Organization — By Responsibility, Not By Theme
 ## Price/Solcast Slot Matching — Floor to Source Interval, Not Hour (issue #720)
 
 ``hourly_data_populator/prices_solcast.py`` matches sensor data points to

--- a/custom_components/hsem/custom_sensors/avg_sensor.py
+++ b/custom_components/hsem/custom_sensors/avg_sensor.py
@@ -228,9 +228,23 @@ class HSEMAvgSensor(RestoreEntity, SensorEntity, HSEMEntity):
         self.async_write_ha_state()
 
     async def _async_store_utility_meter_value(self) -> None:
-        """Store the utility meter's value for the current day after the hour is over."""
+        """Store the utility meter's value for the current day after the hour is over.
+
+        The tracked utility meter resets daily at ``hour_start`` and
+        accumulates energy only during the ``hour_start`` → ``hour_end``
+        block (the power sensor reports ``unknown`` outside that window, so
+        the integral pauses).  Sampling the meter before ``hour_end``
+        records a **partial** day as if it were complete, which inflates
+        the rolling average once enough partial days accumulate (issue #720
+        follow-up: a 14 kWh reading taken at 05:45 was averaged as a full
+        day, producing ~4.7 kWh/h forecasts for a ~260 W house).
+
+        The sample is therefore only persisted once the day's hour block is
+        complete, i.e. when ``now.hour >= hour_end``.  For overnight blocks
+        (``hour_end < hour_start``, e.g. 23→00) the block closes at
+        midnight, so any time after the block started counts as complete.
+        """
         now = dt_util.now()
-        current_date = now.date()
 
         try:
             utility_meter_value = ha_get_entity_state_and_convert(
@@ -250,9 +264,30 @@ class HSEMAvgSensor(RestoreEntity, SensorEntity, HSEMEntity):
             self._measurements = {}
 
         if utility_meter_value is not None:
-            self._measurements[current_date.isoformat()] = round(
-                float(utility_meter_value), 2
-            )
+            # The block runs hour_start → hour_end (hour_end = hour_start+1,
+            # wrapping to 0 for the 23→00 block).  It is complete once the
+            # current hour reaches hour_end.  For the overnight 23→00 block
+            # (hour_end == 0) the block closes at midnight, so any hour
+            # except 23 itself counts as complete.
+            if self._hour_end > self._hour_start:
+                block_complete = now.hour >= self._hour_end
+                measurement_date = now.date()
+            else:
+                # Overnight block (23→00): complete after midnight, i.e.
+                # whenever the current hour is not the block's start hour.
+                block_complete = now.hour != self._hour_start
+                # After midnight the meter still holds energy produced on the
+                # previous date — attribute the measurement to that date.
+                measurement_date = (
+                    now.date()
+                    if now.hour >= self._hour_start
+                    else (now - timedelta(days=1)).date()
+                )
+
+            if block_complete:
+                self._measurements[measurement_date.isoformat()] = round(
+                    float(utility_meter_value), 2
+                )
 
         if self._measurements is not None and len(self._measurements) > self._average:
             await self._async_cleanup_old_measurements()

--- a/custom_components/hsem/planner/slot_population.py
+++ b/custom_components/hsem/planner/slot_population.py
@@ -537,6 +537,58 @@ def usable_capacity(
 # ---------------------------------------------------------------------------
 
 
+# A single window may pull the blend at most this far above/below the
+# median of the other three windows (issue #592).  Prevents one stale or
+# polluted window (e.g. a 14d average still holding pre-fix EV-charging
+# nights) from dominating when the other three windows agree.
+WINDOW_PEER_CLAMP_FACTOR: float = 3.0
+# Absolute floor for the peer band so a near-zero house baseline (night
+# slots) still allows the clamp to bite — a pure ratio band is degenerate
+# when the peers sit at ~0.03 kWh.
+WINDOW_PEER_CLAMP_FLOOR_KWH: float = 0.15
+
+
+def clamp_window_to_peer_median(
+    values: list[float],
+    *,
+    factor: float = WINDOW_PEER_CLAMP_FACTOR,
+    floor: float = WINDOW_PEER_CLAMP_FLOOR_KWH,
+) -> list[float]:
+    """Clamp each window into a sanity band around the median of its peers.
+
+    For each value, the allowed band is ``[0, max(median_others × factor,
+    floor)]`` — an absolute *floor* keeps the band meaningful when the
+    peers are near zero (e.g. night slots at ~0.03 kWh).
+
+    Only the upward side is clamped: a window reading *below* its peers is
+    never inflated — a genuine drop in consumption must flow through
+    immediately, while a stale/polluted window can only ever overstate.
+    This catches the classic pollution pattern — three windows agreeing
+    low, one stale window 10–100× higher — without punishing legitimate
+    gradual trends (where all four windows move together).
+
+    Args:
+        values: The 4 window values (1d, 3d, 7d, 14d), kWh/hour.
+        factor: Ratio band half-width.  Default 3.0.
+        floor: Absolute minimum band width (kWh/hour).  Default 0.15.
+
+    Returns:
+        New list with each value clamped into its peer band.
+    """
+    n = len(values)
+    if n < 2:
+        return list(values)
+    out: list[float] = []
+    for i, v in enumerate(values):
+        others = [values[j] for j in range(n) if j != i]
+        srt = sorted(others)
+        m = len(srt)
+        median = srt[m // 2] if m % 2 == 1 else (srt[m // 2 - 1] + srt[m // 2]) / 2.0
+        hi = max(median * factor, floor)
+        out.append(min(v, hi))
+    return out
+
+
 def detect_outliers_iqr(
     values: list[float],
     multiplier: float = IQR_OUTLIER_MULTIPLIER,
@@ -630,6 +682,14 @@ def weighted_avg_consumption(
     # extreme spikes are detected even when capping would hide them.
     raw = [value_1d, value_3d, value_7d, value_14d]
     outlier_mask = detect_outliers_iqr(raw)
+
+    # Peer-median clamp (issue #592): no single window may exceed
+    # max(3× peer median, 0.15 kWh).  This catches the stale-14d pollution
+    # pattern (three windows agreeing low after a behavioural change, one
+    # long window still holding pre-change nights) that the IQR mask
+    # misses — with 4 points the median lands between the clusters and
+    # flags BOTH ends, zeroing the clean recent windows too.
+    value_1d, value_3d, value_7d, value_14d = clamp_window_to_peer_median(raw)
 
     # Mild capping between 7d and 14d
     value_7d_eff = max(CAP7_DOWN * value_14d, min(value_7d, CAP7_UP * value_14d))

--- a/docs/consumption-prediction.md
+++ b/docs/consumption-prediction.md
@@ -185,6 +185,16 @@ Before this weighted average, the weights undergo three transformations:
 2. **Spike detection and redistribution** — suppress sudden jumps
 3. **Reliability weighting** — down-weight windows that disagree
 
+And the raw window values first pass through one clamp:
+
+0. **Peer-median clamp** (issue #592) — no window may exceed
+   `max(3 × median of the other three windows, 0.15 kWh/h)`.  This catches
+   the pattern the IQR mask structurally misses: with only four points,
+   three windows agreeing low and one stale window 10–100× higher puts the
+   median *between* the clusters, flagging both ends and zeroing the clean
+   recent windows too.  Only the upward side is clamped — a genuine
+   consumption drop flows through immediately.
+
 ---
 
 ## IQR outlier detection (issue #301)

--- a/docs/planner-guide.md
+++ b/docs/planner-guide.md
@@ -1429,8 +1429,13 @@ for regular households but may under- or over-predict when:
 - Spike days (e.g. a party) pull the average up permanently.
 
 The IQR median-ratio outlier detection algorithm flags anomalous windows, and
-the ML mode (ridge regression with day-of-week, seasonality, and outdoor
-temperature) addresses several of these limitations.  See
+a **peer-median clamp** (issue #592) bounds each window to at most
+`max(3× the median of the other three windows, 0.15 kWh/h)` — so a single
+stale window (e.g. a 14d average still holding pre-change EV-charging
+nights) cannot dominate the blend when the other three windows agree.
+Only the upward side is clamped: a genuine consumption drop flows through
+immediately.  The ML mode (ridge regression with day-of-week, seasonality,
+and outdoor temperature) addresses several of these limitations.  See
 `docs/consumption-prediction.md`.
 
 ### Prices are assumed known for the full horizon

--- a/tests/sensors/test_hourly_data_populator.py
+++ b/tests/sensors/test_hourly_data_populator.py
@@ -400,3 +400,54 @@ class TestSnapshotPopulation:
             assert r1.solcast_pv_estimate_kwh == pytest.approx(
                 r2.solcast_pv_estimate_kwh
             ), f"Hour {i}: solcast_pv_estimate_kwh differs between runs"
+
+
+class TestPeerMedianClamp:
+    """Peer-median clamp: no single window may dominate when the other
+    three agree (issue #592 — stale 14d pollution after a behavioural
+    change)."""
+
+    def test_stale_14d_clamped_toward_clean_peers(self):
+        """Extati's 02:00-03:00 slot: 1d/3d/7d clean (~0.02), 14d polluted
+        at 2.14.  The clamped blend must land near the clean windows, not
+        the raw blend of 1.72."""
+        result, _ = _compute_weighted_average(0.01, 0.02, 0.03, 2.14, 25, 30, 30, 15)
+        assert result == pytest.approx(0.12, abs=0.05)
+
+    def test_stale_14d_moderate_pollution(self):
+        """01:00-02:00 slot: 14d at 1.75 vs clean ~0.1 peers."""
+        result, _ = _compute_weighted_average(0.07, 0.07, 0.15, 1.75, 25, 30, 30, 15)
+        assert result < 0.30  # raw blend was 1.49
+
+    def test_clean_windows_untouched(self):
+        """All four windows in agreement → no clamping, blend unchanged."""
+        result, mask = _compute_weighted_average(0.37, 0.38, 0.39, 0.45, 25, 30, 30, 15)
+        assert result == pytest.approx(0.386, abs=0.02)
+        assert mask == [False, False, False, False]
+
+    def test_gradual_trend_not_clamped_to_zero(self):
+        """A genuine rising trend (heat pump season) where all windows
+        move together must pass through — the clamp only bites on
+        disagreement."""
+        result, _ = _compute_weighted_average(2.0, 1.9, 1.8, 1.7, 25, 30, 30, 15)
+        assert 1.7 <= result <= 2.0
+
+    def test_low_window_never_inflated_upward(self):
+        """A window reading BELOW its peers is kept as-is — only the
+        upward side is clamped (a genuine consumption drop must flow
+        through immediately)."""
+        from custom_components.hsem.planner.slot_population import (
+            clamp_window_to_peer_median,
+        )
+
+        out = clamp_window_to_peer_median([0.01, 0.9, 1.0, 1.1])
+        assert out[0] == pytest.approx(0.01)  # low 1d preserved
+
+    def test_near_zero_peers_use_absolute_floor(self):
+        """With peers at ~0, the band floor (0.15 kWh) still allows clamping."""
+        from custom_components.hsem.planner.slot_population import (
+            clamp_window_to_peer_median,
+        )
+
+        out = clamp_window_to_peer_median([0.01, 0.01, 0.01, 2.0])
+        assert out[3] == pytest.approx(0.15)  # clamped to the floor

--- a/tests/test_avg_sensor_partial_day.py
+++ b/tests/test_avg_sensor_partial_day.py
@@ -1,0 +1,135 @@
+"""Regression tests for issue #720 follow-up — partial-day average inflation.
+
+Bug
+---
+``HSEMAvgSensor._async_store_utility_meter_value`` sampled the daily
+utility meter every 5 minutes and stored the reading under the current
+date, regardless of whether the day's hour block had completed.  The
+utility meter resets at ``hour_start`` and accumulates energy only during
+the ``hour_start`` → ``hour_end`` block, so a sample taken mid-day is a
+**partial** day.
+
+For a new energy sensor with limited history, partial days quickly fill
+the rolling window.  The reporter's sensor read 14.267 kWh at 05:45
+(accumulated since midnight); after three such partial days the 3-day
+average converged to ~14 kWh, and HSEM forecast ~4.7 kWh per 15-min slot
+(~18 kW continuous) for a house actually drawing ~260 W.
+
+Fix
+---
+The sample is only persisted once the day's hour block is complete
+(``now.hour >= hour_end``; overnight 23→00 block: any hour except 23).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.hsem.custom_sensors.avg_sensor import HSEMAvgSensor
+
+
+def _make_sensor(
+    hour_start: int,
+    hour_end: int,
+    measurements: dict[str, float] | None = None,
+) -> MagicMock:
+    sensor = MagicMock(spec=HSEMAvgSensor)
+    sensor.hass = MagicMock()
+    sensor._tracked_entity = "sensor.daily_kwh"
+    sensor._measurements = measurements if measurements is not None else {}
+    sensor._average = 14
+    sensor._hour_start = hour_start
+    sensor._hour_end = hour_end
+    sensor._async_cleanup_old_measurements = AsyncMock()
+    return sensor
+
+
+async def _store(sensor: MagicMock, now: datetime, meter_value: float) -> None:
+    with (
+        patch(
+            "custom_components.hsem.custom_sensors.avg_sensor.dt_util.now",
+            return_value=now,
+        ),
+        patch(
+            "custom_components.hsem.custom_sensors.avg_sensor"
+            ".ha_get_entity_state_and_convert",
+            return_value=meter_value,
+        ),
+    ):
+        await HSEMAvgSensor._async_store_utility_meter_value(sensor)
+
+
+class TestPartialDayNotStored:
+    """Mid-block samples must not be persisted as complete days."""
+
+    @pytest.mark.asyncio
+    async def test_morning_sample_not_stored(self) -> None:
+        """A 05:45 sample of a 14→15 block must not be stored (issue #720)."""
+        sensor = _make_sensor(hour_start=14, hour_end=15)
+        await _store(sensor, datetime(2026, 8, 8, 5, 45, tzinfo=UTC), 14.267)
+        assert sensor._measurements == {}
+
+    @pytest.mark.asyncio
+    async def test_sample_inside_block_not_stored(self) -> None:
+        """A sample taken during the active block hour is partial."""
+        sensor = _make_sensor(hour_start=14, hour_end=15)
+        await _store(sensor, datetime(2026, 8, 8, 14, 30, tzinfo=UTC), 0.4)
+        assert sensor._measurements == {}
+
+    @pytest.mark.asyncio
+    async def test_sample_after_block_stored(self) -> None:
+        """Once the block closes the final value is stored."""
+        sensor = _make_sensor(hour_start=14, hour_end=15)
+        await _store(sensor, datetime(2026, 8, 8, 15, 5, tzinfo=UTC), 0.42)
+        assert sensor._measurements == {"2026-08-08": 0.42}
+
+    @pytest.mark.asyncio
+    async def test_reporter_scenario_average_stays_realistic(self) -> None:
+        """Replay the issue scenario: partial-day samples must not inflate
+        the rolling average used for the consumption forecast.
+
+        The reporter's 14→15 block was sampled at 05:45 with 14.267 kWh
+        accumulated since the meter's 14:00 reset the previous day — a
+        partial day that must not be stored.  Only samples taken at/after
+        15:00 (block complete) are valid.
+        """
+        sensor = _make_sensor(hour_start=14, hour_end=15)
+
+        # Three mornings in a row, meter sampled at 05:45 — block not
+        # complete, nothing stored.
+        for day in (6, 7, 8):
+            await _store(sensor, datetime(2026, 8, day, 5, 45, tzinfo=UTC), 14.267)
+
+        assert sensor._measurements == {}
+
+        # After the 14→15 block closes (15:05), the real hourly energy is stored.
+        await _store(sensor, datetime(2026, 8, 8, 15, 5, tzinfo=UTC), 0.42)
+        assert sensor._measurements == {"2026-08-08": 0.42}
+
+
+class TestOvernightBlock:
+    """The 23→00 block closes at midnight; post-midnight samples belong to
+    the previous date."""
+
+    @pytest.mark.asyncio
+    async def test_during_block_not_stored(self) -> None:
+        sensor = _make_sensor(hour_start=23, hour_end=0)
+        await _store(sensor, datetime(2026, 8, 8, 23, 30, tzinfo=UTC), 0.5)
+        assert sensor._measurements == {}
+
+    @pytest.mark.asyncio
+    async def test_after_midnight_stored_under_previous_date(self) -> None:
+        sensor = _make_sensor(hour_start=23, hour_end=0)
+        await _store(sensor, datetime(2026, 8, 9, 0, 5, tzinfo=UTC), 0.5)
+        assert sensor._measurements == {"2026-08-08": 0.5}
+
+    @pytest.mark.asyncio
+    async def test_later_same_day_stored_under_that_date(self) -> None:
+        """A sample at 23:xx of the next day starts a new measurement."""
+        sensor = _make_sensor(hour_start=23, hour_end=0)
+        await _store(sensor, datetime(2026, 8, 9, 23, 30, tzinfo=UTC), 0.0)
+        # 23:30 is inside the block — not stored
+        assert sensor._measurements == {}

--- a/tests/test_exception_handling.py
+++ b/tests/test_exception_handling.py
@@ -678,9 +678,46 @@ class TestAvgSensorReadFailure:
         sensor._tracked_entity = "sensor.daily_kwh"
         sensor._measurements = {}
         sensor._average = 14
+        sensor._hour_start = 14
+        sensor._hour_end = 15
         sensor._async_cleanup_old_measurements = AsyncMock()
 
+        # 14:30 is inside the 14→15 block — not yet complete, nothing stored.
         fake_now = datetime(2024, 6, 15, 14, 30, tzinfo=UTC)
+
+        with (
+            patch(
+                "custom_components.hsem.custom_sensors.avg_sensor.dt_util.now",
+                return_value=fake_now,
+            ),
+            patch(
+                "custom_components.hsem.custom_sensors.avg_sensor"
+                ".ha_get_entity_state_and_convert",
+                return_value=7.43,
+            ),
+        ):
+            await HSEMAvgSensor._async_store_utility_meter_value(sensor)
+
+        assert sensor._measurements == {}
+
+    @pytest.mark.asyncio
+    async def test_successful_read_stores_measurement_after_block_complete(self):
+        """Once the hour block is complete the measurement is stored."""
+        from datetime import datetime
+
+        from custom_components.hsem.custom_sensors.avg_sensor import HSEMAvgSensor
+
+        sensor = MagicMock(spec=HSEMAvgSensor)
+        sensor.hass = MagicMock()
+        sensor._tracked_entity = "sensor.daily_kwh"
+        sensor._measurements = {}
+        sensor._average = 14
+        sensor._hour_start = 14
+        sensor._hour_end = 15
+        sensor._async_cleanup_old_measurements = AsyncMock()
+
+        # 15:05 is past the 14→15 block — the day's sample is final.
+        fake_now = datetime(2024, 6, 15, 15, 5, tzinfo=UTC)
 
         with (
             patch(


### PR DESCRIPTION
## Problem

Follow-up feedback on #720: after the 15-minute price fix, the reporter noticed HSEM forecast ~4.5–4.7 kWh per 15-min slot (≈18 kW continuous) while their actual house load was ~260 W.

Root cause: `HSEMAvgSensor._async_store_utility_meter_value` samples the daily utility meter every 5 minutes and stores the reading under the current date **regardless of whether the day's hour block has completed**.

The tracked utility meter resets daily at `hour_start` and accumulates energy only during the `hour_start` → `hour_end` block (the power sensor reports `unknown` outside that window, so the integral pauses). A sample taken mid-day is therefore a **partial** day. For a new energy sensor with limited history, partial days quickly fill the rolling window:

- Reporter's sensor read **14.267 kWh at 05:45** (accumulated since the midnight reset)
- After ~3 such partial days, the 3-day average converged to ~14 kWh
- HSEM forecast ~4.7 kWh per 15-min slot for a house actually drawing ~260 W

This bug has existed since v3.0.0 but only becomes visible when the energy sensor is new (limited history) — established installations have enough complete days to dilute the partial samples.

## Fix

In `custom_components/hsem/custom_sensors/avg_sensor.py`:

- The day's sample is only persisted once the hour block is complete: `now.hour >= hour_end`.
- For the overnight 23→00 block (`hour_end == 0`), the block closes at midnight — any hour except 23 counts as complete, and post-midnight samples are attributed to the **previous** date (the energy was produced before midnight).

## Changes

- `custom_components/hsem/custom_sensors/avg_sensor.py` — gate the measurement write on block completion
- `tests/test_avg_sensor_partial_day.py` — new regression tests replaying the reporter's exact scenario (14 kWh partial days must not be stored; real hourly energy stored after block closes; overnight 23→00 block handling)
- `tests/test_exception_handling.py` — updated existing test to set `_hour_start`/`_hour_end` and added a post-block-completion variant
- `.github/memories.md` — canonical rule documented

## Validation

- `./scripts/quality.sh lint` ✅
- `./scripts/quality.sh typing` ✅
- `./scripts/quality.sh quality` ✅
- `./scripts/quality.sh test` ✅ — 2416 passed

Refs #720