### PR TITLE
feat(devcontainer): support YubiKey SSH/GPG relay on Windows hosts

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -46,6 +46,54 @@ To uninstall the relay:
    sh .devcontainer/scripts/install-agent-relay.sh uninstall
    ```
 
+**Windows setup**: Docker Desktop on Windows cannot forward Windows named pipes or
+GnuPG's emulated sockets into containers, so the same TCP relay architecture is used.
+The Windows relay ([start-agent-relay.ps1](scripts/start-agent-relay.ps1)) is pure
+PowerShell — no Python or other dependencies needed on the host.
+
+Prerequisites:
+
+- [Gpg4win](https://gpg4win.org/) (or another GnuPG for Windows) with the YubiKey
+  already set up, and `%APPDATA%\gnupg\gpg-agent.conf` containing:
+  ```
+  enable-ssh-support
+  enable-win32-openssh-support
+  ```
+  The second option makes gpg-agent serve the `\\.\pipe\openssh-ssh-agent` named
+  pipe, which the relay forwards to the container on port 9999.
+- Docker Desktop for Windows.
+
+Setup steps:
+
+1. **Install the relay as a per-user Scheduled Task** (starts at logon, restarts on
+   failure, no admin required). Run in PowerShell from the repository root:
+   ```powershell
+   powershell -NoProfile -ExecutionPolicy Bypass -File .devcontainer\scripts\install-agent-relay.ps1 install
+   ```
+   This starts TCP relays on ports 9999 (SSH agent), 9998 (GPG agent), 9997 (scdaemon),
+   and snapshots your public GnuPG key material (`%APPDATA%\gnupg`) into
+   `.devcontainer/gnupg-host/` (git-ignored) so the container can verify signatures
+   and know which keys live on the YubiKey. Re-run `install` after adding new keys.
+
+2. **Check status**:
+   ```powershell
+   powershell -NoProfile -ExecutionPolicy Bypass -File .devcontainer\scripts\install-agent-relay.ps1 status
+   ```
+
+3. **Open the devcontainer** in VS Code (`F1` → `Dev Containers: Reopen in Container`).
+   The `postCreateCommand` automatically starts the container-side socat bridge.
+
+4. **Verify**: run `ssh -T git@github.com` and `gpg --card-status` in the container terminal.
+
+To uninstall the relay:
+   ```powershell
+   powershell -NoProfile -ExecutionPolicy Bypass -File .devcontainer\scripts\install-agent-relay.ps1 uninstall
+   ```
+
+> **Note:** Signing commits or authenticating may require touching the YubiKey or
+> entering its PIN — the pinentry prompt appears on the Windows host, not in the
+> container.
+
 **macOS filesystem performance**
 
 Docker Desktop on macOS runs containers inside a Linux VM, so the default bind-mounted workspace is slower than the native container filesystem. This devcontainer mitigates that by:

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -18,7 +18,8 @@ In the container you will have a dedicated Home Assistant core instance running 
 The devcontainer is pre-configured to use your YubiKey for SSH authentication and GPG signing:
 
 - `gnupg`, `gpg-agent`, `pinentry`, `socat`, `openssh-client`, and `git` are installed in the container
-- Your host `~/.ssh`, `~/.gnupg`, and `~/.gitconfig` are mounted into the container
+- Your host `~/.ssh` and `~/.gitconfig` are staged into `.devcontainer/host-config/` by the `initializeCommand` and then mounted into the container
+- Your host `~/.gnupg` public key material is snapshotted into `.devcontainer/gnupg-host/` by the Windows/macOS installer and mounted into the container
 - `yubikey-manager` CLI (`ykman`) is available for managing your YubiKey
 
 **macOS setup**: Docker Desktop runs inside a Linux VM and cannot forward Unix domain

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -18,7 +18,8 @@ In the container you will have a dedicated Home Assistant core instance running 
 The devcontainer is pre-configured to use your YubiKey for SSH authentication and GPG signing:
 
 - `gnupg`, `gpg-agent`, `pinentry`, `socat`, `openssh-client`, and `git` are installed in the container
-- Your host `~/.ssh` and `~/.gitconfig` are staged into `.devcontainer/host-config/` by the `initializeCommand` and then mounted into the container
+- On Unix hosts, your host `~/.ssh` and `~/.gitconfig` are staged into `.devcontainer/host-config/` by the `initializeCommand` and then mounted into the container
+- On Windows hosts, the installer stages your host `~/.ssh` and `~/.gitconfig` into `.devcontainer/host-config/`
 - Your host `~/.gnupg` public key material is snapshotted into `.devcontainer/gnupg-host/` by the Windows/macOS installer and mounted into the container
 - `yubikey-manager` CLI (`ykman`) is available for managing your YubiKey
 
@@ -72,9 +73,11 @@ Setup steps:
    powershell -NoProfile -ExecutionPolicy Bypass -File .devcontainer\scripts\install-agent-relay.ps1 install
    ```
    This starts TCP relays on ports 9999 (SSH agent), 9998 (GPG agent), 9997 (scdaemon),
-   and snapshots your public GnuPG key material (`%APPDATA%\gnupg`) into
-   `.devcontainer/gnupg-host/` (git-ignored) so the container can verify signatures
-   and know which keys live on the YubiKey. Re-run `install` after adding new keys.
+   stages `%USERPROFILE%\.ssh` and `%USERPROFILE%\.gitconfig` into
+   `.devcontainer/host-config/` (git-ignored), and snapshots your public GnuPG key
+   material (`%APPDATA%\gnupg`) into `.devcontainer/gnupg-host/` (git-ignored) so the
+   container can verify signatures and know which keys live on the YubiKey. Re-run
+   `install` after changing SSH/Git config or adding new keys.
 
 2. **Check status**:
    ```powershell

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -63,6 +63,8 @@ Prerequisites:
   ```
   The second option makes gpg-agent serve the `\\.\pipe\openssh-ssh-agent` named
   pipe, which the relay forwards to the container on port 9999.
+- A shell such as Git Bash or WSL2 so the devcontainer can run
+  `.devcontainer/scripts/initialize-host.sh` during container initialization.
 - Docker Desktop for Windows.
 
 Setup steps:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
   "initializeCommand": {
     "linux": "sh .devcontainer/scripts/initialize-host.sh",
     "darwin": "sh .devcontainer/scripts/initialize-host.sh",
-    "win32": "pwsh -NoProfile -Command \"if ($IsWindows) { Set-ExecutionPolicy -Scope Process Bypass -Force }; & '${localWorkspaceFolder}/.devcontainer/scripts/initialize-host.ps1'\""
+    "win32": "pwsh -NoProfile -Command \"if (\\$IsWindows) { Set-ExecutionPolicy -Scope Process Bypass -Force }; & '${localWorkspaceFolder}/.devcontainer/scripts/initialize-host.ps1'\""
   },
   "runArgs": ["--name", "hsem-devcontainer"],
   "remoteUser": "root",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,14 +11,19 @@
   },
   "postCreateCommand": "/usr/local/bin/setup-python-deps.sh; if [ -z \"$CI\" ]; then /usr/local/bin/devcontainer-agent-bridge.sh /bin/sh -c 'echo SSH agent ready in container || true'; fi",
   "postStartCommand": "if [ -z \"$CI\" ]; then nohup /usr/local/bin/devcontainer-agent-bridge.sh /bin/true >/tmp/agent-bridge.log 2>&1 & fi",
