### PR TITLE
feat(planner): add battery_export_min_price floor for intentional battery-to-grid export — Fixes #752

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -270,6 +270,45 @@ Also in `_build_constraints`, the session-EV AC load is simply
 by definition.  Do not re-introduce a multiply-then-divide by
 `charger_efficiency`.
 
+## Battery Export Minimum Price Floor (Issue #752)
+
+A third per-slot ed cap, in the same `_build_constraints` loop:
+
+3. **Battery-export-min-price floor** — when `battery_export_min_price > 0`
+   and the slot's RAW export price is strictly below the floor
+   (`p_exp[t] < battery_export_min_price`, evaluated on the raw p_exp
+   BEFORE the `min_export_price` and export-≤-import clamps), apply
+   `ed[t] ≤ base_load / η_dis` to that slot.  This is the per-slot,
+   soft-switch companion to the global `no_export` cap — it blocks
+   *intentional* battery-to-grid export only on slots below the user's
+   explicit floor, not everywhere.  Above the floor the optimizer is
+   free to decide whether exporting is worthwhile; reaching the threshold
+   does NOT auto-trigger export.  The non-MILP `apply_excess_export` path
+   enforces the same floor via
+   `export_price >= max(export_min_price, recommended_threshold, battery_export_min_price)`.
+
+   - The mask is computed in `milp_optimizer.py::solve_milp`
+     (`battery_export_blocked`) and passed to `_build_constraints` via the
+     `battery_export_blocked=` kwarg.  Wire it end-to-end:
+     `const.py` (`hsem_batteries_export_min_price` default 0.0) →
+     `flows/batteries_excess_export.py` schema/validator →
+     `models/sensor_config.py::batteries_export_min_price` →
+     `custom_sensors/config_reader.py` →
+     `models/planner_input.py::battery_export_min_price` →
+     `coordinator_builder.py::build_planner_input` →
+     `planner/candidate_generator.py::generate_candidates` →
+     `planner/milp_optimizer.py::solve_milp` (kwarg) →
+     `planner/milp/_constraints.py::_build_constraints` (mask).
+   - The cost function mirrors the floor via
+     `CostWeights.battery_export_min_price`; battery-destined export
+     revenue (and discharge-loss export-destined pricing) is zeroed on
+     blocked slots so scored costs match the optimisation.
+   - The guard applies ONLY to intentional battery-to-grid export
+     (`force_batteries_discharge`).  It does NOT affect normal battery
+     self-consumption, PV export, or PV charging.  With the default
+     `0.0` the planner is identical to the pre-#752 code (backward
+     compatible) — verify the backward-compat invariant in tests.
+
 ## Live-Injection Spike Floor (Issue #592)
 
 In `planner/engine_population.py::_inject_live_data_into_current_slot`, the

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 - **Temperature-adaptive charge rate learning** — 7 temperature buckets track actual charge power at p90, adapting to cold-weather limitations
 - **Battery capacity auto-detection** — learns usable capacity from BMS kWh-remaining readings in the 15-85 % SoC range
 - **Cycle cost accounting** — wear-and-tear costs factored into every charge/discharge decision
+- **Battery export minimum price floor** (issue #752) — optional per-slot hard floor below which intentional battery-to-grid export is forbidden (the optimizer still decides above the floor)
 - **Grid overcurrent protection** — respects main fuse rating, caps total grid draw
 - **Weekday/weekend consumption profiling** — separate EWMA load profiles for workdays and weekends improve prediction accuracy
 

--- a/custom_components/hsem/const.py
+++ b/custom_components/hsem/const.py
@@ -23,6 +23,9 @@ DEFAULT_CONFIG_VALUES = {
     "hsem_batteries_discharge_efficiency": 98,
     "hsem_batteries_enable_excess_export": False,
     "hsem_batteries_excess_export_discharge_buffer": 10,
+    # Per-slot hard floor for intentional battery-to-grid export (issue #752).
+    # 0.0 = disabled (default) — fully backward compatible.
+    "hsem_batteries_export_min_price": 0.0,
     # Wait mode behaviour: "strict" keeps the battery idle, "self_consumption_with_reserve"
     # allows normal household self-consumption while protecting the planner reserve.
     "hsem_batteries_wait_mode_behavior": "strict",

--- a/custom_components/hsem/coordinator_builder.py
+++ b/custom_components/hsem/coordinator_builder.py
@@ -290,6 +290,10 @@ def build_planner_input(
                 else live.battery_usable_capacity_kwh
             ),
         ),
+        # Per-slot hard floor for intentional battery-to-grid export (issue #752).
+        battery_export_min_price=(
+            convert_to_float(cfg.batteries_export_min_price) or 0.0
+        ),
         export_min_price=convert_to_float(cfg.export_electricity_min_price) or 0.0,
         main_fuse_amps=(float(cfg.main_fuse_amps) if cfg.main_fuse_amps > 0 else None),
         main_fuse_phases=cfg.main_fuse_phases,

--- a/custom_components/hsem/custom_sensors/config_reader.py
+++ b/custom_components/hsem/custom_sensors/config_reader.py
@@ -377,6 +377,14 @@ def build_sensor_config(
         )
         or 10.0
     )
+    # Per-slot hard floor for intentional battery-to-grid export (issue #752).
+    # 0.0 = disabled — fully backward compatible.
+    _battery_export_min_price = convert_to_float(
+        get_config_value(config_entry, "hsem_batteries_export_min_price")
+    )
+    cfg.batteries_export_min_price = (
+        _battery_export_min_price if _battery_export_min_price is not None else 0.0
+    )
 
     # Wait mode behaviour
     _wait_mode_behavior = get_config_value(

--- a/custom_components/hsem/flows/batteries_excess_export.py
+++ b/custom_components/hsem/flows/batteries_excess_export.py
@@ -28,6 +28,13 @@ async def get_batteries_excess_export_step_schema(  # NOSONAR
     at runtime from the configured purchase price, expected cycles, and the
     live battery usable capacity using ``calculate_recommended_threshold()``.
 
+    A separate optional ``hsem_batteries_export_min_price`` floor (issue #752)
+    gives the user a hard per-slot guard for *intentional* battery-to-grid
+    export.  When the slot's export price is strictly below this floor the
+    MILP caps the discharge variable so the battery can serve house load but
+    cannot export to the grid.  Defaults to 0 (disabled) which preserves the
+    pre-#752 behaviour.
+
     Args:
         config_entry: Existing config entry (used during options flow editing).
         _user_input: Accumulated user input dict from previous config flow steps
@@ -59,6 +66,22 @@ async def get_batteries_excess_export_step_schema(  # NOSONAR
                     }
                 }
             ),
+            vol.Required(
+                "hsem_batteries_export_min_price",
+                default=get_config_value(
+                    config_entry,
+                    "hsem_batteries_export_min_price",
+                ),
+            ): selector(
+                {
+                    "number": {
+                        "min": 0.0,
+                        "max": 2.0,
+                        "step": 0.01,
+                        "mode": "box",
+                    }
+                }
+            ),
         }
     )
 
