### PR TITLE
fix(sensor): allow self-consumption during wait mode while protecting planner reserve

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -879,3 +879,30 @@ Do **not** create files like `planner_inputs.py` (6 unrelated dataclasses) or
 **Why**: Smaller, focused files give AI agents exactly the context they need.
 Thematic bucketing loads irrelevant code into every prompt, reducing precision
 and causing edit collisions between unrelated classes.
+
+---
+
+## Wait Mode Self-Consumption with Reserve (issue #742)
+
+`batteries_wait_mode` can now optionally allow normal household self-consumption
+instead of keeping the battery strictly idle.
+
+- Config key: `hsem_batteries_wait_mode_behavior`
+- Values: `"strict"` (default) or `"self_consumption_with_reserve"`
+- When set to `"self_consumption_with_reserve"`, the applier
+  (`custom_components/hsem/custom_sensors/applier.py`) switches the inverter to
+  `MaximizeSelfConsumption` and caps the discharge power so only surplus energy
+  above the planner's required reserve (`current_required_battery_kwh`) can be
+  used.  Once the battery reaches the reserve, the applier falls back to strict
+  TOU wait mode.
+- PV surplus during wait-mode self-consumption is directed to charge the battery
+  (`desired_excess = "charge"`), not exported to grid.
+- The cap is computed from the surplus energy and the slot duration so the
+  reserve is preserved even if the house load is high.
+- EV-active slots keep their existing EV discharge cap logic; the wait-mode cap
+  is not applied while an EV is charging.
+
+Files involved: `flows/batteries_wait_mode.py`, `config_flow.py`,
+`options_flow.py`, `translations/en.json`, `const.py`,
+`models/sensor_config.py`, `custom_sensors/config_reader.py`,
+`custom_sensors/applier.py`.

--- a/custom_components/hsem/config_flow.py
+++ b/custom_components/hsem/config_flow.py
@@ -20,6 +20,10 @@ from custom_components.hsem.flows.batteries_schedules import (
     get_batteries_schedules_step_schema,
     validate_batteries_schedules_input,
 )
