### PR TITLE
fix(planner): preserve quarter-hourly prices through planner input

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -822,6 +822,19 @@ fan-out directions:
 
 Regression tests: ``tests/test_15min_price_matching.py``.
 
+**Stage 2 — planner input collapse (same issue):** even with population
+fixed, ``coordinator_builder.build_planner_input`` deduplicated on
+``(day_offset, hour)`` and appended price points *inside* that guard, so
+only the first quarter of each hour survived (192 slots → 48 hourly
+points), and ``populate_prices`` fanned the survivor back across the hour
+via ``align_hourly_prices``.  Fix: ``PricePoint`` carries an optional
+``slot_in_day``; price points are emitted per slot (consumption averages
+and Solcast PV stay hour-deduplicated); ``populate_prices`` keys by
+``(day_offset, slot_in_day)`` with an hourly fallback when present.
+Hour-granular callers (``slot_in_day=None``) are unaffected.
+
+Regression tests: ``tests/test_quarter_hourly_planner_input.py``.
+
 ---
 
 ## Avg Sensor Must Not Store Partial-Day Samples (issue #720 follow-up)

--- a/custom_components/hsem/coordinator_builder.py
+++ b/custom_components/hsem/coordinator_builder.py
@@ -178,6 +178,26 @@ def build_planner_input(
         # distinction between today's hour-3 and tomorrow's hour-3 for
         # multi-day planning horizons (e.g. 48 h or 72 h).
         day_offset = (rec.start.date() - planning_midnight.date()).days
+
+        # Prices are per-slot: 15-min price data must survive to the planner
+        # as distinct quarter-hourly points (issue #720).  Consumption
+        # averages and Solcast PV are genuinely hour-granular and stay
+        # deduplicated below.
+        slot_in_day = (rec.start.hour * 60 + rec.start.minute) // int(
+            cfg.recommendation_interval_minutes
+        )
+        # Multiply by price_share to reverse the per-slot divide applied during
+        # population; the planner receives the original currency/kWh rate.
+        price_points.append(
+            PricePoint(
+                hour=h,
+                import_price=round(rec.import_price * price_share, 5),
+                export_price=round(rec.export_price * price_share, 5),
+                day_offset=day_offset,
+                slot_in_day=slot_in_day,
+            )
+        )
+
         day_hour_key = (day_offset, h)
         if day_hour_key in seen_day_hours:
             continue
@@ -190,16 +210,6 @@ def build_planner_input(
                 avg_3d=round(rec.avg_house_consumption_3d_kwh * slots_per_hour, 3),
                 avg_7d=round(rec.avg_house_consumption_7d_kwh * slots_per_hour, 3),
                 avg_14d=round(rec.avg_house_consumption_14d_kwh * slots_per_hour, 3),
-                day_offset=day_offset,
-            )
-        )
-        # Multiply by price_share to reverse the per-slot divide applied during
-        # population; the planner receives the original currency/kWh rate.
-        price_points.append(
-            PricePoint(
-                hour=h,
-                import_price=round(rec.import_price * price_share, 5),
-                export_price=round(rec.export_price * price_share, 5),
                 day_offset=day_offset,
             )
         )

--- a/custom_components/hsem/models/price_point.py
+++ b/custom_components/hsem/models/price_point.py
@@ -20,9 +20,18 @@ class PricePoint:
             Number of whole calendar days from the planning midnight (0 = today,
             1 = tomorrow, …).  Defaults to 0 for backward compatibility with
             callers that only pass 24 single-day entries.
