### PR TITLE
docs(skills): add repo skill definitions

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: code-review
+description: Activate when reviewing code changes, diffs, or pull requests to identify high-confidence bugs, regressions, security issues, and correctness problems.
+---
+
+# Code Review Skill
+
+Activate this skill when the user asks for a code review, PR review, or diff review.
+
+## Review Goals
+
+- Focus on correctness, regressions, security, data loss, and broken tests.
+- Report only high-confidence findings.
+- Ignore style nits and trivial issues unless they hide a bug.
+- Prefer the smallest actionable set of findings.
+
+## Review Workflow
+
+1. Read the diff and relevant surrounding code.
+2. Trace call paths and invariants.
+3. Check tests, types, and behavior changes.
+4. Compare against repository conventions and docs when the change affects them.
+5. Summarize findings with severity, rationale, and exact file and line references.
+
+## HSEM-Specific Checks
+
+- If the change touches planner logic, read `docs/planner-spec.md` first.
+- If the change touches Huawei Solar entities, read `docs/huawei_entities.md` first.
+- If the change affects PR workflow or release notes, check `.github/memories.md` and `docs/` for consistency.
+- Verify affected tests exist or are updated.
+
+## Output Format
+
+- Start with an overall assessment.
+- List findings sorted by severity.
+- For each finding, include:
+  - file path
+  - line number or lines
+  - concise explanation
+  - why it matters
+- If no issues are found, say so explicitly.

--- a/.github/skills/hsem-canonical-helpers/SKILL.md
+++ b/.github/skills/hsem-canonical-helpers/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: hsem-canonical-helpers
+description: Activate at the start of any code change to ensure canonical helpers and patterns are used instead of re-implementing them inline.
+---
+
+# HSEM Canonical Helpers — Use These, Never Re-Invent
+
+Activate this skill when writing any code that may need efficiency conversion, discharge recommendations, threshold calculation, or logging. These helpers exist for a reason — **never re-implement them inline**.
+
+## Canonical Helpers
+
+### 1. Efficiency Conversion — `clamp_efficiency(pct)`
+
+Location: `custom_components/hsem/utils/misc.py`
+
+```python
+from custom_components.hsem.utils.misc import clamp_efficiency
+
+charge_eff = clamp_efficiency(charge_efficiency_pct)   # returns fraction 0.01-1.0
+```
+
+Never inline `max(min(..., 100.0), 1.0) / 100.0`.
+
+### 2. Discharge/Charge Recommendations — `DISCHARGE_RECS`, `CHARGE_RECS`
+
+Location: `custom_components/hsem/utils/recommendations.py`
+
+```python
+from custom_components.hsem.utils.recommendations import DISCHARGE_RECS, CHARGE_RECS
+
+if slot.recommendation in DISCHARGE_RECS:
+    ...
+```
+
+These are canonical frozensets. Never redefine them locally.
+
+### 3. Recommended Threshold — `calculate_recommended_threshold(...)`
+
+Location: `custom_components/hsem/utils/misc.py`
+
+```python
+from custom_components.hsem.utils.misc import calculate_recommended_threshold
+
+threshold = calculate_recommended_threshold(
+    purchase_price=purchase_price,
+    cycle_cost_per_kwh=cycle_cost_per_kwh,
+    charge_efficiency_pct=charge_efficiency_pct,
+    discharge_efficiency_pct=discharge_efficiency_pct,
+    capacity_loss_pct=capacity_loss_pct,
+    grid_fee=grid_fee,
+)
+```
+
+Never use `cycle_cost * 0.30` as a proxy for the discharge threshold.
+
+### 4. Planner Logger — `HSEM_LOGGER`
+
+Location: `custom_components/hsem/utils/logger.py`
+
+```python
+from custom_components.hsem.utils.logger import HSEM_LOGGER
+```
+
+Use for ALL planner code. Never use `logging.getLogger(__name__)` in planner files.
+
+When creating log statements, never use runtime string formatting — use `%` placeholders and the `extra` argument:
+```python
+HSEM_LOGGER.debug("Processing slot %d with price %.4f", slot_index, price)
+```
+
+### 5. Sensor Name Constants
+
+Location: `custom_components/hsem/utils/sensornames.py`
+
+All HA entity name constants live here. Never hardcode sensor names elsewhere.
+
+## Canonical Patterns
+
+### Floating-Point Comparisons
+
+```python
+# Production code — epsilon guard (NEVER == or !=)
+if abs(value) > 1e-9:        # instead of: if value != 0
+if abs(a - b) < 1e-9:        # instead of: if a == b
+
+# Test code — pytest.approx()
+assert result == pytest.approx(expected, rel=1e-6)
+```
+
+### Module Responsibilities (Know Where Code Lives)
+
+| Layer | Location | Key files |
+|-------|----------|-----------|
+| Planner | `custom_components/hsem/planner/` | `engine.py`, `cost_function.py`, `soc_simulation.py`, `candidate_generator.py`, `candidate_selector.py`, `slot_population.py`, `charge_scheduler.py`, `discharge_scheduler.py`, `milp_optimizer.py`, `ev_planner.py` |
+| ML | `custom_components/hsem/ml/` | `consumption_predictor.py`, `history_reader.py`, `populator.py` |
+| Utils | `custom_components/hsem/utils/` | `recommendations.py`, `misc.py`, `sensornames.py`, `prices.py`, `huawei.py`, `logger.py`, `solar_corrector.py`, `dynamic_floor.py`, `capacity_learner.py`, `charge_rate_learner.py`, `prediction_tracker.py`, `weekday_profile.py`, `ev_mode_resolver.py` |
+
+### Utility Function Centralization
+
+If a utility function is used in 2+ modules, it belongs in `utils/`. Before writing any utility:
+1. Check `utils/misc.py` and other `utils/*.py` modules for existing implementations
+2. If found: import and reuse
+3. If not found AND used 2+ times: create in utils with a public name and docstring
+4. If a one-off helper used in only one module: make it private (`_function_name()`), but refactor to utils if needs grow
+
+### MILP Variable Vector
+
+The MILP in `milp_optimizer.py` uses **8*n** LP variables for battery-only. With EV co-optimisation, it grows to **8n + 2n·E + E** where E is the number of active EVs.
+
+### Cycle Cost Formula
+
+Always uses the mandatory **2x denominator**. Never change this without updating the spec and all affected tests.
+
+### File Size Limit
+
+Hard limit: **30 KB** per file in `planner/` and `utils/`. Check: `wc -c custom_components/hsem/planner/*.py`

