### PR TITLE
feat(config): allow all 12 months as Winter/Spring (TOU year-round)

### DIFF
--- a/custom_components/hsem/translations/da.json
+++ b/custom_components/hsem/translations/da.json
@@ -17,7 +17,6 @@
       "invalid_price_value": "Ugyldig prisværdi - indtast et tal.",
       "invalid_sensor": "Ugyldig input-sensor. Vælg en gyldig sensor.",
       "invalid_time_format": "Ugyldigt tidsformat - forventet HH:MM:SS.",
-      "months_summer_empty": "Mindst én måned skal forblive som sommer. Tildel færre måneder til vinter.",
       "months_winter_empty": "Vintersæsonen skal have mindst én måned.",
       "only_one_entry_allowed": "Kun én konfiguration af HSEM er tilladt.",
       "power_out_of_range": "Effektværdien er uden for det tilladte område.",
@@ -483,7 +482,6 @@
       "invalid_price_value": "Ugyldig prisværdi - indtast et tal.",
       "invalid_sensor": "Ugyldig input-sensor. Vælg en gyldig sensor.",
       "invalid_time_format": "Ugyldigt tidsformat - forventet HH:MM:SS.",
-      "months_summer_empty": "Mindst én måned skal forblive som sommer. Tildel færre måneder til vinter.",
       "months_winter_empty": "Vintersæsonen skal have mindst én måned.",
       "only_one_entry_allowed": "Kun én konfiguration af HSEM er tilladt.",
       "power_out_of_range": "Effektværdien er uden for det tilladte område.",
@@ -716,7 +714,7 @@
           "hsem_months_winter": "Months considered as Winter/Spring"
         },
         "data_description": {
-          "hsem_months_winter": "Select the months that should be considered as Winter/Spring for the seasonal working mode adjustments. You can select multiple months."
+          "hsem_months_winter": "Select the months that should be considered as Winter/Spring for the seasonal working mode adjustments. You can select multiple months. Selecting all 12 months is allowed — this keeps Winter/Spring (TOU) mode active year-round."
         },
         "description": "Configure the months that are considered as Winter/Spring. During these months, the system will prioritize charging the batteries from grid energy to ensure sufficient battery levels during periods of lower solar production. Remaining months will be considered as Summer/Autum months.",
         "title": "Winter/Spring Months"

--- a/custom_components/hsem/translations/en.json
+++ b/custom_components/hsem/translations/en.json
@@ -17,7 +17,6 @@
       "invalid_price_value": "Invalid price value — please enter a number.",
       "invalid_sensor": "Invalid input sensor. Please choose a valid sensor.",
       "invalid_time_format": "Invalid time format — expected HH:MM:SS.",
-      "months_summer_empty": "At least one month must remain in summer. Assign fewer months to winter.",
       "months_winter_empty": "Winter season must have at least one month.",
       "only_one_entry_allowed": "Only one configuration of HSEM is allowed.",
       "power_out_of_range": "Power value is outside the allowed range.",
@@ -338,7 +337,7 @@
           "hsem_months_winter": "Months considered as Winter/Spring"
         },
         "data_description": {
-          "hsem_months_winter": "Select the months that should be considered as Winter/Spring for the seasonal working mode adjustments. You can select multiple months."
+          "hsem_months_winter": "Select the months that should be considered as Winter/Spring for the seasonal working mode adjustments. You can select multiple months. Selecting all 12 months is allowed — this keeps Winter/Spring (TOU) mode active year-round. Selecting all 12 months is allowed — this keeps Winter/Spring (TOU) mode active year-round."
         },
         "description": "Configure the months that are considered as Winter/Spring. During these months, the system will prioritize charging the batteries from grid energy to ensure sufficient battery levels during periods of lower solar production. Remaining months will be considered as Summer/Autum months.",
         "title": "Winter/Spring Months"
@@ -491,7 +490,6 @@
       "invalid_price_value": "Invalid price value — please enter a number.",
       "invalid_sensor": "Invalid input sensor. Please choose a valid sensor.",
       "invalid_time_format": "Invalid time format — expected HH:MM:SS.",
-      "months_summer_empty": "At least one month must remain in summer. Assign fewer months to winter.",
       "months_winter_empty": "Winter season must have at least one month.",
       "only_one_entry_allowed": "Only one configuration of HSEM is allowed.",
       "power_out_of_range": "Power value is outside the allowed range.",
@@ -812,7 +810,7 @@
           "hsem_months_winter": "Months considered as Winter/Spring"
         },
         "data_description": {
-          "hsem_months_winter": "Select the months that should be considered as Winter/Spring for the seasonal working mode adjustments. You can select multiple months."
+          "hsem_months_winter": "Select the months that should be considered as Winter/Spring for the seasonal working mode adjustments. You can select multiple months. Selecting all 12 months is allowed — this keeps Winter/Spring (TOU) mode active year-round. Selecting all 12 months is allowed — this keeps Winter/Spring (TOU) mode active year-round."
         },
         "description": "Configure the months that are considered as Winter/Spring. During these months, the system will prioritize charging the batteries from grid energy to ensure sufficient battery levels during periods of lower solar production. Remaining months will be considered as Summer/Autum months.",
         "title": "Winter/Spring Months"