+from custom_components.hsem.flows.batteries_wait_mode import (
+    get_batteries_wait_mode_step_schema,
+    validate_batteries_wait_mode_input,
+)
 from custom_components.hsem.flows.battery_economics import (
     get_battery_economics_step_schema,
     validate_battery_economics_input,
@@ -113,6 +117,8 @@ _V2_NEW_KEY_DEFAULTS: dict[str, Any] = {
     # Excess export
     "hsem_batteries_enable_excess_export": False,
     "hsem_batteries_excess_export_discharge_buffer": 10,
+    # Wait mode behaviour
+    "hsem_batteries_wait_mode_behavior": "strict",
     # Energy price forecast sensors (optional — None = not configured)
     "hsem_import_electricity_price_forecast_sensor": None,
     "hsem_export_electricity_price_forecast_sensor": None,
@@ -637,7 +643,7 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
             errors = await validate_batteries_schedules_input(user_input)
             if not errors:
                 self._user_input.update(user_input)
-                return await self.async_step_batteries_excess_export()
+                return await self.async_step_batteries_wait_mode()
 
         data_schema = await get_batteries_schedules_step_schema(
             None, hass=self.hass, user_input=self._user_input
@@ -645,6 +651,33 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
 
         return self.async_show_form(
             step_id="batteries_schedules",
+            data_schema=data_schema,
+            errors=errors,
+            last_step=False,
+        )
+
+    async def async_step_batteries_wait_mode(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the batteries_wait_mode config flow step.
+
+        Allows the user to choose between strict wait and self-consumption
+        with reserve protection.
+        """
+        errors = {}
+
+        if user_input is not None:
+            errors = await validate_batteries_wait_mode_input(user_input)
+            if not errors:
+                self._user_input.update(user_input)
+                return await self.async_step_batteries_excess_export()
+
+        data_schema = await get_batteries_wait_mode_step_schema(
+            None, self._user_input, _hass=self.hass
+        )
+
+        return self.async_show_form(
+            step_id="batteries_wait_mode",
             data_schema=data_schema,
             errors=errors,
             last_step=False,

--- a/custom_components/hsem/const.py
+++ b/custom_components/hsem/const.py
@@ -23,6 +23,9 @@ DEFAULT_CONFIG_VALUES = {
     "hsem_batteries_discharge_efficiency": 98,
     "hsem_batteries_enable_excess_export": False,
     "hsem_batteries_excess_export_discharge_buffer": 10,
+    # Wait mode behaviour: "strict" keeps the battery idle, "self_consumption_with_reserve"
+    # allows normal household self-consumption while protecting the planner reserve.
+    "hsem_batteries_wait_mode_behavior": "strict",
     "hsem_batteries_purchase_price": 0.0,
     "hsem_batteries_expected_cycles": 6000,
     "hsem_batteries_cycle_cost": 0.0,

--- a/custom_components/hsem/custom_sensors/applier.py
+++ b/custom_components/hsem/custom_sensors/applier.py
@@ -78,7 +78,42 @@ def _fmt_live_power_w(power_w: float | None) -> str:
     """Format a live power reading for log lines (``None`` → ``n/a``)."""
     if power_w is None:
         return "n/a"
-    return f"{int(power_w)}W"
+    return f"{int(power_w)} W"
+
+
+def _wait_mode_self_consumption_cap_w(
+    battery_capacity_kwh: float,
+    required_capacity_kwh: float,
+    slot_hours: float,
+    max_discharge_power_w: int,
+) -> int:
+    """Return the discharge power cap for wait-mode self-consumption.
+
+    When the battery holds more energy than the planner has reserved for future
+    expensive periods, the surplus may be used for normal household
+    self-consumption.  The cap is the power required to consume exactly that
+    surplus over the slot duration; the inverter will only draw what the house
+    actually needs, so the battery will not discharge faster than the surplus
+    allows.
+
+    Args:
+        battery_capacity_kwh: Current usable battery energy above the discharge
+            floor (kWh).
+        required_capacity_kwh: Energy the planner has reserved for future use
+            (kWh).
+        slot_hours: Duration of the current recommendation slot in hours.
+        max_discharge_power_w: Maximum discharge power supported by the battery
+            pack (W).
+
+    Returns:
+        Discharge power cap in watts.  ``0`` when there is no surplus above the
+        reserve or the slot duration is invalid.
+    """
+    surplus_kwh = max(battery_capacity_kwh - required_capacity_kwh, 0.0)
+    if surplus_kwh <= 1e-9 or slot_hours <= 1e-9:
+        return 0
+    cap_w = int(surplus_kwh / slot_hours * 1000.0)
+    return min(cap_w, max_discharge_power_w)
 
 
 def compute_ev_discharge_cap_w(
@@ -542,12 +577,82 @@ async def async_apply_battery_settings(
             return summary
 
         case Recommendations.BatteriesWaitMode.value:
-            tou_modes = DEFAULT_HSEM_BATTERIES_WAIT_MODE
-            working_mode = WorkingModes.TimeOfUse.value
+            # Strict wait keeps the battery idle in TOU mode.  Self-consumption
+            # with reserve switches to MaximizeSelfConsumption so the house can
+            # use surplus battery energy above the planner's required reserve.
+            if cfg.batteries_wait_mode_behavior == "self_consumption_with_reserve":
+                surplus = (
+                    live.battery_current_capacity_kwh - current_required_battery_kwh
+                )
+                if surplus > 1e-9:
+                    working_mode = WorkingModes.MaximizeSelfConsumption.value
+                else:
+                    tou_modes = DEFAULT_HSEM_BATTERIES_WAIT_MODE
+                    working_mode = WorkingModes.TimeOfUse.value
+            else:
+                tou_modes = DEFAULT_HSEM_BATTERIES_WAIT_MODE
+                working_mode = WorkingModes.TimeOfUse.value
 
         case _:
             # Unrecognised recommendation — nothing to apply.
             return summary
+
+    # Wait mode self-consumption: cap discharge power so only surplus energy
+    # above the planner's required reserve can be used.  This preserves the
+    # reserve for future scheduled discharge windows while still allowing the
+    # house to cover normal self-consumption from the surplus.
+    wait_mode_self_consumption = (
+        recommendation == Recommendations.BatteriesWaitMode.value
+        and cfg.batteries_wait_mode_behavior == "self_consumption_with_reserve"
+        and working_mode == WorkingModes.MaximizeSelfConsumption.value
+        and not ev_active
+    )
+    if wait_mode_self_consumption:
+        slot_hours = slot_duration_hours(rec.start, rec.end)
+        surplus = max(
+            live.battery_current_capacity_kwh - current_required_battery_kwh, 0.0
+        )
+        cap_w = _wait_mode_self_consumption_cap_w(
+            battery_capacity_kwh=live.battery_current_capacity_kwh,
+            required_capacity_kwh=current_required_battery_kwh,
+            slot_hours=slot_hours,
+            max_discharge_power_w=max_discharge_power,
+        )
+        if live.huawei_batteries_max_discharge_power_w != cap_w:
+            discharge_entity = cfg.huawei_solar_batteries_maximum_discharging_power
+            if discharge_entity is None:
+                _LOGGER.debug(
+                    "Wait mode self-consumption discharge power entity not configured; "
+                    "skipping write.",
+                    "warning",
+                )
+                return summary
+            _de_wait: str = discharge_entity  # narrowed for closure
+            wait_cap_result = await async_write_and_verify(
+                entity_id=_de_wait,
+                desired=cap_w,
+                writer=lambda: async_set_number_value(sensor, _de_wait, cap_w),
+                reader=lambda: _read_number_state(sensor, _de_wait),
+            )
+            summary.results.append(wait_cap_result)
+            _LOGGER.debug(
+                "Wait mode self-consumption — capped max discharge power to %d W "
+                "(capacity=%.2f kWh, required=%.2f kWh, surplus=%.2f kWh, "
+                "slot_hours=%.3f)",
+                cap_w,
+                live.battery_current_capacity_kwh,
+                current_required_battery_kwh,
+                surplus,
+                slot_hours,
+            )
+            if wait_cap_result.status == ApplyStatus.FAILED:
+                _LOGGER.debug(
+                    "Wait mode self-consumption discharge cap write FAILED for %s. "
+                    "Blocking further battery writes this cycle.",
+                    discharge_entity,
+                    "error",
+                )
+                return summary
 
     # Override discharge power when EV uses V2H
     if recommendation == Recommendations.EVSmartCharging.value and (
@@ -581,17 +686,23 @@ async def async_apply_battery_settings(
                 )
                 return summary
 
-    # Excess PV use in TOU — fed_to_grid for wait/fully-fed modes, charge otherwise.
+    # Excess PV use in TOU — fed_to_grid for strict wait/fully-fed modes, charge
+    # otherwise.  Wait-mode self-consumption keeps excess PV in the battery so
+    # the surplus above the reserve can be used for household self-consumption.
     # ForceExport maps to WorkingModes.FullyFedToGrid at the hardware level so we
     # check both BatteriesWaitMode and ForceExport recommendations here.
     desired_excess = (
-        "fed_to_grid"
-        if recommendation
-        in (
-            Recommendations.BatteriesWaitMode.value,
-            Recommendations.ForceExport.value,
+        "charge"
+        if wait_mode_self_consumption
+        else (
+            "fed_to_grid"
+            if recommendation
+            in (
+                Recommendations.BatteriesWaitMode.value,
+                Recommendations.ForceExport.value,
+            )
+            else "charge"
         )
-        else "charge"
     )
     if live.huawei_batteries_excess_pv_use_in_tou != desired_excess:
         excess_entity = cfg.huawei_solar_batteries_excess_pv_energy_use_in_tou

--- a/custom_components/hsem/custom_sensors/config_reader.py
+++ b/custom_components/hsem/custom_sensors/config_reader.py
@@ -378,6 +378,16 @@ def build_sensor_config(
         or 10.0
     )
 
+    # Wait mode behaviour
+    _wait_mode_behavior = get_config_value(
+        config_entry, "hsem_batteries_wait_mode_behavior"
+    )
+    cfg.batteries_wait_mode_behavior = (
+        str(_wait_mode_behavior).lower()
+        if _wait_mode_behavior is not None
+        else "strict"
+    )
+
     # EV planned load integration
     cfg.ev_planned_load_enabled = convert_to_boolean(
         get_config_value(config_entry, "hsem_ev_planned_load_enabled")

--- a/custom_components/hsem/flows/batteries_wait_mode.py
+++ b/custom_components/hsem/flows/batteries_wait_mode.py
@@ -1,0 +1,76 @@
+"""Config flow step for battery wait-mode behaviour.
+
+Allows the user to choose whether ``batteries_wait_mode`` keeps the battery
+strictly idle or allows normal household self-consumption while protecting
+the planner's required battery reserve.
+"""
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.selector import selector
+
+from custom_components.hsem.utils.misc import get_config_value
+
+WAIT_MODE_BEHAVIOR_OPTIONS = [
+    {"label": "Strict wait", "value": "strict"},
+    {
+        "label": "Self-consumption with reserve",
+        "value": "self_consumption_with_reserve",
+    },
+]
+
+
+async def get_batteries_wait_mode_step_schema(  # NOSONAR
+    config_entry: ConfigEntry | None,
+    _user_input: dict | None = None,
+    _hass: Any | None = None,
+) -> vol.Schema:
+    """Return the data schema for the 'batteries_wait_mode' step.
+
+    Args:
+        config_entry: Existing config entry (used during options flow editing)
+            or ``None`` for the initial config flow.
+        _user_input: Accumulated user input dict from previous config flow steps
+            (ignored — kept for call-site compatibility).
+        _hass: Home Assistant instance (ignored — kept for call-site compatibility).
+
+    Returns:
+        A ``vol.Schema`` with a single select input for wait-mode behaviour.
+    """
+    return vol.Schema(
+        {
+            vol.Required(
+                "hsem_batteries_wait_mode_behavior",
+                default=get_config_value(
+                    config_entry, "hsem_batteries_wait_mode_behavior"
+                ),
+            ): selector(
+                {
+                    "select": {
+                        "options": WAIT_MODE_BEHAVIOR_OPTIONS,
+                        "mode": "list",
+                        "translation_key": "batteries_wait_mode_behavior",
+                    }
+                }
+            ),
+        }
+    )
+
+
+async def validate_batteries_wait_mode_input(user_input: dict) -> dict[str, str]:
+    """Validate user input for the 'batteries_wait_mode' step.
+
+    Args:
+        user_input: Dict of field name → value submitted by the user.
+
+    Returns:
+        Dict mapping field names to translation error keys; empty on success.
+    """
+    errors: dict[str, str] = {}
+    value = user_input.get("hsem_batteries_wait_mode_behavior")
+    if value not in ("strict", "self_consumption_with_reserve"):
+        errors["hsem_batteries_wait_mode_behavior"] = "invalid_wait_mode_behavior"
+    return errors

--- a/custom_components/hsem/models/sensor_config.py
+++ b/custom_components/hsem/models/sensor_config.py
@@ -122,6 +122,10 @@ class SensorConfig:
 
         batteries_enable_excess_export: Enable opportunistic forced-discharge export.
         batteries_excess_export_discharge_buffer: Safety buffer percentage to keep.
+        batteries_wait_mode_behavior: How ``batteries_wait_mode`` is interpreted.
+            ``strict`` keeps the battery idle; ``self_consumption_with_reserve``
+            allows normal household self-consumption while protecting the
+            planner's required battery reserve.
 
         months_winter: List of month integers (1-12) treated as winter.
         months_summer: List of month integers (1-12) treated as summer.
@@ -228,6 +232,9 @@ class SensorConfig:
     # Excess export
     batteries_enable_excess_export: bool = False
     batteries_excess_export_discharge_buffer: float = 10.0
+
+    # Wait mode behaviour
+    batteries_wait_mode_behavior: str = "strict"
 
     # EV planned load integration — primary EV (optional, disabled by default)
     ev_planned_load_enabled: bool = False

--- a/custom_components/hsem/options_flow.py
+++ b/custom_components/hsem/options_flow.py
@@ -14,6 +14,10 @@ from custom_components.hsem.flows.batteries_schedules import (
     get_batteries_schedules_step_schema,
     validate_batteries_schedules_input,
 )
+from custom_components.hsem.flows.batteries_wait_mode import (
+    get_batteries_wait_mode_step_schema,
+    validate_batteries_wait_mode_input,
+)
 from custom_components.hsem.flows.battery_economics import (
     get_battery_economics_step_schema,
     validate_battery_economics_input,
@@ -402,7 +406,7 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
             errors = await validate_batteries_schedules_input(user_input)
             if not errors:
                 self._user_input.update(user_input)
-                return await self.async_step_batteries_excess_export()
+                return await self.async_step_batteries_wait_mode()
 
         data_schema = await get_batteries_schedules_step_schema(
             self._config_entry, hass=self.hass
@@ -410,6 +414,33 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
 
         return self.async_show_form(
             step_id="batteries_schedules",
+            data_schema=data_schema,
+            errors=errors,
+            last_step=False,
+        )
+
+    async def async_step_batteries_wait_mode(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the batteries_wait_mode options step.
+
+        Allows the user to choose between strict wait and self-consumption
+        with reserve protection.
+        """
+        errors = {}
+
+        if user_input is not None:
+            errors = await validate_batteries_wait_mode_input(user_input)
+            if not errors:
+                self._user_input.update(user_input)
+                return await self.async_step_batteries_excess_export()
+
+        data_schema = await get_batteries_wait_mode_step_schema(
+            self._config_entry, self._user_input, _hass=self.hass
+        )
+
+        return self.async_show_form(
+            step_id="batteries_wait_mode",
             data_schema=data_schema,
             errors=errors,
             last_step=False,

--- a/custom_components/hsem/translations/da.json
+++ b/custom_components/hsem/translations/da.json
@@ -412,6 +412,16 @@
         "description": "Konfigurer energimålere og aktiver ML-baseret forbrugsprognose.",
         "title": "Energi og ML"
       },
+      "batteries_wait_mode": {
+        "data": {
+          "hsem_batteries_wait_mode_behavior": "Ventetilstand-adfærd"
+        },
+        "data_description": {
+          "hsem_batteries_wait_mode_behavior": "Vælg hvordan batteriet opfører sig, når HSEM vælger ventetilstand. Streng ventetilstand holder batteriet inaktivt. Selvforbrug med reserve tillader huset at bruge overskydende batterienergi over planlæggerens nødvendige reserve, hvilket reducerer unødvendig netimport."
+        },
+        "description": "Konfigurer hvordan batteriet opfører sig i ventetilstand.",
+        "title": "Batteri Ventetilstand-adfærd"
+      },
       "ocpp": {
         "data": {
           "hsem_ocpp_enabled": "Aktiver OCPP Server",
@@ -857,6 +867,16 @@
         "description": "Konfigurer energimålere og aktiver ML-baseret forbrugsprognose.",
         "title": "Energi og ML"
       },
+      "batteries_wait_mode": {
+        "data": {
+          "hsem_batteries_wait_mode_behavior": "Ventetilstand-adfærd"
+        },
+        "data_description": {
+          "hsem_batteries_wait_mode_behavior": "Vælg hvordan batteriet opfører sig, når HSEM vælger ventetilstand. Streng ventetilstand holder batteriet inaktivt. Selvforbrug med reserve tillader huset at bruge overskydende batterienergi over planlæggerens nødvendige reserve, hvilket reducerer unødvendig netimport."
+        },
+        "description": "Konfigurer hvordan batteriet opfører sig i ventetilstand.",
+        "title": "Batteri Ventetilstand-adfærd"
+      },
       "ocpp": {
         "data": {
           "hsem_ocpp_enabled": "Aktiver OCPP Server",
@@ -919,6 +939,12 @@
         "36": "36 hours",
         "48": "48 hours",
         "72": "72 hours"
+      }
+    },
+    "batteries_wait_mode_behavior": {
+      "options": {
+        "strict": "Streng ventetilstand — batteriet forbliver inaktivt",
+        "self_consumption_with_reserve": "Selvforbrug med reserve — brug overskud over planlæggerens reserve"
       }
     }
   },

--- a/custom_components/hsem/translations/en.json
+++ b/custom_components/hsem/translations/en.json
@@ -23,7 +23,8 @@
       "price_out_of_range": "Price value is outside the allowed range.",
       "required": "This field is required.",
       "start_time_after_end_time": "Start time must be before end time.",
-      "start_time_equals_end_time": "Start time and end time cannot be the same — this creates a zero-length window. Disable the schedule instead."
+      "start_time_equals_end_time": "Start time and end time cannot be the same — this creates a zero-length window. Disable the schedule instead.",
+      "invalid_wait_mode_behavior": "Invalid wait mode behaviour. Choose Strict wait or Self-consumption with reserve."
     },
     "step": {
       "batteries_excess_export": {
@@ -475,6 +476,16 @@
         },
         "description": "Configure energy meters and enable ML-based consumption prediction.",
         "title": "Energy & ML"
+      },
+      "batteries_wait_mode": {
+        "data": {
+          "hsem_batteries_wait_mode_behavior": "Wait Mode Behaviour"
+        },
+        "data_description": {
+          "hsem_batteries_wait_mode_behavior": "Choose how the battery behaves when HSEM selects Wait mode. Strict wait keeps the battery idle. Self-consumption with reserve allows the house to use surplus battery energy above the planner's required reserve, reducing unnecessary grid import."
+        },
+        "description": "Configure how the battery behaves during Wait mode.",
+        "title": "Battery Wait Mode Behaviour"
       }
     }
   },
@@ -498,7 +509,8 @@
       "price_out_of_range": "Price value is outside the allowed range.",
       "required": "This field is required.",
       "start_time_after_end_time": "Start time must be before end time.",
-      "start_time_equals_end_time": "Start time and end time cannot be the same — this creates a zero-length window. Disable the schedule instead."
+      "start_time_equals_end_time": "Start time and end time cannot be the same — this creates a zero-length window. Disable the schedule instead.",
+      "invalid_wait_mode_behavior": "Invalid wait mode behaviour. Choose Strict wait or Self-consumption with reserve."
     },
     "step": {
       "batteries_excess_export": {
@@ -890,6 +902,16 @@
         },
         "description": "Configure energy meters and enable ML-based consumption prediction.",
         "title": "Energy & ML"
+      },
+      "batteries_wait_mode": {
+        "data": {
+          "hsem_batteries_wait_mode_behavior": "Wait Mode Behaviour"
+        },
+        "data_description": {
+          "hsem_batteries_wait_mode_behavior": "Choose how the battery behaves when HSEM selects Wait mode. Strict wait keeps the battery idle. Self-consumption with reserve allows the house to use surplus battery energy above the planner's required reserve, reducing unnecessary grid import."
+        },
+        "description": "Configure how the battery behaves during Wait mode.",
+        "title": "Battery Wait Mode Behaviour"
       }
     }
   },
