### PR TITLE
feat(sensor): add EV charger calculated power sensors

### DIFF
--- a/custom_components/hsem/custom_sensors/ev_charger_calculated_power_sensor.py
+++ b/custom_components/hsem/custom_sensors/ev_charger_calculated_power_sensor.py
@@ -1,0 +1,213 @@
+"""Diagnostic sensors exposing the planner's calculated EV charger power.
+
+The planner writes its per-slot EV power *command* onto the current
+:class:`~custom_components.hsem.models.hourly_recommendation.HourlyRecommendation`
+(``ev_charger_calculated_power`` for the primary charger and
+``ev_second_charger_calculated_power`` for the second charger).  These values
+are otherwise only visible inside the working-mode sensor attributes, which
+makes them hard to track in history graphs or use directly in automations.
+
+This module exposes each value as its own sensor whose **state equals the
+calculated power in Watts** for the currently active planning slot.  The state
+is ``0`` when the planner has not allocated any EV charging for the slot.
+
+Both sensors are *diagnostic* entities
+(``entity_category = EntityCategory.DIAGNOSTIC``) so they appear in the
+*Diagnostic* section of the device page and are excluded from the default
+Lovelace dashboard.
+
+The sensors subscribe to
+:class:`~custom_components.hsem.coordinator.HSEMDataUpdateCoordinator` and
+update automatically after every coordinator cycle.
+"""
+
+from __future__ import annotations
+
+from typing import Any, override
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor.const import SensorDeviceClass, SensorStateClass
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    EntityCategory,
+    UnitOfPower,
+)
+from homeassistant.helpers.restore_state import RestoreEntity
+
+from custom_components.hsem.coordinator import (
+    CoordinatorData,
+    HSEMDataUpdateCoordinator,
+)
+from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
+from custom_components.hsem.utils.sensornames.ev import (
+    get_ev_charger_calculated_power_sensor_entity_id,
+    get_ev_charger_calculated_power_sensor_name,
+    get_ev_charger_calculated_power_sensor_unique_id,
+    get_ev_second_charger_calculated_power_sensor_entity_id,
+    get_ev_second_charger_calculated_power_sensor_name,
+    get_ev_second_charger_calculated_power_sensor_unique_id,
+)
+
+
+class HSEMEVChargerCalculatedPowerSensorBase(
+    HSEMCoordinatorEntity,
+    RestoreEntity,
+    SensorEntity,
+    HSEMEntity,
+):
+    """Base class for the EV charger calculated power sensors.
+
+    Subclasses set :attr:`_is_second` to select which planner field the
+    sensor exposes, plus the name/unique-id/entity-id getters.
+    """
+
+    _attr_icon = "mdi:ev-station"
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_device_class = SensorDeviceClass.POWER
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = UnitOfPower.WATT
+    _attr_suggested_display_precision = 0
+    _is_second: bool = False
+    # Set by concrete subclasses in __init__.
+    _name: str
+
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        coordinator: HSEMDataUpdateCoordinator,
+    ) -> None:
+        """Initialise the calculated power sensor.
+
+        Args:
+            config_entry: The HSEM config entry.
+            coordinator: The shared :class:`HSEMDataUpdateCoordinator`.
+        """
+        HSEMCoordinatorEntity.__init__(self, coordinator)
+        HSEMEntity.__init__(self, config_entry)
+
+        self._config_entry = config_entry
+        self._restored_state: str | None = None
+
+    # ------------------------------------------------------------------
+    # HA entity properties
+    # ------------------------------------------------------------------
+
+    @property
+    @override
+    def name(self) -> str:
+        """Return the display name."""
+        return self._name
+
+    @property
+    @override
+    def unique_id(self) -> str | None:
+        """Return the unique ID."""
+        return self._attr_unique_id
+
+    @property
+    @override
+    def native_value(self) -> float | None:
+        """Return the calculated charger power (W) for the active slot."""
+        data: CoordinatorData | None = self.coordinator.data
+        rec = data.hourly_recommendation if data is not None else None
+        if rec is None:
+            if self._restored_state is not None:
+                try:
+                    return float(self._restored_state)
+                except ValueError, TypeError:
+                    pass
+            return None
+        if self._is_second:
+            return rec.ev_second_charger_calculated_power
+        return rec.ev_charger_calculated_power
+
+    @property
+    @override
+    def should_poll(self) -> bool:
+        """No polling — driven by the coordinator."""
+        return False
+
+    @property
+    @override
+    def available(self) -> bool:
+        """True once the coordinator has completed at least one successful cycle."""
+        return (
+            self.coordinator.last_update_success and self.coordinator.data is not None
+        ) or self._restored_state is not None
+
+    @property
+    @override
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the active slot context for the calculated power value."""
+        data: CoordinatorData | None = self.coordinator.data
+        rec = data.hourly_recommendation if data is not None else None
+        if rec is None:
+            return {
+                "slot_start": None,
+                "slot_end": None,
+                "ev_total_planned_load_kwh": None,
+            }
+        return {
+            "slot_start": rec.start.isoformat(),
+            "slot_end": rec.end.isoformat(),
+            "ev_total_planned_load_kwh": rec.ev_total_planned_load_kwh,
+        }
+
+    # ------------------------------------------------------------------
+    # HA lifecycle
+    # ------------------------------------------------------------------
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Restore previous state and register coordinator listener."""
+        await super().async_added_to_hass()
+        restored = await self.async_get_last_state()
+        if restored is not None and restored.state not in {
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
+            None,
+        }:
+            self._restored_state = restored.state
+
+
+class HSEMEVChargerCalculatedPowerSensor(HSEMEVChargerCalculatedPowerSensorBase):
+    """Sensor exposing the primary EV charger's calculated power (W)."""
+
+    _attr_translation_key = "ev_charger_calculated_power"
+    _is_second = False
+
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        coordinator: HSEMDataUpdateCoordinator,
+    ) -> None:
+        """Initialise the primary EV charger calculated power sensor."""
+        super().__init__(config_entry, coordinator)
+        self._attr_unique_id = get_ev_charger_calculated_power_sensor_unique_id(
+            config_entry.entry_id
+        )
+        self.entity_id = get_ev_charger_calculated_power_sensor_entity_id()
+        self._name = get_ev_charger_calculated_power_sensor_name()
+
+
+class HSEMEVSecondChargerCalculatedPowerSensor(HSEMEVChargerCalculatedPowerSensorBase):
+    """Sensor exposing the second EV charger's calculated power (W)."""
+
+    _attr_translation_key = "ev_second_charger_calculated_power"
+    _is_second = True
+
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        coordinator: HSEMDataUpdateCoordinator,
+    ) -> None:
+        """Initialise the second EV charger calculated power sensor."""
+        super().__init__(config_entry, coordinator)
+        self._attr_unique_id = get_ev_second_charger_calculated_power_sensor_unique_id(
+            config_entry.entry_id
+        )
+        self.entity_id = get_ev_second_charger_calculated_power_sensor_entity_id()
+        self._name = get_ev_second_charger_calculated_power_sensor_name()

