### PR TITLE
fix(sensor): ignore cancelled tasks in working-mode update done callback

### DIFF
--- a/custom_components/hsem/custom_sensors/working_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/working_mode_sensor.py
@@ -340,7 +340,13 @@ class HSEMWorkingModeSensor(HSEMCoordinatorEntity, SensorEntity, HSEMEntity):
         Registered as a ``done_callback`` on ``_update_task`` so that
         uncaught exceptions inside ``_async_on_coordinator_update()`` are
         recorded without breaking the task lifecycle.
+
+        Cancelled tasks are ignored because cancellation is expected when a
+        newer coordinator push arrives or the entity is unloaded.
         """
+        if task.cancelled():
+            return
+
         exc = task.exception()
         if exc is not None:
             _LOGGER.error("Unhandled exception in working-mode update task: %s", exc)

--- a/tests/test_working_mode_task_lifecycle.py
+++ b/tests/test_working_mode_task_lifecycle.py
@@ -114,6 +114,36 @@ class TestTaskCancellationOnUnload:
     """Task is cancelled cleanly when the entity is unloaded."""
 
     @pytest.mark.asyncio
+    async def test_done_callback_ignores_cancelled_task(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A cancelled task must not be logged as an unhandled exception.
+
+        Regression for issue #736: ``task.exception()`` raises
+        ``asyncio.CancelledError`` when the task was cancelled.  The done
+        callback must detect this and return silently.
+        """
+        sensor = _make_sensor()
+        event = asyncio.Event()
+
+        async def _hanging_coro():
+            await event.wait()
+
+        task = asyncio.get_event_loop().create_task(_hanging_coro())
+        task.add_done_callback(sensor._on_update_task_done)
+
+        # Let the task start and block.
+        await asyncio.sleep(0)
+
+        task.cancel()
+
+        # Must not raise through the done callback.
+        await asyncio.gather(task, return_exceptions=True)
+
+        assert task.cancelled()
+        assert "Unhandled exception" not in caplog.text
+
+    @pytest.mark.asyncio
     async def test_unload_cancels_pending_task(self) -> None:
         """A pending task must be cancelled on ``async_will_remove_from_hass``."""
         sensor = _make_sensor()


### PR DESCRIPTION
## Summary

When a coordinator update fires while the previous working-mode update task is still waiting for inverter/battery writes to settle, the old task is cancelled as designed. However, `HSEMWorkingModeSensor._on_update_task_done()` called `task.exception()` unconditionally, which raises `asyncio.CancelledError` for cancelled tasks. Home Assistant then logged this as an unhandled ERROR.

This change makes the done callback check `task.cancelled()` first and return silently for cancelled tasks, while still logging real exceptions.

Fixes #736

## What changed and why

- `custom_components/hsem/custom_sensors/working_mode_sensor.py`
  - `_on_update_task_done()` now returns early when the task was cancelled.
  - Updated docstring to explain why cancellation is expected.
- `tests/test_working_mode_task_lifecycle.py`
  - Added regression test `test_done_callback_ignores_cancelled_task` that cancels a task registered with the done callback and asserts no "Unhandled exception" log entry and no propagated exception.

## Test and lint results

- `./scripts/quality.sh lint` ✅
- `./scripts/quality.sh typing` ✅
- `./scripts/quality.sh quality` ✅
- `./scripts/quality.sh test` ✅ (2439 passed)

## Documentation

No user-facing documentation changes required. This is an internal task-lifecycle bug fix.