@@ -69,7 +92,9 @@ async def validate_batteries_excess_export_input(
     """Validate user input for batteries excess export configuration.
 
     The price threshold is auto-calculated at runtime from battery
-    depreciation parameters, so only the discharge buffer is validated here.
+    depreciation parameters, so only the discharge buffer and the optional
+    battery export minimum price floor (issue #752) are validated here.
+    Required-field enforcement is handled by the voluptuous schema.
 
     Args:
         user_input: Dict of field name → value submitted by the user.
@@ -84,4 +109,11 @@ async def validate_batteries_excess_export_input(
         max_price=50.0,
         allow_negative=False,
     )
-    return merge_errors(buffer_errors)
+    export_floor_errors = validate_price(
+        user_input,
+        "hsem_batteries_export_min_price",
+        min_price=0.0,
+        max_price=2.0,
+        allow_negative=False,
+    )
+    return merge_errors(buffer_errors, export_floor_errors)

--- a/custom_components/hsem/models/planner_input.py
+++ b/custom_components/hsem/models/planner_input.py
@@ -84,6 +84,17 @@ class PlannerInput:
             Safety buffer kept in the battery before forced export (0-100).
         excess_export_price_threshold:
             Minimum export price required to trigger forced export.
+        battery_export_min_price:
+            Per-slot hard floor on the export price below which intentional
+            battery-to-grid discharge is forbidden (issue #752).  ``0.0``
+            (default) disables the guard.  When ``> 0`` and a slot's
+            ``export_price`` is strictly below this value, the MILP caps
+            the discharge variable so the battery can only serve house
+            load (no grid export) for that slot.  Reaching the threshold
+            does NOT automatically trigger export — the optimizer still
+            decides.  Applies only to intentional battery-to-grid export
+            (``force_batteries_discharge``); does not affect normal battery
+            self-consumption, PV export, or PV charging of the battery.
         export_min_price:
             Minimum export price for grid power control (below this the
             inverter export is throttled to zero).
@@ -148,6 +159,19 @@ class PlannerInput:
     excess_export_enabled: bool = False
     excess_export_discharge_buffer_pct: float = 10.0
     excess_export_price_threshold: float = 0.10
+
+    # --- per-slot hard floor for intentional battery-to-grid export (issue #752) ---
+    #: Per-slot hard floor on the export price below which intentional
+    #: battery-to-grid discharge is forbidden.  ``0.0`` (default) disables
+    #: the guard — fully backward compatible.  When ``> 0`` and a slot's
+    #: ``export_price`` is strictly below this floor, the MILP caps
+    #: ``ed[t]`` so the battery can only serve house load (no grid export)
+    #: for that slot.  The guard applies ONLY to intentional battery-to-grid export (``force_batteries_discharge``); it does NOT restrict
+    #: normal battery self-consumption, battery discharge for house load,
+    #: direct PV export, or PV charging of the battery.  Above the floor
+    #: the optimizer continues to decide freely — reaching the threshold
+    #: does NOT automatically trigger export.
+    battery_export_min_price: float = 0.0
 
     # --- grid export control ---
     export_min_price: float = 0.0

--- a/custom_components/hsem/models/sensor_config.py
+++ b/custom_components/hsem/models/sensor_config.py
@@ -122,6 +122,8 @@ class SensorConfig:
 
         batteries_enable_excess_export: Enable opportunistic forced-discharge export.
         batteries_excess_export_discharge_buffer: Safety buffer percentage to keep.
+        batteries_export_min_price: Per-slot hard floor for intentional
+            battery-to-grid export (issue #752).  ``0.0`` disables the floor.
         batteries_wait_mode_behavior: How ``batteries_wait_mode`` is interpreted.
             ``strict`` keeps the battery idle; ``self_consumption_with_reserve``
             allows normal household self-consumption while protecting the
@@ -232,6 +234,12 @@ class SensorConfig:
     # Excess export
     batteries_enable_excess_export: bool = False
     batteries_excess_export_discharge_buffer: float = 10.0
+    #: Per-slot hard floor for intentional battery-to-grid export (issue #752).
+    #: When ``> 0`` and a slot's export price is strictly below this floor the
+    #: MILP caps the battery discharge variable so the battery can only cover
+    #: house load (no grid export).  ``0.0`` = disabled (default) — fully
+    #: backward compatible.
+    batteries_export_min_price: float = 0.0
 
     # Wait mode behaviour
     batteries_wait_mode_behavior: str = "strict"

--- a/custom_components/hsem/planner/candidate_generator.py
+++ b/custom_components/hsem/planner/candidate_generator.py
@@ -314,12 +314,13 @@ def generate_candidates(
             main_fuse_amps=inp.main_fuse_amps,
             main_fuse_phases=inp.main_fuse_phases,
             max_grid_export_power_kw=inp.max_grid_export_power_kw,
+            battery_export_min_price=inp.battery_export_min_price,
         )
         log_planner(
             "debug",
             "[gen] MILP solve called  cycle_cost=%.6f  no_export=%s  "
             "excess_export_enabled=%s  min_export_price=%.4f  "
-            "ev_configs=%d",
+            "battery_export_min_price=%.4f  ev_configs=%d",
             effective_cycle_cost,
             not inp.excess_export_enabled,
             inp.excess_export_enabled,
@@ -332,6 +333,7 @@ def generate_candidates(
                     capacity_loss_pct=inp.battery_capacity_loss_pct,
                 ),
             ),
+            inp.battery_export_min_price,
             len(ev_configs) if ev_configs else 0,
         )
         if milp_result is not None:

--- a/custom_components/hsem/planner/cost_function.py
+++ b/custom_components/hsem/planner/cost_function.py
@@ -344,14 +344,24 @@ def score_plan(
             import_cost_disc += cost * discount
 
         # 2. Export revenue — clamp export prices below export_min_price
-        #    to 0 to match the applier's physical export block and the MILP's
-        #    clamping (milp_optimizer.py).  Without this the cost function
-        #    would report revenue for exports that can never happen.
+        #    to 0 to match the applier's physical export block and the
+        #    MILP's clamping (milp_optimizer.py).  Additionally zero
+        #    battery-destined export revenue when the slot is below the
+        #    user's ``battery_export_min_price`` floor (issue #752): the
+        #    MILP forbids ``force_batteries_discharge`` there, so that
+        #    export can never be realised by the battery.
         if slot.grid_export_kwh > 1e-9:
             effective_exp_price = exp_price
             if (
                 weights.export_min_price > 1e-9
                 and effective_exp_price < weights.export_min_price
+            ):
+                effective_exp_price = 0.0
+            if (
+                weights.battery_export_min_price > 1e-9
+                and effective_exp_price < weights.battery_export_min_price
+                and slot.batteries_discharged_kwh > 1e-9
+                and slot.solcast_pv_estimate_kwh <= 1e-9
             ):
                 effective_exp_price = 0.0
             rev = slot.grid_export_kwh * effective_exp_price
@@ -396,21 +406,28 @@ def score_plan(
             conversion_loss_cost_disc += conv * discount
         if slot.batteries_discharged_kwh > 1e-9 and discharge_loss_fraction > 1e-9:
             lost_kwh_discharge = slot.batteries_discharged_kwh * discharge_loss_fraction
-            # Destination-aware discharge loss pricing (issue #641).
-            # If the slot is a net exporter, the discharge is destined for
-            # export — price loss at the export price (foregone revenue).
-            # Otherwise, price at the import price (avoided import cost).
+            # Destination-aware discharge loss pricing (issue #641):
+            # net-exporter → price loss at export price; otherwise import price.
             if slot.grid_export_kwh > 1e-9:
-                # Export-destined discharge: use sanitised export price.
                 p_loss = exp_price
                 if (
                     weights.export_min_price > 1e-9
                     and p_loss < weights.export_min_price
                 ):
                     p_loss = 0.0
+                # Battery-destined export floored by battery_export_min_price
+                # (issue #752): when the slot's raw export price is below
+                # the user's floor and the discharge is battery-destined (no
+                # PV surplus), that export can never be realised, so the
+                # foregone-export valuation is 0.
+                if (
+                    weights.battery_export_min_price > 1e-9
+                    and p_loss < weights.battery_export_min_price
+                    and slot.solcast_pv_estimate_kwh <= 1e-9
+                ):
+                    p_loss = 0.0
                 p_loss = max(p_loss, 0.0)
             else:
-                # House-load-covering discharge: use import price (unchanged).
                 p_loss = imp_price_obj
             conv = lost_kwh_discharge * p_loss
             conversion_loss_cost += conv

--- a/custom_components/hsem/planner/cost_types.py
+++ b/custom_components/hsem/planner/cost_types.py
@@ -117,6 +117,16 @@ class CostWeights:
     # in milp_optimizer.py so that cost_function scores match MILP assumptions.
     export_min_price: float = 0.0
 
+    # Per-slot hard floor for intentional battery-to-grid export (issue #752).
+    # When > 0 and a slot's raw ``export_price`` is strictly below this value,
+    # the MILP and ``apply_excess_export`` both forbid marking the slot as
+    # ``ForceBatteriesDischarge`` — the battery may serve house load but not
+    # export to the grid on those slots.  Mirrored in the cost function so that
+    # scored costs match the optimisation assumptions: "battery-destined"
+    # export revenue (discharge loss priced at export) is treated as 0 on
+    # blocked slots because that export can never happen.
+    battery_export_min_price: float = 0.0
+
     # Battery capacity parameters used by the deferred-export correction in
     # the terminal-SoC charge premium (issue #592).  Both must be positive
     # for the correction to activate; defaults keep it disabled so existing

--- a/custom_components/hsem/planner/discharge_scheduler.py
+++ b/custom_components/hsem/planner/discharge_scheduler.py
@@ -213,14 +213,17 @@ def apply_excess_export(
     *,
     export_min_price: float = 0.0,
     recommended_threshold: float = 0.0,
+    battery_export_min_price: float = 0.0,
 ) -> None:
     """Mark high-export-price future slots for forced battery discharge.
 
     Only triggered when the battery holds more energy than needed until
     the next solar surplus.  Grid-charged batteries require a minimum price
     difference; solar-charged batteries export opportunistically but still
-    require ``export_price >= max(export_min_price, recommended_threshold)``
-    — the higher of the user-configured minimum and the cycle-wear cost.
+    require ``export_price >= max(export_min_price, recommended_threshold,
+    battery_export_min_price)`` — the highest of the user-configured minimum
+    (inverter physical floor), the cycle-wear cost, and the per-slot hard
+    floor for intentional battery-to-grid export (issue #752).
 
     Args:
         slots: Mutable list of planned slots.
@@ -237,6 +240,9 @@ def apply_excess_export(
             from :func:`~custom_components.hsem.utils.misc.calculate_recommended_threshold`.
             Used as a floor — exporting below this price costs more in
             battery wear than it earns in revenue.
+        battery_export_min_price: Per-slot hard floor for intentional
+            battery-to-grid export (issue #752).  ``0.0`` disables the
+            guard — fully backward compatible.
     """
     # battery_discharge_budget_kwh is the kWh the battery can export beyond what is
     # already needed to cover future house load.  Solar surplus in a slot does NOT
@@ -245,17 +251,21 @@ def apply_excess_export(
     # draws down the battery, so we drain the budget by max(net, 0) per slot.
     #
     battery_discharge_budget_kwh = float("inf")  # let concentrate + SoC handle limits
+    effective_min_export_price = max(
+        export_min_price, recommended_threshold, battery_export_min_price
+    )
     log_planner(
         "debug",
         "[disch] apply_excess_export  budget=%.3f  current=%.3f  required=%.3f  "
         "price_threshold=%.4f  recommended_threshold=%.4f  "
-        "effective_min_export_price=%.4f",
+        "battery_export_min_price=%.4f  effective_min_export_price=%.4f",
         battery_discharge_budget_kwh,
         current_capacity,
         required_capacity,
         export_price_threshold,
         recommended_threshold,
-        max(export_min_price, recommended_threshold),
+        battery_export_min_price,
+        effective_min_export_price,
     )
     if battery_discharge_budget_kwh < 0:
         log_planner(
@@ -292,7 +302,7 @@ def apply_excess_export(
                     >= s.price.import_price + recommended_threshold
                 )
             )
-            and s.price.export_price >= max(export_min_price, recommended_threshold)
+            and s.price.export_price >= effective_min_export_price
         ),
         key=lambda x: x.price.export_price,
         reverse=True,

--- a/custom_components/hsem/planner/engine_core.py
+++ b/custom_components/hsem/planner/engine_core.py
@@ -175,6 +175,7 @@ def _schedule_slots(
             warnings,
             export_min_price=inp.export_min_price,
             recommended_threshold=rt,
+            battery_export_min_price=inp.battery_export_min_price,
         )
         log_planner(
             "debug",
@@ -474,6 +475,7 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
         charge_efficiency_pct=inp.battery_charge_efficiency_pct,
         discharge_efficiency_pct=inp.battery_discharge_efficiency_pct,
         export_min_price=inp.export_min_price,
+        battery_export_min_price=inp.battery_export_min_price,
         time_discount_rate=inp.time_discount_rate,
         battery_usable_capacity_kwh=usable_kwh,
         max_charge_per_slot_kwh=mcps,

--- a/custom_components/hsem/planner/milp/_constraints.py
+++ b/custom_components/hsem/planner/milp/_constraints.py
@@ -48,6 +48,7 @@ def _build_constraints(
     _has_session_demand: bool,
     max_grid_export_per_slot_kwh: float = 0.0,
     export_limit_active: bool = False,
+    battery_export_blocked: np.ndarray | None = None,  # type: ignore[name-defined]
 ) -> dict:
     """Build all LP constraint matrices and variable bounds.
 
@@ -171,18 +172,34 @@ def _build_constraints(
     # ed[t] ≤ base_load[t] / η_dis.  This prevents the battery from
     # exporting to the grid — it only serves house load.  Used when the
     # user has disabled excess export in the config flow.
+    #
+    # battery_export_blocked[t] (issue #752) is a per-slot mask that
+    # selectively applies the SAME cap (ed[t] ≤ base_load[t] / η_dis) only
+    # to slots where the RAW export_price is strictly below the user's
+    # ``battery_export_min_price``.  The battery may still serve house
+    # load on those slots; only intentional battery-to-grid export (i.e.
+    # discharge above what house load needs) is blocked.  The mask is
+    # evaluated against the raw export price upstream of the
+    # ``min_export_price`` and export-≤-import clamps so the user's
+    # explicit floor is honoured even when other guards are lower.
     # ------------------------------------------------------------------
     ev_discharge_guard_active = (not active_evs) and bool(np.any(ev_accounted > 1e-9))
+    if battery_export_blocked is None:
+        battery_export_blocked = np.zeros(len(base_load), dtype=bool)
     ed_ub_per_slot: list[float] = []
     for t in range(m):
         # Per-slot cap: battery must not discharge more than what's needed
         # to cover house load (minus EV-accounted load when applicable).
         # When no_export=True, all slots get this cap.  Otherwise, only
-        # EV-accounted slots get it.
+        # EV-accounted slots and battery_export_blocked slots get it.
         cap_house_load = base_load[t] / discharge_eff
         if ev_discharge_guard_active and ev_accounted[t] > 1e-9:
             cap_house_load = max(base_load[t] - ev_accounted[t], 0.0) / discharge_eff
-        if no_export or (ev_discharge_guard_active and ev_accounted[t] > 1e-9):
+        if (
+            no_export
+            or bool(battery_export_blocked[t])
+            or (ev_discharge_guard_active and ev_accounted[t] > 1e-9)
+        ):
             ed_ub_per_slot.append(min(cap_house_load, max_dis))
         else:
             ed_ub_per_slot.append(max_dis)

--- a/custom_components/hsem/planner/milp_optimizer.py
+++ b/custom_components/hsem/planner/milp_optimizer.py
@@ -68,6 +68,7 @@ def solve_milp(
     main_fuse_amps: float | None = None,
     main_fuse_phases: int = 3,
     max_grid_export_power_kw: float | None = None,
+    battery_export_min_price: float = 0.0,
 ) -> tuple[list[PlannedSlot], dict] | None:
     """Solve the LP and return a deep-copy slot list with MILP recommendations.
 
@@ -178,6 +179,10 @@ def solve_milp(
             per-slot ``ge[t]`` is hard-bounded to
             ``max_grid_export_power_kw * slot_hours`` kWh so the plan never
             exceeds the site limit.  ``None`` or 0 disables the bound.
+        battery_export_min_price:
+            Per-slot hard floor below which intentional battery-to-grid
+            discharge is forbidden (issue #752). `0.0` disables it.
+            Caps `ed[t]` to `base_load[t]/discharge_eff` on blocked slots.
 
     Returns:
         A tuple ``(slots, diagnostics)`` where:
@@ -194,7 +199,8 @@ def solve_milp(
         "[milp] solve_milp  slots=%d  current=%.3f  usable=%.3f  "
         "max_chg=%.3f  max_dis=%s  cycle_cost=%.6f  "
         "chg_eff=%.2f  dis_eff=%.2f  discount=%.4f  repl_price=%s  "
-        "no_export=%s  min_export_price=%.4f  fuse=%s",
+        "no_export=%s  min_export_price=%.4f  battery_export_min_price=%.4f  "
+        "fuse=%s",
         len(slots),
         current_kwh,
         usable_kwh,
@@ -211,6 +217,7 @@ def solve_milp(
         ),
         no_export,
         min_export_price,
+        battery_export_min_price,
         (
             f"{main_fuse_amps:.1f}A/{main_fuse_phases}ph"
             if main_fuse_amps is not None
@@ -261,6 +268,12 @@ def solve_milp(
     # Replace NaN prices with 0 to prevent solver numerical issues
     p_imp = np.nan_to_num(p_imp, nan=0.0)
     p_exp = np.nan_to_num(p_exp, nan=0.0)
+
+    # Per-slot hard floor for intentional battery-to-grid export (issue
+    # #752). 0.0 (default) → mask all-False, backward compatible.
+    battery_export_blocked = np.zeros(len(future_idx), dtype=bool)
+    if battery_export_min_price > 1e-9:
+        battery_export_blocked = p_exp < battery_export_min_price
 
     # Clamp export prices below min_export_price to 0.
     # The applier physically sets the inverter to GRID_EXPORT_LIMIT_WATT
@@ -575,6 +588,7 @@ def solve_milp(
         _has_session_demand,
         max_grid_export_per_slot_kwh=max_grid_export_per_slot_kwh,
         export_limit_active=export_limit_active,
+        battery_export_blocked=battery_export_blocked,
     )
 
     A_eq = constraints["A_eq"]

--- a/custom_components/hsem/translations/da.json
+++ b/custom_components/hsem/translations/da.json
@@ -29,11 +29,13 @@
       "batteries_excess_export": {
         "data": {
           "hsem_batteries_enable_excess_export": "Aktiver overskuds-eksport",
-          "hsem_batteries_excess_export_discharge_buffer": "Afladningsbuffer (%)"
+          "hsem_batteries_excess_export_discharge_buffer": "Afladningsbuffer (%)",
+          "hsem_batteries_export_min_price": "Batterieksport Min. Pris"
         },
         "data_description": {
           "hsem_batteries_enable_excess_export": "Aktiver eller deaktiver eksport af overskydende batterikapacitet til nettet, når det er økonomisk fordelagtigt.",
-          "hsem_batteries_excess_export_discharge_buffer": "Indstil sikkerhedsbufferprocenten for at opretholde minimum batterireserver (0-50%). Standard er 10% for at sikre tilstrækkelig kapacitet til uventet efterspørgsel."
+          "hsem_batteries_excess_export_discharge_buffer": "Indstil sikkerhedsbufferprocenten for at opretholde minimum batterireserver (0-50%). Standard er 10% for at sikre tilstrækkelig kapacitet til uventet efterspørgsel.",
+          "hsem_batteries_export_min_price": "Hårdt prægulv per slot for tilsigtet batteri-til-net eksport (issue #752). Når værdien > 0, forbyder HSEM at markere et slot som force_batteries_discharge når eksportprisen er strengt under dette gulv — batteriet kan stadig betjene husforbruget i disse slots. At nå tærsklen udløser IKKE automatisk eksport; optimizeren bestemmer stadig, om salg er økonomisk fordelagtigt. Gælder kun for tilsigtet batteri-til-net eksport, ikke for normalt selvforbrug, PV-eksport eller PV-opladning. Sæt til 0 for at deaktivere (standard)."
         },
         "description": "Konfigurer indstillinger for eksport af overskydende batterikapacitet til nettet, når det er økonomisk fordelagtigt.",
         "title": "Overskuds-eksport"
@@ -506,11 +508,13 @@
       "batteries_excess_export": {
         "data": {
           "hsem_batteries_enable_excess_export": "Enable Excess Battery Export",
-          "hsem_batteries_excess_export_discharge_buffer": "Discharge Buffer (%)"
+          "hsem_batteries_excess_export_discharge_buffer": "Discharge Buffer (%)",
+          "hsem_batteries_export_min_price": "Batterieksport Min. Pris"
         },
         "data_description": {
           "hsem_batteries_enable_excess_export": "Enable or disable the excess battery export feature, which automatically exports excess battery capacity to the grid when economically beneficial.",
-          "hsem_batteries_excess_export_discharge_buffer": "Set the safety buffer percentage to maintain minimum battery reserves (0-50%). Default is 10% to ensure adequate capacity for unexpected demand."
+          "hsem_batteries_excess_export_discharge_buffer": "Set the safety buffer percentage to maintain minimum battery reserves (0-50%). Default is 10% to ensure adequate capacity for unexpected demand.",
+          "hsem_batteries_export_min_price": "Hårdt prægulv per slot for tilsigtet batteri-til-net eksport (issue #752). Når værdien > 0, forbyder HSEM at markere et slot som force_batteries_discharge når eksportprisen er strengt under dette gulv — batteriet kan stadig betjene husforbruget i disse slots. At nå tærsklen udløser IKKE automatisk eksport; optimizeren bestemmer stadig, om salg er økonomisk fordelagtigt. Gælder kun for tilsigtet batteri-til-net eksport, ikke for normalt selvforbrug, PV-eksport eller PV-opladning. Sæt til 0 for at deaktivere (standard)."
         },
         "description": "Configure excess battery export settings to automatically sell excess energy to the grid when economically beneficial.",
         "title": "Excess Battery Export"

--- a/custom_components/hsem/translations/en.json
+++ b/custom_components/hsem/translations/en.json
@@ -30,11 +30,13 @@
       "batteries_excess_export": {
         "data": {
           "hsem_batteries_enable_excess_export": "Enable Excess Battery Export",
-          "hsem_batteries_excess_export_discharge_buffer": "Discharge Buffer (%)"
+          "hsem_batteries_excess_export_discharge_buffer": "Discharge Buffer (%)",
+          "hsem_batteries_export_min_price": "Battery Export Min Price"
         },
         "data_description": {
           "hsem_batteries_enable_excess_export": "Enable or disable the excess battery export feature, which automatically exports excess battery capacity to the grid when economically beneficial.",
-          "hsem_batteries_excess_export_discharge_buffer": "Set the safety buffer percentage to maintain minimum battery reserves (0-50%). Default is 10% to ensure adequate capacity for unexpected demand."
+          "hsem_batteries_excess_export_discharge_buffer": "Set the safety buffer percentage to maintain minimum battery reserves (0-50%). Default is 10% to ensure adequate capacity for unexpected demand.",
+          "hsem_batteries_export_min_price": "Per-slot hard floor for intentional battery-to-grid export (issue #752). When > 0, HSEM forbids marking a slot as force_batteries_discharge when the export price is strictly below this floor - the battery can still serve house load in those slots. Reaching the threshold does NOT auto-trigger export; the optimizer still decides whether selling is worthwhile. Applies only to intentional battery-to-grid export, not to normal self-consumption, PV export, or PV charging. Set to 0 to disable (default)."
         },
         "description": "Configure excess battery export settings to automatically sell excess energy to the grid when economically beneficial.",
         "title": "Excess Battery Export"
@@ -516,11 +518,13 @@
       "batteries_excess_export": {
         "data": {
           "hsem_batteries_enable_excess_export": "Enable Excess Battery Export",
-          "hsem_batteries_excess_export_discharge_buffer": "Discharge Buffer (%)"
+          "hsem_batteries_excess_export_discharge_buffer": "Discharge Buffer (%)",
+          "hsem_batteries_export_min_price": "Battery Export Min Price"
         },
         "data_description": {
           "hsem_batteries_enable_excess_export": "Enable or disable the excess battery export feature, which automatically exports excess battery capacity to the grid when economically beneficial.",
-          "hsem_batteries_excess_export_discharge_buffer": "Set the safety buffer percentage to maintain minimum battery reserves (0-50%). Default is 10% to ensure adequate capacity for unexpected demand."
+          "hsem_batteries_excess_export_discharge_buffer": "Set the safety buffer percentage to maintain minimum battery reserves (0-50%). Default is 10% to ensure adequate capacity for unexpected demand.",
+          "hsem_batteries_export_min_price": "Per-slot hard floor for intentional battery-to-grid export (issue #752). When > 0, HSEM forbids marking a slot as force_batteries_discharge when the export price is strictly below this floor - the battery can still serve house load in those slots. Reaching the threshold does NOT auto-trigger export; the optimizer still decides whether selling is worthwhile. Applies only to intentional battery-to-grid export, not to normal self-consumption, PV export, or PV charging. Set to 0 to disable (default)."
         },
         "description": "Configure excess battery export settings to automatically sell excess energy to the grid when economically beneficial.",
         "title": "Excess Battery Export"

--- a/docs/config-flow-reference.md
+++ b/docs/config-flow-reference.md
@@ -205,6 +205,7 @@ Excess battery export configuration.
 |---|---|---|---|
 | Enable excess export | `hsem_batteries_enable_excess_export` | `False` | Master switch |
 | Discharge buffer | `hsem_batteries_excess_export_discharge_buffer` | 10 % | Safety SoC buffer before forced export |
+| Battery export min price | `hsem_batteries_export_min_price` | `0.0` | Per-slot hard floor for intentional battery-to-grid export (issue #752). When > 0, the MILP forbids marking a slot as `force_batteries_discharge` when the export price is strictly below this floor — the battery can still serve house load in those slots. Reaching the threshold does NOT automatically trigger export; the optimizer still decides whether selling is worthwhile. Applies only to intentional battery-to-grid export, not to normal self-consumption, PV export, or PV charging. Set to 0 to disable. |
 | Price threshold | — | Auto-calculated | Computed from battery depreciation settings at runtime |
 
 

--- a/docs/milp-optimization.md
+++ b/docs/milp-optimization.md
@@ -279,6 +279,24 @@ This is a **hard bound** on the `ge[t]` variable — unlike the fuse it needs no
 
 Where $D_v$ is the deadline slot index for EV v.
 
+**Battery export minimum price floor (issue #752):**
+
+For each slot $t$, when `battery_export_min_price > 0` and the slot's **raw** `p_exp[t] < battery_export_min_price` (evaluated before the `min_export_price` and export-≤-import clamps):
+
+$$
+ed[t] \leq \frac{\mathrm{base\_load}[t]}{\eta_{\mathrm{dis}}}
+$$
+
+This is the **per-slot, soft-switch companion to the global `no_export` cap**. Where `no_export` blocks battery export on every slot when `excess_export_enabled = False`, the floor blocks it only on slots where the user's explicit per-slot price guard is unsatisfied. The battery can still serve house load on the blocked slot — it just cannot intentionally export to the grid there. Above the floor the optimizer is free to decide whether exporting is worthwhile; reaching the threshold does **not** automatically trigger export.
+
+Scope: the floor applies only to intentional battery-to-grid export (`ForceBatteriesDischarge`). It does not affect normal battery self-consumption, battery discharge for house load, direct PV export (`ge` is not capped — only `ed` is), or PV charging of the battery.
+
+Evaluation on the **raw** `p_exp` is essential: the user's `battery_export_min_price` floor must be honoured even when the `recommended_threshold` (auto-calculated cycle wear) or the inverter's `export_min_price` physical floor are lower.  Selecting the larger of the three floors would force every user to overwrite their own threshold when they want a stricter guard, defeating the purpose of the dedicated setting.
+
+The non-MILP `apply_excess_export` path enforces the same floor by requiring `export_price >= max(export_min_price, recommended_threshold, battery_export_min_price)` for any slot it would otherwise label `ForceBatteriesDischarge`.
+
+When `battery_export_min_price = 0` (default), no slot is ever blocked by the floor — the behavior is entirely backward compatible with the pre-#752 PLP.
+
 ---
 
 ## Price sanitisation

--- a/docs/planner-guide.md
+++ b/docs/planner-guide.md
@@ -272,6 +272,7 @@ The pre-charge window ends at `schedule.start` and is sized to fill the battery 
 | `excess_export_discharge_buffer_pct` | `10.0` | Safety SoC buffer kept before forced export |
 | `excess_export_price_threshold` | Auto-calculated | Computed at runtime from battery depreciation settings (purchase price, expected cycles, usable capacity) via `calculate_recommended_threshold()`. |
 | `export_min_price` | `0.0` | Below this export price the inverter throttles export to zero |
+| `battery_export_min_price` | `0.0` | Per-slot hard floor for intentional battery-to-grid export (issue #752). When > 0 and a slot's raw `export_price` is strictly below this value, the MILP caps `ed[t]` so the battery can only serve house load (no grid export) for that slot — `force_batteries_discharge` is never labelled there. Reaching the threshold does NOT auto-trigger export; the optimizer still decides. Applies only to intentional battery-to-grid export, not to normal battery self-consumption, PV export, or PV charging. Set to 0 to disable. |
 
 ### Seasonal configuration
 

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -488,9 +488,37 @@ bounds** on the discharge variable `ed[t]` (implemented as variable bounds in
    Note this also suppresses battery-driven grid arbitrage — intentional:
    "excess export disabled" means the battery never feeds the grid.
 
-When both apply, the tighter cap wins.  Because the battery cannot export
-under `no_export`, the MILP labels discharge slots `BatteriesDischargeMode`
-(self-consumption) rather than `ForceBatteriesDischarge` in post-processing.
+3. **Battery export minimum price floor (issue #752)** — when
+   `battery_export_min_price > 0` and the slot's RAW export price is
+   strictly below this floor (`p_exp[t] < battery_export_min_price`), the
+   battery can serve house load on that slot but cannot intentionally
+   export to the grid:
+
+   ```text
+   ed[t] <= base_load[t] / discharge_eff  (only on blocked slots)
+   ```
+
+   This is the per-slot, soft-switch companion to the global `no_export`
+   cap: instead of blocking battery export everywhere, the floor blocks
+   it only on slots whose raw export price is below the user's explicit
+   guard.  The mask is evaluated on the RAW `p_exp` (before the
+   `export_min_price` and export-≤-import clamps) so the user's explicit
+   price signal is honoured even when the recommended threshold or
+   inverter physical floor are lower.  Above the floor the optimiser is
+   free to decide whether exporting is worthwhile — reaching the
+   threshold does NOT auto-trigger export.  The guard applies only to
+   intentional battery-to-grid export (`ForceBatteriesDischarge`); it
+   does NOT restrict normal battery self-consumption, battery discharge
+   for house load, direct PV export, or PV charging of the battery.  The
+   non-MILP `apply_excess_export` path applies the same floor by
+   requiring `export_price >= max(export_min_price,
+   recommended_threshold, battery_export_min_price)` for any slot it
+   would otherwise label `ForceBatteriesDischarge`.
+
+When any apply, the tighter cap wins.  When the battery cannot export on
+a slot (`no_export` or a blocked-by-floor slot), the MILP labels
+discharge slots `BatteriesDischargeMode` (self-consumption) rather than
+`ForceBatteriesDischarge` in post-processing.
 
 ### EV co-optimisation (MILP)
 
@@ -932,6 +960,33 @@ cost) and the LP prefers curtailment (cost 0) over export (cost > 0).
 Invariant: ``export_price < export_min_price`` → planner treats export
 revenue as 0 in both optimisation and scoring.
 
+**Battery export minimum price floor (``battery_export_min_price``, issue
+#752):** When ``battery_export_min_price > 0`` and a slot's raw
+``export_price`` is strictly below this floor, the MILP forbids
+intentional battery-to-grid discharge in that slot (either by capping
+``ed[t]`` to ``base_load[t] / discharge_eff``, or by requiring
+``export_price >= battery_export_min_price`` before
+``apply_excess_export`` labels a slot ``ForceBatteriesDischarge``). To
+keep cost-function scores consistent with the optimisation assumptions:
+
+- ``CostWeights.battery_export_min_price`` mirrors the floor in
+  ``score_plan``.
+- When ``export_price < battery_export_min_price`` AND the slot is a net
+  exporter AND PV alone cannot account for the export (i.e. no material PV
+  surplus available on the slot), the export-destined portion is treated as
+  battery-destined and the export revenue (and discharge-loss
+  destination-aware pricing) is zeroed for that slot — that export can
+  never be realised by the battery.
+- Slots where PV would be exported (``solcast_pv_estimate_kwh > 0``)
+  still receive full export revenue.  The floor never restricts PV export.
+- Above the floor the optimizer decides freely — reaching the threshold
+  does NOT auto-trigger export.
+
+Invariant: ``battery_export_min_price > 0`` AND ``export_price <
+battery_export_min_price`` AND the slot's export is battery-destined (no
+PV surplus available) → the cost function scores that slot's
+export-destined revenue and discharge-loss valuation as 0.
+
 **Export-≤-import clamp (MILP unbounded-LP fix, issue #635):**
 Before solving, the MILP also clamps ``export_price[t]`` to never
 exceed ``import_price[t]`` for the same slot:
@@ -1092,6 +1147,16 @@ case `terminal_soc_value = 0.0` and `score == total_cost + penalties`.
 - Given two otherwise-identical plans, the one that ends with more stored
   battery energy must have the lower `terminal_soc_value` and therefore the
   lower `score` (all else equal).
+- (issue #752) When `battery_export_min_price > 0` and a slot's raw
+  `export_price` is strictly below this floor, the MILP never schedules
+  intentional battery-to-grid export on that slot — `grid_export_kwh` may
+  be > 0 there only when PV surplus alone would have been exported.
+- (issue #752) The non-MILP `apply_excess_export` path never labels a
+  slot `ForceBatteriesDischarge` when `export_price <
+  battery_export_min_price`.
+- (issue #752) With `battery_export_min_price = 0` (default) the
+  planner produces identical results to the pre-#752 code (backward
+  compatible).
 
 ## Price interval semantics
 

--- a/tests/planner/test_battery_export_min_price.py
+++ b/tests/planner/test_battery_export_min_price.py
@@ -1,0 +1,567 @@
+"""Regression tests for the battery_export_min_price floor (issue #752).
+
+Covers the optional per-slot hard floor for *intentional* battery-to-grid
+export.  When ``battery_export_min_price > 0`` and a slot's RAW export
+price is strictly below this floor, the planner must forbid labelling
+that slot ``force_batteries_discharge``.  Above the floor the optimizer
+is still free to decide whether exporting is worthwhile (reaching the
+threshold does NOT auto-trigger export).  The guard applies only to
+intentional battery-to-grid export — it does not affect normal battery
+self-consumption, PV export, or PV charging.  Default ``0.0`` is fully
+backward compatible.
+
+Test surfaces:
+
+- MILP path: ``solve_milp(..., battery_export_min_price=...)`` caps
+  ``ed[t]`` on blocked slots via the ``battery_export_blocked`` mask.
+- Non-MILP path: ``apply_excess_export(..., battery_export_min_price=...)``
+  requires ``export_price >= max(export_min_price, recommended_threshold,
+  battery_export_min_price)`` for any slot it would otherwise tag
+  ``ForceBatteriesDischarge``.
+- Cost function: ``CostWeights.battery_export_min_price`` zeroes
+  battery-destined export revenue on blocked slots so scored costs match
+  the optimisation assumptions.
+- Backward compatibility: ``battery_export_min_price = 0`` is identical to
+  the pre-#752 behaviour (no slot is blocked by the floor).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from custom_components.hsem.models.planned_slot import PlannedSlot
+from custom_components.hsem.planner.cost_function import score_plan
+from custom_components.hsem.planner.cost_types import CostWeights
+from custom_components.hsem.planner.discharge_scheduler import apply_excess_export
+from custom_components.hsem.planner.milp_optimizer import (
+    is_scipy_available,
+    solve_milp,
+)
+from custom_components.hsem.utils.prices import SlotPrice
+from custom_components.hsem.utils.recommendations import Recommendations
+
+_TZ = UTC
+_NOW = datetime(2024, 6, 15, 12, 0, tzinfo=_TZ)
+
+
+# ---------------------------------------------------------------------------
+# Slot helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_milp_slot(
+    *,
+    hour: int,
+    import_price: float = 0.50,
+    export_price: float = 0.40,
+    pv_kwh: float = 0.0,
+    consumption_kwh: float = 0.3,
+) -> PlannedSlot:
+    """Build a minimal PlannedSlot anchored at 2024-06-15 hour *hour*."""
+    start = datetime(2024, 6, 15, hour, 0, tzinfo=_TZ)
+    s = PlannedSlot(
+        start=start,
+        end=start + timedelta(hours=1),
+        price=SlotPrice(import_price=import_price, export_price=export_price),
+    )
+    s.avg_house_consumption_kwh = consumption_kwh
+    s.solcast_pv_estimate_kwh = pv_kwh
+    s.ev_planned_load_kwh = 0.0
+    s.estimated_net_consumption_kwh = consumption_kwh - pv_kwh
+    return s
+
+
+def _make_excess_slot(
+    *,
+    hour: int,
+    export_price: float = 0.50,
+    import_price: float = 0.20,
+    estimated_net_consumption_kwh: float = 0.5,
+    recommendation: str | None = None,
+) -> PlannedSlot:
+    """Build a PlannedSlot for apply_excess_export tests."""
+    start = datetime(2024, 6, 15, hour, 0, tzinfo=_TZ)
+    return PlannedSlot(
+        start=start,
+        end=start + timedelta(hours=1),
+        price=SlotPrice(import_price=import_price, export_price=export_price),
+        solcast_pv_estimate_kwh=0.0,
+        avg_house_consumption_kwh=0.5,
+        estimated_net_consumption_kwh=estimated_net_consumption_kwh,
+        recommendation=recommendation,
+    )
+
+
+# ===========================================================================
+# MILP — solve_milp battery_export_min_price paths
+# ===========================================================================
+
+
+@pytest.mark.skipif(not is_scipy_available(), reason="scipy not available")
+class TestMilpBatteryExportMinPrice:
+    """MILP enforces the floor via the battery_export_blocked mask."""
+
+    def test_disabled_does_not_block_any_slot(self) -> None:
+        """With battery_export_min_price=0 the behaviour matches pre-#752."""
+        # Battery full, expensive prices, near-equal import/export — the
+        # LP would happily dump battery energy to the grid.
+        slots = [
+            _make_milp_slot(hour=h, import_price=3.0, export_price=2.9)
+            for h in range(12, 16)
+        ]
+
+        floor0 = solve_milp(
+            slots,
+            _NOW,
+            current_kwh=9.0,
+            usable_kwh=9.0,
+            max_charge_per_slot=5.0,
+            max_discharge_per_slot=5.0,
+            battery_export_min_price=0.0,
+        )
+        baseline = solve_milp(
+            slots,
+            _NOW,
+            current_kwh=9.0,
+            usable_kwh=9.0,
+            max_charge_per_slot=5.0,
+            max_discharge_per_slot=5.0,
+            # Omit battery_export_min_price entirely — exercises default.
+        )
+        assert floor0 is not None
+        assert baseline is not None
+        f0_slots, _ = floor0
+        base_slots, _ = baseline
+
+        # Total grid export must match — default and explicit 0 share behaviour.
+        assert sum(float(s.grid_export_kwh) for s in f0_slots) == pytest.approx(
+            sum(float(s.grid_export_kwh) for s in base_slots), rel=1e-6
+        )
+        # Default allows intentional battery-to-grid export on these slots.
+        assert sum(float(s.grid_export_kwh) for s in f0_slots) > 0.1
+
+    def test_blocks_intentional_export_below_floor(self) -> None:
+        """Below the floor the battery can serve house load but cannot export."""
+        # Two slots, both at export_price = 0.10.  floor = 0.15 must block
+        # both.  Battery is full; prices high enough that without the guard
+        # the LP would dump battery energy to the grid.
+        slots = [
+            _make_milp_slot(hour=h, import_price=3.0, export_price=0.10)
+            for h in range(12, 14)
+        ]
+
+        result = solve_milp(
+            slots,
+            _NOW,
+            current_kwh=9.0,
+            usable_kwh=9.0,
+            max_charge_per_slot=5.0,
+            max_discharge_per_slot=5.0,
+            battery_export_min_price=0.15,
+        )
+        assert result is not None
+        out, _diag = result
+        # Battery may still cover house load (0.3 kWh AC / 0.97 eff ≈ 0.309).
+        for s in out:
+            assert s.batteries_discharged_kwh <= 0.3 / 0.97 + 1e-6
+            # No battery-destined export may be scheduled on these slots.
+            # PV export is unrestricted but no PV is present here.
+            assert s.grid_export_kwh <= 1e-6
+
+    def test_above_floor_still_export_allowed(self) -> None:
+        """At export_price >= floor the LP is free to export (no auto-trigger)."""
+        # floor = 0.15; one slot at 0.16 (>= floor), 0 PV, house load tiny.
+        # The LP must be ALLOWED to export — but it must NOT export at
+        # 0.16 because exporting that kWh is dominated by holding it for
+        # a later higher-price opportunity.  (We instead verify a high
+        # export-price slot DOES export.)
+        slots_high = [
+            _make_milp_slot(hour=h, import_price=3.0, export_price=2.0)
+            for h in range(12, 14)
+        ]
+        res_high = solve_milp(
+            slots_high,
+            _NOW,
+            current_kwh=9.0,
+            usable_kwh=9.0,
+            max_charge_per_slot=5.0,
+            max_discharge_per_slot=5.0,
+            battery_export_min_price=0.15,
+        )
+        assert res_high is not None
+        out_high, _ = res_high
+        # Above the floor the LP may export.  Sanity: at €2 export it
+        # should do so (battery full, no PV).
+        assert sum(float(s.grid_export_kwh) for s in out_high) > 0.1
+
+    def test_mixed_high_and_low_slots(self) -> None:
+        """Only slots below the floor are blocked — high slots export."""
+        # Slot at 0.10 (blocked by floor=0.15) and slot at 0.50 (allowed).
+        slots = [
+            _make_milp_slot(hour=12, import_price=3.0, export_price=0.10),
+            _make_milp_slot(hour=13, import_price=3.0, export_price=0.50),
+        ]
+
+        result = solve_milp(
+            slots,
+            _NOW,
+            current_kwh=9.0,
+            usable_kwh=9.0,
+            max_charge_per_slot=5.0,
+            max_discharge_per_slot=5.0,
+            battery_export_min_price=0.15,
+        )
+        assert result is not None
+        out, _ = result
+        # The blocked slot must contribute zero battery-destined export.
+        assert out[0].grid_export_kwh <= 1e-6
+        # The high-price slot is free to export — verify it exports.
+        assert out[1].grid_export_kwh > 0.1
+
+    def test_pv_export_unrestricted_below_floor(self) -> None:
+        """PV surplus must still export even on battery-blocked slots."""
+        # 2 kWh PV surplus slots, export_price below floor.  PV must be
+        # free to export — the floor only blocks battery-to-grid export.
+        slots = [
+            _make_milp_slot(hour=12, pv_kwh=3.0, export_price=0.10),
+            _make_milp_slot(hour=13, pv_kwh=3.0, export_price=0.10),
+        ]
+
+        result = solve_milp(
+            slots,
+            _NOW,
+            current_kwh=0.5,
+            usable_kwh=9.0,
+            max_charge_per_slot=5.0,
+            max_discharge_per_slot=5.0,
+            battery_export_min_price=0.15,
+        )
+        assert result is not None
+        out, _ = result
+        total_export = sum(float(s.grid_export_kwh) for s in out)
+        # Each slot has ~3 kWh PV surplus minus 0.3 kWh house load;
+        # the battery is too full to absorb much.  PV export must be > 0.
+        assert total_export > 0.5
+        # Battery must NOT be the source — no discharge > house load.
+        for s in out:
+            assert s.batteries_discharged_kwh <= 1e-6
+
+    def test_floor_evaluated_on_raw_export_price(self) -> None:
+        """Floor uses raw export_price, not the min_export_price-clamped one.
+
+        If the floor were evaluated AFTER the min_export_price clamp
+        (which sets p_exp < min_export_price to 0), slots with
+        0 < export_price < battery_export_min_price would NOT be blocked
+        because min_export_price=0 doesn't clamp them.  This test ensures
+        the floor is independent of that clamp.
+        """
+        # min_export_price is 0 (disabled), but battery_export_min_price
+        # is 0.15.  Slot export_price = 0.10 must still be blocked.
+        slot = _make_milp_slot(hour=12, import_price=3.0, export_price=0.10)
+
+        result = solve_milp(
+            [slot],
+            _NOW,
+            current_kwh=9.0,
+            usable_kwh=9.0,
+            max_charge_per_slot=5.0,
+            max_discharge_per_slot=5.0,
+            min_export_price=0.0,
+            battery_export_min_price=0.15,
+        )
+        assert result is not None
+        out, _ = result
+        assert out[0].grid_export_kwh <= 1e-6
+
+
+# ===========================================================================
+# Non-MILP — apply_excess_export battery_export_min_price path
+# ===========================================================================
+
+
+class TestApplyExcessExportFloor:
+    """apply_excess_export honours the floor for non-MILP candidates."""
+
+    def test_below_floor_slot_not_marked_force_discharge(self) -> None:
+        """Slot whose export_price < floor is NOT tagged ForceBatteriesDischarge."""
+        slot = _make_excess_slot(
+            hour=1,
+            export_price=0.10,
+            import_price=0.05,
+            estimated_net_consumption_kwh=-1.5,  # PV surplus, exportable
+        )
+        warnings: list[str] = []
+
+        apply_excess_export(
+            slots=[slot],
+            now=datetime(2024, 6, 15, 0, 0, tzinfo=_TZ),
+            current_capacity=1.0,
+            required_capacity=0.0,
+            export_price_threshold=0.10,
+            warnings=warnings,
+            # Both min_export_price and recommended_threshold are below
+            # the slot's price, so without the new floor this would
+            # mark the slot as ForceBatteriesDischarge.
+            export_min_price=0.0,
+            recommended_threshold=0.0,
+            battery_export_min_price=0.15,
+        )
+
+        assert slot.recommendation != Recommendations.ForceBatteriesDischarge.value
+        assert warnings == []
+
+    def test_at_floor_slot_still_may_be_marked(self) -> None:
+        """At export_price >= floor the candidate is eligible (no auto-trigger).
+
+        The slot at exactly 0.15 (== floor) is eligible to be tagged
+        ForceBatteriesDischarge when the optimizer decides to do so.  We
+        don't assert that the optimizer *must* mark it (that depends on
+        the budget logic), just that the floor itself doesn't refuse it.
+        """
+        slot = _make_excess_slot(
+            hour=1,
+            export_price=0.15,
+            import_price=0.05,
+            estimated_net_consumption_kwh=-1.5,
+        )
+        warnings: list[str] = []
+
+        apply_excess_export(
+            slots=[slot],
+            now=datetime(2024, 6, 15, 0, 0, tzinfo=_TZ),
+            current_capacity=1.0,
+            required_capacity=0.0,
+            export_price_threshold=0.10,
+            warnings=warnings,
+            export_min_price=0.0,
+            recommended_threshold=0.0,
+            battery_export_min_price=0.15,
+        )
+
+        # The slot is eligible (>= floor) AND surplus AND exportable.
+        # apply_excess_export will mark it.
+        assert slot.recommendation == Recommendations.ForceBatteriesDischarge.value
+        assert len(warnings) == 1
+
+    def test_floor_takes_precedence_over_lower_thresholds(self) -> None:
+        """Floor > recommended_threshold > 0 — floor decides.
+
+        A slot at export_price=0.12 is above recommended_threshold=0.10
+        but below battery_export_min_price=0.15.  Without the floor, the
+        pre-#752 logic (export_price >= max(export_min_price,
+        recommended_threshold)) would mark it.  With the floor it must
+        NOT be marked.
+        """
+        slot = _make_excess_slot(
+            hour=1,
+            export_price=0.12,
+            import_price=0.05,
+            estimated_net_consumption_kwh=-1.5,
+        )
+        warnings: list[str] = []
+
+        apply_excess_export(
+            slots=[slot],
+            now=datetime(2024, 6, 15, 0, 0, tzinfo=_TZ),
+            current_capacity=1.0,
+            required_capacity=0.0,
+            export_price_threshold=0.10,
+            warnings=warnings,
+            export_min_price=0.0,
+            recommended_threshold=0.10,
+            battery_export_min_price=0.15,
+        )
+
+        assert slot.recommendation != Recommendations.ForceBatteriesDischarge.value
+        assert warnings == []
+
+    def test_disabled_floor_matches_baseline(self) -> None:
+        """With battery_export_min_price=0 the behaviour matches pre-#752."""
+        slot_baseline = _make_excess_slot(
+            hour=1,
+            export_price=0.50,
+            import_price=0.20,
+            estimated_net_consumption_kwh=-1.0,
+        )
+        slot_floor0 = _make_excess_slot(
+            hour=1,
+            export_price=0.50,
+            import_price=0.20,
+            estimated_net_consumption_kwh=-1.0,
+        )
+        warnings_baseline: list[str] = []
+        warnings_floor0: list[str] = []
+
+        apply_excess_export(
+            slots=[slot_baseline],
+            now=datetime(2024, 6, 15, 0, 0, tzinfo=_TZ),
+            current_capacity=1.0,
+            required_capacity=0.0,
+            export_price_threshold=0.10,
+            warnings=warnings_baseline,
+        )
+        # Explicit 0 must match omitted (default).
+        apply_excess_export(
+            slots=[slot_floor0],
+            now=datetime(2024, 6, 15, 0, 0, tzinfo=_TZ),
+            current_capacity=1.0,
+            required_capacity=0.0,
+            export_price_threshold=0.10,
+            warnings=warnings_floor0,
+            battery_export_min_price=0.0,
+        )
+
+        assert slot_baseline.recommendation == slot_floor0.recommendation
+        assert len(warnings_floor0) == len(warnings_baseline)
+
+
+# ===========================================================================
+# Cost function — CostWeights.battery_export_min_price consistency
+# ===========================================================================
+
+
+def _slot_with_export(
+    *,
+    hour: int,
+    export_price: float,
+    grid_export_kwh: float,
+    pv_kwh: float = 0.0,
+    batteries_discharged_kwh: float = 0.0,
+) -> PlannedSlot:
+    """Build a finished slot with explicit grid_export and battery discharge."""
+    start = datetime(2024, 6, 15, hour, 0, tzinfo=_TZ)
+    s = PlannedSlot(
+        start=start,
+        end=start + timedelta(hours=1),
+        price=SlotPrice(import_price=0.50, export_price=export_price),
+    )
+    s.avg_house_consumption_kwh = 0.5
+    s.solcast_pv_estimate_kwh = pv_kwh
+    s.ev_planned_load_kwh = 0.0
+    s.estimated_net_consumption_kwh = 0.5 - pv_kwh
+    s.grid_export_kwh = grid_export_kwh
+    s.grid_import_kwh = 0.0
+    s.batteries_charged_kwh = 0.0
+    s.batteries_discharged_kwh = batteries_discharged_kwh
+    s.estimated_battery_soc_pct = 50.0
+    s.estimated_battery_capacity_kwh = 10.0
+    return s
+
+
+class TestCostFunctionFloor:
+    """score_plan zeroes battery-destined export revenue on blocked slots."""
+
+    def test_battery_destined_export_zeroed_below_floor(self) -> None:
+        """Below the floor, a battery-destined export earns nothing in score.
+
+        A slot with PV=0 (so export can only be battery-destined), export
+        1.0 kWh at 0.10, and battery discharge 1.05 kWh.  With floor=0.15,
+        the cost function must value that export at 0 (it can never be
+        realised).  Without the floor the export revenue would be 0.10.
+        """
+        slot = _slot_with_export(
+            hour=12,
+            export_price=0.10,
+            grid_export_kwh=1.0,
+            pv_kwh=0.0,
+            batteries_discharged_kwh=1.05,
+        )
+
+        weights = CostWeights(
+            export_min_price=0.0,
+            battery_export_min_price=0.15,
+        )
+        bd = score_plan([slot], initial_battery_kwh=10.0, weights=weights)
+        assert bd.export_revenue == pytest.approx(0.0, abs=1e-9)
+
+        # Without the floor (default 0), export revenue should be 0.10.
+        weights_no_floor = CostWeights(
+            export_min_price=0.0,
+            battery_export_min_price=0.0,
+        )
+        bd2 = score_plan(
+            [slot],
+            initial_battery_kwh=10.0,
+            weights=weights_no_floor,
+        )
+        assert bd2.export_revenue == pytest.approx(0.10, rel=1e-6)
+
+    def test_pv_destined_export_not_zeroed_below_floor(self) -> None:
+        """A slot with PV surplus exporting below the floor is NOT zeroed.
+
+        With pv_kwh = 1.2 kWh and house load 0.5, the 1.0 kWh export is
+        PV-destined.  The floor only blocks battery-destined export.
+        """
+        slot = _slot_with_export(
+            hour=12,
+            export_price=0.10,
+            grid_export_kwh=1.0,
+            pv_kwh=1.5,
+            batteries_discharged_kwh=0.0,
+        )
+
+        weights = CostWeights(
+            export_min_price=0.0,
+            battery_export_min_price=0.15,
+        )
+        bd = score_plan(
+            [slot],
+            initial_battery_kwh=10.0,
+            weights=weights,
+        )
+        assert bd.export_revenue == pytest.approx(0.10, rel=1e-6)
+
+    def test_above_floor_export_revenue_retained(self) -> None:
+        """At export_price >= floor, the cost function keeps export revenue."""
+        slot = _slot_with_export(
+            hour=12,
+            export_price=0.20,
+            grid_export_kwh=1.0,
+            pv_kwh=0.0,
+            batteries_discharged_kwh=1.05,
+        )
+
+        weights = CostWeights(
+            export_min_price=0.0,
+            battery_export_min_price=0.15,
+        )
+        bd = score_plan(
+            [slot],
+            initial_battery_kwh=10.0,
+            weights=weights,
+        )
+        assert bd.export_revenue == pytest.approx(0.20, rel=1e-6)
+
+    def test_disabled_floor_matches_baseline(self) -> None:
+        """battery_export_min_price = 0 is identical to the pre-#752 cost function."""
+        slot = _slot_with_export(
+            hour=12,
+            export_price=0.10,
+            grid_export_kwh=1.0,
+            pv_kwh=0.0,
+            batteries_discharged_kwh=1.05,
+        )
+
+        weights_zero = CostWeights(
+            export_min_price=0.0,
+            battery_export_min_price=0.0,
+        )
+        weights_default = CostWeights(
+            export_min_price=0.0,
+            # Default battery_export_min_price is 0.0 in dataclass.
+        )
+
+        bd_zero = score_plan(
+            [slot],
+            initial_battery_kwh=10.0,
+            weights=weights_zero,
+        )
+        bd_default = score_plan(
+            [slot],
+            initial_battery_kwh=10.0,
+            weights=weights_default,
+        )
+
+        assert bd_zero.total_cost == pytest.approx(bd_default.total_cost, rel=1e-9)

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -894,6 +894,7 @@ class TestFlowValidatorsUseConfigValidator:
             {
                 "hsem_batteries_enable_excess_export": True,
                 "hsem_batteries_excess_export_discharge_buffer": 51,
+                "hsem_batteries_export_min_price": 0.0,
             }
         )
         assert (
@@ -911,6 +912,7 @@ class TestFlowValidatorsUseConfigValidator:
             {
                 "hsem_batteries_enable_excess_export": True,
                 "hsem_batteries_excess_export_discharge_buffer": 10,
+                "hsem_batteries_export_min_price": 0.0,
             }
         )
         assert errors == {}

--- a/tests/test_excess_battery_export.py
+++ b/tests/test_excess_battery_export.py
@@ -150,8 +150,9 @@ class TestValidateBatteriesExcessExportInput:
     """Unit tests for the config-flow input validator.
 
     The price threshold is no longer a manual input — it is auto-calculated
-    at runtime from battery depreciation parameters.  Only the discharge
-    buffer field is validated here.
+    at runtime from battery depreciation parameters.  The discharge buffer
+    and the optional battery export minimum price floor (issue #752) are
+    validated here.
     """
 
     @pytest.mark.asyncio
@@ -160,6 +161,7 @@ class TestValidateBatteriesExcessExportInput:
         user_input = {
             "hsem_batteries_enable_excess_export": True,
             "hsem_batteries_excess_export_discharge_buffer": 10,
+            "hsem_batteries_export_min_price": 0.0,
         }
         errors = await validate_batteries_excess_export_input(user_input)
         assert errors == {}
@@ -170,6 +172,7 @@ class TestValidateBatteriesExcessExportInput:
         user_input = {
             "hsem_batteries_enable_excess_export": False,
             "hsem_batteries_excess_export_discharge_buffer": 0,
+            "hsem_batteries_export_min_price": 0.0,
         }
         errors = await validate_batteries_excess_export_input(user_input)
         assert errors == {}
@@ -180,6 +183,7 @@ class TestValidateBatteriesExcessExportInput:
         user_input = {
             "hsem_batteries_enable_excess_export": False,
             "hsem_batteries_excess_export_discharge_buffer": 50,
+            "hsem_batteries_export_min_price": 0.0,
         }
         errors = await validate_batteries_excess_export_input(user_input)
         assert errors == {}
@@ -190,6 +194,7 @@ class TestValidateBatteriesExcessExportInput:
         user_input = {
             "hsem_batteries_enable_excess_export": True,
             "hsem_batteries_excess_export_discharge_buffer": 51,
+            "hsem_batteries_export_min_price": 0.0,
         }
         errors = await validate_batteries_excess_export_input(user_input)
         assert "hsem_batteries_excess_export_discharge_buffer" in errors
@@ -200,6 +205,7 @@ class TestValidateBatteriesExcessExportInput:
         user_input = {
             "hsem_batteries_enable_excess_export": True,
             "hsem_batteries_excess_export_discharge_buffer": -1,
+            "hsem_batteries_export_min_price": 0.0,
         }
         errors = await validate_batteries_excess_export_input(user_input)
         assert "hsem_batteries_excess_export_discharge_buffer" in errors
@@ -210,6 +216,7 @@ class TestValidateBatteriesExcessExportInput:
         user_input = {
             "hsem_batteries_enable_excess_export": True,
             "hsem_batteries_excess_export_discharge_buffer": 10.5,
+            "hsem_batteries_export_min_price": 0.0,
         }
         errors = await validate_batteries_excess_export_input(user_input)
         assert errors == {}
@@ -219,3 +226,47 @@ class TestValidateBatteriesExcessExportInput:
         """Empty dict should not raise — missing optional fields are skipped."""
         errors = await validate_batteries_excess_export_input({})
         assert errors == {}
+
+    @pytest.mark.asyncio
+    async def test_battery_export_min_price_at_zero_is_valid(self):
+        """Floor of 0.0 is the default (disabled) and must be accepted."""
+        user_input = {
+            "hsem_batteries_enable_excess_export": True,
+            "hsem_batteries_excess_export_discharge_buffer": 10,
+            "hsem_batteries_export_min_price": 0.0,
+        }
+        errors = await validate_batteries_excess_export_input(user_input)
+        assert errors == {}
+
+    @pytest.mark.asyncio
+    async def test_battery_export_min_price_at_max_is_valid(self):
+        """Floor of 2.0 is at the maximum boundary and must be accepted."""
+        user_input = {
+            "hsem_batteries_enable_excess_export": True,
+            "hsem_batteries_excess_export_discharge_buffer": 10,
+            "hsem_batteries_export_min_price": 2.0,
+        }
+        errors = await validate_batteries_excess_export_input(user_input)
+        assert errors == {}
+
+    @pytest.mark.asyncio
+    async def test_battery_export_min_price_above_max_is_invalid(self):
+        """Floor > 2.0 must be rejected."""
+        user_input = {
+            "hsem_batteries_enable_excess_export": True,
+            "hsem_batteries_excess_export_discharge_buffer": 10,
+            "hsem_batteries_export_min_price": 2.01,
+        }
+        errors = await validate_batteries_excess_export_input(user_input)
+        assert "hsem_batteries_export_min_price" in errors
+
+    @pytest.mark.asyncio
+    async def test_battery_export_min_price_negative_is_invalid(self):
+        """Negative floor must be rejected."""
+        user_input = {
+            "hsem_batteries_enable_excess_export": True,
+            "hsem_batteries_excess_export_discharge_buffer": 10,
+            "hsem_batteries_export_min_price": -0.01,
+        }
+        errors = await validate_batteries_excess_export_input(user_input)
+        assert "hsem_batteries_export_min_price" in errors


### PR DESCRIPTION
## Summary

Adds an optional per-slot hard floor on the export price below which intentional battery-to-grid discharge is forbidden.  When `battery_export_min_price > 0` and a slot's raw export price is strictly below this floor, the MILP caps `ed[t]` so the battery can only serve house load (no grid export) on that slot.  Above the floor the optimizer decides freely — reaching the threshold does NOT auto-trigger export.

The guard applies only to intentional battery-to-grid export (`ForceBatteriesDischarge`); it does not affect normal battery self-consumption, PV export, or PV charging.  Default `0.0` is fully backward compatible.

## Branch

`feat/752-battery-export-min-price`

## Files Changed

| File | Change |
|---|---|
| `custom_components/hsem/const.py` | Add `hsem_batteries_export_min_price` default (`0.0`) |
| `custom_components/hsem/flows/batteries_excess_export.py` | Add schema field + validation for the new floor |
| `custom_components/hsem/models/sensor_config.py` | Add `batteries_export_min_price` field |
| `custom_components/hsem/custom_sensors/config_reader.py` | Read new config key into `SensorConfig` |
| `custom_components/hsem/models/planner_input.py` | Add `battery_export_min_price` field |
| `custom_components/hsem/coordinator_builder.py` | Wire into `PlannerInput` |
| `custom_components/hsem/planner/candidate_generator.py` | Pass floor to `solve_milp` |
| `custom_components/hsem/planner/milp_optimizer.py` | Compute `battery_export_blocked` mask from raw `p_exp` |
| `custom_components/hsem/planner/milp/_constraints.py` | Apply per-slot `ed[t]` cap on blocked slots |
| `custom_components/hsem/planner/discharge_scheduler.py` | Enforce floor in `apply_excess_export` |
| `custom_components/hsem/planner/cost_types.py` | Add `battery_export_min_price` to `CostWeights` |
| `custom_components/hsem/planner/cost_function.py` | Zero battery-destined export revenue on blocked slots |
| `custom_components/hsem/planner/engine_core.py` | Pass floor to `CostWeights` |
| `custom_components/hsem/translations/en.json` | Add user-facing strings (config + options) |
| `custom_components/hsem/translations/da.json` | Add Danish translations (config + options) |
| `docs/planner-spec.md` | Document MILP constraint + cost-function invariant |
| `docs/planner-guide.md` | Document new planner input field |
| `docs/config-flow-reference.md` | Document new config flow field |
| `docs/milp-optimization.md` | Document new MILP bound |
| `.github/memories.md` | Document canonical wiring pattern |
| `README.md` | Add feature bullet |
| `tests/planner/test_battery_export_min_price.py` | 14 regression tests (MILP, non-MILP, cost function) |
| `tests/test_excess_battery_export.py` | Update validator tests for new field |
| `tests/test_config_validation.py` | Update validator tests for new field |

## What Changed and Why

Issue #752 requested an optional advanced setting `battery_export_min_price` that gives users a simple, predictable guard for intentional battery-to-grid export while keeping HSEM's existing cost-based optimization fully intact.

The implementation follows the same pattern as the existing `no_export` cap (issue #592) but applies it per-slot based on the raw export price:

1. **MILP path**: `solve_milp` computes a `battery_export_blocked` boolean mask from the raw `p_exp` array (before the `min_export_price` and export-≤-import clamps).  This mask is passed to `_build_constraints`, which applies `ed[t] ≤ base_load[t] / discharge_eff` on blocked slots — the same cap used by `no_export`, but selectively.

2. **Non-MILP path**: `apply_excess_export` now requires `export_price >= max(export_min_price, recommended_threshold, battery_export_min_price)` for any slot it would otherwise label `ForceBatteriesDischarge`.

3. **Cost function**: `CostWeights.battery_export_min_price` mirrors the floor so that battery-destined export revenue (and discharge-loss export-destined pricing) is zeroed on blocked slots — scored costs match the optimisation assumptions.

## Tests Added or Updated

- **14 new regression tests** in `tests/planner/test_battery_export_min_price.py`:
  - MILP: disabled floor matches baseline, blocks below floor, allows above floor, mixed slots, PV export unrestricted, raw-price evaluation
  - Non-MILP: below floor not marked, at floor eligible, floor takes precedence, disabled matches baseline
  - Cost function: battery-destined zeroed, PV-destined retained, above floor retained, disabled matches baseline
- **Updated** `tests/test_excess_battery_export.py` and `tests/test_config_validation.py` to include the new required field in validator test inputs

## Test and Lint Results

- `./scripts/quality.sh lint` — ✅ All checks passed
- `./scripts/quality.sh typing` — ✅ 0 errors in 287 source files
- `./scripts/quality.sh quality` — ✅ 0 errors, 0 warnings
- `./scripts/quality.sh test` — ✅ 2,495 passed, 0 failed

## Backward Compatibility

With `battery_export_min_price = 0` (default), the planner produces identical results to the pre-#752 code.  The feature is entirely opt-in.

Fixes #752