### PR TITLE
fix(applier): verify TOU schedule against Period attributes, not entity state

### DIFF
--- a/custom_components/hsem/custom_sensors/applier.py
+++ b/custom_components/hsem/custom_sensors/applier.py
@@ -57,6 +57,7 @@ from custom_components.hsem.utils.huawei import (
     async_set_grid_export_power_watt,
     async_set_tou_periods,
     async_stop_forcible_discharge,
+    extract_tou_periods,
 )
 from custom_components.hsem.utils.inverter_verify import (
     ApplyResult,
@@ -727,8 +728,11 @@ async def async_apply_battery_settings(
             )
             return summary
 
-    # TOU periods — no read-back verification (TOU period state is complex JSON;
-    # hash comparison is sufficient; single attempt only).
+    # TOU periods — verified against the entity's live ``Period N`` attributes
+    # (see :func:`_read_tou_periods`).  The gate below uses the pre-write
+    # LiveState snapshot only to decide *whether* a write is needed;
+    # verification must re-read HA, because that snapshot by definition still
+    # holds the old schedule.
     if (
         working_mode == WorkingModes.TimeOfUse.value
         and tou_modes
@@ -743,19 +747,14 @@ async def async_apply_battery_settings(
                 "warning",
             )
             return summary
+        _te: str = tou_entity  # narrowed for closure
         result = await async_write_and_verify(
-            entity_id=tou_entity,
-            desired=generate_hash(str(tou_modes)),
+            entity_id=_te,
+            desired=list(tou_modes),
             writer=lambda: async_set_tou_periods(sensor, battery_device_id, tou_modes),
-            reader=lambda: generate_hash(
-                str(
-                    sensor.hass.states.get(tou_entity).state
-                    if tou_entity and sensor.hass.states.get(tou_entity) is not None
-                    else ""
-                )
-            ),
-            # TOU periods may take longer to propagate; skip equality check
-            # since we always write when the hash differs.
+            reader=lambda: _read_tou_periods(sensor, _te),
+            # The LiveState gate above already established a difference, so the
+            # first attempt must write rather than short-circuit on a stale read.
             skip_if_equal=False,
             max_retries=2,
         )
@@ -890,6 +889,32 @@ def _read_number_state(
         return float(state.state)
     except ValueError, TypeError:
         return None
+
+
+def _read_tou_periods(
+    sensor: Any, entity_id: str | None
+) -> list[str] | None:  # NOSONAR -- HA internal type; circular import risk
+    """Read the live TOU schedule from HA and return it as a period list.
+
+    The schedule lives in the entity's ``Period 1``…``Period 10`` attributes.
+    The entity *state* is only the number of configured periods, so it can
+    never be used to verify a written schedule.  This reads HA directly rather
+    than :class:`LiveState`, whose snapshot is captured before the write and
+    would therefore never reflect it.
+
+    Args:
+        sensor: HSEM sensor instance with a ``hass`` attribute.
+        entity_id: HA entity ID to read.
+
+    Returns:
+        Current period strings, or ``None`` when the entity is unavailable.
+    """
+    if not entity_id:
+        return None
+    state = sensor.hass.states.get(entity_id)
+    if state is None or state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE, None):
+        return None
+    return extract_tou_periods(state.attributes)
 
 
 def _read_select_state(

--- a/custom_components/hsem/custom_sensors/state_collector.py
+++ b/custom_components/hsem/custom_sensors/state_collector.py
@@ -45,6 +45,7 @@ from custom_components.hsem.utils.ha_helpers import (
     async_resolve_entity_id_from_unique_id,
     ha_get_entity_state_and_convert,
 )
+from custom_components.hsem.utils.huawei import extract_tou_periods
 from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
 from custom_components.hsem.utils.misc import get_config_value
 from custom_components.hsem.utils.sensornames.diagnostics import (
@@ -360,11 +361,7 @@ async def async_collect_live_state(
             )
             if isinstance(entity_data, State):
                 tou.raw_state = entity_data.state
-                tou.periods = [
-                    entity_data.attributes[f"Period {i}"]
-                    for i in range(1, 11)
-                    if f"Period {i}" in entity_data.attributes
-                ]
+                tou.periods = list(extract_tou_periods(entity_data.attributes))
             else:
                 state.add_missing_entity("TOU periods entity is not of type State")
         except (

--- a/custom_components/hsem/utils/huawei.py
+++ b/custom_components/hsem/utils/huawei.py
@@ -4,6 +4,7 @@ Includes functions to set the maximum grid export power percentage and
 to configure Time-of-Use (TOU) periods for batteries.
 """
 
+from collections.abc import Mapping
 from typing import Any
 
 import voluptuous as vol
@@ -15,6 +16,9 @@ from homeassistant.exceptions import (
 )
 
 from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+
+MAX_TOU_PERIODS = 10
+"""Number of TOU period slots a Huawei battery exposes."""
 
 
 async def async_set_grid_export_power_pct(
@@ -305,3 +309,24 @@ async def async_stop_forcible_discharge(self: Any, device_id: str) -> None:
             "HA error during stop_forcible_charge (device_id=%s)", device_id
         )
         raise
+
+
+def extract_tou_periods(attributes: Mapping[str, Any]) -> list[str]:
+    """Return the TOU period strings held in a Huawei TOU entity's attributes.
+
+    The Huawei TOU entity exposes its schedule as ``Period 1`` … ``Period 10``
+    attributes; its *state* is only the number of configured periods and must
+    never be used to compare schedules.
+
+    Args:
+        attributes: Attribute mapping of the TOU periods entity.
+
+    Returns:
+        Period strings in slot order, e.g. ``["00:00-23:59/1234567/+"]``.
+        Empty when the entity exposes no period attributes.
+    """
+    return [
+        str(attributes[key])
+        for key in (f"Period {i}" for i in range(1, MAX_TOU_PERIODS + 1))
+        if key in attributes
+    ]

--- a/tests/test_tou_read_back.py
+++ b/tests/test_tou_read_back.py
@@ -1,0 +1,55 @@
+"""Tests for TOU schedule read-back and verification.
+
+The Huawei TOU entity's *state* is the number of configured periods; the
+schedule itself lives in its ``Period 1``…``Period 10`` attributes.  Verifying
+a written schedule against the state can never succeed.
+"""
+
+from unittest.mock import MagicMock
+
+from custom_components.hsem.custom_sensors.applier import _read_tou_periods
+from custom_components.hsem.utils.huawei import extract_tou_periods
+
+TOU_ENTITY = "sensor.batteries_tou"
+
+
+class TestExtractTouPeriods:
+    """The schedule lives in attributes; the state is only a period count."""
+
+    def test_reads_period_attributes_in_order(self):
+        attrs = {
+            "Period 2": "06:00-08:00/1234567/-",
+            "Period 1": "00:00-23:59/1234567/+",
+            "friendly_name": "TOU",
+        }
+        assert extract_tou_periods(attrs) == [
+            "00:00-23:59/1234567/+",
+            "06:00-08:00/1234567/-",
+        ]
+
+    def test_no_period_attributes_returns_empty(self):
+        assert extract_tou_periods({"friendly_name": "TOU"}) == []
+
+    def test_state_value_is_never_used(self):
+        """A count-like state must not leak into the extracted schedule."""
+        assert extract_tou_periods({"Period 1": "00:00-00:01/1234567/+"}) != ["1"]
+
+
+class TestReadTouPeriods:
+    """``_read_tou_periods`` must reflect HA *after* a write, not LiveState."""
+
+    def test_reads_live_attributes(self):
+        sensor = MagicMock()
+        state = MagicMock()
+        state.state = "1"
+        state.attributes = {"Period 1": "00:00-00:01/1234567/+"}
+        sensor.hass.states.get.return_value = state
+        assert _read_tou_periods(sensor, TOU_ENTITY) == ["00:00-00:01/1234567/+"]
+
+    def test_missing_entity_returns_none(self):
+        sensor = MagicMock()
+        sensor.hass.states.get.return_value = None
+        assert _read_tou_periods(sensor, TOU_ENTITY) is None
+
+    def test_no_entity_id_returns_none(self):
+        assert _read_tou_periods(MagicMock(), None) is None


### PR DESCRIPTION
## Problem

The TOU write is verified by hashing the desired period list and comparing it against a hash of the TOU entity's **state**. That state is only the *number* of configured periods — the schedule itself lives in the entity's `Period 1`…`Period 10` attributes. The two can never match, so a successful write is always reported as `FAILED`.

```python
desired=generate_hash(str(tou_modes)),                       # ['00:00-00:01/1234567/+']
reader=lambda: generate_hash(str(states.get(tou_entity).state)),   # "1"
```

Confirmed by recomputing the hashes from a live failure:

```
desired = a5e4eea0…  = sha256("['00:00-00:01/1234567/+']")
actual  = 6b86b273…  = sha256("1")
```

Because the failure path returns early, **every genuine TOU period change also blocks the remaining battery writes for that cycle** — working mode, discharge cap, and everything after it.

## Evidence

Observed on a fork of this integration running 6.2.2. The write itself succeeds on the first attempt; only the verification fails:

```
11:10:22.541  Set TOU periods … ['00:00-00:01/1234567/+']
11:10:22.541  TOU entity last_updated → Period 1: 00:00-00:01/1234567/+   ← applied
11:10:43.816  ERROR write-and-verify FAILED after 2 attempt(s)
11:12:20.161  next hardware command finally lands                        ← +96 s
```

`last_changed` on that entity does not move, because the state (`"1"`) is unchanged — only `last_updated` and the attribute do. That is the same reason the verification cannot see the write.

The condition is self-limiting rather than a retry loop: the write gate compares against `live.tou_periods.periods`, which is attribute-derived and therefore correct, so once the hardware matches no further writes are attempted. It fires once per genuine payload change.

## Fix

Verification re-reads the entity and compares the `Period 1`…`Period 10` attributes.

It has to read Home Assistant directly rather than `LiveState` — that snapshot is captured before the write and by definition still holds the old schedule, so verifying against it would fail on every attempt for the same underlying reason.

The Period-attribute parsing already existed in `state_collector.py`; this moves it to `utils/huawei.extract_tou_periods()` so the applier and collector share one definition.

Also corrects the comment claiming "no read-back verification" and "single attempt only", which contradicts the call it documents (`max_retries=2`, with verification). That comment is plausibly what kept this hidden.

## Validation

- 2517 existing tests pass, plus 6 new ones covering attribute extraction and the read-back helper
- `ruff format` / `ruff check`, `mypy`, `pyright` clean on Python 3.14.7
- Running in production on the reporting system: two TOU writes in both directions (placeholder ↔ full-day window), each verified on the first attempt, no ERROR and no aborted cycles

## Unrelated, noted in passing

`_LOGGER.debug("…", "warning")` appears in several places in `applier.py`, passing a level name as a positional `%`-format argument to a message with no placeholders. Not touched here.
