### PR TITLE
perf(coordinator): run options-update pipeline as a background task

### DIFF
--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -476,6 +476,12 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         # gate can skip re-fitting when no new history has arrived.
         self._ml_predictor: ConsumptionPredictor | None = None
 
+        # Background task handle for option-change-triggered pipeline runs.
+        # Tracked so repeated toggles cancel the pending run and so teardown
+        # can cancel a still-running task (issue: switch toggles felt frozen
+        # because the update listener awaited the full MILP/ML pipeline).
+        self._options_update_task: asyncio.Task | None = None
+
     # ------------------------------------------------------------------
     # HA lifecycle
     # ------------------------------------------------------------------
@@ -554,9 +560,48 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             await ocpp.stop()
             self._ocpp_server = None
 
+        # Cancel any pending options-update background task.
+        task = getattr(self, "_options_update_task", None)
+        if task is not None and not task.done():
+            task.cancel()
+            self._options_update_task = None
+
     async def async_options_updated(self) -> None:
-        """Re-run the pipeline when the user saves new options."""
-        await self._async_handle_update(None)
+        """Schedule a pipeline re-run after an options change.
+
+        Runs the update cycle as a **background task** so the caller (the
+        config-entry update listener, triggered synchronously by
+        ``async_update_entry`` from switch/number/time entities) returns
+        immediately.  Without this, toggling a switch would block the HA
+        service call until the entire read → plan (MILP/ML) → apply
+        pipeline finished — making the UI feel frozen.
+
+        Repeated toggles cancel any still-pending run and reschedule, so
+        the pipeline always reflects the latest option state.  The
+        ``_update_lock`` in ``_async_handle_update`` additionally dedupes
+        against any concurrently running scheduled cycle.
+        """
+        if (
+            self._options_update_task is not None
+            and not self._options_update_task.done()
+        ):
+            self._options_update_task.cancel()
+        self._options_update_task = self.hass.async_create_task(
+            self._async_options_update_background(),
+            name="hsem_options_update",
+        )
+
+    async def _async_options_update_background(self) -> None:
+        """Background wrapper: run the update cycle, swallowing cancellation."""
+        try:
+            await self._async_handle_update(None)
+        except asyncio.CancelledError:
+            # Superseded by a newer options update — not an error.
+            async_log(
+                "debug",
+                "[coordinator] options-update task cancelled — superseded by a "
+                "newer options change.",
+            )
 
     # ------------------------------------------------------------------
     # Internal update pipeline

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -28,6 +28,7 @@ and fast we use one of two approaches depending on what is being verified:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import inspect
 from typing import Any
 from unittest.mock import MagicMock
@@ -68,6 +69,7 @@ def _make_bare_coordinator() -> HSEMDataUpdateCoordinator:
     cfg.recommendation_interval_minutes = 60
     cfg.recommendation_interval_length = 24
     coord._cfg = cfg
+    coord._options_update_task = None
     return coord
 
 
@@ -226,6 +228,118 @@ class TestCoordinatorTeardown:
         coordinator = _make_bare_coordinator()
         # Both handles are None — no error expected
         await coordinator.async_teardown()