+  "initializeCommand": {
+    "linux": "sh .devcontainer/scripts/initialize-host.sh",
+    "darwin": "sh .devcontainer/scripts/initialize-host.sh",
+    "win32": "powershell -NoProfile -ExecutionPolicy Bypass -File .devcontainer/scripts/initialize-host.ps1"
+  },
   "runArgs": ["--name", "hsem-devcontainer"],
   "remoteUser": "root",
   "forwardPorts": [8123],
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/hsem,type=bind,consistency=cached",
   "workspaceFolder": "/workspaces/hsem",
   "mounts": [
-    "type=bind,source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/root/.ssh,readonly",
-    "type=bind,source=${localEnv:HOME}${localEnv:USERPROFILE}/.gitconfig,target=/root/.gitconfig",
+    "type=bind,source=${localWorkspaceFolder}/.devcontainer/host-config/.ssh,target=/root/.ssh,readonly",
+    "type=bind,source=${localWorkspaceFolder}/.devcontainer/host-config/.gitconfig,target=/root/.gitconfig",
     "source=hsem-cache,target=/workspaces/hsem/.cache,type=volume"
   ],
   "containerEnv": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,9 +17,8 @@
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/hsem,type=bind,consistency=cached",
   "workspaceFolder": "/workspaces/hsem",
   "mounts": [
-    "type=bind,source=${localEnv:HOME}/.ssh,target=/root/.ssh,readonly",
-    "type=bind,source=${localEnv:HOME}/.gnupg,target=/root/.gnupg",
-    "type=bind,source=${localEnv:HOME}/.gitconfig,target=/root/.gitconfig",
+    "type=bind,source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/root/.ssh,readonly",
+    "type=bind,source=${localEnv:HOME}${localEnv:USERPROFILE}/.gitconfig,target=/root/.gitconfig",
     "source=hsem-cache,target=/workspaces/hsem/.cache,type=volume"
   ],
   "containerEnv": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
   "initializeCommand": {
     "linux": "sh .devcontainer/scripts/initialize-host.sh",
     "darwin": "sh .devcontainer/scripts/initialize-host.sh",
-    "win32": "pwsh -NoProfile -ExecutionPolicy Bypass -File ${localWorkspaceFolder}/.devcontainer/scripts/initialize-host.ps1"
+    "win32": "pwsh -NoProfile -Command \"if ($IsWindows) { Set-ExecutionPolicy -Scope Process Bypass -Force }; & '${localWorkspaceFolder}/.devcontainer/scripts/initialize-host.ps1'\""
   },
   "runArgs": ["--name", "hsem-devcontainer"],
   "remoteUser": "root",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
   "initializeCommand": {
     "linux": "sh .devcontainer/scripts/initialize-host.sh",
     "darwin": "sh .devcontainer/scripts/initialize-host.sh",
-    "win32": "pwsh -NoProfile -ExecutionPolicy Bypass -File .devcontainer/scripts/initialize-host.ps1"
+    "win32": "pwsh -NoProfile -ExecutionPolicy Bypass -File ${localWorkspaceFolder}/.devcontainer/scripts/initialize-host.ps1"
   },
   "runArgs": ["--name", "hsem-devcontainer"],
   "remoteUser": "root",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,11 +11,7 @@
   },
   "postCreateCommand": "/usr/local/bin/setup-python-deps.sh; if [ -z \"$CI\" ]; then /usr/local/bin/devcontainer-agent-bridge.sh /bin/sh -c 'echo SSH agent ready in container || true'; fi",
   "postStartCommand": "if [ -z \"$CI\" ]; then nohup /usr/local/bin/devcontainer-agent-bridge.sh /bin/true >/tmp/agent-bridge.log 2>&1 & fi",
-  "initializeCommand": {
-    "linux": "sh .devcontainer/scripts/initialize-host.sh",
-    "darwin": "sh .devcontainer/scripts/initialize-host.sh",
-    "win32": "pwsh -NoProfile -Command \"if (\\$IsWindows) { Set-ExecutionPolicy -Scope Process Bypass -Force }; & '${localWorkspaceFolder}/.devcontainer/scripts/initialize-host.ps1'\""
-  },
+  "initializeCommand": "sh .devcontainer/scripts/initialize-host.sh",
   "runArgs": ["--name", "hsem-devcontainer"],
   "remoteUser": "root",
   "forwardPorts": [8123],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
   "initializeCommand": {
     "linux": "sh .devcontainer/scripts/initialize-host.sh",
     "darwin": "sh .devcontainer/scripts/initialize-host.sh",
-    "win32": "powershell -NoProfile -ExecutionPolicy Bypass -File .devcontainer/scripts/initialize-host.ps1"
+    "win32": "pwsh -NoProfile -ExecutionPolicy Bypass -File .devcontainer/scripts/initialize-host.ps1"
   },
   "runArgs": ["--name", "hsem-devcontainer"],
   "remoteUser": "root",

--- a/.devcontainer/scripts/devcontainer-agent-bridge.sh
+++ b/.devcontainer/scripts/devcontainer-agent-bridge.sh
@@ -55,7 +55,8 @@ echo "scdaemon bridge ready:    /tmp/S.scdaemon -> ${AGENT_HOST}:${SCDAEMON_PORT
 # Docker Desktop bind mounts and are recreated as symlinks below.
 #
 # Source selection:
-#  - macOS/Linux: the host ~/.gnupg bind mount at /root/.gnupg.
+#  - macOS/Linux: the host ~/.gnupg bind mount at /root/.gnupg, or the
+#    macOS/Linux installer snapshot under .devcontainer/gnupg-host.
 #  - Windows: GnuPG lives in %APPDATA%\gnupg, so the Windows installer
 #    snapshots the public key material into .devcontainer/gnupg-host
 #    (inside the workspace bind mount) instead.

--- a/.devcontainer/scripts/devcontainer-agent-bridge.sh
+++ b/.devcontainer/scripts/devcontainer-agent-bridge.sh
@@ -59,6 +59,9 @@ echo "scdaemon bridge ready:    /tmp/S.scdaemon -> ${AGENT_HOST}:${SCDAEMON_PORT
 #  - Windows: GnuPG lives in %APPDATA%\gnupg, so the Windows installer
 #    snapshots the public key material into .devcontainer/gnupg-host
 #    (inside the workspace bind mount) instead.
+#
+# CI creates an empty ~/.gitconfig directory as a bind-mount stub, so we
+# must not copy it (git rejects a directory as its config file).
 GPG_SRC=/root/.gnupg
 GPG_SNAPSHOT=/workspaces/hsem/.devcontainer/gnupg-host
 if [ ! -e "${GPG_SRC}/pubring.kbx" ] && [ ! -e "${GPG_SRC}/pubring.gpg" ] \
@@ -68,7 +71,9 @@ if [ ! -e "${GPG_SRC}/pubring.kbx" ] && [ ! -e "${GPG_SRC}/pubring.gpg" ] \
 fi
 rm -rf /tmp/gpg-home
 mkdir -p /tmp/gpg-home
-find "${GPG_SRC}" -mindepth 1 -maxdepth 1 ! -type s -exec cp -a {} /tmp/gpg-home/ \;
+if [ -d "${GPG_SRC}" ]; then
+    find "${GPG_SRC}" -mindepth 1 -maxdepth 1 ! -type s -exec cp -a {} /tmp/gpg-home/ \;
+fi
 rm -f /tmp/gpg-home/S.gpg-agent /tmp/gpg-home/S.scdaemon /tmp/gpg-home/S.gpg-agent.ssh
 ln -sf /tmp/S.gpg-agent /tmp/gpg-home/S.gpg-agent
 ln -sf /tmp/S.scdaemon /tmp/gpg-home/S.scdaemon
@@ -78,8 +83,13 @@ export SSH_AUTH_SOCK=/tmp/ssh-agent.sock
 export GNUPGHOME=/tmp/gpg-home
 
 # Create writable global git config (host ~/.gitconfig is mounted read-only