--- a/.github/skills/hsem-code-quality/SKILL.md
+++ b/.github/skills/hsem-code-quality/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: hsem-code-quality
+description: Activate before every commit and PR to run the full HSEM quality gate pipeline — lint, typing, quality checks, and tests.
+---
+
+# HSEM Code Quality — Pre-Commit & Pre-PR Gates
+
+Activate this skill **before every commit** and **before opening any PR**.
+
+## Four Quality Gates — All Must Pass
+
+Run these in order. If any fails, fix the issues before proceeding.
+
+### Gate 1: Lint
+
+```bash
+./scripts/quality.sh lint
+```
+
+Runs: ruff format → ruff check. Auto-formats and checks for style violations.
+
+### Gate 2: Type Checking
+
+```bash
+./scripts/quality.sh typing
+```
+
+Runs: mypy type checking. Must pass with **0 errors**.
+
+Rules:
+- `disable_error_code` is empty in `pyproject.toml` — never add new suppressions
+- No `# type: ignore` without a comment justifying why
+
+### Gate 3: Quality
+
+```bash
+./scripts/quality.sh quality
+```
+
+Runs: pyright + vulture static checks. Must pass with **0 errors**.
+
+### Gate 4: Tests
+
+```bash
+./scripts/quality.sh test
+```
+
+Runs: pytest with coverage on Python 3.14.
+
+For faster iteration during development:
+```bash
+./scripts/quality.sh test tests/test_module.py           # specific file
+./scripts/quality.sh test tests/test_module.py::test_fn   # specific test
+```
+
+### All Gates at Once
+
+```bash
+./scripts/quality.sh all
+```
+
+## File Size Check
+
+Hard limit: **30 KB per file** in `planner/` and `utils/`. Check before PR:
+```bash
+wc -c custom_components/hsem/planner/*.py
+wc -c custom_components/hsem/utils/*.py
+```
+
+If a file exceeds 30 KB, split it before adding more features.
+
+## Pre-Commit Hook (Optional but Recommended)
+
+```bash
+pre-commit run --all-files
+```
+
+## Code Standards Quick Reference
+
+- **Float comparisons**: epsilon guard in production (`abs(x) > 1e-9`), `pytest.approx()` in tests
+- **Type hints**: every public function has parameter and return type annotations; use `| None`, not `Optional[...]`
+- **Docstrings**: Google-style for public modules, classes, functions, methods
+- **`@override`**: every method that overrides a base class method
+- **Import order**: standard library → third-party → `homeassistant.*` → `custom_components.hsem.*`
+- **String formatting**: f-strings for runtime, `%`-formatting for logging
+- **Encoding**: `open(file, encoding='utf-8')` in text mode
+- **Paths**: `pathlib` over `os.path`
+- **Modular code**: DRY principle, break into components
+
+## Verify Before Commit
+
+```bash
+git --no-optional-locks status
+```
+
+Only intended changes should appear. If any of the four gates fail, fix them before committing. Do not submit a PR with formatting, linting, typing, or test failures.