+
+
+# ---------------------------------------------------------------------------
+# Options-update background task
+# ---------------------------------------------------------------------------
+
+
+class TestOptionsUpdateBackgroundTask:
+    """async_options_updated must schedule the pipeline as a background task.
+
+    Regression: the config-entry update listener (fired by
+    ``async_update_entry`` from switch/number/time entities) used to await
+    the full MILP/ML pipeline inline.  The toggle itself was fast (HA fires
+    listeners as tasks), but the *effect* of a toggle was delayed because
+    each options change ran a full synchronous pipeline cycle.  The fix
+    schedules the cycle via ``hass.async_create_task`` with
+    cancel-and-reschedule semantics so repeated toggles collapse into one
+    run and the listener returns immediately.
+    """
+
+    @pytest.mark.asyncio
+    async def test_options_updated_schedules_background_task(self) -> None:
+        """async_options_updated returns immediately after scheduling a task."""
+        coordinator = _make_bare_coordinator()
+        coordinator.hass = MagicMock()
+
+        scheduled: list[asyncio.Task] = []
+
+        def _create_task(coro: Any, *, name: str) -> asyncio.Task:
+            task = asyncio.get_running_loop().create_task(coro, name=name)
+            scheduled.append(task)
+            return task
+
+        coordinator.hass.async_create_task = MagicMock(side_effect=_create_task)
+
+        # Make the pipeline cycle a no-op so the task completes quickly.
+        async def _noop_cycle(*args: Any, **kwargs: Any) -> None:
+            await asyncio.sleep(0)
+
+        coordinator._async_handle_update = _noop_cycle  # type: ignore[method-assign]  # test monkey-patch
+
+        await coordinator.async_options_updated()
+
+        # The method must have scheduled exactly one background task.
+        coordinator.hass.async_create_task.assert_called_once()  # type: ignore[union-attr]  # mock assertion
+        assert len(scheduled) == 1
+        assert scheduled[0].get_name() == "hsem_options_update"
+
+        # Let the background task finish.
+        await scheduled[0]
+
+    @pytest.mark.asyncio
+    async def test_repeated_toggle_cancels_pending_task(self) -> None:
+        """A second options update cancels the still-pending first task."""
+        coordinator = _make_bare_coordinator()
+        coordinator.hass = MagicMock()
+
+        scheduled: list[asyncio.Task] = []
+
+        def _create_task(coro: Any, *, name: str) -> asyncio.Task:
+            task = asyncio.get_running_loop().create_task(coro, name=name)
+            scheduled.append(task)
+            return task
+
+        coordinator.hass.async_create_task = MagicMock(side_effect=_create_task)
+
+        # A cycle that blocks until cancelled.
+        started = asyncio.Event()
+
+        async def _blocking_cycle(*args: Any, **kwargs: Any) -> None:
+            started.set()
+            await asyncio.sleep(60)
+
+        coordinator._async_handle_update = _blocking_cycle  # type: ignore[method-assign]  # test monkey-patch
+
+        await coordinator.async_options_updated()
+        assert len(scheduled) == 1
+        await started.wait()  # ensure the first task is actually running
+
+        await coordinator.async_options_updated()
+        assert len(scheduled) == 2
+        assert scheduled[0].cancelled() or scheduled[0].cancelling()
+
+        # Clean up: let the second task be cancelled too so we don't leak.
+        scheduled[1].cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await scheduled[1]
+
+    @pytest.mark.asyncio
+    async def test_teardown_cancels_pending_options_task(self) -> None:
+        """async_teardown must cancel a still-running options-update task."""
+        coordinator = _make_bare_coordinator()
+        coordinator.hass = MagicMock()
+
+        async def _blocking_cycle(*args: Any, **kwargs: Any) -> None:
+            await asyncio.sleep(60)
+
+        coordinator._async_handle_update = _blocking_cycle  # type: ignore[method-assign]  # test monkey-patch
+        coordinator.hass.async_create_task = MagicMock(  # type: ignore[method-assign]  # test monkey-patch
+            side_effect=lambda coro, *, name: asyncio.get_running_loop().create_task(
+                coro, name=name
+            )
+        )
+
+        await coordinator.async_options_updated()
+        task = coordinator._options_update_task
+        assert task is not None and not task.done()
+
+        await coordinator.async_teardown()
+
+        assert task.cancelling() or task.cancelled() or task.done()
+        assert coordinator._options_update_task is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Toggling HSEM switches (e.g. `switch.hsem_ev_force_charge_now`) felt unresponsive — the *effect* of a toggle was delayed by a full read → plan (MILP/ML) → apply pipeline cycle.

The chain: `HSEMSwitch.async_turn_on` → `_persist_state()` → `async_update_entry()` → the config-entry update listener `async_update_options` → `await coordinator.async_options_updated()` → the **entire update cycle, MILP solve included**, awaited inline.

HA fires the listener as a task so the service call itself returns, but every toggle still ran a complete synchronous pipeline cycle, and rapid toggles (or multiple entities persisting in quick succession, e.g. several switches + a number) would run back-to-back full cycles.

## Fix

`async_options_updated()` now schedules the update cycle via `hass.async_create_task()` and returns immediately:

- **Cancel-and-reschedule**: repeated toggles cancel the still-pending task and schedule a fresh one, collapsing rapid option changes into a single pipeline run that reflects the latest state.
- The existing `_update_lock` in `_async_handle_update` still dedupes against any concurrently running scheduled (timer-driven) cycle.
- `async_teardown()` cancels a pending task so unload is clean.

## Tests

Added `TestOptionsUpdateBackgroundTask` in `tests/test_coordinator.py`:

- `test_options_updated_schedules_background_task` — scheduling returns immediately, task named `hsem_options_update`.
- `test_repeated_toggle_cancels_pending_task` — second update cancels the still-pending first task.
- `test_teardown_cancels_pending_options_task` — teardown cancels a pending task.

## Validation

- `./scripts/quality.sh lint` — ✅
- `./scripts/quality.sh typing` — ✅
- `./scripts/quality.sh quality` — ✅
- `./scripts/quality.sh test` — ✅ 2438 passed