--- a/custom_components/hsem/sensor.py
+++ b/custom_components/hsem/sensor.py
@@ -26,6 +26,10 @@ from custom_components.hsem.custom_sensors.degraded_mode_sensor import (
 from custom_components.hsem.custom_sensors.effective_discharge_floor_sensor import (
     HSEMEffectiveDischargeFloorSensor,
 )
+from custom_components.hsem.custom_sensors.ev_charger_calculated_power_sensor import (
+    HSEMEVChargerCalculatedPowerSensor,
+    HSEMEVSecondChargerCalculatedPowerSensor,
+)
 from custom_components.hsem.custom_sensors.ev_charging_sensor import (
     HSEMEVChargingSensor,
 )
@@ -126,6 +130,12 @@ async def async_setup_entry(  # NOSONAR -- HA platform callback, must be async
     ev_second_optimal_charging_plan_sensor = HSEMEVSecondOptimalChargingPlanSensor(
         config_entry, coordinator
     )
+    ev_charger_calculated_power_sensor = HSEMEVChargerCalculatedPowerSensor(
+        config_entry, coordinator
+    )
+    ev_second_charger_calculated_power_sensor = (
+        HSEMEVSecondChargerCalculatedPowerSensor(config_entry, coordinator)
+    )
 
     # Forecast accuracy sensor — exposes predicted-vs-actual metrics.
     forecast_accuracy_sensor = HSEMForecastAccuracySensor(config_entry, coordinator)
@@ -188,6 +198,8 @@ async def async_setup_entry(  # NOSONAR -- HA platform callback, must be async
             ev_charging_sensor,
             ev_optimal_charging_plan_sensor,
             ev_second_optimal_charging_plan_sensor,
+            ev_charger_calculated_power_sensor,
+            ev_second_charger_calculated_power_sensor,
             applier_status_sensor,
             plan_explanation_sensor,
             forecast_accuracy_sensor,

--- a/custom_components/hsem/translations/en.json
+++ b/custom_components/hsem/translations/en.json
@@ -996,6 +996,9 @@
           "error": "Error"
         }
       },
+      "ev_charger_calculated_power": {
+        "name": "EV Charger Calculated Power"
+      },
       "ev_charging": {
         "name": "EV Charging Active",
         "state": {
@@ -1013,6 +1016,9 @@
           "waiting": "Waiting",
           "unavailable": "Unavailable"
         }
+      },
+      "ev_second_charger_calculated_power": {
+        "name": "EV 2 Charger Calculated Power"
       },
       "ev_second_optimal_charging_plan": {
         "name": "EV 2 Optimal Charging Plan",

--- a/custom_components/hsem/utils/sensornames/ev.py
+++ b/custom_components/hsem/utils/sensornames/ev.py
@@ -72,6 +72,46 @@ def get_ev_second_optimal_charging_plan_sensor_entity_id() -> str:
     return f"sensor.{s(f'{DOMAIN}_ev_second_optimal_charging_plan')}"
 
 
+# EV Charger Calculated Power Sensor
+def get_ev_charger_calculated_power_sensor_name() -> str:
+    """Return the display name for the EV charger calculated power sensor."""
+    return "EV Charger Calculated Power"
+
+
+def get_ev_charger_calculated_power_sensor_unique_id(entry_id: str) -> str:
+    """Return a unique ID for the EV charger calculated power sensor.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_ev_charger_calculated_power"
+
+
+def get_ev_charger_calculated_power_sensor_entity_id() -> str:
+    """Return the entity_id for the EV charger calculated power sensor."""
+    return f"sensor.{s(f'{DOMAIN}_ev_charger_calculated_power')}"
+
+
+# EV Second Charger Calculated Power Sensor
+def get_ev_second_charger_calculated_power_sensor_name() -> str:
+    """Return the display name for the second EV charger calculated power sensor."""
+    return "EV 2 Charger Calculated Power"
+
+
+def get_ev_second_charger_calculated_power_sensor_unique_id(entry_id: str) -> str:
+    """Return a unique ID for the second EV charger calculated power sensor.
+
+    Args:
+        entry_id (str): The config entry ID for uniqueness across entries.
+    """
+    return f"{DOMAIN}_{entry_id}_ev_second_charger_calculated_power"
+
+
+def get_ev_second_charger_calculated_power_sensor_entity_id() -> str:
+    """Return the entity_id for the second EV charger calculated power sensor."""
+    return f"sensor.{s(f'{DOMAIN}_ev_second_charger_calculated_power')}"
+
+
 # EV Target SoC Number
 def get_ev_target_soc_number_key() -> str:
     """Return the entity description key for the EV target SoC number entity."""

--- a/docs/sensors-reference.md
+++ b/docs/sensors-reference.md
@@ -329,6 +329,33 @@ Diagnostic sensors displaying the EV charging plan details.
 
 ---
 
+## EV charger calculated power sensors
+
+Diagnostic sensors exposing the planner's calculated EV charger power for the
+**current slot** as their state, so it can be graphed and used in automations
+without parsing the working-mode sensor attributes.
+
+**Entities:**
+- `sensor.hsem_ev_charger_calculated_power` — Primary EV
+- `sensor.hsem_ev_second_charger_calculated_power` — Second EV
+
+| State | Unit | Description |
+|---|---|---|
+| ≥ 0 | W | Target AC power for the charger in the active slot (`0` when no charging is planned) |
+
+**Key attributes:**
+
+| Attribute | Description |
+|---|---|
+| `slot_start` / `slot_end` | ISO-8601 window of the active planning slot |
+| `ev_total_planned_load_kwh` | Total EV AC load planned for the slot (kWh) |
+
+These mirror `ev_charger_calculated_power` and
+`ev_second_charger_calculated_power` from the `hourly_recommendation` attribute
+of the working-mode sensor.
+
+---
+
 ## Daily plan-vs-actual sensor
 
 Diagnostic sensor tracking daily cumulative plan-vs-actual energy deviations.
@@ -511,6 +538,8 @@ Detects when the inverter is actively curtailing PV production.
 | `sensor.hsem_battery_soc_sensor` | Battery State of Charge | Battery SoC snapshot | Percentage (0–100) |
 | `sensor.hsem_daily_plan_vs_actual` | Daily Plan vs Actual | Daily energy plan-vs-actual tracking | Dict with cumulative metrics |
 | `sensor.hsem_degraded_mode_sensor` | System Health | Overall system health | `ok`, `degraded`, `error` |
+| `sensor.hsem_ev_charger_calculated_power` | EV Charger Calculated Power | Planner target power for primary EV charger | Watts (W) |
+| `sensor.hsem_ev_second_charger_calculated_power` | EV 2 Charger Calculated Power | Planner target power for second EV charger | Watts (W) |
 | `sensor.hsem_ev_charging_sensor` | EV Charging Active | Any EV actively charging | `on`, `off` |
 | `sensor.hsem_ev_optimal_charging_plan` | EV Optimal Charging Plan | Primary EV plan state | `charging`, `waiting`, etc. |
 | `sensor.hsem_ev_second_optimal_charging_plan` | EV Second Optimal Charging Plan | Second EV plan state | `charging`, `waiting`, etc. |

--- a/tests/sensors/test_ev_charger_calculated_power_sensor.py
+++ b/tests/sensors/test_ev_charger_calculated_power_sensor.py
@@ -1,0 +1,217 @@
+"""Tests for the EV charger calculated power sensors.
+
+Acceptance criteria
+-------------------
+- ``native_value`` equals ``ev_charger_calculated_power`` (primary) and
+  ``ev_second_charger_calculated_power`` (second) from the current
+  ``HourlyRecommendation``.
+- ``native_value`` returns ``None`` when the coordinator has no data or no
+  active slot, falling back to the restored state when available.
+- ``available`` is False before the first cycle and True after.
+- ``extra_state_attributes`` expose the active slot window and planned load.
+- The sensors are wired as diagnostic power-measurement entities.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from homeassistant.components.sensor.const import SensorDeviceClass, SensorStateClass
+from homeassistant.const import EntityCategory, UnitOfPower
+
+from custom_components.hsem.coordinator import CoordinatorData
+from custom_components.hsem.custom_sensors.ev_charger_calculated_power_sensor import (
+    HSEMEVChargerCalculatedPowerSensor,
+    HSEMEVChargerCalculatedPowerSensorBase,
+    HSEMEVSecondChargerCalculatedPowerSensor,
+)
+from custom_components.hsem.models.hourly_recommendation import HourlyRecommendation
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_rec(
+    *,
+    ev_power: float = 11000.0,
+    ev_second_power: float = 0.0,
+) -> HourlyRecommendation:
+    """Return a minimal HourlyRecommendation for the current slot."""
+    now = datetime.now(UTC)
+    return HourlyRecommendation(
+        start=now,
+        end=now + timedelta(minutes=15),
+        recommendation="ev_smart_charging",
+        avg_house_consumption_kwh=0.0,
+        avg_house_consumption_1d_kwh=0.0,
+        avg_house_consumption_3d_kwh=0.0,
+        avg_house_consumption_7d_kwh=0.0,
+        avg_house_consumption_14d_kwh=0.0,
+        batteries_charged_kwh=0.0,
+        batteries_discharged_kwh=0.0,
+        estimated_battery_capacity_kwh=0.0,
+        estimated_battery_soc_pct=50.0,
+        estimated_cost_currency=0.0,
+        estimated_net_consumption_kwh=0.0,
+        export_price=0.0,
+        grid_export_kwh=0.0,
+        grid_import_kwh=0.0,
+        import_price=0.0,
+        solcast_pv_estimate_kwh=0.0,
+        ev_charger_calculated_power=ev_power,
+        ev_second_charger_calculated_power=ev_second_power,
+        ev_total_planned_load_kwh=2.75,
+    )
+
+
+def _make_sensor(
+    cls: type[HSEMEVChargerCalculatedPowerSensorBase],
+    data: CoordinatorData | None,
+) -> HSEMEVChargerCalculatedPowerSensorBase:
+    """Return a bare sensor wired to a mock coordinator."""
+    coordinator = MagicMock()
+    coordinator.data = data
+    coordinator.last_update_success = data is not None
+
+    sensor: HSEMEVChargerCalculatedPowerSensorBase = object.__new__(cls)
+    sensor.coordinator = coordinator
+    sensor._config_entry = MagicMock()
+    sensor._restored_state = None
+    return sensor
+
+
+# ===========================================================================
+# 1. Entity metadata
+# ===========================================================================
+
+
+class TestEntityMetadata:
+    """The sensors have the correct HA entity metadata."""
+
+    @pytest.mark.parametrize(
+        "cls",
+        [HSEMEVChargerCalculatedPowerSensor, HSEMEVSecondChargerCalculatedPowerSensor],
+    )
+    def test_sensor_is_diagnostic_power_measurement(self, cls):
+        """Both sensors must be diagnostic W power-measurement entities."""
+        sensor = _make_sensor(cls, None)
+        assert sensor._attr_entity_category is EntityCategory.DIAGNOSTIC
+        assert sensor._attr_device_class is SensorDeviceClass.POWER
+        assert sensor._attr_state_class is SensorStateClass.MEASUREMENT
+        assert sensor._attr_native_unit_of_measurement == UnitOfPower.WATT
+
+    def test_primary_translation_key(self):
+        """Primary sensor must use the ev_charger_calculated_power translation key."""
+        sensor = _make_sensor(HSEMEVChargerCalculatedPowerSensor, None)
+        assert sensor._attr_translation_key == "ev_charger_calculated_power"
+
+    def test_second_translation_key(self):
+        """Second sensor must use the ev_second_charger_calculated_power key."""
+        sensor = _make_sensor(HSEMEVSecondChargerCalculatedPowerSensor, None)
+        assert sensor._attr_translation_key == "ev_second_charger_calculated_power"
+
+
+# ===========================================================================
+# 2. Native value
+# ===========================================================================
+
+
+class TestNativeValue:
+    """native_value reflects the planner's calculated power per charger."""
+
+    def test_primary_returns_ev_charger_calculated_power(self):
+        """Primary sensor state must equal ev_charger_calculated_power."""
+        data = CoordinatorData(hourly_recommendation=_make_rec(ev_power=11000.0))
+        sensor = _make_sensor(HSEMEVChargerCalculatedPowerSensor, data)
+        assert sensor.native_value == pytest.approx(11000.0)
+
+    def test_second_returns_ev_second_charger_calculated_power(self):
+        """Second sensor state must equal ev_second_charger_calculated_power."""
+        data = CoordinatorData(hourly_recommendation=_make_rec(ev_second_power=3700.0))
+        sensor = _make_sensor(HSEMEVSecondChargerCalculatedPowerSensor, data)
+        assert sensor.native_value == pytest.approx(3700.0)
+
+    def test_primary_zero_when_no_charging_planned(self):
+        """Primary sensor reports 0 W when the planner allocates no EV power."""
+        data = CoordinatorData(hourly_recommendation=_make_rec(ev_power=0.0))
+        sensor = _make_sensor(HSEMEVChargerCalculatedPowerSensor, data)
+        assert sensor.native_value == pytest.approx(0.0)
+
+    def test_none_when_no_coordinator_data(self):
+        """native_value must be None before the first coordinator cycle."""
+        sensor = _make_sensor(HSEMEVChargerCalculatedPowerSensor, None)
+        assert sensor.native_value is None
+
+    def test_none_when_no_active_slot(self):
+        """native_value must be None when there is no active slot."""
+        sensor = _make_sensor(HSEMEVChargerCalculatedPowerSensor, CoordinatorData())
+        assert sensor.native_value is None
+
+    def test_falls_back_to_restored_state(self):
+        """native_value uses the restored state when no data is available."""
+        sensor = _make_sensor(HSEMEVChargerCalculatedPowerSensor, None)
+        sensor._restored_state = "7400"
+        assert sensor.native_value == pytest.approx(7400.0)
+
+    def test_invalid_restored_state_returns_none(self):
+        """A non-numeric restored state must not crash the sensor."""
+        sensor = _make_sensor(HSEMEVChargerCalculatedPowerSensor, None)
+        sensor._restored_state = "not-a-number"
+        assert sensor.native_value is None
+
+
+# ===========================================================================
+# 3. Availability
+# ===========================================================================
+
+
+class TestAvailability:
+    """available reflects coordinator health and restore state."""
+
+    def test_unavailable_before_first_cycle(self):
+        """Sensor must be unavailable before the first successful cycle."""
+        sensor = _make_sensor(HSEMEVChargerCalculatedPowerSensor, None)
+        assert sensor.available is False
+
+    def test_available_after_cycle(self):
+        """Sensor must be available once the coordinator has data."""
+        data = CoordinatorData(hourly_recommendation=_make_rec())
+        sensor = _make_sensor(HSEMEVChargerCalculatedPowerSensor, data)
+        assert sensor.available is True
+
+    def test_available_with_restored_state(self):
+        """A restored state keeps the sensor available across restarts."""
+        sensor = _make_sensor(HSEMEVChargerCalculatedPowerSensor, None)
+        sensor._restored_state = "11000"
+        assert sensor.available is True
+
+
+# ===========================================================================
+# 4. Attributes
+# ===========================================================================
+
+
+class TestAttributes:
+    """extra_state_attributes expose the active slot context."""
+
+    def test_attributes_with_active_slot(self):
+        """Attributes include slot window and total planned EV load."""
+        rec = _make_rec()
+        data = CoordinatorData(hourly_recommendation=rec)
+        sensor = _make_sensor(HSEMEVChargerCalculatedPowerSensor, data)
+        attrs = sensor.extra_state_attributes
+        assert attrs["slot_start"] == rec.start.isoformat()
+        assert attrs["slot_end"] == rec.end.isoformat()
+        assert attrs["ev_total_planned_load_kwh"] == pytest.approx(2.75)
+
+    def test_attributes_without_data(self):
+        """Attributes are None-filled when no active slot exists."""
+        sensor = _make_sensor(HSEMEVChargerCalculatedPowerSensor, None)
+        attrs = sensor.extra_state_attributes
+        assert attrs["slot_start"] is None
+        assert attrs["slot_end"] is None
+        assert attrs["ev_total_planned_load_kwh"] is None


### PR DESCRIPTION
## Summary
Split the planner's EV charger power outputs out of the working-mode sensor into dedicated diagnostic sensors whose state equals the calculated power in Watts.

## Branch
`agents/split-ev-charger-power-sensors`

## Files changed
- `custom_components/hsem/custom_sensors/ev_charger_calculated_power_sensor.py`
- `custom_components/hsem/sensor.py`
- `custom_components/hsem/utils/sensornames/ev.py`
- `custom_components/hsem/translations/en.json`
- `docs/sensors-reference.md`
- `tests/sensors/test_ev_charger_calculated_power_sensor.py`

## What changed and why
- Added separate sensors for `ev_charger_calculated_power` and `ev_second_charger_calculated_power`.
- Exposed them as diagnostic power sensors so the values are easier to graph and automate against.
- Kept slot context available via sensor attributes.
- Updated translations and sensor reference docs.

## Tests
- `./scripts/quality.sh lint`
- `./scripts/quality.sh typing`
- `./scripts/quality.sh quality`
- `./scripts/quality.sh test`
- `tests/sensors/` — 140 passed
- `tests/test_ha_mock_integration.py` — 123 passed

## Known limitations
- No functional limitations known.

## Configuration changes
- None.