--- a/.github/skills/hsem-doc-sync/SKILL.md
+++ b/.github/skills/hsem-doc-sync/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: hsem-doc-sync
+description: Activate after every code change to verify all documentation files that describe the changed behaviour are updated and consistent with the implementation.
+---
+
+# HSEM Documentation Sync — Keep Docs in Sync with Code
+
+Activate this skill **after making code changes** and **before opening a PR**. Stale documentation causes confusion and bugs — every doc that describes changed behaviour must be updated in the same PR.
+
+## Documentation Files — Check Every One
+
+When behaviour changes, check **every** file below. If it describes something you changed, update it:
+
+| File | When to check |
+|------|---------------|
+| `docs/planner-guide.md` | Planner inputs, outputs, cost function, or scenarios changed |
+| `docs/planner-spec.md` | Planner semantics, invariants, formulas, or safety gates changed |
+| `docs/config-flow-reference.md` | Config/options flow steps changed |
+| `docs/ev-charge-plan-setup.md` | EV planned load setup changed |
+| `docs/huawei_entities.md` | New Huawei entities wired or existing ones changed |
+| `.github/memories.md` | Canonical patterns, module map, open issues, or architectural decisions changed |
+| `README.md` | User-facing features, descriptions, or links changed |
+| `translations/en.json` | Any user-facing string added, changed, or removed |
+
+## Documentation Rules
+
+### Spec-Implementation Consistency (Highest Priority)
+
+- `docs/planner-spec.md` and the planner implementation **must never diverge silently**
+- If a change intentionally alters planner semantics, update the spec in the same commit
+- The spec is the source of truth — code must match it exactly
+
+### Memories.md
+
+- Module responsibility map must reflect current file layout
+- Canonical patterns must be accurate
+- Open issue numbers must be up to date
+- New architectural decisions must be recorded
+
+### Translations
+
+- Every user-facing string (field labels, errors, aborts) must have a key in `translations/en.json`
+- Boolean/switch fields must have translation entries
+- For `huawei_solar` fields: update **both** `config.step.huawei_solar` and `options.step.huawei_solar`
+
+### README.md
+
+- User-facing feature descriptions must be accurate
+- Links must resolve correctly
+- Setup/configuration instructions must reflect current flows
+
+## Verification Checklist
+
+Before opening a PR:
+
+- [ ] Read every docs file listed above
+- [ ] For each file: does it describe something I changed? If yes, update it
+- [ ] `docs/planner-spec.md` consistent with planner implementation
+- [ ] `.github/memories.md` module map matches current file layout
+- [ ] `translations/en.json` has entries for all new/changed user-facing strings
+- [ ] No stale or misleading documentation remains
+
+## Anti-Patterns to Avoid
+
+- ❌ Updating the planner code but not `docs/planner-spec.md`
+- ❌ Adding a new config field but not `docs/config-flow-reference.md`
+- ❌ Changing a feature but leaving old behavior in `README.md`
+- ❌ Adding a user-facing string but skipping `translations/en.json`
+- ❌ Wiring a new Huawei entity but not `docs/huawei_entities.md`
+- ❌ Recording a pattern in code but not in `.github/memories.md`

--- a/.github/skills/hsem-ha-compliance/SKILL.md
+++ b/.github/skills/hsem-ha-compliance/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: hsem-ha-compliance
+description: Activate when making changes that touch Home Assistant integration surfaces — config flows, entities, translations, services, device info, async patterns, or platform setup.
+---
+
+# HSEM Home Assistant Compliance Checklist
+
+Activate this skill when your change touches any of these HA integration surfaces:
+- Config flow (`config_flow.py`, `flows/`)
+- Entity classes and platforms
+- Translations (`translations/en.json`)
+- Services (`services.yaml`)
+- Device info, unique IDs
+- Async patterns, setup/unload
+- Dependencies, `manifest.json`
+
+## Section 1 — Development Checklist (HA Silver/Gold)
+
+### Dependencies
+- [ ] No new third-party deps in `manifest.json` without justification
+- [ ] Dev-only deps go in `pyproject.toml`
+- [ ] All `manifest.json` requirements pinned to exact versions (`"pkg==1.2.3"`)
+- [ ] `REQUIREMENTS` constant is deprecated — use `manifest.json` only
+
+### API & Async
+- [ ] All device/API-specific code lives in a third-party PyPI library; HA code only interacts with library objects
+- [ ] All `hass.async_create_task()` calls have error handling (no fire-and-forget without `try/except`)
+- [ ] No blocking calls (`time.sleep`, `requests`, `open()`) on the event loop — offload via `hass.async_add_executor_job()`
+
+### Config Flow
+- [ ] Every `async_step_*` returns a proper dict
+- [ ] No state leaks between steps
+- [ ] `async_migrate_entry` handles version bumps
+- [ ] Voluptuous schemas present for all configuration validation
+- [ ] Default parameters in schema, not in `setup()`
+- [ ] Use generic keys from `homeassistant.const` where possible
+- [ ] No `customize` dependency — never depend on users adding things to `customize`
+
+### Translations
+- [ ] Every user-facing string has a key in `translations/en.json`
+- [ ] Field labels, errors, aborts, boolean/switch fields all present
+- [ ] Both `config` and `options` steps updated for `huawei_solar` if applicable
+
+### Entities
+- [ ] Correct MRO: mixins before base — `CoordinatorEntity, RestoreEntity, SensorEntity`
+- [ ] No bare `Entity`
+- [ ] Every entity has `unique_id` (stable, uses config entry ID)
+- [ ] Every entity has `device_info` with `identifiers={(DOMAIN, entry.entry_id)}`
+
+### Services
+- [ ] Registered in `async_setup_entry`, removed in `async_unload_entry`
+- [ ] All have voluptuous schemas
+
+### Platform Communication
+- [ ] Share data via `hass.data[DOMAIN]`
+- [ ] Notify platforms of updates via `homeassistant.helpers.dispatcher`
+- [ ] Prefix all custom event names with the domain name
+
+## Section 2 — Style Guidelines
+
+- [ ] File headers: every `.py` file starts with a docstring describing what the file does
+- [ ] Import order: standard library → third-party → `homeassistant.*` → `custom_components.hsem.*`
+- [ ] Alphabetical ordering for constants and list/dict content
+- [ ] Use HA constants: `CONF_NAME`, `UnitOfEnergy`, `PERCENTAGE`, `Platform`, `STATE_ON`/`STATE_OFF`
+- [ ] No hardcoded strings: no `"on"`, `"off"`, `"kWh"`, `"%"`, `"unknown"` — use HA constants
+- [ ] Logging: use `%`-formatting, no component name in message, no period at end, restrict `_LOGGER.info`
+- [ ] Type hints: every public function, use `| None` (not `Optional`), `@override` on overrides
+- [ ] Docstrings: Google-style, summary line (imperative, period)
+- [ ] Planner code uses `HSEM_LOGGER` from `utils/logger.py`; non-planner may use `logging.getLogger(__name__)`
+
+## Section 3 — PR Scope Rules
+
+- [ ] Single platform per PR
+- [ ] No feature creep — only what the issue requires
+- [ ] No mixed cleanups — don't mix refactors with features
+- [ ] One issue per PR
+- [ ] No unmerged dependencies
+
+## Section 4 — Testing
+
+- [ ] Use mock-based approach (`MagicMock`/`AsyncMock`) — compatible with Windows
+- [ ] Config flow tests: fresh install, reconfigure, abort-on-duplicate, validation errors
+- [ ] Entity tests: assert `unique_id`, `device_info`, `native_value`, `native_unit_of_measurement`, `state`, `extra_state_attributes`
+- [ ] Float comparisons: `pytest.approx()` in tests, epsilon guard in production
+
+## Section 5 — Unload & Cleanup
+
+- [ ] Every listener, timer, task created in setup is cancelled/removed in teardown
+- [ ] `hass.data[DOMAIN]` popped on unload