+        slot_in_day:
+            Optional 0-based index of the sub-hourly slot within its calendar
+            day (0-95 for 15-min slots, 0-47 for 30-min, 0-23 for 60-min).
+            ``None`` (default) means the point is hour-granular — existing
+            hourly callers are unaffected.  When set, the planner keys the
+            point by ``(day_offset, slot_in_day)`` so quarter-hourly prices
+            (e.g. Nord Pool 15-min MTUs) survive to the MILP instead of being
+            collapsed to one price per hour (issue #720).
     """
 
     hour: int  # 0-23
     import_price: float = 0.0
     export_price: float = 0.0
     day_offset: int = 0
+    slot_in_day: int | None = None

--- a/custom_components/hsem/planner/slot_population.py
+++ b/custom_components/hsem/planner/slot_population.py
@@ -138,6 +138,36 @@ def populate_prices(
         tsi is not None,
     )
     if tsi is not None:
+        # Sub-hourly path: when the points carry slot_in_day (issue #720),
+        # key by (day_offset, slot_in_day) so quarter-hourly prices land on
+        # their own slots instead of being fanned out from one hourly value.
+        if any(pp.slot_in_day is not None for pp in price_points):
+            imp_by_slot = {
+                (pp.day_offset, pp.slot_in_day): pp.import_price
+                for pp in price_points
+                if pp.slot_in_day is not None
+            }
+            exp_by_slot = {
+                (pp.day_offset, pp.slot_in_day): pp.export_price
+                for pp in price_points
+                if pp.slot_in_day is not None
+            }
+            # Hourly fallback for slots the source does not cover (e.g. a
+            # 60-min price source feeding 15-min slots).
+            imp_by_hour = {
+                (pp.day_offset, pp.hour): pp.import_price for pp in price_points
+            }
+            exp_by_hour = {
+                (pp.day_offset, pp.hour): pp.export_price for pp in price_points
+            }
+            for slot, meta in zip(slots, tsi.slots):
+                key = (meta.key.day_offset, meta.key.slot_in_day)
+                hour_key = (meta.key.day_offset, meta.hour)
+                imp = imp_by_slot.get(key, imp_by_hour.get(hour_key, 0.0))
+                exp = exp_by_slot.get(key, exp_by_hour.get(hour_key, 0.0))
+                slot.price = SlotPrice(import_price=imp, export_price=exp)
+            return
+
         # Use (day_offset, hour) keys when any entry carries a non-zero
         # day_offset so that tomorrow's prices are not overwritten by today's.
         imp_prices: dict[int, float] | dict[tuple[int, int], float]

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -1138,12 +1138,22 @@ Common configurations:
    slots (issue #720).  With hourly price data and 15-min slots the single
    hourly point fans out to all four quarter-hour slots of the hour.
 
-2. **Planner input** (`coordinator._build_planner_input`):
-   When assembling `PricePoint` objects for the planner engine, each stored
-   per-slot price is multiplied by `eds_share` to recover the original
-   hourly-equivalent rate.
-   The planner's cost function always works with full currency/kWh rates, not
-   fractions.
+2. **Planner input** (`coordinator_builder.build_planner_input`):
+   Recommendation slots are deduplicated on `(day_offset, hour)` for
+   consumption averages and Solcast PV (genuinely hour-granular), but
+   **price points are emitted per slot** with an explicit `slot_in_day`
+   field, so quarter-hourly prices survive as distinct `PricePoint`
+   entries (192 for a 48 h horizon at 15-min slots).  Each stored per-slot
+   price is multiplied by `eds_share` to recover the original
+   hourly-equivalent rate.  The planner's cost function always works with
+   full currency/kWh rates, not fractions.
+
+3. **Slot population** (`planner.slot_population.populate_prices`):
+   When price points carry `slot_in_day`, slots are keyed by
+   `(day_offset, slot_in_day)` so each quarter-hourly price lands on its
+   own planner slot; slots the source does not cover fall back to the
+   hourly value.  Points without `slot_in_day` (legacy hourly callers)
+   use the existing `align_hourly_prices` fan-out unchanged.
 
 The divide and multiply are exact inverses — they cancel perfectly and the
 planner always receives the original price rate regardless of configuration.
@@ -1165,6 +1175,9 @@ planner always receives the original price rate regardless of configuration.
 - With 15-min price data and 15-min slots, each quarter-hour price must land
   on exactly its own slot — four distinct prices within an hour must produce
   four distinct slot prices (issue #720).
+- With 15-min price data, 15-min slots, and a 48 h horizon, the planner must
+  receive 192 distinct price points (not 48 collapsed hourly ones) and the
+  MILP must see intra-hour price variation (issue #720 stage 2).
 
 ## Candidate plans
 

--- a/tests/test_quarter_hourly_planner_input.py
+++ b/tests/test_quarter_hourly_planner_input.py
@@ -1,0 +1,209 @@
+"""Regression tests for issue #720 (stage 2) — planner input must not
+collapse quarter-hourly prices to hourly.
+
+Bug
+---
+``coordinator_builder.build_planner_input`` deduplicated recommendation
+slots on ``(day_offset, hour)`` and appended price points *inside* that
+guard, so only the first quarter of each hour survived — 192 correct
+quarter-hourly slots were reduced to 48 hourly price points.
+``planner.slot_population.populate_prices`` then fanned the survivor back
+across the hour via ``align_hourly_prices``, so the MILP saw one flat
+price per hour even when Nord Pool 15-min MTU data provided 96 distinct
+prices per day.
+
+Fix (three parts)
+-----------------
+1. ``PricePoint`` gained an optional ``slot_in_day`` field (hour-granular
+   callers unaffected).
+2. ``build_planner_input`` appends price points per slot (outside the
+   hourly dedup guard) and sets ``slot_in_day``; consumption averages and
+   Solcast PV stay hour-deduplicated.
+3. ``populate_prices`` keys by ``(day_offset, slot_in_day)`` when points
+   carry it, with an hourly fallback for uncovered slots.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from custom_components.hsem.models.planned_slot import PlannedSlot
+from custom_components.hsem.models.price_point import PricePoint
+from custom_components.hsem.models.time_series import TimeSeriesIndex
+from custom_components.hsem.planner.slot_population import (
+    populate_prices,
+)
+
+
+def _tsi(now: datetime, interval: int = 15, hours: int = 48) -> TimeSeriesIndex:
+    return TimeSeriesIndex.from_now(now, interval_minutes=interval, horizon_hours=hours)
+
+
+def _slots_from_tsi(tsi: TimeSeriesIndex) -> list[PlannedSlot]:
+    return [PlannedSlot(start=m.start, end=m.end) for m in tsi]
+
+
+class TestSlotInDayPricePoints:
+    """96 distinct 15-min prices must reach 96 distinct planner slots."""
+
+    def setup_method(self) -> None:
+        self.now = datetime(2026, 8, 9, 12, 0, 0, tzinfo=UTC)
+
+    def _make_points(self, days: int = 2) -> list[PricePoint]:
+        points = []
+        for d in range(days):
+            for i in range(96):
+                hour = i // 4
+                price = 1.0 + d * 100 + i * 0.01  # unique per slot per day
+                points.append(
+                    PricePoint(
+                        hour=hour,
+                        import_price=price,
+                        export_price=price - 0.1,
+                        day_offset=d,
+                        slot_in_day=i,
+                    )
+                )
+        return points
+
+    def test_quarter_hourly_prices_land_on_distinct_slots(self) -> None:
+        tsi = _tsi(self.now)
+        slots = _slots_from_tsi(tsi)
+        points = self._make_points()
+        populate_prices(slots, points, tsi=tsi)
+
+        for d in range(2):
+            for i in range(96):
+                slot = slots[d * 96 + i]
+                expected = 1.0 + d * 100 + i * 0.01
+                assert slot.price.import_price == pytest.approx(expected), (
+                    f"day {d} slot {i}: expected {expected}, "
+                    f"got {slot.price.import_price}"
+                )
+                assert slot.price.export_price == pytest.approx(expected - 0.1)
+
+    def test_intra_hour_variation_preserved(self) -> None:
+        """The Nord Pool SE4 example from the issue: hour 17 has four very
+        different quarter-hourly prices; all four must survive."""
+        tsi = _tsi(self.now, hours=24)
+        slots = _slots_from_tsi(tsi)
+        points = [
+            PricePoint(
+                hour=17,
+                import_price=p,
+                export_price=p,
+                day_offset=0,
+                slot_in_day=17 * 4 + q,
+            )
+            for q, p in enumerate([0.179, 0.363, 0.476, 0.603])
+        ]
+        populate_prices(slots, points, tsi=tsi)
+
+        got = [slots[17 * 4 + q].price.import_price for q in range(4)]
+        assert got == pytest.approx([0.179, 0.363, 0.476, 0.603])
+
+    def test_hourly_fallback_for_uncovered_slots(self) -> None:
+        """A point set that only covers slot :00 of each hour (e.g. a
+        60-min source) must still fan out to the remaining quarters via the
+        hourly fallback."""
+        tsi = _tsi(self.now, hours=24)
+        slots = _slots_from_tsi(tsi)
+        points = [
+            PricePoint(
+                hour=h,
+                import_price=0.10 + h * 0.01,
+                export_price=0.05,
+                day_offset=0,
+                slot_in_day=h * 4,  # only the :00 slot of each hour
+            )
+            for h in range(24)
+        ]
+        populate_prices(slots, points, tsi=tsi)
+
+        for i, slot in enumerate(slots):
+            hour = i // 4
+            assert slot.price.import_price == pytest.approx(0.10 + hour * 0.01)
+
+    def test_legacy_hourly_points_unchanged(self) -> None:
+        """Points without slot_in_day use the existing hourly path."""
+        tsi = _tsi(self.now, hours=24)
+        slots = _slots_from_tsi(tsi)
+        points = [
+            PricePoint(hour=h, import_price=0.20 + h * 0.01, export_price=0.1)
+            for h in range(24)
+        ]
+        populate_prices(slots, points, tsi=tsi)
+
+        for i, slot in enumerate(slots):
+            hour = i // 4
+            assert slot.price.import_price == pytest.approx(0.20 + hour * 0.01)
+
+
+class TestBuildPlannerInputSlotInDay:
+    """coordinator_builder must emit one price point per recommendation slot."""
+
+    def test_price_point_count_matches_slots(self) -> None:
+        """48 h horizon at 15-min slots → 192 price points, not 48."""
+        from custom_components.hsem.coordinator_builder import build_planner_input
+        from custom_components.hsem.models.hourly_recommendation import (
+            HourlyRecommendation,
+        )
+        from custom_components.hsem.models.live_state import LiveState
+        from custom_components.hsem.models.sensor_config import SensorConfig
+
+        cfg = SensorConfig()
+        cfg.recommendation_interval_minutes = 15
+        cfg.recommendation_interval_length = 48
+        cfg.electricity_price_update_interval = 15
+
+        base = datetime(2026, 8, 9, 0, 0, 0, tzinfo=UTC)
+
+        def _rec(i: int) -> HourlyRecommendation:
+            start = base + timedelta(minutes=15 * i)
+            return HourlyRecommendation(
+                start=start,
+                end=start + timedelta(minutes=15),
+                recommendation="idle",
+                avg_house_consumption_kwh=0.1,
+                avg_house_consumption_1d_kwh=0.1,
+                avg_house_consumption_3d_kwh=0.1,
+                avg_house_consumption_7d_kwh=0.1,
+                avg_house_consumption_14d_kwh=0.1,
+                batteries_charged_kwh=0.0,
+                batteries_discharged_kwh=0.0,
+                estimated_battery_capacity_kwh=0.0,
+                estimated_battery_soc_pct=0.0,
+                estimated_cost_currency=0.0,
+                estimated_net_consumption_kwh=0.0,
+                export_price=round(0.05 + i * 0.001, 5),
+                grid_export_kwh=0.0,
+                grid_import_kwh=0.0,
+                import_price=round(0.10 + i * 0.001, 5),
+                solcast_pv_estimate_kwh=0.0,
+            )
+
+        recs = [_rec(i) for i in range(192)]
+
+        inp = build_planner_input(
+            cfg=cfg,
+            live=LiveState(),
+            hourly_recommendations=recs,
+            batteries_schedules=[],
+            previous_winner_name=None,
+            previous_winner_score=0.0,
+        )
+
+        assert len(inp.price_points) == 192
+        assert len(inp.consumption_averages) == 48  # still hour-deduplicated
+        assert len(inp.solcast_slots) == 48
+
+        # Distinct quarter-hourly prices must survive with distinct slot_in_day.
+        slot_keys = {(pp.day_offset, pp.slot_in_day) for pp in inp.price_points}
+        assert len(slot_keys) == 192
+
+        # First hour of day 0: four distinct prices, none collapsed.
+        first_hour = [pp for pp in inp.price_points if pp.day_offset == 0][:4]
+        prices = [pp.import_price for pp in first_hour]
+        assert len(set(prices)) == 4


### PR DESCRIPTION
## Problem

Follow-up on #720: the beta3 fix (source-interval flooring in `hourly_data_populator/prices_solcast.py`) made 15-min prices land in the correct *recommendation slots* — but @Ambilights confirmed the prices are still collapsed one stage later, before the planner sees them.

**Root cause (exactly as diagnosed by @Ambilights):**

1. `PricePoint` had no sub-hourly field, so it structurally could not carry more than one price per hour.
2. `coordinator_builder.build_planner_input` deduplicated on `(day_offset, hour)` and appended price points *inside* that guard — only the first quarter of each hour survived (192 correct quarter-hourly slots → 48 hourly points; `:15`, `:30`, `:45` dropped).
3. `populate_prices` fanned the survivor back across the hour via `align_hourly_prices`.

Net pipeline: 192 correct quarter-hourly slots → 48 hourly points → 192 identical-within-the-hour slots. The diagnostic `price_points=48` (instead of 192) confirmed it.

Nord Pool SE4 example from the issue: hour 17 had prices 179 / 363 / 476 / **603** SEK/MWh — planned at 179 for all four quarters, under a third of the actual peak.

## Fix (three parts)

1. **`models/price_point.py`** — new optional `slot_in_day: int | None = None` field. Existing hour-granular callers (all test fixtures, diagnostics) are unaffected.
2. **`coordinator_builder.py`** — price points are appended **per slot**, outside the `(day_offset, hour)` dedup guard, with `slot_in_day` set. Consumption averages and Solcast PV stay hour-deduplicated (they genuinely are hour-granular).
3. **`planner/slot_population.py`** — `populate_prices` keys by `(day_offset, slot_in_day)` when points carry it, with an hourly fallback for slots the source doesn't cover (e.g. a 60-min price source feeding 15-min slots). Points without `slot_in_day` use the existing `align_hourly_prices` path unchanged.

The hourly path is untouched: 60-min price sources and `price_share != 1.0` configurations behave exactly as before.

## Changes

- `custom_components/hsem/models/price_point.py` — `slot_in_day` field
- `custom_components/hsem/coordinator_builder.py` — per-slot price point emission
- `custom_components/hsem/planner/slot_population.py` — slot-keyed matching with hourly fallback
- `tests/test_quarter_hourly_planner_input.py` — regression tests: 96 distinct prices → 96 distinct slots, the Nord Pool SE4 hour-17 example, hourly fallback for 60-min sources, legacy hourly path unchanged, and `build_planner_input` emitting 192 price points vs 48 consumption/PV points
- `docs/planner-spec.md` — price interval semantics: new stage-2/stage-3 description and invariant
- `.github/memories.md` — canonical rule updated with the stage-2 collapse

## Validation

- `./scripts/quality.sh lint` ✅
- `./scripts/quality.sh typing` ✅
- `./scripts/quality.sh quality` ✅
- `./scripts/quality.sh test` ✅ — 2430 passed
- File sizes: `slot_population.py` 29.9 KB, `coordinator_builder.py` 19.5 KB, `price_point.py` 1.4 KB (all within limits)

Credit: root-cause analysis and fix sketch by @Ambilights in #720.

Refs #720