### PR TITLE
perf(devcontainer): improve macOS filesystem performance

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -46,6 +46,15 @@ To uninstall the relay:
    sh .devcontainer/scripts/install-agent-relay.sh uninstall
    ```
 
+**macOS filesystem performance**
+
+Docker Desktop on macOS runs containers inside a Linux VM, so the default bind-mounted workspace is slower than the native container filesystem. This devcontainer mitigates that by:
+
+- Mounting the workspace with `consistency=cached` to reduce cross-VM sync overhead.
+- Storing Python tool caches (`__pycache__`, `.mypy_cache`, `.pytest_cache`, `.ruff_cache`, `uv`) in a named Docker volume (`hsem-cache`) instead of inside the bind-mounted workspace.
+
+These changes are automatic after rebuilding the container. You may see an empty `.cache` folder on your Mac; this is expected and harmless — the actual cache data lives inside the Docker volume.
+
 **Linux note**: On a native Linux Docker host, you can add `--privileged` and USB
 device mounts via `runArgs` in `devcontainer.json` for direct hardware access.
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,13 +14,21 @@
   "runArgs": ["--name", "hsem-devcontainer"],
   "remoteUser": "root",
   "forwardPorts": [8123],
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/hsem,type=bind,consistency=cached",
+  "workspaceFolder": "/workspaces/hsem",
   "mounts": [
     "type=bind,source=${localEnv:HOME}/.ssh,target=/root/.ssh,readonly",
     "type=bind,source=${localEnv:HOME}/.gnupg,target=/root/.gnupg",
-    "type=bind,source=${localEnv:HOME}/.gitconfig,target=/root/.gitconfig"
+    "type=bind,source=${localEnv:HOME}/.gitconfig,target=/root/.gitconfig",
+    "source=hsem-cache,target=/workspaces/hsem/.cache,type=volume"
   ],
   "containerEnv": {
     "WORKSPACE_DIR": "/workspaces/hsem",
+    "PYTHONPYCACHEPREFIX": "/workspaces/hsem/.cache/pycache",
+    "MYPY_CACHE_DIR": "/workspaces/hsem/.cache/mypy",
+    "PYTEST_CACHE_DIR": "/workspaces/hsem/.cache/pytest",
+    "RUFF_CACHE_DIR": "/workspaces/hsem/.cache/ruff",
+    "UV_CACHE_DIR": "/workspaces/hsem/.cache/uv",
     "SSH_AUTH_SOCK": "/tmp/ssh-agent.sock",
     "SSH_AGENT_PORT": "9999",
     "GPG_AGENT_PORT": "9998",

--- a/.devcontainer/scripts/devcontainer-agent-bridge.sh
+++ b/.devcontainer/scripts/devcontainer-agent-bridge.sh
@@ -49,10 +49,13 @@ echo "SSH agent bridge ready:  /tmp/ssh-agent.sock -> ${AGENT_HOST}:${SSH_PORT}"
 echo "GPG agent bridge ready:   /tmp/S.gpg-agent -> ${AGENT_HOST}:${GPG_PORT}"
 echo "scdaemon bridge ready:    /tmp/S.scdaemon -> ${AGENT_HOST}:${SCDAEMON_PORT}"
 
-# Copy host gnupg data to container-local writable directory, then
-# replace the sockets with our relayed ones
+# Copy host gnupg data to a container-local writable directory, then
+# replace the sockets with our relayed ones.
+# Skip host agent sockets here: they cannot be reliably copied across
+# Docker Desktop bind mounts and are recreated as symlinks below.
 rm -rf /tmp/gpg-home
-cp -a /root/.gnupg /tmp/gpg-home
+mkdir -p /tmp/gpg-home
+find /root/.gnupg -mindepth 1 -maxdepth 1 ! -type s -exec cp -a {} /tmp/gpg-home/ \;
 rm -f /tmp/gpg-home/S.gpg-agent /tmp/gpg-home/S.scdaemon /tmp/gpg-home/S.gpg-agent.ssh
 ln -sf /tmp/S.gpg-agent /tmp/gpg-home/S.gpg-agent
 ln -sf /tmp/S.scdaemon /tmp/gpg-home/S.scdaemon

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__
 */dist/*
 .mypy_cache
 .ruff_cache
+.cache
 
 # misc
 .coverage


### PR DESCRIPTION
Improves devcontainer disk performance on macOS by following the VS Code "Improve disk performance" guidance for targeted named volumes.

Changes:
- Mount the workspace bind mount with `consistency=cached`.
- Add a named Docker volume (`hsem-cache`) for `.cache`.
- Redirect write-heavy Python tool caches into the named volume via container env vars:
  - `PYTHONPYCACHEPREFIX`
  - `MYPY_CACHE_DIR`
  - `PYTEST_CACHE_DIR`
  - `RUFF_CACHE_DIR`
  - `UV_CACHE_DIR`
- Update `.gitignore` to ignore the local `.cache` mount point.
- Document the macOS performance setup in `.devcontainer/README.md`.

This keeps source code on the host-synced bind mount while moving high-churn cache directories into the native container filesystem.