--- a/.github/skills/hsem-ha-quality/SKILL.md
+++ b/.github/skills/hsem-ha-quality/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: hsem-ha-quality
+description: Activate when writing or reviewing Home Assistant integration code to ensure Bronze and Silver quality tier standards — HA constants, entity patterns, coordinator usage, config flow, and async correctness.
+---
+
+# HSEM Home Assistant Quality — Bronze & Silver Tier Standards
+
+Activate this skill when writing or reviewing any code that touches Home Assistant integration surfaces. It enforces Bronze and Silver quality tier requirements from the [HA integration quality scale](https://developers.home-assistant.io/docs/quality_scale/).
+
+## Bronze Tier — Must Have (Non-Negotiable)
+
+These are required for any HA integration to function correctly.
+
+### Constants — Never Hardcode
+
+```python
+# ✅ Use HA constants from homeassistant.const
+from homeassistant.const import (
+    CONF_NAME,
+    PERCENTAGE,
+    STATE_ON,
+    STATE_OFF,
+    UnitOfEnergy,
+    Platform,
+)
+
+# ❌ Never hardcode strings
+state = "on"           # use STATE_ON
+unit = "kWh"           # use UnitOfEnergy.KILO_WATT_HOUR
+unit = "%"             # use PERCENTAGE
+```
+
+Always check [`homeassistant/const.py`](https://github.com/home-assistant/core/blob/dev/homeassistant/const.py) before defining your own constant.
+
+### Entity Pattern — Correct MRO
+
+```python
+# ✅ Correct: mixins BEFORE base class
+class HSEMBatterySensor(CoordinatorEntity, RestoreEntity, SensorEntity):
+    ...
+
+# ❌ Wrong: bare Entity, wrong order
+class HSEMBatterySensor(SensorEntity, CoordinatorEntity):  # MRO violation
+    ...
+class HSEMBatterySensor(Entity):  # never use bare Entity
+    ...
+```
+
+### Device Info & Unique ID — Every Entity
+
+```python
+# ✅ Every entity MUST have both
+@property
+def unique_id(self) -> str:
+    return f"{self._entry.entry_id}_{self.entity_description.key}"
+
+@property
+def device_info(self) -> DeviceInfo:
+    return DeviceInfo(
+        identifiers={(DOMAIN, self._entry.entry_id)},
+        name="HSEM",
+        manufacturer="HSEM",
+        model="Energy Management",
+    )
+```
+
+### Config Flow — Every Step Returns Proper Dict
+
+```python
+# ✅ Every async_step_* returns a dict
+async def async_step_user(self, user_input=None):
+    if user_input is not None:
+        return self.async_create_entry(title="HSEM", data=user_input)
+    return self.async_show_form(step_id="user", data_schema=STEP_USER_SCHEMA)
+
+# ❌ State leaks between steps — never store mutable state on self
+```
+
+### Manifest — Pinned Dependencies
+
+```json
+{
+  "requirements": ["some-lib==1.2.3"],
+  "dependencies": [],
+  "codeowners": ["@owner"]
+}
+```
+- Pin to exact versions: `"pkg==1.2.3"`
+- `REQUIREMENTS` constant is deprecated — use `manifest.json` only
+- No new third-party deps without justification
+
+## Silver Tier — Should Have
+
+### Async Correctness
+
+```python
+# ✅ Offload blocking calls
+result = await self.hass.async_add_executor_job(cpu_intensive_fn)
+
+# ✅ Error handling on tasks
+try:
+    self._task = hass.async_create_task(self._poll())
+except Exception:
+    _LOGGER.exception("Poll failed")
+
+# ❌ Blocking on event loop
+time.sleep(1)           # use asyncio.sleep
+requests.get(url)       # use aiohttp / hass.helpers.aiohttp_client
+open("file")            # use aiofiles or executor_job
+```
+
+### Coordinator Pattern
+
+```python
+# ✅ Use DataUpdateCoordinator for periodic/shared polling
+from homeassistant.helpers.update_coordinator import (
+    DataUpdateCoordinator,
+    CoordinatorEntity,
+)
+
+class HSEMCoordinator(DataUpdateCoordinator):
+    async def _async_update_data(self):
+        """Fetch latest data."""
+        ...
+
+# Entities extend CoordinatorEntity to get auto-updates
+class HSEMSensor(CoordinatorEntity, SensorEntity):
+    @property
+    def native_value(self):
+        return self.coordinator.data.get("my_value")
+```
+
+### Translations — Every User-Facing String
+
+Every string the user sees must be in `translations/en.json`:
+- Config flow step titles, descriptions, field labels
+- Error messages (`error`, `abort`)
+- Options flow fields
+- Entity names in `entity` section
+
+```json
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "HSEM Setup",
+        "data": {
+          "name": "Integration Name"
+        }
+      }
+    },
+    "error": {
+      "invalid_config": "Invalid configuration"
+    },
+    "abort": {
+      "already_configured": "Already configured"
+    }
+  }
+}
+```
+
+### Unload & Cleanup
+
+```python
+# ✅ Register in setup, remove in unload
+async def async_setup_entry(hass, entry):
+    entry.async_on_unload(entry.add_update_listener(update_listener))
+    hass.data[DOMAIN][entry.entry_id] = coordinator
+
+async def async_unload_entry(hass, entry):
+    # All listeners, timers, tasks must be cancelled
+    hass.data[DOMAIN].pop(entry.entry_id)
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+```
+
+### Platform Communication
+
+```python
+# ✅ Share data via hass.data, notify via dispatcher
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+hass.data[DOMAIN] = shared_data
+async_dispatcher_send(hass, f"{DOMAIN}_updated")
+
+# ✅ Prefix custom event names with domain
+hass.bus.async_fire("hsem_solar_update", {...})  # not "solar_update"
+```
+
+### Logging Standards
+
+```python
+# ✅ Correct logging patterns
+_LOGGER = logging.getLogger(__name__)   # for non-planner code
+_LOGGER.debug("Value updated to %s", value)  # %-formatting for logging
+_LOGGER.info("Important user event")          # no period at end
+
+# ❌ Wrong
+_LOGGER.info(f"Value is {value}")    # f-string in logging
+_LOGGER.error("Failed.")             # period at end
+```
+
+### Type Hints Enforced
+
+```python
+# ✅ Modern Python 3.10+ syntax
+def get_price(unit: str | None = None) -> float:
+    ...
+
+# ❌ Old syntax
+from typing import Optional
+def get_price(unit: Optional[str] = None) -> float:
+    ...
+```
+
+## Bronze/Silver Quick Checklist
+
+**Bronze (every integration):**
+- [ ] No hardcoded strings — use HA constants
+- [ ] Correct entity MRO (CoordinatorEntity, RestoreEntity, SensorEntity)
+- [ ] Unique ID and device_info on every entity
+- [ ] Config flow returns proper dicts, no state leaks
+- [ ] manifest.json dependencies pinned
+
+**Silver (expected quality):**
+- [ ] Async patterns correct, no blocking on event loop
+- [ ] DataUpdateCoordinator for periodic polling
+- [ ] Full translations for all user-facing strings
+- [ ] Proper unload: all listeners/timers/tasks cleaned up
+- [ ] Platform communication via dispatcher, domain-prefixed events
+- [ ] Logging: %-formatting, no periods, proper levels
+- [ ] Modern type hints with `| None`

--- a/.github/skills/hsem-huawei-wiring/SKILL.md
+++ b/.github/skills/hsem-huawei-wiring/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: hsem-huawei-wiring
+description: Activate when adding, modifying, or using any Huawei Solar inverter/battery sensor entity in HSEM. Follow the full wiring protocol from const.py through coordinator.py.
+---
+
+# HSEM Huawei Solar Sensor Wiring
+
+Activate this skill when you need to:
+- Add a new Huawei Solar entity to HSEM
+- Use an existing Huawei Solar entity value
+- Reference battery/inverter parameters (max SoC, charge cutoff, rated capacity, etc.)
+
+## Golden Rule
+
+**Every hardware value consumed or written by HSEM MUST use the entity exposed by the [`wlcrs/huawei_solar`](https://github.com/wlcrs/huawei_solar) Home Assistant integration.** Never hard-code numeric battery constants — always source from the live HA entity.
+
+## Step 1: Check `docs/huawei_entities.md` First
+
+This is the canonical, verified list of every entity exposed by the `wlcrs/huawei_solar` integration on this installation. Only fall back to searching the upstream repo when an entity is not yet listed there.
+
+## Step 2: If Entity Already Exists in HSEM
+
+Re-use it. Do not hard-code the value. The entity should already be wired through `flows/huawei_solar.py`, `sensor_config.py`, `config_reader.py`, `state_collector.py`, and `live_state.py`.
+
+## Step 3: If Entity Exists in `wlcrs/huawei_solar` But NOT Yet Wired Into HSEM
+
+Add it through the **full stack in this exact order**:
+
+1. **`const.py`** — Add a default entity-id string under `DEFAULT_CONFIG_VALUES`
+2. **`flows/huawei_solar.py`** — Add to the schema and validation
+3. **`translations/en.json`** — Add `data` label and `data_description` for the new field in **both** `config.step.huawei_solar` and `options.step.huawei_solar`
+4. **`models/sensor_config.py`** — Add the `str | None` field
+5. **`custom_sensors/config_reader.py`** — Read from config entry
+6. **`custom_sensors/state_collector.py`** — Read the HA entity state
+7. **`models/live_state.py`** — Add the field to `LiveState`
+8. **`coordinator.py`** — Pass to `PlannerInput` (if planner-relevant)
+
+## Step 4: If Entity Is New to `docs/huawei_entities.md`
+
+Add it to `docs/huawei_entities.md` as part of the same PR that wires it into HSEM.
+
+## Key Entity Mappings
+
+| Register / Source | Entity | Meaning |
+|---|---|---|
+| `STORAGE_CHARGING_CUTOFF_CAPACITY` | `number.batteries_end_of_charge_soc` | Max SoC during charging (90-100 %) |
+| `STORAGE_GRID_CHARGE_CUTOFF_STATE_OF_CHARGE` | `number.batteries_grid_charge_cutoff_soc` | Max SoC when charging from grid |
+| `STORAGE_DISCHARGING_CUTOFF_CAPACITY` | `number.batteries_end_of_discharge_soc` | Min SoC floor |
+| `STORAGE_MAXIMUM_CHARGING_POWER` | `number.batteries_maximum_charging_power` | Max charge power (W) |
+| `STORAGE_MAXIMUM_DISCHARGING_POWER` | `number.batteries_maximum_discharging_power` | Max discharge power (W) |
+| `STORAGE_STATE_OF_CAPACITY` | `sensor.batteries_state_of_capacity` | Current SoC (%) |
+| `STORAGE_RATED_CAPACITY` | `sensor.batteries_rated_capacity` | Nameplate capacity (Wh) |
+| `STORAGE_WORKING_MODE_SETTINGS` | `select.batteries_working_mode` | Working mode select |
+| `STORAGE_EXCESS_PV_ENERGY_USE_IN_TOU` | `select.batteries_excess_pv_energy_use_in_tou` | Excess PV use mode in TOU |
+| `STORAGE_HUAWEI_LUNA2000_TOU_…_PERIODS` | `sensor.batteries_tou_charging_and_discharging_periods` | TOU period schedule |
+
+## Never Do This
+
+- Never use a fixed numeric constant for a value that the inverter reports (max SoC, charge cutoff, rated capacity)
+- Never guess an entity ID — check `docs/huawei_entities.md` first
+- Never skip a step in the wiring stack
+- Never forget to update `translations/en.json` for both `config` and `options` steps

--- a/.github/skills/hsem-planner-change/SKILL.md
+++ b/.github/skills/hsem-planner-change/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: hsem-planner-change
+description: Activate when making any change to the HSEM planner layer — engine, cost function, SoC simulation, candidate generation, slot population, MILP optimizer, or safety gates.
+---
+
+# HSEM Planner Change — Spec Compliance & Invariants
+
+Activate this skill when touching **any file under `custom_components/hsem/planner/`**: `engine.py`, `cost_function.py`, `soc_simulation.py`, `candidate_generator.py`, `candidate_selector.py`, `slot_population.py`, `charge_scheduler.py`, `discharge_scheduler.py`, `milp_optimizer.py`, `ev_planner.py`, or safety gates.
+
+## Step 1: Read the Planner Specification
+
+**Always read `docs/planner-spec.md` before touching any planner code.** This is the single source of truth for planner semantics.
+
+## Step 2: Verify These Invariants for Every Planner Change
+
+Every planner change must satisfy ALL of these invariants:
+
+- [ ] **Energy balance per slot** — energy in equals energy out for every time slot
+- [ ] **SoC bounds** — battery SoC never leaves configured min/max bounds
+- [ ] **Cost identity** — `winner.cost == final_output.cost` (no post-selection mutation)
+- [ ] **Slot identity** — `winner.slots == final_output.slots`
+- [ ] **Terminal SoC accounting** — terminal SoC affects cost; emptying the battery is not free
+- [ ] **No-action baseline** — includes normal PV/battery self-consumption
+- [ ] **Safety gates** — read-only, degraded, and dry-run gates block hardware writes
+- [ ] **Forced discharge/export** — changes SoC and cost/revenue correctly
+- [ ] **Grid charge prices** — actual grid import, not stored energy
+- [ ] **Float comparisons** — use epsilon guard (`abs(x) > 1e-9`) in production, `pytest.approx()` in tests
+- [ ] **MILP variable vector** — 8*n base, growing to 8n + 2n·E + E with EV co-optimisation
+- [ ] **Cycle cost formula** — uses mandatory 2x denominator
+
+## Step 3: Update the Spec If Semantics Change
+
+If a change intentionally alters planner semantics (formulas, invariants, safety gates, behavior), **update `docs/planner-spec.md` in the same PR**. Spec and implementation must never diverge silently.
+
+## Step 4: Add or Update Tests
+
+Add tests covering the affected invariants. Every planner change must have regression test coverage for:
+- Energy balance
+- SoC bounds
+- Cost function correctness
+- Terminal SoC handling
+- Safety gate behavior
+
+## Step 5: Do Not Break in Slot Loops
+
+Never use `break` in slot iteration loops unless the loop is explicitly ordered and early exit is provably correct.
+
+## Step 6: Use HSEM_LOGGER for Planner Logging
+
+```python
+from custom_components.hsem.utils.logger import HSEM_LOGGER
+# Never use logging.getLogger(__name__) in planner code
+```
+
+When creating log statements, never use runtime string formatting — use `%` placeholders and the `extra` argument.
+
+## Step 7: Check File Size
+
+Hard limit: 30 KB per file in `planner/` and `utils/`. Check before PR:
+```bash
+wc -c custom_components/hsem/planner/*.py
+```
+
+## Definition of Done for Planner Work
+
+- [ ] `docs/planner-spec.md` read and understood
+- [ ] All invariants verified
+- [ ] Spec updated if semantics changed
+- [ ] Tests added or updated
+- [ ] Spec and implementation are consistent
+- [ ] Lint, typing, quality, and test checks pass

--- a/.github/skills/hsem-pr-workflow/SKILL.md
+++ b/.github/skills/hsem-pr-workflow/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: hsem-pr-workflow
+description: Activate when creating, updating, or managing a pull request for the HSEM repository. Covers conventional commits, PR description, quality gates, and merge rules.
+---
+
+# HSEM Pull Request Workflow
+
+Activate this skill when:
+- Creating a new pull request
+- Updating an existing PR after follow-up commits
+- Preparing to merge a PR
+
+## Pre-PR Checklist
+
+Before opening a PR, all four quality gates must pass:
+
+```bash
+./scripts/quality.sh lint     # ruff format + ruff check
+./scripts/quality.sh typing   # mypy — 0 errors
+./scripts/quality.sh quality  # pyright + vulture — 0 errors
+./scripts/quality.sh test     # pytest with coverage
+```
+
+Or run all at once:
+```bash
+./scripts/quality.sh all
+```
+
+Verify: `git --no-optional-locks status` shows only intended changes.
+
+## Documentation Update
+
+Before opening a PR, check and update ALL documentation that describes changed behavior:
+
+- [ ] `docs/planner-guide.md` — if planner inputs/outputs/cost function changed
+- [ ] `docs/planner-spec.md` — if planner semantics changed
+- [ ] `docs/config-flow-reference.md` — if config/options flow steps changed
+- [ ] `docs/ev-charge-plan-setup.md` — if EV planned load changed
+- [ ] `.github/memories.md` — if canonical patterns or module map changed
+- [ ] `README.md` — if user-facing features changed
+- [ ] `docs/huawei_entities.md` — if new Huawei entities wired
+- [ ] `translations/en.json` — if user-facing strings changed
+
+**A PR is not done until all affected docs are consistent with the implementation.**
+
+## Commit Messages — Conventional Commits
+
+Format: `<type>(<scope>): <description>`
+
+Types: `feat`, `fix`, `docs`, `refactor`, `perf`, `test`, `ci`
+
+Scopes should be specific to the domain: `sensor`, `flow`, `config`, `planner`, `milp`, etc.
+
+Examples:
+```
+fix(planner): correct cycle cost denominator — Fixes #444
+feat(sensor): add temperature-adaptive charge rate — Fixes #123
+```
+
+## Creating a PR
+
+### PR Title
+Must follow Conventional Commits format: `<type>(<scope>): <description>`
+
+### PR Description Must Include
+- Summary of changes
+- Branch name
+- Files changed
+- What changed and why
+- Tests added or updated
+- Test and lint results
+- Known limitations or open questions
+- Any required configuration changes
+- `Fixes #<ISSUE_NUMBER>` (if applicable)
+
+### PR Scope Rules
+- [ ] Single platform per PR
+- [ ] No feature creep
+- [ ] No mixed cleanups with features
+- [ ] One issue per PR
+- [ ] No unmerged dependencies
+
+## Keeping an Open PR Up to Date
+
+After every follow-up commit on a branch that already has an open PR:
+
+1. **Update the PR title** if the scope or description has changed
+2. **Update the PR body** to reflect ALL changes made so far
+3. **Tick off** completed items in any checklist inside the PR description
+4. **Never leave the PR description stale** after follow-up commits
+
+### How to Update a PR
+
+Always use a temp file for the body — never pass multiline body inline:
+
+```bash
+# Write PR body to a temp file first
+cat > /tmp/pr_body.md << 'EOF'
+<markdown body here>
+EOF
+
+# Edit the PR
+gh pr edit <PR_NUMBER> --title "<type>(scope): updated title" --body-file /tmp/pr_body.md
+
+# Clean up
+rm /tmp/pr_body.md
+```
+
+**Never use `--body "..."` with inline multiline text** — PowerShell corrupts newlines and backticks.
+
+## Merge Rules
+
+Before merging ANY PR:
+- [ ] All four quality gates pass (`./scripts/quality.sh all`)
+- [ ] All CI/status checks are green
+- [ ] Code review requirements are met (if applicable)
+- [ ] Tests passing locally and in CI
+- [ ] All documentation updated and consistent
+
+**Never merge without explicit user permission.**
+
+After merge, delete the branch locally and remotely.
+
+## PR Review Request
+
+If requesting a Copilot code review:
+```bash
+# Use the request_copilot_review tool
+```
+
+## Definition of Done
+
+A PR is complete when:
+- [ ] All tests pass locally and in CI
+- [ ] New behavior is covered by tests
+- [ ] Code follows project style and conventions
+- [ ] All lint/type/quality checks pass
+- [ ] Documentation is updated
+- [ ] No secrets committed
+- [ ] No technical debt introduced
+- [ ] PR description is accurate and complete

--- a/.github/skills/hsem-pre-flight/SKILL.md
+++ b/.github/skills/hsem-pre-flight/SKILL.md
@@ -63,7 +63,7 @@ Based on the change type, read these docs before touching code:
 
 ## Step 6: Understand the Affected Code
 
-Search and read the relevant source files. Do not guess file paths — use `grep` and `find_path` to locate them.
+Search and read the relevant source files. Do not guess file paths — use `grep` and `glob` to locate them.
 
 ## Reminder: One Issue Per Branch
 

--- a/.github/skills/hsem-pre-flight/SKILL.md
+++ b/.github/skills/hsem-pre-flight/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: hsem-pre-flight
+description: Run before starting any HSEM code change. Checkout main, pull latest, read repository memory and relevant docs, create a feature branch.
+---
+
+# HSEM Pre-Flight — Start Any Code Change
+
+Activate this skill **before writing any code** — when the user asks to fix a bug, implement a feature, or make any change to the HSEM codebase.
+
+## Step 1: Checkout Main and Pull Latest
+
+```bash
+git checkout main
+git pull
+```
+
+## Step 2: Read Repository Memory
+
+Read `.github/memories.md`. Pay special attention to:
+- Module responsibility map (planner, ML, utils layers)
+- Canonical patterns (clamp_efficiency, DISCHARGE_RECS, calculate_recommended_threshold, HSEM_LOGGER)
+- MILP variable vector layout (8*n base, growing with EV co-optimisation)
+- File size limits (30 KB hard limit in planner/ and utils/)
+- Cycle cost formula with mandatory 2x denominator
+- File organization patterns (by responsibility, not by theme)
+- Huawei entity wiring protocol
+- Testing and logging rules
+
+## Step 3: Read Any Issue Being Solved
+
+If this is issue-driven work, read the full GitHub issue before touching any code.
+
+## Step 4: Create a Feature Branch
+
+Format: `<type>/<issue-number>-<slug>`
+
+| Type | Use for |
+|------|---------|
+| `feat` | New features |
+| `fix` | Bug fixes |
+| `chore` | Repository/code chores |
+| `docs` | Documentation updates |
+| `refactor` | Code refactoring |
+| `perf` | Performance improvements |
+| `test` | Test additions/updates |
+| `ci` | CI/CD changes |
+
+Examples: `fix/444-milp-cycle-cost`, `feat/123-add-solar-forecast`
+
+All branches MUST be based on main unless the user explicitly instructs otherwise.
+
+## Step 5: Identify Relevant Documentation
+
+Based on the change type, read these docs before touching code:
+
+| Change touches | Must read |
+|---------------|-----------|
+| Planner engine, cost function, SoC simulation, candidate generation, slot population, safety gates | `docs/planner-spec.md` |
+| Huawei Solar sensors | `docs/huawei_entities.md` |
+| Config/options flow | `docs/config-flow-reference.md` |
+| EV charging | `docs/ev-charge-plan-setup.md` |
+| Planner inputs/outputs | `docs/planner-guide.md` |
+
+## Step 6: Understand the Affected Code
+
+Search and read the relevant source files. Do not guess file paths — use `grep` and `find_path` to locate them.
+
+## Reminder: One Issue Per Branch
+
+Solve **one issue only** per branch and PR. Do not combine multiple issues. Do not refactor unrelated code.


### PR DESCRIPTION
## Summary
- Added a new repository [code-review](https://github.com/woopstar/hsem/tree/agents/create-code-review-skill/.github/skills/code-review) skill
- Mirrored the existing HSEM agent skills into [`.github/skills`](https://github.com/woopstar/hsem/tree/agents/create-code-review-skill/.github/skills) so they can be discovered from the repo

## Branch
- `agents/create-code-review-skill`

## Files changed
- `.github/skills/code-review/SKILL.md`
- `.github/skills/hsem-canonical-helpers/SKILL.md`
- `.github/skills/hsem-code-quality/SKILL.md`
- `.github/skills/hsem-doc-sync/SKILL.md`
- `.github/skills/hsem-ha-compliance/SKILL.md`
- `.github/skills/hsem-ha-quality/SKILL.md`
- `.github/skills/hsem-huawei-wiring/SKILL.md`
- `.github/skills/hsem-planner-change/SKILL.md`
- `.github/skills/hsem-pre-flight/SKILL.md`
- `.github/skills/hsem-pr-workflow/SKILL.md`

## What changed and why
- The new `code-review` skill provides a dedicated review workflow for diffs and pull requests.
- The mirrored HSEM skills let GitHub/Copilot discover the existing guidance from the repository itself instead of only from the local `.agents` folder.

## Tests
- Not run (documentation/skill file changes only)

## Notes
- Local `git push` was unavailable in this environment due SSH authentication, so the branch was published via the GitHub MCP tools instead.