@@ -935,6 +957,12 @@
         "36": "36 hours",
         "48": "48 hours",
         "72": "72 hours"
+      }
+    },
+    "batteries_wait_mode_behavior": {
+      "options": {
+        "strict": "Strict wait — battery remains idle",
+        "self_consumption_with_reserve": "Self-consumption with reserve — use surplus above the planner reserve"
       }
     }
   },

--- a/docs/config-flow-reference.md
+++ b/docs/config-flow-reference.md
@@ -12,7 +12,7 @@ The config flow is a multi-step wizard. Steps appear in this order:
 quick_setup → init → prices → months → solcast → huawei_solar
     → battery_economics → power → ev → [ev_second] → ev_planned_load
     → [ev_second_planned_load] → ocpp → batteries_schedules
-    → batteries_excess_export → weighted_values
+    → batteries_wait_mode → batteries_excess_export → weighted_values
     → energy_and_ml
 ```
 
@@ -188,6 +188,14 @@ Battery charge/discharge schedule windows (up to three).
 | End time | `hsem_batteries_enable_batteries_schedule_N_end` | Varies | Window end (HH:MM:SS) |
 
 Schedule 1 and 2 are enabled by default; schedule 3 is disabled by default.
+
+### Step: `batteries_wait_mode`
+
+Battery wait-mode behaviour.
+
+| Field | Key | Default | Description |
+|---|---|---|---|
+| Wait mode behaviour | `hsem_batteries_wait_mode_behavior` | `strict` | `strict` keeps the battery idle in Wait mode; `self_consumption_with_reserve` allows normal household self-consumption while protecting the planner's required battery reserve |
 
 ### Step: `batteries_excess_export`
 

--- a/docs/planner-guide.md
+++ b/docs/planner-guide.md
@@ -388,7 +388,7 @@ Each `PlannedSlot` in the output list covers one time interval and carries:
 | `force_batteries_discharge` | Forced discharge (excess export to grid) |
 | `force_export` | Negative import price — all available energy exported to earn money |
 | `ev_smart_charging` | EV charging load is allocated to this slot (planner or runtime resolver) |
-| `batteries_wait_mode` | Battery idle — neither charging nor discharging |
+| `batteries_wait_mode` | Battery idle by default; when **Wait mode behaviour** is set to *Self-consumption with reserve*, normal household self-consumption is allowed using energy above the planner's required reserve |
 | `time_passed` | Slot is in the past — no recommendation applied |
 | `missing_input_entities` | Required HA entities were unavailable when this slot was scheduled |
 
@@ -444,6 +444,13 @@ recommendation it is not changed by later rules in the same layer.
 | 4 | Winter month | `batteries_wait_mode` |
 | 5 | Summer month, solar surplus available | `batteries_charge_solar` |
 | 5 | Summer month, no solar surplus | `batteries_discharge_mode` |
+
+> **Wait mode behaviour:** the `batteries_wait_mode` recommendation normally keeps the
+> battery idle.  When `hsem_batteries_wait_mode_behavior` is set to
+> `self_consumption_with_reserve`, the applier switches the inverter to
+> `MaximizeSelfConsumption` and caps discharge power so only surplus energy above
+> the planner's required reserve is used.  This reduces unnecessary grid import
+> while still preserving capacity for future scheduled discharge windows.
 
 **Discharge concentration** (`concentrate_discharge_on_expensive_slots`) runs after the
 seasonal fill but before candidate generation. It re-evaluates all discharge-mode

--- a/docs/sensors-reference.md
+++ b/docs/sensors-reference.md
@@ -34,7 +34,7 @@ all planner output as attributes.
 | `force_batteries_discharge` | Forced discharge to grid (excess export) |
 | `force_export` | Negative import price — all energy exported |
 | `ev_smart_charging` | EV charging load allocated |
-| `batteries_wait_mode` | Battery idle |
+| `batteries_wait_mode` | Battery idle; may allow self-consumption above the planner reserve depending on **Wait mode behaviour** |
 | `time_passed` | Slot is in the past |
 | `missing_input_entities` | Required HA entities unavailable |
 
@@ -58,6 +58,7 @@ all planner output as attributes.
 | `months_winter` / `months_summer` | list[int] | Configured winter/summer month ranges |
 | `batteries_enable_excess_export` | bool | Excess export gating enabled |
 | `batteries_excess_export_discharge_buffer` | float | Discharge buffer for excess export |
+| `batteries_wait_mode_behavior` | string | Wait mode behaviour: `strict` or `self_consumption_with_reserve` |
 | `house_consumption_energy_weight_1d` | float | 1-day consumption prediction weight |
 | `house_consumption_energy_weight_3d` | float | 3-day weight |
 | `house_consumption_energy_weight_7d` | float | 7-day weight |

--- a/docs/services-reference.md
+++ b/docs/services-reference.md
@@ -62,7 +62,7 @@ ignored.
 | `batteries_charge_grid` | Force-charge the battery from the grid |
 | `batteries_charge_solar` | Charge the battery from PV only |
 | `batteries_discharge_mode` | Discharge the battery to cover house load |
-| `batteries_wait_mode` | Battery idle — neither charging nor discharging |
+| `batteries_wait_mode` | Battery idle by default; follows the configured **Wait mode behaviour** when selected by the planner |
 | `ev_smart_charging` | Prioritise EV charging |
 | `force_batteries_discharge` | Force-discharge the battery to the grid (export) |
 | `force_export` | Export all available energy to the grid |

--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -191,6 +191,9 @@ exposes, PV forecast will be all zeros.
 HSEM classifies each month as winter or summer based on the _Winter Months_
 setting. In winter mode the planner uses `batteries_wait_mode` — it does not
 actively charge from solar. In summer mode it uses solar charging strategies.
+You can change **Wait mode behaviour** to *Self-consumption with reserve* if
+you want the battery to cover normal household load during wait periods while
+still protecting the planner's required reserve.
 
 - **Check:** `sensor.hsem_plan_explanation` → `forecast_mode`. Does it
   match your expectation for the current month?
@@ -326,7 +329,10 @@ the day, the battery will be in `batteries_wait_mode` outside that window.
 **5d. Planner in winter wait mode**
 
 In winter months, the planner uses `batteries_wait_mode` by default — it
-doesn't actively charge or discharge. This is intentional.
+doesn't actively charge or discharge. This is intentional, but you can enable
+**Self-consumption with reserve** in the **Battery Wait Mode Behaviour** step if
+you prefer the battery to cover household load using surplus capacity above the
+planner reserve.
 
 - **Check:** `sensor.hsem_plan_explanation` → `forecast_mode` is `winter`
   and `selected_strategy` is `winter_wait`.

--- a/tests/sensors/test_applier.py
+++ b/tests/sensors/test_applier.py
@@ -159,3 +159,76 @@ class TestComputeEvDischargeCapW:
             sub_window_ws=[],
         )
         assert cap == 0
+
+
+# ---------------------------------------------------------------------------
+# _wait_mode_self_consumption_cap_w — reserve-preserving discharge cap (issue #742)
+# ---------------------------------------------------------------------------
+
+
+class TestWaitModeSelfConsumptionCapW:
+    """Unit tests for the wait-mode self-consumption discharge cap."""
+
+    @staticmethod
+    def _cap(**kwargs):
+        from custom_components.hsem.custom_sensors.applier import (
+            _wait_mode_self_consumption_cap_w,
+        )
+
+        return _wait_mode_self_consumption_cap_w(**kwargs)
+
+    def test_no_surplus_returns_zero(self):
+        cap = self._cap(
+            battery_capacity_kwh=2.0,
+            required_capacity_kwh=2.0,
+            slot_hours=0.25,
+            max_discharge_power_w=5000,
+        )
+        assert cap == 0
+
+    def test_below_reserve_returns_zero(self):
+        cap = self._cap(
+            battery_capacity_kwh=1.5,
+            required_capacity_kwh=2.0,
+            slot_hours=0.25,
+            max_discharge_power_w=5000,
+        )
+        assert cap == 0
+
+    def test_surplus_converted_to_power(self):
+        """1 kWh surplus over a 1-hour slot → 1000 W cap."""
+        cap = self._cap(
+            battery_capacity_kwh=3.0,
+            required_capacity_kwh=2.0,
+            slot_hours=1.0,
+            max_discharge_power_w=5000,
+        )
+        assert cap == 1000
+
+    def test_surplus_over_short_slot(self):
+        """1 kWh surplus over a 15-minute slot → 4000 W cap."""
+        cap = self._cap(
+            battery_capacity_kwh=3.0,
+            required_capacity_kwh=2.0,
+            slot_hours=0.25,
+            max_discharge_power_w=5000,
+        )
+        assert cap == 4000
+
+    def test_cap_limited_by_max_discharge_power(self):
+        cap = self._cap(
+            battery_capacity_kwh=10.0,
+            required_capacity_kwh=0.0,
+            slot_hours=0.25,
+            max_discharge_power_w=2500,
+        )
+        assert cap == 2500
+
+    def test_zero_slot_hours_returns_zero(self):
+        cap = self._cap(
+            battery_capacity_kwh=5.0,
+            required_capacity_kwh=0.0,
+            slot_hours=0.0,
+            max_discharge_power_w=5000,
+        )
+        assert cap == 0

--- a/tests/test_batteries_wait_mode.py
+++ b/tests/test_batteries_wait_mode.py
@@ -1,0 +1,129 @@
+"""Tests for battery wait-mode self-consumption feature (issue #742).
+
+Covers:
+- Default constant value for wait-mode behaviour in ``const.py``
+- Input validation in ``flows/batteries_wait_mode.py``
+- Discharge cap helper in ``custom_sensors/applier.py``
+"""
+
+import pytest
+
+from custom_components.hsem.const import DEFAULT_CONFIG_VALUES
+from custom_components.hsem.custom_sensors.applier import (
+    _wait_mode_self_consumption_cap_w,
+)
+from custom_components.hsem.flows.batteries_wait_mode import (
+    validate_batteries_wait_mode_input,
+)
+
+# ---------------------------------------------------------------------------
+# Default constant value tests
+# ---------------------------------------------------------------------------
+
+
+class TestWaitModeDefaults:
+    """Verify the wait-mode behaviour default is safe."""
+
+    def test_wait_mode_strict_by_default(self):
+        """Wait mode must default to strict to preserve existing behaviour."""
+        assert DEFAULT_CONFIG_VALUES["hsem_batteries_wait_mode_behavior"] == "strict"
+
+
+# ---------------------------------------------------------------------------
+# _wait_mode_self_consumption_cap_w tests
+# ---------------------------------------------------------------------------
+
+
+class TestWaitModeSelfConsumptionCapW:
+    """Unit tests for the reserve-preserving discharge cap helper."""
+
+    def test_no_surplus_returns_zero(self):
+        cap = _wait_mode_self_consumption_cap_w(
+            battery_capacity_kwh=2.0,
+            required_capacity_kwh=2.0,
+            slot_hours=0.25,
+            max_discharge_power_w=5000,
+        )
+        assert cap == 0
+
+    def test_below_reserve_returns_zero(self):
+        cap = _wait_mode_self_consumption_cap_w(
+            battery_capacity_kwh=1.5,
+            required_capacity_kwh=2.0,
+            slot_hours=0.25,
+            max_discharge_power_w=5000,
+        )
+        assert cap == 0
+
+    def test_surplus_converted_to_power(self):
+        """1 kWh surplus over a 1-hour slot -> 1000 W cap."""
+        cap = _wait_mode_self_consumption_cap_w(
+            battery_capacity_kwh=3.0,
+            required_capacity_kwh=2.0,
+            slot_hours=1.0,
+            max_discharge_power_w=5000,
+        )
+        assert cap == 1000
+
+    def test_surplus_over_short_slot(self):
+        """1 kWh surplus over a 15-minute slot -> 4000 W cap."""
+        cap = _wait_mode_self_consumption_cap_w(
+            battery_capacity_kwh=3.0,
+            required_capacity_kwh=2.0,
+            slot_hours=0.25,
+            max_discharge_power_w=5000,
+        )
+        assert cap == 4000
+
+    def test_cap_limited_by_max_discharge_power(self):
+        cap = _wait_mode_self_consumption_cap_w(
+            battery_capacity_kwh=10.0,
+            required_capacity_kwh=0.0,
+            slot_hours=0.25,
+            max_discharge_power_w=2500,
+        )
+        assert cap == 2500
+
+    def test_zero_slot_hours_returns_zero(self):
+        cap = _wait_mode_self_consumption_cap_w(
+            battery_capacity_kwh=5.0,
+            required_capacity_kwh=0.0,
+            slot_hours=0.0,
+            max_discharge_power_w=5000,
+        )
+        assert cap == 0
+
+
+# ---------------------------------------------------------------------------
+# validate_batteries_wait_mode_input tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidateBatteriesWaitModeInput:
+    """Unit tests for the wait-mode config-flow input validator."""
+
+    @pytest.mark.asyncio
+    async def test_strict_value_is_valid(self):
+        errors = await validate_batteries_wait_mode_input(
+            {"hsem_batteries_wait_mode_behavior": "strict"}
+        )
+        assert errors == {}
+
+    @pytest.mark.asyncio
+    async def test_self_consumption_value_is_valid(self):
+        errors = await validate_batteries_wait_mode_input(
+            {"hsem_batteries_wait_mode_behavior": "self_consumption_with_reserve"}
+        )
+        assert errors == {}
+
+    @pytest.mark.asyncio
+    async def test_invalid_value_is_rejected(self):
+        errors = await validate_batteries_wait_mode_input(
+            {"hsem_batteries_wait_mode_behavior": "something_else"}
+        )
+        assert "hsem_batteries_wait_mode_behavior" in errors
+
+    @pytest.mark.asyncio
+    async def test_missing_field_is_rejected(self):
+        errors = await validate_batteries_wait_mode_input({})
+        assert "hsem_batteries_wait_mode_behavior" in errors


### PR DESCRIPTION
## Summary

This PR adds a new **Wait mode behaviour** configuration option that lets the battery continue normal household self-consumption during `batteries_wait_mode`, while still protecting the planner's required battery reserve for future expensive periods.

Fixes #742

## Branch

`fix/742-wait-mode-self-consumption`

## Files changed

- `custom_components/hsem/const.py` — default value for new option
- `custom_components/hsem/models/sensor_config.py` — new dataclass field
- `custom_components/hsem/custom_sensors/config_reader.py` — read option into config
- `custom_components/hsem/flows/batteries_wait_mode.py` — new config/options flow step
- `custom_components/hsem/config_flow.py` — wire new step into config flow
- `custom_components/hsem/options_flow.py` — wire new step into options flow
- `custom_components/hsem/custom_sensors/applier.py` — implement self-consumption with reserve cap
- `custom_components/hsem/translations/en.json` — UI strings and selector options
- `docs/config-flow-reference.md` — document new step
- `docs/planner-guide.md` — explain wait-mode behaviour option
- `docs/sensors-reference.md` — update state/attribute descriptions
- `docs/services-reference.md` — update override mode description
- `docs/troubleshooting-guide.md` — mention the new option
- `.github/memories.md` — record the new behaviour and files involved
- `tests/test_batteries_wait_mode.py` — new tests for defaults, validator, and cap helper
- `tests/sensors/test_applier.py` — additional unit tests for the cap helper

## What changed and why

### Problem

When HSEM selected `batteries_wait_mode`, the inverter was placed in strict TOU wait mode. This prevented the battery from discharging to cover household demand, causing grid import even when usable battery capacity was available above the amount the planner actually needed to reserve for future expensive slots.

### Solution

A new option `hsem_batteries_wait_mode_behavior` is introduced with two values:

- **`strict`** (default) — preserves existing behaviour; the battery stays idle.
- **`self_consumption_with_reserve`** — when the current battery capacity exceeds the planner's required reserve, the inverter switches to `MaximizeSelfConsumption` and discharge power is capped to the surplus energy above the reserve. Once capacity drops to the reserve, the applier falls back to strict wait mode.

With the self-consumption option enabled, PV surplus during wait mode is also directed to charge the battery rather than being exported to grid.

### Key implementation details

- Discharge cap = `surplus_kwh / slot_hours * 1000` watts, clamped to the pack's max discharge power.
- The cap is recalculated every coordinator cycle, so the reserve is protected as capacity changes.
- EV-active slots keep their existing EV discharge cap logic; the wait-mode cap is not applied while an EV is charging.

## Tests added or updated

- `tests/test_batteries_wait_mode.py` — 11 new tests covering:
  - Default value (`strict`)
  - `_wait_mode_self_consumption_cap_w` helper (no surplus, below reserve, power conversion, max-power clamp, zero slot hours)
  - Flow validator (valid values, invalid value, missing field)
- `tests/sensors/test_applier.py` — 7 additional tests for the cap helper

## Test and lint results

All four quality gates pass:

```
./scripts/quality.sh lint     ✅
./scripts/quality.sh typing   ✅
./scripts/quality.sh quality  ✅
./scripts/quality.sh test     ✅ 2456 passed, 4 warnings
```

## Known limitations

- The SoC simulation still models wait mode as no discharge, so the plan's predicted grid import/cost for wait-mode slots is conservative when self-consumption is enabled. This is intentional for this first iteration to keep the planner change minimal; the actual hardware behaviour now matches the user's intent.
- The feature currently applies only to the Huawei Solar inverter path via the working-mode and max-discharge-power entities.