-# and may point to /opt/homebrew/bin/gpg which doesn't exist in the container)
-cp /root/.gitconfig /tmp/gitconfig 2>/dev/null || true
+# and may point to /opt/homebrew/bin/gpg which doesn't exist in the
+# container). In CI the stub is an empty directory; start from scratch then.
+if [ -f /root/.gitconfig ]; then
+    cp /root/.gitconfig /tmp/gitconfig
+else
+    : > /tmp/gitconfig
+fi
 git config -f /tmp/gitconfig gpg.program /usr/bin/gpg 2>/dev/null || true
 export GIT_CONFIG_GLOBAL=/tmp/gitconfig
 

--- a/.devcontainer/scripts/devcontainer-agent-bridge.sh
+++ b/.devcontainer/scripts/devcontainer-agent-bridge.sh
@@ -53,9 +53,22 @@ echo "scdaemon bridge ready:    /tmp/S.scdaemon -> ${AGENT_HOST}:${SCDAEMON_PORT
 # replace the sockets with our relayed ones.
 # Skip host agent sockets here: they cannot be reliably copied across
 # Docker Desktop bind mounts and are recreated as symlinks below.
+#
+# Source selection:
+#  - macOS/Linux: the host ~/.gnupg bind mount at /root/.gnupg.
+#  - Windows: GnuPG lives in %APPDATA%\gnupg, so the Windows installer
+#    snapshots the public key material into .devcontainer/gnupg-host
+#    (inside the workspace bind mount) instead.
+GPG_SRC=/root/.gnupg
+GPG_SNAPSHOT=/workspaces/hsem/.devcontainer/gnupg-host
+if [ ! -e "${GPG_SRC}/pubring.kbx" ] && [ ! -e "${GPG_SRC}/pubring.gpg" ] \
+    && [ -d "${GPG_SNAPSHOT}" ]; then
+    GPG_SRC="${GPG_SNAPSHOT}"
+    echo "Using Windows gnupg snapshot: ${GPG_SNAPSHOT}"
+fi
 rm -rf /tmp/gpg-home
 mkdir -p /tmp/gpg-home
-find /root/.gnupg -mindepth 1 -maxdepth 1 ! -type s -exec cp -a {} /tmp/gpg-home/ \;
+find "${GPG_SRC}" -mindepth 1 -maxdepth 1 ! -type s -exec cp -a {} /tmp/gpg-home/ \;
 rm -f /tmp/gpg-home/S.gpg-agent /tmp/gpg-home/S.scdaemon /tmp/gpg-home/S.gpg-agent.ssh
 ln -sf /tmp/S.gpg-agent /tmp/gpg-home/S.gpg-agent
 ln -sf /tmp/S.scdaemon /tmp/gpg-home/S.scdaemon

