### PR TITLE
fix(sensor): parse nordpool raw_today/raw_tomorrow price format

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -898,6 +898,12 @@ entries rather than replacing existing ones.
 Regression tests: ``tests/test_15min_price_matching.py``
 (``TestNordpoolRawFormat``).
 
+**Observability rule:** when a configured price sensor yields zero matched
+data points, the populator logs a ``warning`` naming the sensor.  A
+``debug`` message is logged for Solcast sensors (PV forecast is optional).
+This makes format mismatches visible instead of silently planning with
+``import_price = 0.0`` (issue #750).
+
 ---
 
 ## File Organization — By Responsibility, Not By Theme

--- a/.github/memories.md
+++ b/.github/memories.md
@@ -881,6 +881,25 @@ Regression tests: ``tests/planner/test_zero_pv_solar_charge_mislabel.py``.
 
 ---
 
+## Nordpool Price Format — raw_today/raw_tomorrow (issue #750)
+
+``custom-components/nordpool`` publishes ``raw_today`` / ``raw_tomorrow``
+attributes as ``{"start": datetime, "end": datetime, "value": price}``.
+HSEM's price populator (``custom_sensors/hourly_data_populator/prices_solcast.py``)
+mapped those attributes as ``{"k": "hour", "v": "price"}``, so every entry
+was silently skipped and all planner slots got ``import_price = 0.0``.
+
+**Canonical rule:** the ``data_sources`` mapping for ``raw_today`` /
+``raw_tomorrow`` accepts both the legacy ``hour``/``price`` format and
+the nordpool ``start``/``value`` format.  The mapping is a list of
+fallbacks — add new formats as additional ``{"k": ..., "v": ...}``
+entries rather than replacing existing ones.
+
+Regression tests: ``tests/test_15min_price_matching.py``
+(``TestNordpoolRawFormat``).
+
+---
+
 ## File Organization — By Responsibility, Not By Theme
 
 AI agents naturally bucket related things together (e.g. "all planner inputs in one file").

--- a/custom_components/hsem/custom_sensors/hourly_data_populator/prices_solcast.py
+++ b/custom_components/hsem/custom_sensors/hourly_data_populator/prices_solcast.py
@@ -177,8 +177,14 @@ async def _async_update_hourly_field(
     # Each source exposes a different attribute key / time-key / value-key
     data_sources: dict[str, list[dict[str, str]]] = {
         "forecast": [{"k": "hour", "v": "price"}],
-        "raw_tomorrow": [{"k": "hour", "v": "price"}],
-        "raw_today": [{"k": "hour", "v": "price"}],
+        "raw_tomorrow": [
+            {"k": "hour", "v": "price"},
+            {"k": "start", "v": "value"},  # custom-components/nordpool
+        ],
+        "raw_today": [
+            {"k": "hour", "v": "price"},
+            {"k": "start", "v": "value"},  # custom-components/nordpool
+        ],
         "prices": [{"k": "start", "v": "price"}],
         "prices_today": [
             {"k": "start", "v": "price"},
@@ -370,8 +376,14 @@ def _update_hourly_field_from_attrs(
 
     data_sources: dict[str, list[dict[str, str]]] = {
         "forecast": [{"k": "hour", "v": "price"}],
-        "raw_tomorrow": [{"k": "hour", "v": "price"}],
-        "raw_today": [{"k": "hour", "v": "price"}],
+        "raw_tomorrow": [
+            {"k": "hour", "v": "price"},
+            {"k": "start", "v": "value"},  # custom-components/nordpool
+        ],
+        "raw_today": [
+            {"k": "hour", "v": "price"},
+            {"k": "start", "v": "value"},  # custom-components/nordpool
+        ],
         "prices": [{"k": "start", "v": "price"}],
         "prices_today": [
             {"k": "start", "v": "price"},

--- a/custom_components/hsem/custom_sensors/hourly_data_populator/prices_solcast.py
+++ b/custom_components/hsem/custom_sensors/hourly_data_populator/prices_solcast.py
@@ -77,7 +77,7 @@ async def async_populate_price_and_solcast(
     solcast_source_minutes = 60
 
     # Import price — read from primary sensor (may embed forecast attributes)
-    await _async_update_hourly_field(
+    import_matched = await _async_update_hourly_field(
         sensor,
         recommendations,
         cfg.import_electricity_price_sensor,
@@ -88,7 +88,7 @@ async def async_populate_price_and_solcast(
     )
     # Import price — fallback to dedicated forecast sensor if configured
     if cfg.import_electricity_price_forecast_sensor:
-        await _async_update_hourly_field(
+        import_matched += await _async_update_hourly_field(
             sensor,
             recommendations,
             cfg.import_electricity_price_forecast_sensor,
@@ -97,8 +97,15 @@ async def async_populate_price_and_solcast(
             cfg.solcast_pv_forecast_forecast_likelihood,
             price_source_minutes,
         )
+    if import_matched == 0:
+        _LOGGER.warning(
+            "No import price data matched from sensor(s) %s — "
+            "planner will use 0.0 for all slots. "
+            "Check that the sensor is available and its attribute format is supported.",
+            cfg.import_electricity_price_sensor,
+        )
     # Export price — read from primary sensor
-    await _async_update_hourly_field(
+    export_matched = await _async_update_hourly_field(
         sensor,
         recommendations,
         cfg.export_electricity_price_sensor,
@@ -109,7 +116,7 @@ async def async_populate_price_and_solcast(
     )
     # Export price — fallback to dedicated forecast sensor
     if cfg.export_electricity_price_forecast_sensor:
-        await _async_update_hourly_field(
+        export_matched += await _async_update_hourly_field(
             sensor,
             recommendations,
             cfg.export_electricity_price_forecast_sensor,
@@ -118,8 +125,15 @@ async def async_populate_price_and_solcast(
             cfg.solcast_pv_forecast_forecast_likelihood,
             price_source_minutes,
         )
+    if export_matched == 0:
+        _LOGGER.warning(
+            "No export price data matched from sensor(s) %s — "
+            "planner will use 0.0 for all slots. "
+            "Check that the sensor is available and its attribute format is supported.",
+            cfg.export_electricity_price_sensor,
+        )
     # Solcast today
-    await _async_update_hourly_field(
+    solcast_today_matched = await _async_update_hourly_field(
         sensor,
         recommendations,
         cfg.solcast_pv_forecast_forecast_today,
@@ -128,8 +142,14 @@ async def async_populate_price_and_solcast(
         cfg.solcast_pv_forecast_forecast_likelihood,
         solcast_source_minutes,
     )
+    if solcast_today_matched == 0:
+        _LOGGER.debug(
+            "No Solcast today data matched from sensor %s — "
+            "PV estimates will be 0.0 for today.",
+            cfg.solcast_pv_forecast_forecast_today,
+        )
     # Solcast tomorrow
-    await _async_update_hourly_field(
+    solcast_tomorrow_matched = await _async_update_hourly_field(
         sensor,
         recommendations,
         cfg.solcast_pv_forecast_forecast_tomorrow,
@@ -138,6 +158,12 @@ async def async_populate_price_and_solcast(
         cfg.solcast_pv_forecast_forecast_likelihood,
         solcast_source_minutes,
     )
+    if solcast_tomorrow_matched == 0:
+        _LOGGER.debug(
+            "No Solcast tomorrow data matched from sensor %s — "
+            "PV estimates will be 0.0 for tomorrow.",
+            cfg.solcast_pv_forecast_forecast_tomorrow,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -153,7 +179,7 @@ async def _async_update_hourly_field(
     share: float,
     solcast_likelihood_key: str,
     source_interval_minutes: int,
-) -> None:
+) -> int:
     """Match sensor attribute data to recommendation slots and write one field.
 
     Args:
@@ -163,16 +189,19 @@ async def _async_update_hourly_field(
         field_name: Attribute name on :class:`HourlyRecommendation` to set.
         share: Divisor applied to each raw value (accounts for sub-hourly slots).
         solcast_likelihood_key: Attribute key for Solcast PV estimate field.
+
+    Returns:
+        Number of data points successfully matched to at least one slot.
     """
     if sensor_id is None:
-        return
+        return 0
 
     source_window = timedelta(minutes=source_interval_minutes)
 
     sensor_state = sensor.hass.states.get(sensor_id)
     if not sensor_state:
         _LOGGER.debug(f"Input sensor {sensor_id} was not found for data.")
-        return
+        return 0
 
     # Each source exposes a different attribute key / time-key / value-key
     data_sources: dict[str, list[dict[str, str]]] = {
@@ -201,6 +230,7 @@ async def _async_update_hourly_field(
         "forecasts": [{"k": "start_time", "v": "per_kwh"}],
     }
 
+    matched = 0
     for attr, kv_list in data_sources.items():
         sensor_data = sensor_state.attributes.get(attr) or []
         if not sensor_data:
@@ -263,6 +293,9 @@ async def _async_update_hourly_field(
                     obj_start = normalize_datetime(obj.start)
                     if dt_key <= obj_start < dt_key + source_window:
                         setattr(obj, field_name, round(value, 5))
+                        matched += 1
+
+    return matched
 
 
 # ---------------------------------------------------------------------------
@@ -292,7 +325,7 @@ def populate_price_and_solcast_from_snapshot(
     price_source_minutes = cfg.electricity_price_update_interval
     solcast_source_minutes = 60
 
-    _update_hourly_field_from_attrs(
+    import_matched = _update_hourly_field_from_attrs(
         recommendations,
         snapshot.sensor_attributes.get(cfg.import_electricity_price_sensor or ""),
         "import_price",
@@ -301,7 +334,7 @@ def populate_price_and_solcast_from_snapshot(
         price_source_minutes,
     )
     if cfg.import_electricity_price_forecast_sensor:
-        _update_hourly_field_from_attrs(
+        import_matched += _update_hourly_field_from_attrs(
             recommendations,
             snapshot.sensor_attributes.get(
                 cfg.import_electricity_price_forecast_sensor or ""
@@ -311,7 +344,14 @@ def populate_price_and_solcast_from_snapshot(
             cfg.solcast_pv_forecast_forecast_likelihood,
             price_source_minutes,
         )
-    _update_hourly_field_from_attrs(
+    if import_matched == 0:
+        _LOGGER.warning(
+            "No import price data matched from sensor(s) %s — "
+            "planner will use 0.0 for all slots. "
+            "Check that the sensor is available and its attribute format is supported.",
+            cfg.import_electricity_price_sensor,
+        )
+    export_matched = _update_hourly_field_from_attrs(
         recommendations,
         snapshot.sensor_attributes.get(cfg.export_electricity_price_sensor or ""),
         "export_price",
@@ -320,7 +360,7 @@ def populate_price_and_solcast_from_snapshot(
         price_source_minutes,
     )
     if cfg.export_electricity_price_forecast_sensor:
-        _update_hourly_field_from_attrs(
+        export_matched += _update_hourly_field_from_attrs(
             recommendations,
             snapshot.sensor_attributes.get(
                 cfg.export_electricity_price_forecast_sensor or ""
@@ -330,7 +370,14 @@ def populate_price_and_solcast_from_snapshot(
             cfg.solcast_pv_forecast_forecast_likelihood,
             price_source_minutes,
         )
-    _update_hourly_field_from_attrs(
+    if export_matched == 0:
+        _LOGGER.warning(
+            "No export price data matched from sensor(s) %s — "
+            "planner will use 0.0 for all slots. "
+            "Check that the sensor is available and its attribute format is supported.",
+            cfg.export_electricity_price_sensor,
+        )
+    solcast_today_matched = _update_hourly_field_from_attrs(
         recommendations,
         snapshot.sensor_attributes.get(cfg.solcast_pv_forecast_forecast_today or ""),
         "solcast_pv_estimate_kwh",
@@ -338,7 +385,13 @@ def populate_price_and_solcast_from_snapshot(
         cfg.solcast_pv_forecast_forecast_likelihood,
         solcast_source_minutes,
     )
-    _update_hourly_field_from_attrs(
+    if solcast_today_matched == 0:
+        _LOGGER.debug(
+            "No Solcast today data matched from sensor %s — "
+            "PV estimates will be 0.0 for today.",
+            cfg.solcast_pv_forecast_forecast_today,
+        )
+    solcast_tomorrow_matched = _update_hourly_field_from_attrs(
         recommendations,
         snapshot.sensor_attributes.get(cfg.solcast_pv_forecast_forecast_tomorrow or ""),
         "solcast_pv_estimate_kwh",
@@ -346,6 +399,12 @@ def populate_price_and_solcast_from_snapshot(
         cfg.solcast_pv_forecast_forecast_likelihood,
         solcast_source_minutes,
     )
+    if solcast_tomorrow_matched == 0:
+        _LOGGER.debug(
+            "No Solcast tomorrow data matched from sensor %s — "
+            "PV estimates will be 0.0 for tomorrow.",
+            cfg.solcast_pv_forecast_forecast_tomorrow,
+        )
 
 
 def _update_hourly_field_from_attrs(
@@ -355,7 +414,7 @@ def _update_hourly_field_from_attrs(
     share: float,
     solcast_likelihood_key: str,
     source_interval_minutes: int,
-) -> None:
+) -> int:
     """Match pre-read sensor attribute data to recommendation slots.
 
     This is the snapshot-based counterpart of ``_async_update_hourly_field``.
@@ -368,9 +427,12 @@ def _update_hourly_field_from_attrs(
         field_name: Attribute name on :class:`HourlyRecommendation` to set.
         share: Divisor applied to each raw value.
         solcast_likelihood_key: Attribute key for Solcast PV estimate field.
+
+    Returns:
+        Number of data points successfully matched to at least one slot.
     """
     if attributes is None:
-        return
+        return 0
 
     source_window = timedelta(minutes=source_interval_minutes)
 
@@ -400,6 +462,7 @@ def _update_hourly_field_from_attrs(
         "forecasts": [{"k": "start_time", "v": "per_kwh"}],
     }
 
+    matched = 0
     for attr, kv_list in data_sources.items():
         sensor_data = attributes.get(attr) or []
         if not sensor_data:
@@ -435,3 +498,6 @@ def _update_hourly_field_from_attrs(
                     obj_start = normalize_datetime(obj.start)
                     if dt_key <= obj_start < dt_key + source_window:
                         setattr(obj, field_name, round(value, 5))
+                        matched += 1
+
+    return matched

--- a/tests/test_15min_price_matching.py
+++ b/tests/test_15min_price_matching.py
@@ -212,3 +212,117 @@ class TestQuarterHourlyPriceMatching:
             assert rec.import_price == pytest.approx(expected, abs=1e-4), (
                 f"Hour {h}: expected {expected}, got {rec.import_price}"
             )
+
+
+class TestNordpoolRawFormat:
+    """Regression tests for issue #750 — nordpool raw_today/raw_tomorrow
+    entries use ``start``/``end``/``value`` keys, not ``hour``/``price``.
+
+    Bug
+    ---
+    ``custom-components/nordpool`` publishes ``raw_today`` and
+    ``raw_tomorrow`` attributes as::
+
+        {"start": datetime, "end": datetime, "value": price}
+
+    HSEM's price populator mapped those attributes as ``{"k": "hour",
+    "v": "price"}``, so ``data.get("hour")`` returned ``None`` for every
+    entry and all prices were silently skipped.  Every planner slot ended
+    up with ``import_price = 0.0`` — no error, no warning.
+
+    Fix
+    ---
+    The ``raw_today`` / ``raw_tomorrow`` mapping now accepts both the
+    legacy ``hour``/``price`` format and the nordpool ``start``/``value``
+    format.
+    """
+
+    def setup_method(self) -> None:
+        self.base = datetime(2026, 8, 11, 0, 0, 0, tzinfo=UTC)
+
+    def _nordpool_entries(self, count: int = 96) -> list[dict[str, str]]:
+        """Entries in the exact format published by custom-components/nordpool."""
+        return [
+            {
+                "start": (self.base + timedelta(minutes=15 * i)).isoformat(),
+                "end": (self.base + timedelta(minutes=15 * (i + 1))).isoformat(),
+                "value": f"{0.5 + i * 0.01:.5f}",
+            }
+            for i in range(count)
+        ]
+
+    def test_nordpool_raw_today_prices_ingested(self) -> None:
+        """Nordpool-format raw_today entries must land on the correct slots."""
+        cfg = _Cfg(price_interval=15, slot_interval=15)
+        recs = [
+            _make_rec(
+                self.base + timedelta(minutes=15 * i),
+                self.base + timedelta(minutes=15 * (i + 1)),
+            )
+            for i in range(96)
+        ]
+        raw = self._nordpool_entries()
+        attrs = {
+            "sensor.eds_import": {"raw_today": raw},
+            "sensor.eds_export": {"raw_today": raw},
+        }
+        _populate(recs, attrs, cfg)
+
+        for i, rec in enumerate(recs):
+            expected = 0.5 + i * 0.01
+            assert rec.import_price == pytest.approx(expected, abs=1e-5), (
+                f"Slot {i} ({rec.start}): expected {expected}, got {rec.import_price}"
+            )
+            assert rec.export_price == pytest.approx(expected, abs=1e-5)
+
+    def test_nordpool_raw_tomorrow_prices_ingested(self) -> None:
+        """Nordpool-format raw_tomorrow entries must land on the correct slots."""
+        cfg = _Cfg(price_interval=15, slot_interval=15)
+        recs = [
+            _make_rec(
+                self.base + timedelta(minutes=15 * i),
+                self.base + timedelta(minutes=15 * (i + 1)),
+            )
+            for i in range(96)
+        ]
+        raw = self._nordpool_entries()
+        attrs = {
+            "sensor.eds_import": {"raw_tomorrow": raw},
+            "sensor.eds_export": {"raw_tomorrow": raw},
+        }
+        _populate(recs, attrs, cfg)
+
+        for i, rec in enumerate(recs):
+            expected = 0.5 + i * 0.01
+            assert rec.import_price == pytest.approx(expected, abs=1e-5), (
+                f"Slot {i} ({rec.start}): expected {expected}, got {rec.import_price}"
+            )
+
+    def test_legacy_hour_price_format_still_works(self) -> None:
+        """The legacy ``hour``/``price`` format must continue to work."""
+        cfg = _Cfg(price_interval=15, slot_interval=15)
+        recs = [
+            _make_rec(
+                self.base + timedelta(minutes=15 * i),
+                self.base + timedelta(minutes=15 * (i + 1)),
+            )
+            for i in range(4)
+        ]
+        raw = [
+            {
+                "hour": (self.base + timedelta(minutes=15 * i)).isoformat(),
+                "price": f"{0.10 + i * 0.01:.5f}",
+            }
+            for i in range(4)
+        ]
+        attrs = {
+            "sensor.eds_import": {"raw_today": raw},
+            "sensor.eds_export": {"raw_today": raw},
+        }
+        _populate(recs, attrs, cfg)
+
+        for i, rec in enumerate(recs):
+            expected = 0.10 + i * 0.01
+            assert rec.import_price == pytest.approx(expected, abs=1e-5), (
+                f"Slot {i}: expected {expected}, got {rec.import_price}"
+            )


### PR DESCRIPTION
## Summary

Fixes a silent failure where HSEM ingested **no prices at all** from the `custom-components/nordpool` integration. Every planner slot got `import_price = 0.0` and `export_price = 0.0`, disabling all price-based optimisation with no error or warning.

Also adds a **warning log** when a configured price sensor yields zero matched data points, making this class of failure visible instead of silent.

## Root Cause

`custom_sensors/hourly_data_populator/prices_solcast.py` maps sensor attributes to time/value keys:

```python
"raw_tomorrow": [{"k": "hour", "v": "price"}],
"raw_today":    [{"k": "hour", "v": "price"}],
```

But `custom-components/nordpool` publishes entries as:

```python
{"start": datetime, "end": datetime, "value": price}
```

Neither `hour` nor `price` exists, so `data.get("hour")` returned `None` for every entry and all 96 price points per day were silently skipped.

This affects both the live path (`_async_update_hourly_field`) and the snapshot path (`_update_hourly_field_from_attrs`).

## Fix

### 1. Nordpool format support

Added `{"k": "start", "v": "value"}` as a fallback key pair for `raw_today` / `raw_tomorrow` in both `data_sources` mappings:

```python
"raw_tomorrow": [
    {"k": "hour", "v": "price"},
    {"k": "start", "v": "value"},  # custom-components/nordpool
],
"raw_today": [
    {"k": "hour", "v": "price"},
    {"k": "start", "v": "value"},  # custom-components/nordpool
],
```

The existing `kv_list` loop already iterates over fallback key pairs, so this is a minimal, backward-compatible change. Energi Data Service and other sources using the `hour`/`price` format are unaffected.

### 2. Zero-match warning

Both population functions now return the number of matched data points. When a configured import/export price sensor produces **zero matches**, a warning is logged:

```
No import price data matched from sensor(s) sensor.nordpool_import —
planner will use 0.0 for all slots.
Check that the sensor is available and its attribute format is supported.
```

Solcast PV sensors log at `debug` level instead, since PV forecast is optional and zero PV is a valid state (night, winter).

## Files Changed

| File | Change |
|------|--------|
| `custom_components/hsem/custom_sensors/hourly_data_populator/prices_solcast.py` | Add `start`/`value` fallback for `raw_today`/`raw_tomorrow`; return match count; warn on zero matches |
| `tests/test_15min_price_matching.py` | Add `TestNordpoolRawFormat` regression tests |
| `.github/memories.md` | Document the canonical rule for price-format fallbacks and the observability rule |

## Testing

New regression tests in `TestNordpoolRawFormat`:

- `test_nordpool_raw_today_prices_ingested` — 96 nordpool-format entries land on 96 distinct 15-min slots
- `test_nordpool_raw_tomorrow_prices_ingested` — same for `raw_tomorrow`
- `test_legacy_hour_price_format_still_works` — the existing `hour`/`price` format is unchanged

All 2477 tests pass (including the previously failing `test_price_point_count_matches_slots`, which was fixed by #739 on main).

## Quality Gates

- [x] `./scripts/quality.sh lint` — passed
- [x] `./scripts/quality.sh typing` — passed (0 errors)
- [x] `./scripts/quality.sh quality` — passed (0 errors)
- [x] `./scripts/quality.sh test` — passed (2477 tests)

Fixes #750