--- a/custom_components/hsem/utils/config_validator.py
+++ b/custom_components/hsem/utils/config_validator.py
@@ -195,7 +195,12 @@ def validate_months(
 
     * The winter field is present.
     * All supplied month values are valid integers in [1, 12].
-    * At least one month is assigned to each season (winter and summer).
+    * At least one month is assigned to winter.
+
+    An empty summer set (all 12 months classified as winter) is explicitly
+    allowed — TOU year-round installs (issue #725) run Winter/Spring mode in
+    every month so an external automation layer keeps predictable working-mode
+    control.
 
     Args:
         user_input: Dict containing the month config fields.
@@ -221,11 +226,7 @@ def validate_months(
         errors[winter_field] = "months_winter_empty"
         return errors
 
-    all_months = set(range(1, 13))
-    summer_months = all_months - set(winter_months)
-    if not summer_months:
-        errors[winter_field] = "months_summer_empty"
-
+    # Note: an empty summer set (all months winter) is valid — see docstring.
     return errors
 
 

--- a/docs/config-flow-reference.md
+++ b/docs/config-flow-reference.md
@@ -60,8 +60,8 @@ Seasonal month classification.
 
 | Field | Key | Default | Description |
 |---|---|---|---|
-| Summer months | `hsem_months_summer` | `[5, 6, 7, 8, 9]` | Months classified as summer |
-| Winter months | `hsem_months_winter` | `[1, 2, 3, 4, 10, 11, 12]` | Months classified as winter |
+| Summer months | `hsem_months_summer` | `[5, 6, 7, 8, 9]` | Months classified as summer (derived as the complement of winter) |
+| Winter months | `hsem_months_winter` | `[1, 2, 3, 4, 10, 11, 12]` | Months classified as winter. Selecting **all 12 months** is allowed (issue #725) — this keeps Winter/Spring (TOU) mode active year-round and the summer set is empty. |
 
 ### Step: `solcast`
 

--- a/docs/planner-guide.md
+++ b/docs/planner-guide.md
@@ -277,7 +277,7 @@ The pre-charge window ends at `schedule.start` and is sized to fill the battery 
 
 | Field | Default | Description |
 |---|---|---|
-| `months_winter` | `[1,2,3,4,10,11,12]` | Months classified as winter |
+| `months_winter` | `[1,2,3,4,10,11,12]` | Months classified as winter. All 12 months may be winter (TOU year-round, issue #725); the summer set is then empty. |
 | `house_power_includes_ev` | `True` | Whether the house consumption sensor already includes EV charger power |
 
 ### Main fuse / tariff protection

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -311,10 +311,11 @@ class TestValidateMonths:
         errors = validate_months({"hsem_months_winter": []})
         assert errors["hsem_months_winter"] == "required"
 
-    def test_all_months_in_winter_leaves_no_summer(self):
+    def test_all_months_in_winter_is_allowed(self):
+        """All 12 months as winter (TOU year-round, issue #725) must pass."""
         all_months = [str(i) for i in range(1, 13)]
         errors = validate_months({"hsem_months_winter": all_months})
-        assert errors["hsem_months_winter"] == "months_summer_empty"
+        assert errors == {}
 
     def test_invalid_month_value(self):
         errors = validate_months({"hsem_months_winter": ["0", "13"]})
@@ -738,7 +739,8 @@ class TestFlowValidatorsUseConfigValidator:
         errors = await validate_months_input(
             None, {"hsem_months_winter": [str(i) for i in range(1, 13)]}
         )
-        assert errors["hsem_months_winter"] == "months_summer_empty"
+        # All months as winter is allowed (TOU year-round, issue #725).
+        assert errors == {}
 
     @pytest.mark.asyncio
     async def test_validate_schedule_1_disabled_passes(self):

--- a/tests/test_months_validation.py
+++ b/tests/test_months_validation.py
@@ -139,12 +139,10 @@ class TestValidateMonthsInput:
         assert errors["hsem_months_winter"] == "required"
 
     async def test_validate_all_months_winter(self):
-        """Test validation fails when all months are winter (no summer)."""
+        """All months as winter (TOU year-round, issue #725) must pass."""
         user_input = {"hsem_months_winter": [str(i) for i in range(1, 13)]}
         errors = await validate_months_input(None, user_input)
-        assert "hsem_months_winter" in errors
-        # Centralized validator returns a translation key, not a human-readable string.
-        assert errors["hsem_months_winter"] == "months_summer_empty"
+        assert not errors
 
     async def test_validate_integer_months(self):
         """Test validation works with integer month values."""


### PR DESCRIPTION
## Summary

Fixes #725

v6.0.0's months step rejected selecting all 12 months as Winter/Spring with *"At least one month must remain in summer"*. That broke TOU year-round installs (e.g. households running an external automation layer on top of HSEM that requires the inverter in TOU with predictable working-mode control) — a configuration that was valid and deliberate on v5.

## Changes

- `custom_components/hsem/utils/config_validator.py` — removed the `months_summer_empty` check from `validate_months()`; an empty summer set is now valid. Docstring documents the TOU year-round rationale.
- `custom_components/hsem/translations/en.json` / `da.json` — removed the obsolete `months_summer_empty` error keys; extended the months step `data_description` to state that selecting all 12 months is allowed and keeps Winter/Spring (TOU) mode active year-round.
- `docs/config-flow-reference.md`, `docs/planner-guide.md` — months field tables updated.

## Tests

- `tests/test_config_validation.py` — `test_all_months_in_winter_leaves_no_summer` → `test_all_months_in_winter_is_allowed` (now asserts no error); `TestFlowValidatorsUseConfigValidator::test_validate_months_all_in_winter` updated likewise.
- `tests/test_months_validation.py` — `test_validate_all_months_winter` now asserts no error.

## Validation

- `pytest tests/test_months_validation.py tests/test_config_validation.py tests/test_config_flow_user_journeys.py` — 143 passed
- `./scripts/quality.sh lint` — passed
- `./scripts/quality.sh typing` (mypy) — passed
- `./scripts/quality.sh quality` (pyright) — 0 errors, 0 warnings