--- a/.devcontainer/scripts/initialize-host.ps1
+++ b/.devcontainer/scripts/initialize-host.ps1
@@ -33,10 +33,10 @@ Write-Host "Staging host config from: $HostConfigDir"
 $SshSource = Join-Path $HostConfigDir '.ssh'
 $SshTarget = Join-Path $StageDir '.ssh'
 if (Test-Path $SshSource) {
-    if (Test-Path $SshTarget) {
-        Remove-Item -Recurse -Force $SshTarget
+    New-Item -ItemType Directory -Force -Path $SshTarget | Out-Null
+    Get-ChildItem -LiteralPath $SshSource -Force | ForEach-Object {
+        Copy-Item -LiteralPath $_.FullName -Destination $SshTarget -Recurse -Force
     }
-    Copy-Item -Recurse -Path $SshSource -Destination $SshTarget
 } else {
     New-Item -ItemType Directory -Force -Path $SshTarget | Out-Null
 }

--- a/.devcontainer/scripts/initialize-host.ps1
+++ b/.devcontainer/scripts/initialize-host.ps1
@@ -22,7 +22,10 @@ New-Item -ItemType Directory -Force -Path $StageDir | Out-Null
 
 $HostConfigDir = $env:USERPROFILE
 if (-not $HostConfigDir) {
-    Write-Error 'Unable to determine host config directory (USERPROFILE not set).'
+    $HostConfigDir = $env:HOME
+}
+if (-not $HostConfigDir) {
+    Write-Error 'Unable to determine host config directory (USERPROFILE or HOME not set).'
 }
 
 Write-Host "Staging host config from: $HostConfigDir"

--- a/.devcontainer/scripts/initialize-host.ps1
+++ b/.devcontainer/scripts/initialize-host.ps1
@@ -41,7 +41,12 @@ if (Test-Path $SshSource) {
 $GitconfigSource = Join-Path $HostConfigDir '.gitconfig'
 $GitconfigTarget = Join-Path $StageDir '.gitconfig'
 if (Test-Path $GitconfigSource) {
-    Copy-Item -Path $GitconfigSource -Destination $GitconfigTarget -Force
+    $GitconfigItem = Get-Item -LiteralPath $GitconfigSource
+    if ($GitconfigItem.PSIsContainer) {
+        New-Item -ItemType File -Force -Path $GitconfigTarget | Out-Null
+    } else {
+        Copy-Item -LiteralPath $GitconfigSource -Destination $GitconfigTarget -Force
+    }
 } else {
     New-Item -ItemType File -Force -Path $GitconfigTarget | Out-Null
 }

--- a/.devcontainer/scripts/initialize-host.ps1
+++ b/.devcontainer/scripts/initialize-host.ps1
@@ -1,0 +1,49 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+    Stages host SSH config and gitconfig for devcontainer bind mounts.
+
+.DESCRIPTION
+    Devcontainer variable substitution cannot reliably resolve the correct
+    host path on Windows. This script runs on the Windows host before the
+    container starts, snapshots %USERPROFILE%\.ssh and %USERPROFILE%\.gitconfig
+    into a known workspace-relative path, and ensures the mount sources always
+    exist.
+#>
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$RepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$StageDir = Join-Path (Join-Path $RepoRoot '.devcontainer') 'host-config'
+
+New-Item -ItemType Directory -Force -Path $StageDir | Out-Null
+
+$HostConfigDir = $env:USERPROFILE
+if (-not $HostConfigDir) {
+    Write-Error 'Unable to determine host config directory (USERPROFILE not set).'
+}
+
+Write-Host "Staging host config from: $HostConfigDir"
+
+$SshSource = Join-Path $HostConfigDir '.ssh'
+$SshTarget = Join-Path $StageDir '.ssh'
+if (Test-Path $SshSource) {
+    if (Test-Path $SshTarget) {
+        Remove-Item -Recurse -Force $SshTarget
+    }
+    Copy-Item -Recurse -Path $SshSource -Destination $SshTarget
+} else {
+    New-Item -ItemType Directory -Force -Path $SshTarget | Out-Null
+}
+
+$GitconfigSource = Join-Path $HostConfigDir '.gitconfig'
+$GitconfigTarget = Join-Path $StageDir '.gitconfig'
+if (Test-Path $GitconfigSource) {
+    Copy-Item -Path $GitconfigSource -Destination $GitconfigTarget -Force
+} else {
+    New-Item -ItemType File -Force -Path $GitconfigTarget | Out-Null
+}
+
+Write-Host "Host config staged in: $StageDir"

--- a/.devcontainer/scripts/initialize-host.sh
+++ b/.devcontainer/scripts/initialize-host.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+# Stages host SSH config and gitconfig for devcontainer bind mounts.
+#
+# Devcontainer variable substitution cannot reliably resolve the correct host
+# path on every platform (e.g. WSL2 reports a Linux HOME but the user's SSH
+# keys live under their Windows user profile). This script runs on the host
+# before the container starts, snapshots the relevant files into a known
+# workspace-relative path, and ensures the mount sources always exist.
+#
+# Supported host platforms: native Linux, native macOS, Windows (native
+# PowerShell calls the companion .ps1 script), and WSL2 on Windows.
+
+set -eu
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+STAGE_DIR="${REPO_ROOT}/.devcontainer/host-config"
+
+mkdir -p "${STAGE_DIR}"
+
+# Locate the host directory that contains .ssh and .gitconfig.
+HOST_CONFIG_DIR=""
+
+# WSL2: prefer the Windows user profile even though $HOME points to the
+# WSL filesystem. The user's YubiKey/GnuPG setup is on the Windows side.
+if [ -f /proc/sys/kernel/osrelease ] && grep -qi microsoft /proc/sys/kernel/osrelease; then
+    WIN_USERPROFILE=""
+    if command -v powershell.exe >/dev/null 2>&1; then
+        WIN_USERPROFILE="$(powershell.exe -NoProfile -Command 'Write-Host -NoNewline $env:USERPROFILE' 2>/dev/null || true)"
+    elif command -v cmd.exe >/dev/null 2>&1; then
+        WIN_USERPROFILE="$(cmd.exe /c 'echo %USERPROFILE%' 2>/dev/null | tr -d '\r' || true)"
+    fi
+
+    if [ -n "${WIN_USERPROFILE}" ] && command -v wslpath >/dev/null 2>&1; then
+        HOST_CONFIG_DIR="$(wslpath -u "${WIN_USERPROFILE}")"
+    fi
+fi
+
+# Fall back to the Unix home directory for native Linux/macOS or WSL setups
+# without a resolvable Windows profile.
+if [ -z "${HOST_CONFIG_DIR}" ]; then
+    if [ -z "${HOME:-}" ]; then
+        echo "Unable to determine host config directory (HOME not set)." >&2
+        exit 1
+    fi
+    HOST_CONFIG_DIR="${HOME}"
+fi
+
+echo "Staging host config from: ${HOST_CONFIG_DIR}"
+
+# .ssh: copy if it exists, otherwise create an empty directory so the bind
+# mount source always exists and the container can start.
+if [ -d "${HOST_CONFIG_DIR}/.ssh" ]; then
+    rm -rf "${STAGE_DIR}/.ssh"
+    cp -R "${HOST_CONFIG_DIR}/.ssh" "${STAGE_DIR}/.ssh"
+else
+    mkdir -p "${STAGE_DIR}/.ssh"
+fi
+
+# .gitconfig: copy if it exists, otherwise create an empty file.
+if [ -f "${HOST_CONFIG_DIR}/.gitconfig" ]; then
+    cp -f "${HOST_CONFIG_DIR}/.gitconfig" "${STAGE_DIR}/.gitconfig"
+else
+    : > "${STAGE_DIR}/.gitconfig"
+fi
+
+echo "Host config staged in: ${STAGE_DIR}"

--- a/.devcontainer/scripts/install-agent-relay.ps1
+++ b/.devcontainer/scripts/install-agent-relay.ps1
@@ -10,10 +10,12 @@
 
     Install registers an auto-start mechanism for the relay: a per-user
     Scheduled Task (restarts on failure) when policy allows it, otherwise
-    a hidden launcher in the user's Startup folder. It also snapshots the
-    public GnuPG key material (%APPDATA%\gnupg) into
-    .devcontainer/gnupg-host so the container can import public keys and
-    key stubs; re-run install to refresh the snapshot after adding keys.
+    a hidden launcher in the user's Startup folder. It also stages the host
+    .ssh and .gitconfig files into .devcontainer/host-config and snapshots
+    the public GnuPG key material (%APPDATA%\gnupg) into
+    .devcontainer/gnupg-host so the container can import public keys and key
+    stubs; re-run install to refresh the snapshots after changing SSH/Git
+    config or adding keys.
 
     No administrator rights are required.
 
@@ -38,6 +40,7 @@ $ErrorActionPreference = 'Stop'
 $TaskName = 'HSEM Agent Relay'
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $RelaySrc = Join-Path $ScriptDir 'start-agent-relay.ps1'
+$HostConfigStage = Join-Path $ScriptDir 'initialize-host.ps1'
 $InstallDir = Join-Path $env:APPDATA 'hsem-agent-relay'
 $RelayDst = Join-Path $InstallDir 'start-agent-relay.ps1'
 $LogFile = Join-Path $InstallDir 'agent-relay.log'
@@ -75,6 +78,12 @@ function Install-Relay {
         }
 
     Copy-Item $RelaySrc $RelayDst -Force
+
+    if (Test-Path $HostConfigStage) {
+        & $HostConfigStage
+    } else {
+        Write-Host "WARNING: Host config staging script not found at $HostConfigStage"
+    }
 
     # Snapshot GnuPG public key material for the container bridge.
     $gpgHome = Join-Path $env:APPDATA 'gnupg'

--- a/.devcontainer/scripts/install-agent-relay.ps1
+++ b/.devcontainer/scripts/install-agent-relay.ps1
@@ -13,9 +13,8 @@
     a hidden launcher in the user's Startup folder. It also stages the host
     .ssh and .gitconfig files into .devcontainer/host-config and snapshots
     the public GnuPG key material (%APPDATA%\gnupg) into
-    .devcontainer/gnupg-host so the container can import public keys and key
-    stubs; re-run install to refresh the snapshots after changing SSH/Git
-    config or adding keys.
+    .devcontainer/gnupg-host so the container can import public keys; rerun
+    install after changing SSH/Git config or adding keys.
 
     No administrator rights are required.
 
@@ -47,13 +46,7 @@ $LogFile = Join-Path $InstallDir 'agent-relay.log'
 $StartupVbs = Join-Path ([Environment]::GetFolderPath('Startup')) 'hsem-agent-relay.vbs'
 $WorkspaceRoot = Split-Path -Parent (Split-Path -Parent $ScriptDir)
 $GpgSnapshot = Join-Path $WorkspaceRoot '.devcontainer\gnupg-host'
-
-# GnuPG files the container needs: public keys (classic keyring and the
-# keyboxd store used by GnuPG 2.5+), trust db, key stubs and revocation
-# certificates. Sockets, locks, sshcontrol and host-specific agent config
-# are excluded — the container never runs its own agent.
-$GpgIncludes = @('pubring.kbx', 'pubring.gpg', 'trustdb.gpg', 'common.conf')
-$GpgIncludeDirs = @('openpgp-revocs.d', 'private-keys-v1.d', 'public-keys.d')
+$GpgExportFile = Join-Path $InstallDir 'public-keys.asc'
 
 function Install-Relay {
     Write-Host 'Installing HSEM agent relay as a Scheduled Task...'
@@ -65,6 +58,10 @@ function Install-Relay {
     if (-not (Get-Command gpgconf.exe -ErrorAction SilentlyContinue)) {
         Write-Host 'WARNING: gpgconf not found in PATH. Install Gpg4win and ensure'
         Write-Host '         gpg-agent.conf contains "enable-win32-openssh-support".'
+    }
+    if (-not (Get-Command gpg.exe -ErrorAction SilentlyContinue)) {
+        Write-Host 'ERROR: gpg.exe not found in PATH.'
+        exit 1
     }
 
     New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
@@ -90,26 +87,17 @@ function Install-Relay {
     if (Test-Path $gpgHome) {
         if (Test-Path $GpgSnapshot) { Remove-Item $GpgSnapshot -Recurse -Force }
         New-Item -ItemType Directory -Force -Path $GpgSnapshot | Out-Null
-        foreach ($file in $GpgIncludes) {
-            $src = Join-Path $gpgHome $file
-            if (Test-Path $src) { Copy-Item $src $GpgSnapshot }
+        Remove-Item $GpgExportFile -Force -ErrorAction SilentlyContinue
+        & gpg.exe --homedir $gpgHome --batch --yes --armor --export |
+            Set-Content -Path $GpgExportFile -Encoding ASCII
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Failed to export public keys from the host GnuPG home.'
         }
-        foreach ($dir in $GpgIncludeDirs) {
-            $src = Join-Path $gpgHome $dir
-            if (Test-Path $src) {
-                $dst = Join-Path $GpgSnapshot $dir
-                New-Item -ItemType Directory -Force -Path $dst | Out-Null
-                Get-ChildItem $src -File |
-                    Where-Object { $_.Name -notlike '*.lock' } |
-                    Copy-Item -Destination $dst
-            }
+        & gpg.exe --homedir $GpgSnapshot --batch --yes --import $GpgExportFile | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            throw 'Failed to import exported public keys into the container snapshot.'
         }
-        # Flatten the keyboxd store: container GnuPG 2.4 (non-keyboxd)
-        # expects a classic keyring at pubring.kbx.
-        $kbx = Join-Path $GpgSnapshot 'public-keys.d\pubring.db'
-        if ((Test-Path $kbx) -and -not (Test-Path (Join-Path $GpgSnapshot 'pubring.kbx'))) {
-            Copy-Item $kbx (Join-Path $GpgSnapshot 'pubring.kbx')
-        }
+        Remove-Item $GpgExportFile -Force -ErrorAction SilentlyContinue
         Write-Host "Snapshot of $gpgHome -> $GpgSnapshot"
     } else {
         Write-Host "WARNING: GnuPG home not found at $gpgHome; skipping snapshot."

--- a/.devcontainer/scripts/install-agent-relay.ps1
+++ b/.devcontainer/scripts/install-agent-relay.ps1
@@ -1,0 +1,201 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Install/uninstall the HSEM agent relay as a per-user Scheduled Task.
+
+.DESCRIPTION
+    The relay bridges YubiKey GPG/SSH agent endpoints over TCP so Docker
+    containers can access them (Docker Desktop cannot forward Windows
+    named pipes or GnuPG emulated sockets into containers).
+
+    Install registers an auto-start mechanism for the relay: a per-user
+    Scheduled Task (restarts on failure) when policy allows it, otherwise
+    a hidden launcher in the user's Startup folder. It also snapshots the
+    public GnuPG key material (%APPDATA%\gnupg) into
+    .devcontainer/gnupg-host so the container can import public keys and
+    key stubs; re-run install to refresh the snapshot after adding keys.
+
+    No administrator rights are required.
+
+.PARAMETER Action
+    install    - Register and start the relay task (run once, or to
+                 refresh the gnupg snapshot).
+    uninstall  - Stop and remove the task and copied files.
+    status     - Show task state and listening ports.
+
+.EXAMPLE
+    powershell -NoProfile -ExecutionPolicy Bypass -File .devcontainer\scripts\install-agent-relay.ps1 install
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory, Position = 0)]
+    [ValidateSet('install', 'uninstall', 'status')]
+    [string]$Action
+)
+
+$ErrorActionPreference = 'Stop'
+
+$TaskName = 'HSEM Agent Relay'
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RelaySrc = Join-Path $ScriptDir 'start-agent-relay.ps1'
+$InstallDir = Join-Path $env:APPDATA 'hsem-agent-relay'
+$RelayDst = Join-Path $InstallDir 'start-agent-relay.ps1'
+$LogFile = Join-Path $InstallDir 'agent-relay.log'
+$StartupVbs = Join-Path ([Environment]::GetFolderPath('Startup')) 'hsem-agent-relay.vbs'
+$WorkspaceRoot = Split-Path -Parent (Split-Path -Parent $ScriptDir)
+$GpgSnapshot = Join-Path $WorkspaceRoot '.devcontainer\gnupg-host'
+
+# GnuPG files the container needs: public keys (classic keyring and the
+# keyboxd store used by GnuPG 2.5+), trust db, key stubs and revocation
+# certificates. Sockets, locks, sshcontrol and host-specific agent config
+# are excluded — the container never runs its own agent.
+$GpgIncludes = @('pubring.kbx', 'pubring.gpg', 'trustdb.gpg', 'common.conf')
+$GpgIncludeDirs = @('openpgp-revocs.d', 'private-keys-v1.d', 'public-keys.d')
+
+function Install-Relay {
+    Write-Host 'Installing HSEM agent relay as a Scheduled Task...'
+
+    if (-not (Test-Path $RelaySrc)) {
+        Write-Host "ERROR: Relay script not found at $RelaySrc"
+        exit 1
+    }
+    if (-not (Get-Command gpgconf.exe -ErrorAction SilentlyContinue)) {
+        Write-Host 'WARNING: gpgconf not found in PATH. Install Gpg4win and ensure'
+        Write-Host '         gpg-agent.conf contains "enable-win32-openssh-support".'
+    }
+
+    New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+
+    # Stop any already-running relay (it may hold an older script version
+    # in memory or stale connections to the agents).
+    Get-CimInstance Win32_Process -Filter "Name = 'powershell.exe'" |
+        Where-Object { $_.CommandLine -like '*hsem-agent-relay*' } |
+        ForEach-Object {
+            Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue
+        }
+
+    Copy-Item $RelaySrc $RelayDst -Force
+
+    # Snapshot GnuPG public key material for the container bridge.
+    $gpgHome = Join-Path $env:APPDATA 'gnupg'
+    if (Test-Path $gpgHome) {
+        if (Test-Path $GpgSnapshot) { Remove-Item $GpgSnapshot -Recurse -Force }
+        New-Item -ItemType Directory -Force -Path $GpgSnapshot | Out-Null
+        foreach ($file in $GpgIncludes) {
+            $src = Join-Path $gpgHome $file
+            if (Test-Path $src) { Copy-Item $src $GpgSnapshot }
+        }
+        foreach ($dir in $GpgIncludeDirs) {
+            $src = Join-Path $gpgHome $dir
+            if (Test-Path $src) {
+                $dst = Join-Path $GpgSnapshot $dir
+                New-Item -ItemType Directory -Force -Path $dst | Out-Null
+                Get-ChildItem $src -File |
+                    Where-Object { $_.Name -notlike '*.lock' } |
+                    Copy-Item -Destination $dst
+            }
+        }
+        # Flatten the keyboxd store: container GnuPG 2.4 (non-keyboxd)
+        # expects a classic keyring at pubring.kbx.
+        $kbx = Join-Path $GpgSnapshot 'public-keys.d\pubring.db'
+        if ((Test-Path $kbx) -and -not (Test-Path (Join-Path $GpgSnapshot 'pubring.kbx'))) {
+            Copy-Item $kbx (Join-Path $GpgSnapshot 'pubring.kbx')
+        }
+        Write-Host "Snapshot of $gpgHome -> $GpgSnapshot"
+    } else {
+        Write-Host "WARNING: GnuPG home not found at $gpgHome; skipping snapshot."
+    }
+
+    $psExe = Join-Path $PSHOME 'powershell.exe'
+    $taskArgs = "-NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$RelayDst`""
+    $installed = $false
+
+    # Preferred: per-user Scheduled Task (restarts the relay on failure).
+    # Some corporate policies deny task creation; fall back to a Startup
+    # folder launcher, which needs no special rights.
+    try {
+        $action = New-ScheduledTaskAction -Execute $psExe -Argument $taskArgs `
+            -WorkingDirectory $InstallDir
+        $trigger = New-ScheduledTaskTrigger -AtLogOn
+        $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries `
+            -DontStopIfGoingOnBatteries -ExecutionTimeLimit ([TimeSpan]::Zero) `
+            -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1)
+
+        Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false `
+            -ErrorAction SilentlyContinue
+        Register-ScheduledTask -TaskName $TaskName -Action $action `
+            -Trigger $trigger -Settings $settings `
+            -Description 'TCP relays for YubiKey SSH/GPG agents into Docker devcontainers' `
+            -ErrorAction Stop | Out-Null
+        Start-ScheduledTask -TaskName $TaskName
+        $installed = $true
+        Write-Host "  Auto-start:   Scheduled Task '$TaskName' (starts at logon, restarts on failure)"
+    } catch {
+        Write-Host "Scheduled Task unavailable ($($_.Exception.Message));"
+        Write-Host 'falling back to Startup folder launcher.'
+    }
+
+    if (-not $installed) {
+        # Hidden launcher: wscript runs the relay without a console window.
+        # For troubleshooting, run start-agent-relay.ps1 manually in a
+        # visible console to see its log output.
+        $vbs = @"
+Set sh = CreateObject("Wscript.Shell")
+sh.CurrentDirectory = "$InstallDir"
+sh.Run """$psExe"" -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File ""$RelayDst""", 0, False
+"@
+        Set-Content -Path $StartupVbs -Value $vbs -Encoding ASCII
+        # Start it now (same as at next logon).
+        Start-Process wscript.exe -ArgumentList "`"$StartupVbs`""
+        Write-Host "  Auto-start:   Startup launcher $StartupVbs"
+    }
+
+    Write-Host ''
+    Write-Host 'Installed. The relay starts automatically at logon.'
+    Write-Host "  Relay script: $RelayDst"
+    Write-Host ''
+    Write-Host 'Ports: 9999 (SSH agent), 9998 (GPG agent), 9997 (scdaemon)'
+}
+
+function Uninstall-Relay {
+    Write-Host 'Uninstalling HSEM agent relay...'
+    Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false `
+        -ErrorAction SilentlyContinue
+    Remove-Item $StartupVbs -Force -ErrorAction SilentlyContinue
+    Get-CimInstance Win32_Process -Filter "Name = 'powershell.exe'" |
+        Where-Object { $_.CommandLine -like '*hsem-agent-relay*' } |
+        ForEach-Object {
+            Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue
+        }
+    Remove-Item $InstallDir -Recurse -Force -ErrorAction SilentlyContinue
+    Write-Host 'Uninstalled.'
+    Write-Host "Note: the gnupg snapshot at $GpgSnapshot was left in place; delete it manually if unwanted."
+}
+
+function Get-RelayStatus {
+    $task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+    $startup = Test-Path $StartupVbs
+    if ($task) {
+        Write-Host "Service: Scheduled Task ($($task.State))"
+    } elseif ($startup) {
+        Write-Host "Service: Startup launcher installed ($StartupVbs)"
+    } else {
+        Write-Host 'Service: NOT INSTALLED'
+    }
+    $listeners = Get-NetTCPConnection -State Listen -ErrorAction SilentlyContinue |
+        Where-Object { $_.LocalPort -in 9997, 9998, 9999 }
+    if ($listeners) {
+        $listeners | ForEach-Object {
+            Write-Host "Listening: $($_.LocalAddress):$($_.LocalPort) (PID $($_.OwningProcess))"
+        }
+    } else {
+        Write-Host 'No relay ports listening (may need a moment to start)'
+    }
+}
+
+switch ($Action) {
+    'install' { Install-Relay }
+    'uninstall' { Uninstall-Relay }
+    'status' { Get-RelayStatus }
+}

--- a/.devcontainer/scripts/install-agent-relay.sh
+++ b/.devcontainer/scripts/install-agent-relay.sh
@@ -20,6 +20,9 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RELAY_SRC="$SCRIPT_DIR/start-agent-relay.py"
 RELAY_DST="$APP_SUPPORT/hsem-agent-relay.py"
 TEMPLATE="$SCRIPT_DIR/com.hsem.agent-relay.plist.template"
+GPG_HOME="${HOME}/.gnupg"
+GPG_SNAPSHOT="$SCRIPT_DIR/../gnupg-host"
+GPG_EXPORT="$APP_SUPPORT/hsem-agent-relay.public-keys.asc"
 
 install_service() {
     echo "Installing HSEM agent relay as LaunchAgent..."
@@ -32,6 +35,19 @@ install_service() {
     # Copy relay to Application Support (launchd can't access arbitrary paths)
     mkdir -p "$APP_SUPPORT"
     cp "$RELAY_SRC" "$RELAY_DST"
+
+    # Snapshot the host public keys so the container can import them without
+    # depending on the host .gnupg bind mount.
+    if [ -d "$GPG_HOME" ] && command -v gpg >/dev/null 2>&1; then
+        rm -rf "$GPG_SNAPSHOT"
+        mkdir -p "$GPG_SNAPSHOT"
+        gpg --homedir "$GPG_HOME" --batch --yes --armor --export > "$GPG_EXPORT"
+        GNUPGHOME="$GPG_SNAPSHOT" gpg --batch --yes --import "$GPG_EXPORT" >/dev/null 2>&1
+        rm -f "$GPG_EXPORT"
+        echo "Snapshot of $GPG_HOME -> $GPG_SNAPSHOT"
+    else
+        echo "WARNING: GnuPG home not found or gpg unavailable; skipping snapshot."
+    fi
 
     # Create LaunchAgents dir if needed
     mkdir -p "$HOME/Library/LaunchAgents"

--- a/.devcontainer/scripts/start-agent-relay.ps1
+++ b/.devcontainer/scripts/start-agent-relay.ps1
@@ -1,0 +1,277 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Start TCP relays for SSH agent, GPG agent, and scdaemon on a Windows host.
+
+.DESCRIPTION
+    Docker Desktop for Windows runs inside a Linux VM and cannot reach
+    Windows named pipes or GnuPG's emulated sockets from a container.
+    This script listens on TCP ports (localhost only) and forwards traffic
+    to the host agents, allowing the devcontainer to use the YubiKey.
+
+    Backends:
+      SSH agent  -> \\.\pipe\openssh-ssh-agent named pipe, served by
+                    gpg-agent when gpg-agent.conf contains
+                    "enable-win32-openssh-support" (Gpg4win).
+      GPG agent  -> GnuPG socket-emulation file (S.gpg-agent): the file
+                    contains a localhost TCP port and a 16-byte nonce that
+                    must be sent immediately after connecting.
+      scdaemon   -> Same mechanism (S.scdaemon), for direct card access
+                    (e.g. ykman / gpg --card-status from the container).
+
+    GnuPG socket paths are resolved via "gpgconf --list-dirs" with a
+    fallback to %LOCALAPPDATA%\gnupg. The port and nonce are re-read for
+    every connection because gpg-agent rewrites them when it restarts.
+
+    Concurrency model: one runspace per relay accept loop, plus one
+    runspace per accepted connection. ThreadPool scriptblock callbacks
+    crash under Windows PowerShell 5.1 -File, and .NET CopyToAsync avoids
+    needing PowerShell callbacks at all. If a relay dies, the watchdog
+    exits with an error so a supervising Scheduled Task can restart it.
+
+.PARAMETER SshPort
+    TCP port for the SSH agent relay (default 9999).
+
+.PARAMETER GpgPort
+    TCP port for the GPG agent relay (default 9998).
+
+.PARAMETER ScdaemonPort
+    TCP port for the scdaemon relay (default 9997).
+
+.EXAMPLE
+    powershell -NoProfile -File start-agent-relay.ps1
+#>
+[CmdletBinding()]
+param(
+    [int]$SshPort = 9999,
+    [int]$GpgPort = 9998,
+    [int]$ScdaemonPort = 9997
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Log {
+    param([string]$Message)
+    $ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+    [Console]::WriteLine("[$ts] $Message")
+}
+
+function Get-GpgconfDirs {
+    # Parse "gpgconf --list-dirs" into a hashtable (entry name -> path).
+    $dirs = @{}
+    $gpgconf = Get-Command gpgconf.exe -ErrorAction SilentlyContinue
+    if ($gpgconf) {
+        try {
+            & $gpgconf.Source --list-dirs 2>$null | ForEach-Object {
+                $sep = $_.IndexOf(':')
+                if ($sep -gt 0) {
+                    $dirs[$_.Substring(0, $sep)] =
+                        [Uri]::UnescapeDataString($_.Substring($sep + 1))
+                }
+            }
+        } catch {
+            Write-Log "gpgconf --list-dirs failed: $_"
+        }
+    }
+    if (-not $dirs.ContainsKey('socketdir')) {
+        $dirs['socketdir'] = Join-Path $env:LOCALAPPDATA 'gnupg'
+    }
+    return $dirs
+}
+
+# Runs a single accepted connection in its own runspace: pumps bytes in
+# both directions with CopyToAsync and closes everything when either side
+# disconnects. WaitAny (not WaitAll) is essential: the agent protocols are
+# persistent, so when the client goes away the backend->client pump would
+# otherwise block forever and leak the gpg-agent connection, eventually
+# stalling the agent's pipe server.
+# State: @(Client, BackendStream, BackendCloseTarget).
+$ConnectionHandlerSource = @'
+param($s)
+$client = $s[0]; $backendStream = $s[1]; $backendTarget = $s[2]
+try {
+    $cs = $client.GetStream()
+    $t1 = $cs.CopyToAsync($backendStream)
+    $t2 = $backendStream.CopyToAsync($cs)
+    [void][System.Threading.Tasks.Task]::WaitAny(@($t1, $t2))
+} catch {
+    [Console]::Error.WriteLine("connection handler error: $_")
+} finally {
+    try { $backendTarget.Close() } catch {}
+    try { $client.Close() } catch {}
+}
+'@
+
+# TCP listener -> Windows named pipe (SSH agent protocol).
+$PipeRelaySource = @'
+param([int]$ListenPort, [string]$PipeName, [string]$Label, [string]$HandlerSource)
+
+$listener = [System.Net.Sockets.TcpListener]::new(
+    [System.Net.IPAddress]::Loopback, $ListenPort)
+$listener.Start()
+[Console]::WriteLine("$Label relay: 127.0.0.1:$ListenPort -> \\.\pipe\$PipeName")
+
+$handlers = @()
+while ($true) {
+    $client = $listener.AcceptTcpClient()
+    try {
+        # PipeOptions.Asynchronous is required: the connection handler
+        # closes the pipe while a pump read is still pending, and only
+        # overlapped IO cancels cleanly. Without it the blocking read
+        # on a synchronous handle wedges gpg-agent's pipe server.
+        $pipe = [System.IO.Pipes.NamedPipeClientStream]::new(
+            '.', $PipeName, [System.IO.Pipes.PipeDirection]::InOut,
+            [System.IO.Pipes.PipeOptions]::Asynchronous)
+        $pipe.Connect(5000)
+    } catch {
+        [Console]::Error.WriteLine("$Label relay: pipe connect failed: $_")
+        $client.Close()
+        continue
+    }
+
+    $rs = [System.Management.Automation.Runspaces.RunspaceFactory]::CreateRunspace(
+        [System.Management.Automation.Runspaces.InitialSessionState]::CreateDefault())
+    $rs.Open()
+    $ps = [System.Management.Automation.PowerShell]::Create()
+    $ps.Runspace = $rs
+    [void]$ps.AddScript($HandlerSource).AddArgument(@($client, $pipe, $pipe))
+    [void]$ps.BeginInvoke()
+    $handlers += @{ PS = $ps; RS = $rs }
+
+    # Reap finished connection handlers.
+    $alive = @()
+    foreach ($h in $handlers) {
+        if ($h.PS.InvocationStateInfo.State -eq 'Running') {
+            $alive += $h
+        } else {
+            try { $h.PS.EndInvoke($null) } catch {}
+            $h.PS.Dispose(); $h.RS.Close(); $h.RS.Dispose()
+        }
+    }
+    $handlers = $alive
+}
+'@
+
+# TCP listener -> GnuPG emulated socket (localhost TCP port + nonce).
+$GpgRelaySource = @'
+param([int]$ListenPort, [string]$SocketFile, [string]$Label, [string]$HandlerSource)
+
+$listener = [System.Net.Sockets.TcpListener]::new(
+    [System.Net.IPAddress]::Loopback, $ListenPort)
+$listener.Start()
+[Console]::WriteLine("$Label relay: 127.0.0.1:$ListenPort -> $SocketFile")
+
+$handlers = @()
+while ($true) {
+    $client = $listener.AcceptTcpClient()
+    try {
+        # Re-read port + nonce per connection: gpg-agent rewrites the
+        # file when it restarts.
+        $bytes = [System.IO.File]::ReadAllBytes($SocketFile)
+        $nl = [Array]::IndexOf($bytes, [byte]10)
+        if ($nl -lt 1 -or $bytes.Length -le ($nl + 1)) {
+            throw 'unrecognized socket file format'
+        }
+        $port = [int][System.Text.Encoding]::ASCII.GetString($bytes, 0, $nl)
+        $nonce = New-Object byte[] ($bytes.Length - $nl - 1)
+        [Array]::Copy($bytes, $nl + 1, $nonce, 0, $nonce.Length)
+
+        $backend = [System.Net.Sockets.TcpClient]::new()
+        $backend.NoDelay = $true
+        $backend.Connect([System.Net.IPAddress]::Loopback, $port)
+        $bs = $backend.GetStream()
+        $bs.Write($nonce, 0, $nonce.Length)
+        $bs.Flush()
+    } catch {
+        [Console]::Error.WriteLine("$Label relay: backend connect failed: $_")
+        $client.Close()
+        continue
+    }
+
+    $rs = [System.Management.Automation.Runspaces.RunspaceFactory]::CreateRunspace(
+        [System.Management.Automation.Runspaces.InitialSessionState]::CreateDefault())
+    $rs.Open()
+    $ps = [System.Management.Automation.PowerShell]::Create()
+    $ps.Runspace = $rs
+    [void]$ps.AddScript($HandlerSource).AddArgument(@($client, $bs, $backend))
+    [void]$ps.BeginInvoke()
+    $handlers += @{ PS = $ps; RS = $rs }
+
+    # Reap finished connection handlers.
+    $alive = @()
+    foreach ($h in $handlers) {
+        if ($h.PS.InvocationStateInfo.State -eq 'Running') {
+            $alive += $h
+        } else {
+            try { $h.PS.EndInvoke($null) } catch {}
+            $h.PS.Dispose(); $h.RS.Close(); $h.RS.Dispose()
+        }
+    }
+    $handlers = $alive
+}
+'@
+
+function New-RelayRunspace {
+    # Start one relay accept loop in its own runspace. Returns a state
+    # object for the watchdog loop.
+    param(
+        [Parameter(Mandatory)] [string]$Label,
+        [Parameter(Mandatory)] [string]$RelaySource,
+        [Parameter(Mandatory)] [object[]]$Arguments
+    )
+
+    $rs = [System.Management.Automation.Runspaces.RunspaceFactory]::CreateRunspace(
+        [System.Management.Automation.Runspaces.InitialSessionState]::CreateDefault())
+    $rs.Open()
+    $ps = [System.Management.Automation.PowerShell]::Create()
+    $ps.Runspace = $rs
+    [void]$ps.AddScript($RelaySource)
+    foreach ($arg in $Arguments) { [void]$ps.AddArgument($arg) }
+    [void]$ps.BeginInvoke()
+    return @{ Label = $Label; Runspace = $rs; PowerShell = $ps }
+}
+
+# --- Main -----------------------------------------------------------------
+
+# Socket files do not need to exist yet: scdaemon in particular starts
+# lazily on first card access, and the relays re-read the socket file for
+# every connection.
+$gpgconfDirs = Get-GpgconfDirs
+$gpgSocket = $gpgconfDirs['agent-socket']
+if (-not $gpgSocket) {
+    $gpgSocket = Join-Path $gpgconfDirs['socketdir'] 'S.gpg-agent'
+}
+# gpgconf has no scdaemon-socket entry; it lives in the socket dir.
+$scdaemonSocket = Join-Path $gpgconfDirs['socketdir'] 'S.scdaemon'
+
+# All relays bind unconditionally. If a backend socket file does not exist
+# yet (scdaemon starts lazily), connections fail with a logged error until
+# the daemon appears.
+$relays = @()
+$relays += New-RelayRunspace -Label 'SSH agent' -RelaySource $PipeRelaySource `
+    -Arguments @($SshPort, 'openssh-ssh-agent', 'SSH agent', $ConnectionHandlerSource)
+$relays += New-RelayRunspace -Label 'GPG agent' -RelaySource $GpgRelaySource `
+    -Arguments @($GpgPort, $gpgSocket, 'GPG agent', $ConnectionHandlerSource)
+$relays += New-RelayRunspace -Label 'scdaemon' -RelaySource $GpgRelaySource `
+    -Arguments @($ScdaemonPort, $scdaemonSocket, 'scdaemon', $ConnectionHandlerSource)
+
+Write-Log ''
+Write-Log 'Container can connect to:'
+Write-Log "  SSH agent: host.docker.internal:$SshPort"
+Write-Log "  GPG agent: host.docker.internal:$GpgPort"
+Write-Log "  scdaemon:  host.docker.internal:$ScdaemonPort"
+Write-Log 'Press Ctrl+C to stop.'
+
+# Watchdog: a dead relay means a fatal setup error (e.g. port in use).
+# Exit with an error so a supervising Scheduled Task can restart us.
+while ($true) {
+    Start-Sleep -Seconds 5
+    foreach ($relay in $relays) {
+        $state = $relay.PowerShell.InvocationStateInfo.State
+        if ($state -ne 'Running') {
+            $reason = $relay.PowerShell.InvocationStateInfo.Reason
+            Write-Log "FATAL: $($relay.Label) relay stopped ($state): $reason"
+            exit 1
+        }
+    }
+}

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -46,6 +46,11 @@ jobs:
         run: |
           mkdir -p ~/.ssh ~/.gnupg
           : > ~/.gitconfig
+          if ! command -v powershell >/dev/null 2>&1 && command -v pwsh >/dev/null 2>&1; then
+            mkdir -p ~/.local/bin
+            ln -s "$(command -v pwsh)" ~/.local/bin/powershell
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          fi
 
       - name: Run all quality gates
         uses: devcontainers/ci@v0.3

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -43,7 +43,9 @@ jobs:
       - uses: actions/checkout@v7.0.1
 
       - name: Create mount stubs for CI
-        run: mkdir -p ~/.ssh ~/.gnupg ~/.gitconfig
+        run: |
+          mkdir -p ~/.ssh ~/.gnupg
+          : > ~/.gitconfig
 
       - name: Run all quality gates
         uses: devcontainers/ci@v0.3

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,8 @@ config/*
 cycle.log
 core
 
+# Windows devcontainer: snapshot of host GnuPG public key material
+# (created by .devcontainer/scripts/install-agent-relay.ps1)
+.devcontainer/gnupg-host/
+
 test-results.xml

--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,8 @@ core
 # (created by .devcontainer/scripts/install-agent-relay.ps1)
 .devcontainer/gnupg-host/
 
+# Devcontainer: per-host snapshots of SSH config and gitconfig created by
+# initializeCommand so cross-platform bind mounts always have a valid source.
+.devcontainer/host-config/
+
 test-results.xml


### PR DESCRIPTION
## Summary

Adds Windows host support to the existing YubiKey SSH/GPG devcontainer relay. Docker Desktop on Windows cannot forward Windows named pipes or GnuPG's emulated sockets into containers, so the same TCP-relay architecture used for macOS is implemented in pure PowerShell.

## Branch

`feat/devcontainer-windows-yubikey`

## Files changed

- `.devcontainer/scripts/start-agent-relay.ps1` — new TCP relay: SSH agent via `\\.\pipe\openssh-ssh-agent` named pipe (port 9999), GPG agent and scdaemon via GnuPG socket-emulation files (ports 9998/9997). Uses one runspace per listener and per connection; `PipeOptions.Asynchronous` + `Task.WaitAny` to avoid wedging gpg-agent's pipe server.
- `.devcontainer/scripts/install-agent-relay.ps1` — new installer: registers a per-user Scheduled Task (falls back to a hidden Startup-folder launcher when policy blocks task creation), stages `%USERPROFILE%\.ssh` and `%USERPROFILE%\.gitconfig` into `.devcontainer/host-config/`, and snapshots `%APPDATA%\gnupg` public key material into `.devcontainer/gnupg-host/` for the container.
- `.devcontainer/scripts/devcontainer-agent-bridge.sh` — falls back to the workspace gnupg snapshot when `/root/.gnupg` has no keyring (Windows layout).
- `.devcontainer/scripts/initialize-host.sh` — Unix/WSL2 staging script: copies/symlinks host `~/.ssh` and `~/.gitconfig` into `.devcontainer/host-config/` before the container starts. On WSL2 it resolves the Windows user profile so the Windows-side SSH config is used.
- `.devcontainer/scripts/initialize-host.ps1` — native Windows staging script: snapshots host `~/.ssh` and `~/.gitconfig` into `.devcontainer/host-config\`; now treats CI-style `.gitconfig` directory stubs as empty config files, falls back to `HOME` when `USERPROFILE` is unavailable, and copies SSH entries explicitly for cross-platform reliability.
- `.devcontainer/devcontainer.json` — uses a single spec-compliant Unix `initializeCommand` and keeps mounts pointed at the staged `.devcontainer/host-config/` directory. Windows host-config staging now happens through the installer instead of a lifecycle object.
- `.devcontainer/README.md` — Windows setup section and updated YubiKey/GPG support description, including that the installer stages `.ssh` and `.gitconfig`.
- `.gitignore` — ignores `.devcontainer/gnupg-host/` and `.devcontainer/host-config/`.
- `.github/workflows/lint-and-test.yml` — creates a file stub for `~/.gitconfig` in CI instead of a directory, and adds a `powershell` shim on Ubuntu runners.

## Why

The devcontainer previously only supported YubiKey forwarding on macOS. This enables the same workflow on Windows hosts without requiring Python or admin rights.

## Testing

Live-tested on Windows 11 with Gpg4win 2.5.21 and a YubiKey:
- SSH relay returns the YubiKey SSH key (`ssh-rsa cardno:...`).
- GPG relay returns assuan greeting (`OK Pleased to meet you`).
- scdaemon relay returns greeting (`OK GNU Privacy Guard's Smartcard server ready`).
- Sequential connections are stable; pipe server remains healthy.
- Install/status/uninstall cycle verified.
- The `initialize-host.ps1` staging script was run locally and produced the expected `.devcontainer/host-config/.ssh` and `.gitconfig` entries.
- Verified the Windows initializer still succeeds when `.gitconfig` is a directory stub, matching the CI mount-stub behavior.
- Verified the Windows initializer also succeeds when only `HOME` is set, matching the Linux CI environment.
- Updated the CI workflow stub so `~/.gitconfig` is created as a file, preventing devcontainer copy failures in GitHub Actions.
- The Windows installer now stages host SSH/Git config explicitly, so Windows support no longer depends on a lifecycle object that CI interprets incorrectly.

## Notes / limitations

- PIN/touch prompts appear on the Windows host, not in the container.
- On Windows, re-run `powershell -NoProfile -ExecutionPolicy Bypass -File .devcontainer\scripts\install-agent-relay.ps1 install` after changing SSH/Git config or adding new GPG keys.
- The relay binds to `127.0.0.1` only; the container reaches it via `host.docker.internal`.
- The gnupg snapshot contains only public keys and stubs — no private key material leaves the host.
- `.devcontainer/host-config/` is git-ignored and regenerated by the Unix initialize command or the Windows installer.