### PR TITLE
perf(entity, coordinator): instant switch toggles with debounced planner off event loop

### DIFF
--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -30,6 +30,7 @@ it from the config entry and passes it to the relevant entity constructors.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
@@ -112,6 +113,12 @@ from custom_components.hsem.utils.weekday_profile import weekday_profile
 
 if TYPE_CHECKING:
     from custom_components.hsem.ml.consumption_predictor import ConsumptionPredictor
+
+
+# Seconds to wait after the last options change before scheduling a planner
+# run.  Rapid switch/number/time toggles restart this timer, so the planner
+# only rebuilds once after the user stops clicking.
+OPTIONS_UPDATE_DEBOUNCE_SECONDS = 0.25
 
 
 # ---------------------------------------------------------------------------
@@ -481,6 +488,9 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         # can cancel a still-running task (issue: switch toggles felt frozen
         # because the update listener awaited the full MILP/ML pipeline).
         self._options_update_task: asyncio.Task | None = None
+        # Debounce task for option changes.  Rapid toggles restart this timer
+        # so the planner only runs once after the user stops clicking.
+        self._options_update_debounce_task: asyncio.Task | None = None
 
     # ------------------------------------------------------------------
     # HA lifecycle
@@ -560,14 +570,18 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
             await ocpp.stop()
             self._ocpp_server = None
 
-        # Cancel any pending options-update background task.
+        # Cancel any pending options-update background task and debounce timer.
         task = getattr(self, "_options_update_task", None)
         if task is not None and not task.done():
             task.cancel()
             self._options_update_task = None
+        debounce_task = getattr(self, "_options_update_debounce_task", None)
+        if debounce_task is not None and not debounce_task.done():
+            debounce_task.cancel()
+            self._options_update_debounce_task = None
 
     async def async_options_updated(self) -> None:
