### PR TITLE
fix(ev): force charge now works when smart charging is disabled, and switch no longer resets on options save

### DIFF
--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -128,9 +128,109 @@ class _SimpleSlot:
 
     start: datetime
     end: datetime
-    estimated_net_consumption_kwh: float = 0.0
-    batteries_charged_kwh: float = 0.0
-    recommendation: str | None = None
+    estimated_net_consumption_kwh: float
+    batteries_charged_kwh: float
+    recommendation: str | None
+
+
+# ---------------------------------------------------------------------------
+# Force-charge-now override helper
+# ---------------------------------------------------------------------------
+
+
+def _apply_force_charge_now(
+    *,
+    config_entry: ConfigEntry,
+    hourly_recommendations: list[HourlyRecommendation],
+    ev_plan: EVChargingPlan | None,
+    ev_second_plan: EVChargingPlan | None,
+    now: datetime,
+) -> None:
+    """Apply the force-charge-now override to the current slot.
+
+    When the user toggles ``hsem_ev_force_charge_now`` (or the second-EV
+    equivalent), the current slot's recommendation is overridden to
+    ``ev_smart_charging`` and the calculated charger power is set to the
+    charger's maximum AC power.
+
+    Crucially, force-charge works **even when smart charging is disabled**.
+    The EV planner returns ``smart_charging_disabled`` with zero allocated
+    power in that case, so this function also flips the plan state to
+    ``charging`` so the plan sensor reflects the forced charge.
+
+    Args:
+        config_entry: The HSEM config entry (to read the force-charge switches).
+        hourly_recommendations: The list of hourly recommendations to modify.
+        ev_plan: The primary EV charging plan (may be ``None``).
+        ev_second_plan: The second EV charging plan (may be ``None``).
+        now: Current time (timezone-aware), used to locate the current slot.
+    """
+    force_primary = bool(get_config_value(config_entry, "hsem_ev_force_charge_now"))
+    force_second = bool(
+        get_config_value(config_entry, "hsem_ev_second_force_charge_now")
+    )
+    if not force_primary and not force_second:
+        return
+
+    now_slot = next(
+        (
+            r
+            for r in hourly_recommendations
+            if as_tz(r.start, now.tzinfo) <= now < as_tz(r.end, now.tzinfo)
+        ),
+        None,
+    )
+    if now_slot is None:
+        return
+
+    if force_primary:
+        now_slot.recommendation = Recommendations.EVSmartCharging.value
+        pwr_kw = float(
+            get_config_value(
+                config_entry,
+                "hsem_ev_planned_load_charger_power_kw",
+            )
+            or 0.0
+        )
+        now_slot.ev_charger_calculated_power = (
+            round(pwr_kw * 1000) if pwr_kw > 0 else 0.0
+        )
+        # Flip plan state so the sensor shows "charging" instead of
+        # "smart_charging_disabled" when the user forces a charge.
+        if ev_plan is not None and ev_plan.state == "smart_charging_disabled":
+            ev_plan.state = "charging"
+        async_log(
+            "debug",
+            "[coordinator] Force-Charge-Now: primary EV "
+            "→ overriding current slot to ev_smart_charging at %dW",
+            now_slot.ev_charger_calculated_power,
+        )
+
+    if force_second:
+        now_slot.recommendation = Recommendations.EVSmartCharging.value
+        pwr_kw = float(
+            get_config_value(
+                config_entry,
+                "hsem_ev_second_planned_load_charger_power_kw",
+            )
+            or 0.0
+        )
+        now_slot.ev_second_charger_calculated_power = (
+            round(pwr_kw * 1000) if pwr_kw > 0 else 0.0
+        )
+        # Flip plan state so the sensor shows "charging" instead of
+        # "smart_charging_disabled" when the user forces a charge.
+        if (
+            ev_second_plan is not None
+            and ev_second_plan.state == "smart_charging_disabled"
+        ):
+            ev_second_plan.state = "charging"
+        async_log(
+            "debug",
+            "[coordinator] Force-Charge-Now: second EV "
+            "→ overriding current slot to ev_smart_charging at %dW",
+            now_slot.ev_second_charger_calculated_power,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -999,69 +1099,17 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                 # 8c. Force-charge-now override: when the user toggles the
                 # "EV Force Charge Now" switch, override the current slot's
                 # recommendation and calculated power to charge at max speed.
-                force_primary = bool(
-                    get_config_value(self._config_entry, "hsem_ev_force_charge_now")
+                # Force-charge works even when smart charging is disabled —
+                # the plan state is flipped to "charging" so the plan sensor
+                # reflects the forced charge instead of
+                # "smart_charging_disabled".
+                _apply_force_charge_now(
+                    config_entry=self._config_entry,
+                    hourly_recommendations=self._hourly_recommendations,
+                    ev_plan=self._ev_charging_plan,
+                    ev_second_plan=self._ev_second_charging_plan,
+                    now=now,
                 )
-                force_second = bool(
-                    get_config_value(
-                        self._config_entry, "hsem_ev_second_force_charge_now"
-                    )
-                )
-                if force_primary or force_second:
-                    now_slot = next(
-                        (
-                            r
-                            for r in self._hourly_recommendations
-                            if as_tz(r.start, now.tzinfo)
-                            <= now
-                            < as_tz(r.end, now.tzinfo)
-                        ),
-                        None,
-                    )
-                    if now_slot is not None:
-                        # Max AC power = charger_power_kw * 1000
-                        if force_primary:
-                            now_slot.recommendation = (
-                                Recommendations.EVSmartCharging.value
-                            )
-                            pwr_kw = float(
-                                get_config_value(
-                                    self._config_entry,
-                                    "hsem_ev_planned_load_charger_power_kw",
-                                )
-                                or 0.0
-                            )
-                            now_slot.ev_charger_calculated_power = (
-                                round(pwr_kw * 1000) if pwr_kw > 0 else 0.0
-                            )
-                            async_log(
-                                "debug",
-                                "[coordinator] Force-Charge-Now: primary EV "
-                                "→ overriding current slot to ev_smart_charging "
-                                "at %dW",
-                                now_slot.ev_charger_calculated_power,
-                            )
-                        if force_second:
-                            now_slot.recommendation = (
-                                Recommendations.EVSmartCharging.value
-                            )
-                            pwr_kw = float(
-                                get_config_value(
-                                    self._config_entry,
-                                    "hsem_ev_second_planned_load_charger_power_kw",
-                                )
-                                or 0.0
-                            )
-                            now_slot.ev_second_charger_calculated_power = (
-                                round(pwr_kw * 1000) if pwr_kw > 0 else 0.0
-                            )
-                            async_log(
-                                "debug",
-                                "[coordinator] Force-Charge-Now: second EV "
-                                "→ overriding current slot to ev_smart_charging "
-                                "at %dW",
-                                now_slot.ev_second_charger_calculated_power,
-                            )
 
                 # 9. Find the current time-slot recommendation.
                 self._hourly_recommendations.sort(key=lambda x: x.start)
@@ -1140,6 +1188,22 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                     slot_minutes = cfg.recommendation_interval_minutes
                     if slot_minutes > 0 and target_kw > 0:
                         target_kw = (target_kw / slot_minutes) * 60.0
+                    # Force-charge-now overrides the planner target when the
+                    # plan is disabled (smart charging off) — the OCPP charger
+                    # must still receive the max-power command.
+                    force_primary = bool(
+                        get_config_value(self._config_entry, "hsem_ev_force_charge_now")
+                    )
+                    if force_primary:
+                        pwr_kw = float(
+                            get_config_value(
+                                self._config_entry,
+                                "hsem_ev_planned_load_charger_power_kw",
+                            )
+                            or 0.0
+                        )
+                        if pwr_kw > 0:
+                            target_kw = pwr_kw
                     await ocpp_server.update_charge_target(cpid, target_kw, now=now)
                 else:
                     await ocpp_server.update_charge_target(cpid, 0.0, now=now)

--- a/custom_components/hsem/options_flow.py
+++ b/custom_components/hsem/options_flow.py
@@ -480,11 +480,27 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
             if not errors:
                 self._user_input.update(user_input)
 
+                # Preserve entity-managed options that the options-flow schemas
+                # do not collect — switches (force-charge-now, smart charging,
+                # read-only, verbose logging, battery schedules, …), numbers
+                # (target SoC, charge-rate overrides), times (deadlines), and
+                # selector values (solcast likelihood).  Without this merge,
+                # ``async_create_entry`` would rewrite the options dict with
+                # only the schema fields, silently resetting every switch to
+                # its default (issue: force-charge switch turns itself off
+                # after saving the options flow).
+                preserved = {
+                    k: v
+                    for k, v in self._config_entry.options.items()
+                    if k not in self._user_input
+                }
+                merged = {**preserved, **self._user_input}
+
                 self.update_config_entry_data()
 
                 return self.async_create_entry(
-                    title=self._user_input.get("device_name", NAME),
-                    data=self._user_input,
+                    title=merged.get("device_name", NAME),
+                    data=merged,
                 )
 
         data_schema = await get_energy_and_ml_step_schema(self._config_entry)

--- a/docs/ev-charge-plan-setup.md
+++ b/docs/ev-charge-plan-setup.md
@@ -236,6 +236,23 @@ can be profitable or free.
 - No additional entities are required — it uses the import price sensor
   already configured for the planner.
 
+### Force Charge Now
+
+Toggling `switch.hsem_ev_force_charge_now` (or
+`switch.hsem_ev_second_force_charge_now` for the second EV) immediately
+overrides the current slot to charge the EV at its maximum configured AC
+power (`hsem_ev_planned_load_charger_power_kw`).
+
+**Force charge works even when smart charging is disabled.** When
+`switch.hsem_ev_smart_charging` is off the EV planner normally returns
+`smart_charging_disabled` with no slot allocation — but the force-charge
+switch bypasses this and issues the charge command anyway.  The plan sensor
+(`sensor.hsem_ev_optimal_charging_plan`) flips to `charging` so dashboards
+reflect the forced session.
+
+Use this for ad-hoc "charge now" scenarios (e.g. unexpected trip) without
+enabling the full smart-charging schedule.
+
 ### Session-aware EV demand
 
 When the EV is actively plugged in and drawing power, the MILP planner treats

--- a/tests/test_config_flow_user_journeys.py
+++ b/tests/test_config_flow_user_journeys.py
@@ -233,6 +233,106 @@ class TestReconfigureOptionsFlow:
         assert flow._user_input["device_name"] == "Fresh Config"
 
 
+class TestOptionsFlowPreservesEntityManagedOptions:
+    """Regression: saving the options flow must not reset entity-managed options.
+
+    Switches (force-charge-now, smart charging, read-only, …), numbers
+    (target SoC), times (deadline), and learned charge rates are persisted
+    by their entities directly into ``config_entry.options`` and are NOT
+    collected by any options-flow schema.  When the options flow finishes
+    with ``async_create_entry(data=self._user_input)``, HA replaces the
+    entire options dict — dropping those keys and resetting the switches
+    to their defaults (False).  The fix merges existing options that the
+    flow did not touch into the final data payload.
+    """
+
+    @pytest.mark.asyncio
+    async def test_force_charge_switch_survives_options_save(self) -> None:
+        """hsem_ev_force_charge_now=True must survive an options-flow save."""
+        from custom_components.hsem.options_flow import HSEMOptionsFlow
+
+        config_entry = MagicMock()
+        config_entry.options = {
+            "device_name": "My HSEM",
+            "hsem_ev_force_charge_now": True,
+            "hsem_ev_smart_charging": True,
+            "hsem_ev_second_force_charge_now": True,
+            "hsem_ev_second_smart_charging": False,
+            "hsem_ev_target_soc": 90,
+            "hsem_ev_deadline_time": "06:30:00",
+            "hsem_read_only": True,
+        }
+        config_entry.data = {}
+
+        flow = HSEMOptionsFlow.__new__(HSEMOptionsFlow)
+        flow._config_entry = config_entry
+        flow._user_input = {"device_name": "My HSEM"}
+        flow.hass = MagicMock()
+        flow.async_create_entry = MagicMock(  # type: ignore[method-assign]  # test monkey-patch
+            side_effect=lambda **kwargs: {
+                "type": "create_entry",
+                "title": kwargs.get("title"),
+                "data": kwargs.get("data"),
+            }
+        )
+
+        with patch(
+            "custom_components.hsem.options_flow.validate_energy_and_ml_input",
+            new=AsyncMock(return_value={}),
+        ):
+            result = await flow.async_step_energy_and_ml(
+                user_input={"hsem_ml_consumption_enabled": False}
+            )
+
+        assert result["type"] == "create_entry"
+        saved = result["data"]
+        # Entity-managed options must be preserved.
+        assert saved["hsem_ev_force_charge_now"] is True
+        assert saved["hsem_ev_smart_charging"] is True
+        assert saved["hsem_ev_second_force_charge_now"] is True
+        assert saved["hsem_ev_second_smart_charging"] is False
+        assert saved["hsem_ev_target_soc"] == 90
+        assert saved["hsem_ev_deadline_time"] == "06:30:00"
+        assert saved["hsem_read_only"] is True
+        # New values from the flow must also be present.
+        assert saved["hsem_ml_consumption_enabled"] is False
+
+    @pytest.mark.asyncio
+    async def test_flow_schema_values_override_preserved_options(self) -> None:
+        """When the flow collects a value that also exists in options, the
+        flow's new value must win (normal reconfigure behavior)."""
+        from custom_components.hsem.options_flow import HSEMOptionsFlow
+
+        config_entry = MagicMock()
+        config_entry.options = {
+            "device_name": "Old Name",
+            "hsem_ev_force_charge_now": True,
+        }
+        config_entry.data = {}
+
+        flow = HSEMOptionsFlow.__new__(HSEMOptionsFlow)
+        flow._config_entry = config_entry
+        flow._user_input = {"device_name": "New Name"}
+        flow.hass = MagicMock()
+        flow.async_create_entry = MagicMock(  # type: ignore[method-assign]  # test monkey-patch
+            side_effect=lambda **kwargs: {
+                "type": "create_entry",
+                "title": kwargs.get("title"),
+                "data": kwargs.get("data"),
+            }
+        )
+
+        with patch(
+            "custom_components.hsem.options_flow.validate_energy_and_ml_input",
+            new=AsyncMock(return_value={}),
+        ):
+            result = await flow.async_step_energy_and_ml(user_input={})
+
+        saved = result["data"]
+        assert saved["device_name"] == "New Name"  # flow value wins
+        assert saved["hsem_ev_force_charge_now"] is True  # preserved
+
+
 # ---------------------------------------------------------------------------
 # Error recovery — config flow resilience (Bronze rule: config-flow-test-coverage)
 # ---------------------------------------------------------------------------

--- a/tests/test_ha_mock_integration.py
+++ b/tests/test_ha_mock_integration.py
@@ -886,6 +886,189 @@ class TestDryRunCycle:
 
         assert captured[0].state is not None
 
+    def test_force_charge_overrides_smart_charging_disabled(self) -> None:
+        """Force-charge-now must work even when smart charging is disabled.
+
+        Regression: when ``hsem_ev_smart_charging`` is off the EV planner
+        returns ``smart_charging_disabled`` with zero allocated power.  The
+        force-charge-now override must still:
+
+        - set the current-slot recommendation to ``ev_smart_charging``,
+        - write the max charger power to ``ev_charger_calculated_power``,
+        - flip the plan state from ``smart_charging_disabled`` to
+          ``charging`` so the plan sensor reflects the forced charge.
+        """
+        from datetime import UTC, datetime, timedelta
+
+        from custom_components.hsem.coordinator import _apply_force_charge_now
+        from custom_components.hsem.models.hourly_recommendation import (
+            HourlyRecommendation,
+        )
+        from custom_components.hsem.planner.ev_planner import EVChargingPlan
+        from custom_components.hsem.utils.recommendations import Recommendations
+
+        now = datetime.now(UTC)
+        slot_start = now - timedelta(minutes=5)
+        slot_end = now + timedelta(minutes=10)
+
+        config_entry = make_fake_config_entry(
+            {
+                "hsem_ev_smart_charging": False,
+                "hsem_ev_force_charge_now": True,
+                "hsem_ev_planned_load_charger_power_kw": 11.0,
+            }
+        )
+
+        # Planner returned smart_charging_disabled with no EV allocation.
+        plan = EVChargingPlan(state="smart_charging_disabled")
+        rec = HourlyRecommendation(
+            start=slot_start,
+            end=slot_end,
+            avg_house_consumption_kwh=0.0,
+            avg_house_consumption_1d_kwh=0.0,
+            avg_house_consumption_3d_kwh=0.0,
+            avg_house_consumption_7d_kwh=0.0,
+            avg_house_consumption_14d_kwh=0.0,
+            batteries_charged_kwh=0.0,
+            batteries_discharged_kwh=0.0,
+            estimated_battery_capacity_kwh=0.0,
+            estimated_battery_soc_pct=0.0,
+            estimated_cost_currency=0.0,
+            estimated_net_consumption_kwh=0.0,
+            export_price=0.0,
+            grid_export_kwh=0.0,
+            grid_import_kwh=0.0,
+            import_price=0.0,
+            recommendation=Recommendations.BatteriesWaitMode.value,
+            solcast_pv_estimate_kwh=0.0,
+        )
+
+        _apply_force_charge_now(
+            config_entry=config_entry,
+            hourly_recommendations=[rec],
+            ev_plan=plan,
+            ev_second_plan=None,
+            now=now,
+        )
+
+        assert rec.recommendation == Recommendations.EVSmartCharging.value
+        assert rec.ev_charger_calculated_power == 11000.0
+        assert plan.state == "charging"
+
+    def test_force_charge_second_ev_overrides_smart_charging_disabled(
+        self,
+    ) -> None:
+        """Force-charge-now for the second EV must work when its smart charging is off."""
+        from datetime import UTC, datetime, timedelta
+
+        from custom_components.hsem.coordinator import _apply_force_charge_now
+        from custom_components.hsem.models.hourly_recommendation import (
+            HourlyRecommendation,
+        )
+        from custom_components.hsem.planner.ev_planner import EVChargingPlan
+        from custom_components.hsem.utils.recommendations import Recommendations
+
+        now = datetime.now(UTC)
+        slot_start = now - timedelta(minutes=5)
+        slot_end = now + timedelta(minutes=10)
+
+        config_entry = make_fake_config_entry(
+            {
+                "hsem_ev_second_smart_charging": False,
+                "hsem_ev_second_force_charge_now": True,
+                "hsem_ev_second_planned_load_charger_power_kw": 7.4,
+            }
+        )
+
+        plan2 = EVChargingPlan(state="smart_charging_disabled")
+        rec = HourlyRecommendation(
+            start=slot_start,
+            end=slot_end,
+            avg_house_consumption_kwh=0.0,
+            avg_house_consumption_1d_kwh=0.0,
+            avg_house_consumption_3d_kwh=0.0,
+            avg_house_consumption_7d_kwh=0.0,
+            avg_house_consumption_14d_kwh=0.0,
+            batteries_charged_kwh=0.0,
+            batteries_discharged_kwh=0.0,
+            estimated_battery_capacity_kwh=0.0,
+            estimated_battery_soc_pct=0.0,
+            estimated_cost_currency=0.0,
+            estimated_net_consumption_kwh=0.0,
+            export_price=0.0,
+            grid_export_kwh=0.0,
+            grid_import_kwh=0.0,
+            import_price=0.0,
+            recommendation=Recommendations.BatteriesWaitMode.value,
+            solcast_pv_estimate_kwh=0.0,
+        )
+
+        _apply_force_charge_now(
+            config_entry=config_entry,
+            hourly_recommendations=[rec],
+            ev_plan=None,
+            ev_second_plan=plan2,
+            now=now,
+        )
+
+        assert rec.recommendation == Recommendations.EVSmartCharging.value
+        assert rec.ev_second_charger_calculated_power == 7400.0
+        assert plan2.state == "charging"
+
+    def test_force_charge_off_leaves_plan_state_unchanged(self) -> None:
+        """With force-charge off and smart charging off, plan state is untouched."""
+        from datetime import UTC, datetime, timedelta
+
+        from custom_components.hsem.coordinator import _apply_force_charge_now
+        from custom_components.hsem.models.hourly_recommendation import (
+            HourlyRecommendation,
+        )
+        from custom_components.hsem.planner.ev_planner import EVChargingPlan
+        from custom_components.hsem.utils.recommendations import Recommendations
+
+        now = datetime.now(UTC)
+        config_entry = make_fake_config_entry(
+            {
+                "hsem_ev_smart_charging": False,
+                "hsem_ev_force_charge_now": False,
+            }
+        )
+
+        plan = EVChargingPlan(state="smart_charging_disabled")
+        rec = HourlyRecommendation(
+            start=now - timedelta(minutes=5),
+            end=now + timedelta(minutes=10),
+            avg_house_consumption_kwh=0.0,
+            avg_house_consumption_1d_kwh=0.0,
+            avg_house_consumption_3d_kwh=0.0,
+            avg_house_consumption_7d_kwh=0.0,
+            avg_house_consumption_14d_kwh=0.0,
+            batteries_charged_kwh=0.0,
+            batteries_discharged_kwh=0.0,
+            estimated_battery_capacity_kwh=0.0,
+            estimated_battery_soc_pct=0.0,
+            estimated_cost_currency=0.0,
+            estimated_net_consumption_kwh=0.0,
+            export_price=0.0,
+            grid_export_kwh=0.0,
+            grid_import_kwh=0.0,
+            import_price=0.0,
+            recommendation=Recommendations.BatteriesWaitMode.value,
+            solcast_pv_estimate_kwh=0.0,
+        )
+
+        _apply_force_charge_now(
+            config_entry=config_entry,
+            hourly_recommendations=[rec],
+            ev_plan=plan,
+            ev_second_plan=None,
+            now=now,
+        )
+
+        assert rec.recommendation == Recommendations.BatteriesWaitMode.value
+        assert rec.ev_charger_calculated_power == 0.0
+        assert plan.state == "smart_charging_disabled"
+
 
 # ---------------------------------------------------------------------------
 # TestEntityStateAfterCoordinatorPush — entities reflect coordinator data


### PR DESCRIPTION
## Problem

Two related EV force-charge bugs:

### 1. Force charge did not work when smart charging was disabled

With `switch.hsem_ev_smart_charging` off, toggling `switch.hsem_ev_force_charge_now` (or the second-EV equivalent) had no visible effect:

- `sensor.hsem_ev_optimal_charging_plan` showed **"Smart Charging Disabled"** even during a forced charge.
- `sensor.hsem_ev_charging_sensor` stayed **off**.
- The OCPP charge target was pushed as **0 kW**, so the charger never received the start command.

Root cause: with smart charging disabled, `build_ev_charging_plan()` returns early with `state = "smart_charging_disabled"` and **zero allocated slots / power**. The coordinator's force-charge override (step 8c) set the slot recommendation and charger power, but never updated the plan state, and the OCPP charge-target push derived its value from the plan's `current_slot_planned_load_kwh` (0).

### 2. Force-charge switch appeared to turn itself off

After enabling `switch.hsem_ev_force_charge_now`, saving the HSEM options flow (Configure → Save) silently reset the switch to off.

Root cause: `options_flow.async_step_energy_and_ml` finished with `async_create_entry(data=self._user_input)`, replacing the entry's entire options dict with only the keys collected by the flow schemas. Entity-managed options — switches (force-charge-now, smart charging, read-only, verbose logging, battery schedules), numbers (target SoC, charge-rate overrides), times (deadlines), selector values — were dropped, so `get_config_value` fell back to `data`/defaults (`False`). The switch's update listener then re-read the lost value and the switch flipped off.

## Fix

- **`custom_components/hsem/coordinator.py`**: extracted the force-charge override into `_apply_force_charge_now()`. The helper now **flips the plan state to `charging`** when the force switch is on and the plan was `smart_charging_disabled` — for **both the primary and the second EV**. In the **OCPP charge-target push**, the target is overridden with the max charger power when the force switch is on.
- **`custom_components/hsem/options_flow.py`**: before `async_create_entry`, merge existing options that the flow did not touch into the final payload. Flow-collected values still win on conflict (normal reconfigure behavior).
- **`docs/ev-charge-plan-setup.md`**: documented that force charge works even with smart charging disabled.

## Tests

- `tests/test_ha_mock_integration.py` — 3 regression tests for the force-charge override (primary EV, second EV, off-switch no-op).
- `tests/test_config_flow_user_journeys.py` — 2 regression tests for options-flow preservation (entity-managed options survive a save; flow values still override preserved ones).

## Validation

- `./scripts/quality.sh lint` — ✅
- `./scripts/quality.sh typing` — ✅
- `./scripts/quality.sh quality` — ✅
- `./scripts/quality.sh test` — ✅ 2430 passed