-        """Schedule a pipeline re-run after an options change.
+        """Schedule a debounced pipeline re-run after an options change.
 
         Runs the update cycle as a **background task** so the caller (the
         config-entry update listener, triggered synchronously by
@@ -576,20 +590,51 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
         service call until the entire read → plan (MILP/ML) → apply
         pipeline finished — making the UI feel frozen.
 
-        Repeated toggles cancel any still-pending run and reschedule, so
-        the pipeline always reflects the latest option state.  The
-        ``_update_lock`` in ``_async_handle_update`` additionally dedupes
-        against any concurrently running scheduled cycle.
+        A short debounce window is used so rapid switch/number/time toggles
+        only trigger a single planner run after the user stops clicking.
+        The background task is created with ``eager_start=False`` so the
+        switch service call returns before any setup work begins.
         """
+        if (
+            self._options_update_debounce_task is not None
+            and not self._options_update_debounce_task.done()
+        ):
+            self._options_update_debounce_task.cancel()
+        self._options_update_debounce_task = self.hass.async_create_task(
+            self._async_options_update_debounced(),
+            name="hsem_options_update_debounce",
+            eager_start=False,
+        )
+
+    async def _async_options_update_debounced(self) -> None:
+        """Wait for the debounce window, then schedule the planner run."""
+        try:
+            await asyncio.sleep(OPTIONS_UPDATE_DEBOUNCE_SECONDS)
+        except asyncio.CancelledError:
+            # Superseded by a newer options update — not an error.
+            async_log(
+                "debug",
+                "[coordinator] options-update debounce cancelled — "
+                "superseded by a newer options change.",
+            )
+            return
+
+        # Cancel any still-pending previous options-update task before
+        # scheduling a fresh run with the latest option state.
         if (
             self._options_update_task is not None
             and not self._options_update_task.done()
         ):
             self._options_update_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._options_update_task
+
         self._options_update_task = self.hass.async_create_task(
             self._async_options_update_background(),
             name="hsem_options_update",
+            eager_start=False,
         )
+        self._options_update_debounce_task = None
 
     async def _async_options_update_background(self) -> None:
         """Background wrapper: run the update cycle, swallowing cancellation."""
@@ -1011,7 +1056,12 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                     # standard Home Assistant log when the user enables
                     # verbose logging.
                     set_hsem_verbose(cfg.verbose_logging)
-                    planner_output = run_planner(planner_input)
+                    # Run the planner in HA's executor pool.  The MILP/ML
+                    # solver is CPU-bound; running it in the event-loop
+                    # thread blocks the HA UI for the full solve duration.
+                    planner_output = await self.hass.async_add_executor_job(
+                        run_planner, planner_input
+                    )
                     self._last_planner_output = planner_output
 
                     # Record the time this plan was created so the slot-boundary

--- a/custom_components/hsem/custom_switches/switch.py
+++ b/custom_components/hsem/custom_switches/switch.py
@@ -98,15 +98,19 @@ class HSEMSwitch(HSEMEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on and persist to config entry."""
         self._attr_is_on = True
-        await self._persist_state()
+        # Write HA state immediately so the UI toggle reflects the user action
+        # before the config-entry update triggers a background planner run.
         self.async_write_ha_state()
+        await self._persist_state()
 
     @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off and persist to config entry."""
         self._attr_is_on = False
-        await self._persist_state()
+        # Write HA state immediately so the UI toggle reflects the user action
+        # before the config-entry update triggers a background planner run.
         self.async_write_ha_state()
+        await self._persist_state()
 
     async def _persist_state(self) -> None:
         """Write the current on/off value to the config entry options."""

--- a/custom_components/hsem/custom_times/time.py
+++ b/custom_components/hsem/custom_times/time.py
@@ -147,8 +147,10 @@ class HSEMTimeEntity(HSEMEntity, TimeEntity):
             The new time selected by the user.
         """
         self._attr_native_value = value
-        await self._persist_value()
+        # Write HA state immediately so the UI reflects the new time before
+        # the config-entry update triggers a background planner run.
         self.async_write_ha_state()
+        await self._persist_value()
 
     # ------------------------------------------------------------------
     # Config-entry persistence

--- a/custom_components/hsem/ml/populator.py
+++ b/custom_components/hsem/ml/populator.py
@@ -199,8 +199,12 @@ async def populate_ml_house_consumption(
                 _last_temp_fetch = now_ts
 
     # Train — retrain gate skips fitting when no new data has arrived.
+    # The fit is CPU-bound (numpy ridge solve), so run it in HA's executor
+    # pool to avoid blocking the event loop.
     was_fitted_before = predictor.trained
-    predictor.train(history, reference_time, temperatures)
+    await hass.async_add_executor_job(
+        predictor.train, history, reference_time, temperatures
+    )
 
     if predictor.trained and not was_fitted_before:
         HSEM_LOGGER.info(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -31,7 +31,7 @@ import asyncio
 import contextlib
 import inspect
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -70,6 +70,7 @@ def _make_bare_coordinator() -> HSEMDataUpdateCoordinator:
     cfg.recommendation_interval_length = 24
     coord._cfg = cfg
     coord._options_update_task = None
+    coord._options_update_debounce_task = None
     return coord
 
 
@@ -246,9 +247,13 @@ class TestOptionsUpdateBackgroundTask:
     schedules the cycle via ``hass.async_create_task`` with
     cancel-and-reschedule semantics so repeated toggles collapse into one
     run and the listener returns immediately.
+
+    A short debounce window is used so rapid toggles only trigger a single
+    planner run after the user stops clicking.
     """
 
     @pytest.mark.asyncio
+    @patch("custom_components.hsem.coordinator.OPTIONS_UPDATE_DEBOUNCE_SECONDS", 0.0)
     async def test_options_updated_schedules_background_task(self) -> None:
         """async_options_updated returns immediately after scheduling a task."""
         coordinator = _make_bare_coordinator()
@@ -256,7 +261,7 @@ class TestOptionsUpdateBackgroundTask:
 
         scheduled: list[asyncio.Task] = []
 
-        def _create_task(coro: Any, *, name: str) -> asyncio.Task:
+        def _create_task(coro: Any, *, name: str, **kwargs: Any) -> asyncio.Task:
             task = asyncio.get_running_loop().create_task(coro, name=name)
             scheduled.append(task)
             return task
@@ -271,23 +276,30 @@ class TestOptionsUpdateBackgroundTask:
 
         await coordinator.async_options_updated()
 
-        # The method must have scheduled exactly one background task.
+        # The method must have scheduled exactly one debounce task with
+        # eager-start disabled so the switch service call returns immediately.
         coordinator.hass.async_create_task.assert_called_once()  # type: ignore[union-attr]  # mock assertion
+        call_kwargs = coordinator.hass.async_create_task.call_args[1]  # type: ignore[attr-defined]
+        assert call_kwargs.get("eager_start") is False
         assert len(scheduled) == 1
-        assert scheduled[0].get_name() == "hsem_options_update"
+        assert scheduled[0].get_name() == "hsem_options_update_debounce"
 
-        # Let the background task finish.
+        # Let the debounce task finish; it then schedules the background task.
         await scheduled[0]
+        assert len(scheduled) == 2
+        assert scheduled[1].get_name() == "hsem_options_update"
+        await scheduled[1]
 
     @pytest.mark.asyncio
+    @patch("custom_components.hsem.coordinator.OPTIONS_UPDATE_DEBOUNCE_SECONDS", 0.0)
     async def test_repeated_toggle_cancels_pending_task(self) -> None:
-        """A second options update cancels the still-pending first task."""
+        """Repeated options updates collapse into a single background run."""
         coordinator = _make_bare_coordinator()
         coordinator.hass = MagicMock()
 
         scheduled: list[asyncio.Task] = []
 
-        def _create_task(coro: Any, *, name: str) -> asyncio.Task:
+        def _create_task(coro: Any, *, name: str, **kwargs: Any) -> asyncio.Task:
             task = asyncio.get_running_loop().create_task(coro, name=name)
             scheduled.append(task)
             return task
@@ -305,20 +317,29 @@ class TestOptionsUpdateBackgroundTask:
 
         await coordinator.async_options_updated()
         assert len(scheduled) == 1
-        await started.wait()  # ensure the first task is actually running
+        debounce_task = scheduled[0]
+        assert debounce_task.get_name() == "hsem_options_update_debounce"
 
-        await coordinator.async_options_updated()
+        # Let the debounce task fire and start the background update cycle.
+        await started.wait()
         assert len(scheduled) == 2
-        assert scheduled[0].cancelled() or scheduled[0].cancelling()
+        background_task = scheduled[1]
+        assert background_task.get_name() == "hsem_options_update"
 
-        # Clean up: let the second task be cancelled too so we don't leak.
-        scheduled[1].cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await scheduled[1]
+        # A second toggle cancels the previous debounce/background tasks and
+        # schedules a fresh debounce task.
+        await coordinator.async_options_updated()
+        assert len(scheduled) == 3
+        assert scheduled[2].get_name() == "hsem_options_update_debounce"
+
+        # Let the new debounce task fire so it cancels the old background task.
+        await scheduled[2]
+        assert background_task.cancelled() or background_task.cancelling()
 
     @pytest.mark.asyncio
+    @patch("custom_components.hsem.coordinator.OPTIONS_UPDATE_DEBOUNCE_SECONDS", 0.0)
     async def test_teardown_cancels_pending_options_task(self) -> None:
-        """async_teardown must cancel a still-running options-update task."""
+        """async_teardown must cancel pending debounce and options-update tasks."""
         coordinator = _make_bare_coordinator()
         coordinator.hass = MagicMock()
 
@@ -327,14 +348,21 @@ class TestOptionsUpdateBackgroundTask:
 
         coordinator._async_handle_update = _blocking_cycle  # type: ignore[method-assign]  # test monkey-patch
         coordinator.hass.async_create_task = MagicMock(  # type: ignore[method-assign]  # test monkey-patch
-            side_effect=lambda coro, *, name: asyncio.get_running_loop().create_task(
-                coro, name=name
+            side_effect=lambda coro, *, name, **kwargs: (
+                asyncio.get_running_loop().create_task(coro, name=name)
             )
         )
 
         await coordinator.async_options_updated()
+        debounce_task = coordinator._options_update_debounce_task
+        assert debounce_task is not None and not debounce_task.done()
+
+        # Wait for the debounce task to schedule the background task.
+        await debounce_task
         task = coordinator._options_update_task
         assert task is not None and not task.done()
+        # The debounce task is cleared once it has scheduled the background run.
+        assert coordinator._options_update_debounce_task is None
 
         await coordinator.async_teardown()
 

--- a/tests/test_entity_platform_classes.py
+++ b/tests/test_entity_platform_classes.py
@@ -237,11 +237,30 @@ class TestHSEMTimeEntitySetValue:
 
     @pytest.mark.asyncio
     async def test_set_value_calls_async_write_ha_state(self) -> None:
-        """async_write_ha_state is called after persisting to push the update to HA."""
+        """async_write_ha_state is called to push the update to HA."""
         entity = self._make_entity()
         entity.async_write_ha_state = MagicMock()  # type: ignore[method-assign,misc]  # test monkey-patch
         await entity.async_set_value(time(8, 0, 0))
         entity.async_write_ha_state.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_set_value_writes_state_before_persisting(self) -> None:
+        """UI feedback happens before the config-entry update triggers planning."""
+        entity = self._make_entity()
+        calls: list[str] = []
+
+        def _track_write_state() -> None:
+            calls.append("write_state")
+
+        def _track_update_entry(*args: object, **kwargs: object) -> None:
+            calls.append("update_entry")
+
+        entity.async_write_ha_state = _track_write_state  # type: ignore[method-assign,misc,assignment]  # test monkey-patch
+        entity.hass.config_entries.async_update_entry = _track_update_entry  # type: ignore[method-assign,misc,assignment]  # test monkey-patch
+
+        await entity.async_set_value(time(8, 0, 0))
+
+        assert calls == ["write_state", "update_entry"]
 
     @pytest.mark.asyncio
     async def test_set_value_multiple_times(self) -> None:

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,170 @@
+"""Tests for the HSEM switch entity.
+
+Verifies that toggling a switch updates the HA state instantly and then
+persists the new value to the config entry.  This ordering matters because
+the config-entry update triggers a background planner run, and the UI must
+not wait for that run to complete before reflecting the toggle.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.hsem.custom_switches.description import (
+    HSEMSwitchEntityDescription,
+)
+from custom_components.hsem.custom_switches.switch import HSEMSwitch
+from custom_components.hsem.utils.sensornames.controls import (
+    get_read_only_switch_key,
+)
+
+
+def _mock_config_entry(**option_overrides: object) -> MagicMock:
+    """Return a minimal mock ConfigEntry."""
+    entry = MagicMock()
+    entry.entry_id = "test_entry_id"
+    entry.options = {
+        get_read_only_switch_key(): False,
+        **option_overrides,
+    }
+    return entry
+
+
+def _mock_hass() -> MagicMock:
+    """Return a minimal Home Assistant mock."""
+    hass = MagicMock()
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+    return hass
+
+
+def _make_switch(
+    key: str = get_read_only_switch_key(),
+    default: bool = False,
+) -> HSEMSwitch:
+    """Build an HSEMSwitch with mocked hass/config entry."""
+    hass = _mock_hass()
+    config_entry = _mock_config_entry(**{key: default})
+    description = HSEMSwitchEntityDescription(
+        key=key,
+        name="Read Only",
+        description="Disable automatic working-mode changes.",
+    )
+    return HSEMSwitch(hass, config_entry, description)
+
+
+class TestHSEMSwitchTurnOn:
+    """Tests for async_turn_on."""
+
+    @pytest.mark.asyncio
+    async def test_turn_on_sets_is_on(self) -> None:
+        """Turning on must set _attr_is_on to True."""
+        switch = _make_switch(default=False)
+        switch.async_write_ha_state = MagicMock()  # type: ignore[method-assign,misc]
+        await switch.async_turn_on()
+        assert switch.is_on is True
+
+    @pytest.mark.asyncio
+    async def test_turn_on_writes_state(self) -> None:
+        """async_write_ha_state must be called so HA reflects the toggle."""
+        switch = _make_switch(default=False)
+        switch.async_write_ha_state = MagicMock()  # type: ignore[method-assign,misc]
+        await switch.async_turn_on()
+        switch.async_write_ha_state.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_turn_on_persists_to_config_entry(self) -> None:
+        """The new on value must be written to the config entry options."""
+        switch = _make_switch(default=False)
+        switch.async_write_ha_state = MagicMock()  # type: ignore[method-assign,misc]
+        await switch.async_turn_on()
+        switch.hass.config_entries.async_update_entry.assert_called_once()  # type: ignore[attr-defined]
+        call_kwargs = switch.hass.config_entries.async_update_entry.call_args[1]  # type: ignore[attr-defined]
+        assert call_kwargs["options"][get_read_only_switch_key()] is True
+
+    @pytest.mark.asyncio
+    async def test_turn_on_writes_state_before_persisting(self) -> None:
+        """UI feedback must happen before the config-entry update is triggered."""
+        switch = _make_switch(default=False)
+        calls: list[str] = []
+
+        def _track_write_state() -> None:
+            calls.append("write_state")
+
+        def _track_update_entry(*args: Any, **kwargs: Any) -> None:
+            calls.append("update_entry")
+
+        switch.async_write_ha_state = _track_write_state  # type: ignore[method-assign,misc,assignment]
+        switch.hass.config_entries.async_update_entry = _track_update_entry  # type: ignore[method-assign,misc,assignment]
+
+        await switch.async_turn_on()
+
+        assert calls == ["write_state", "update_entry"]
+
+
+class TestHSEMSwitchTurnOff:
+    """Tests for async_turn_off."""
+
+    @pytest.mark.asyncio
+    async def test_turn_off_sets_is_on(self) -> None:
+        """Turning off must set _attr_is_on to False."""
+        switch = _make_switch(default=True)
+        switch.async_write_ha_state = MagicMock()  # type: ignore[method-assign,misc]
+        await switch.async_turn_off()
+        assert switch.is_on is False
+
+    @pytest.mark.asyncio
+    async def test_turn_off_writes_state(self) -> None:
+        """async_write_ha_state must be called so HA reflects the toggle."""
+        switch = _make_switch(default=True)
+        switch.async_write_ha_state = MagicMock()  # type: ignore[method-assign,misc]
+        await switch.async_turn_off()
+        switch.async_write_ha_state.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_turn_off_persists_to_config_entry(self) -> None:
+        """The new off value must be written to the config entry options."""
+        switch = _make_switch(default=True)
+        switch.async_write_ha_state = MagicMock()  # type: ignore[method-assign,misc]
+        await switch.async_turn_off()
+        switch.hass.config_entries.async_update_entry.assert_called_once()  # type: ignore[attr-defined]
+        call_kwargs = switch.hass.config_entries.async_update_entry.call_args[1]  # type: ignore[attr-defined]
+        assert call_kwargs["options"][get_read_only_switch_key()] is False
+
+    @pytest.mark.asyncio
+    async def test_turn_off_writes_state_before_persisting(self) -> None:
+        """UI feedback must happen before the config-entry update is triggered."""
+        switch = _make_switch(default=True)
+        calls: list[str] = []
+
+        def _track_write_state() -> None:
+            calls.append("write_state")
+
+        def _track_update_entry(*args: Any, **kwargs: Any) -> None:
+            calls.append("update_entry")
+
+        switch.async_write_ha_state = _track_write_state  # type: ignore[method-assign,misc,assignment]
+        switch.hass.config_entries.async_update_entry = _track_update_entry  # type: ignore[method-assign,misc,assignment]
+
+        await switch.async_turn_off()
+
+        assert calls == ["write_state", "update_entry"]
+
+
+class TestHSEMSwitchConfigUpdateListener:
+    """Tests for the config-entry update listener on the switch."""
+
+    @pytest.mark.asyncio
+    async def test_config_update_listener_updates_state(self) -> None:
+        """When the config entry changes externally, the switch state updates."""
+        switch = _make_switch(default=False)
+        switch.async_write_ha_state = MagicMock()  # type: ignore[method-assign,misc]
+
+        updated_entry = _mock_config_entry(**{get_read_only_switch_key(): True})
+        await switch._async_handle_config_update(switch.hass, updated_entry)
+
+        assert switch.is_on is True
+        switch.async_write_ha_state.assert_called_once()


### PR DESCRIPTION
## Summary

Follow-up to #735. PR #735 moved the options-update planner pipeline to a background task, but the background task was still scheduled with HA's default **eager start**. In recent HA versions that means the CPU-bound MILP/ML planner runs synchronously inside the switch service call, so the whole HA UI freezes until the planner finishes.

This PR fixes that by:
1. Writing the switch/time HA state **before** updating the config entry, so the UI sees the toggle instantly.
2. Adding a short **debounce** (250 ms) so rapid switch/number/time toggles only trigger one planner run after the user stops clicking.
3. Scheduling both the debounce and the planner background tasks with `eager_start=False` so the switch service call returns before any setup work begins.
4. Running `run_planner` in HA's **executor pool** so the MILP/ML solve does not block the event loop.
5. Running ML consumption-model training in the executor pool for the same reason.

## Branch

`perf/switch-async-state-write`

## Files changed

- `custom_components/hsem/custom_switches/switch.py`
- `custom_components/hsem/custom_times/time.py`
- `custom_components/hsem/coordinator.py`
- `custom_components/hsem/ml/populator.py`
- `tests/test_switch.py` (new)
- `tests/test_entity_platform_classes.py`
- `tests/test_coordinator.py`

## What changed and why

### Instant UI feedback

`HSEMSwitch.async_turn_on`/`async_turn_off` and `HSEMTimeEntity.async_set_value` now call `self.async_write_ha_state()` **before** persisting to the config entry. The config-entry update still triggers the coordinator's planner run, but the user sees the toggle/time change immediately.

### Debounced planner rebuilds

`HSEMDataUpdateCoordinator.async_options_updated()` now schedules a 250 ms debounce task. Repeated toggles restart the timer, so the planner only rebuilds once after the user stops clicking. When the debounce fires, any still-pending previous options-update task is cancelled and a fresh background run is scheduled.

### Off-event-loop execution

Both the debounce task and the background planner task are created with `eager_start=False`, preventing HA from running any coordinator setup work synchronously inside the switch service call.

Inside `_async_run_update_cycle`, the planner is executed with:

```python
planner_output = await self.hass.async_add_executor_job(run_planner, planner_input)
```

ML training is executed with:

```python
await hass.async_add_executor_job(predictor.train, history, reference_time, temperatures)
```

Both keep the HA event loop responsive while the heavy compute runs in HA's executor pool.

## Tests added or updated

- Added `tests/test_switch.py` covering turn-on/turn-off state, persistence, and the `async_write_ha_state` → `async_update_entry` ordering.
- Updated `tests/test_entity_platform_classes.py` to verify the same ordering for time entities.
- Updated `tests/test_coordinator.py` to test the debounce behavior (debounce task scheduling, repeated-toggle collapse, teardown cleanup, `eager_start=False`).

## Test and lint results

- `./scripts/quality.sh lint` ✅
- `./scripts/quality.sh typing` ✅
- `./scripts/quality.sh test` ✅ — 2449 passed
- `python -m vulture ...` ✅
- `python -m pyright` on changed files ✅

The full-repo `python -m pyright` run exits with code 247 in this environment (OOM/memory limit), but pyright passes on the changed files.

## Related

- Follow-up to #735