### PR TITLE
fix(populator): auto-detect source interval per attribute; store raw values

### DIFF
--- a/custom_components/hsem/coordinator_builder.py
+++ b/custom_components/hsem/coordinator_builder.py
@@ -137,36 +137,11 @@ def build_planner_input(
     price_points: list[PricePoint] = []
     solcast_slots: list[SolcastSlot] = []
 
-    # Number of recommendation slots that fit inside one wall-clock hour.
-    # Used to up-scale per-slot energy values back to hourly totals before
-    # passing them to the planner engine (which works in Wh per hour).
+    # slots_per_hour is used to up-scale per-slot consumption averages to
+    # hourly totals for the planner engine.  Prices and Solcast PV are now
+    # stored at face value by the populator (no divide/multiply round-trip),
+    # so slots_per_hour is only needed for the consumption averages below.
     slots_per_hour = 60.0 / cfg.recommendation_interval_minutes
-
-    # ------------------------------------------------------------------
-    # Price interval semantics — see also hourly_data_populator.py
-    # ------------------------------------------------------------------
-    # `price_share` is the ratio of the price update interval to the slot width:
-    #
-    #   price_share = electricity_price_update_interval / recommendation_interval_minutes
-    #
-    # In `hourly_data_populator._async_update_hourly_field`, each price was
-    # divided by `price_share` before storing into the per-slot recommendation
-    # object.  Here we multiply it back to recover the original price rate
-    # (currency/kWh) before handing it to the planner.
-    #
-    # This forward-and-back pair is intentional: the divide converts the price
-    # to a per-slot representation suitable for matching slot boundaries, while
-    # the multiply here converts it back to the original hourly rate required by
-    # the planner's cost function.
-    #
-    # Common configurations:
-    #   Price 60 min / slots 15 min  →  price_share = 4.0
-    #   Price 30 min / slots 15 min  →  price_share = 2.0
-    #   Price 15 min / slots 15 min  →  price_share = 1.0  (no-op)
-    #   Price 60 min / slots 60 min  →  price_share = 1.0  (no-op)
-    price_share = (
-        cfg.electricity_price_update_interval / cfg.recommendation_interval_minutes
-    )
 
     # Midnight of the planning day — used to compute per-slot day_offset.
     planning_midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
@@ -186,13 +161,12 @@ def build_planner_input(
         slot_in_day = (rec.start.hour * 60 + rec.start.minute) // int(
             cfg.recommendation_interval_minutes
         )
-        # Multiply by price_share to reverse the per-slot divide applied during
-        # population; the planner receives the original currency/kWh rate.
+        # Prices are stored at face value by the populator (no scaling).
         price_points.append(
             PricePoint(
                 hour=h,
-                import_price=round(rec.import_price * price_share, 5),
-                export_price=round(rec.export_price * price_share, 5),
+                import_price=round(rec.import_price, 5),
+                export_price=round(rec.export_price, 5),
                 day_offset=day_offset,
                 slot_in_day=slot_in_day,
             )
@@ -216,7 +190,7 @@ def build_planner_input(
         solcast_slots.append(
             SolcastSlot(
                 hour=h,
-                pv_estimate=round(rec.solcast_pv_estimate_kwh * slots_per_hour, 3),
+                pv_estimate=round(rec.solcast_pv_estimate_kwh, 3),
                 day_offset=day_offset,
             )
         )

--- a/custom_components/hsem/custom_sensors/hourly_data_populator/prices_solcast.py
+++ b/custom_components/hsem/custom_sensors/hourly_data_populator/prices_solcast.py
@@ -34,47 +34,20 @@ async def async_populate_price_and_solcast(
     point to the corresponding :class:`HourlyRecommendation` by datetime, and
     writes the value into the appropriate field.
 
+    The actual source interval (cadence of the data) is **auto-detected** from
+    consecutive timestamps in each attribute array.  This means the planner
+    correctly handles mixed-cadence sensors in the same sensor entity — for
+    example an EDS sensor that has 15-min ``prices_today`` entries but only
+    hourly ``forecast`` entries for tomorrow — without requiring any hardcoded
+    per-attribute overrides.
+
     Args:
         sensor: The ``HSEMWorkingModeSensor`` instance for HA access and logging.
         recommendations: Mutable list of recommendation slots to update.
         cfg: Current sensor configuration.
     """
-    # ---------------------------------------------------------------------------
-    # Price interval semantics
-    # ---------------------------------------------------------------------------
-    # Prices are a *rate* (currency/kWh), not an energy quantity, so they
-    # must NOT be summed across slots.  However, the price sensor publishes
-    # one value per update interval (15, 30, or 60 min) while HSEM may plan
-    # at a finer resolution (e.g. 15-min slots inside a 60-min interval).
-    #
-    # `price_share` converts between the two resolutions:
-    #
-    #   price_share = electricity_price_update_interval / recommendation_interval_minutes
-    #
-    # In `_async_update_hourly_field` (below) each raw price value is divided by
-    # `price_share` before writing to the per-slot recommendation object.  This
-    # stores the price *scaled to one recommendation slot's share* of the price
-    # update interval.
-    #
-    # The inverse multiply (`rec.import_price * price_share`) is applied later in
-    # `coordinator_builder.build_planner_input` to recover the original price rate
-    # before passing it to the planner engine.
-    #
-    # Common configurations and their price_share values:
-    #   Price 60 min  / slots 15 min  →  price_share = 4.0
-    #   Price 30 min  / slots 15 min  →  price_share = 2.0
-    #   Price 15 min  / slots 15 min  →  price_share = 1.0  (no scaling)
-    #   Price 60 min  / slots 60 min  →  price_share = 1.0  (no scaling)
-    price_share = (
-        cfg.electricity_price_update_interval / cfg.recommendation_interval_minutes
-    )
-    # Solcast forecasts are always given as hourly totals (Wh/h), so the share
-    # factor is always relative to 60 minutes regardless of price configuration.
-    solcast_share = 60.0 / cfg.recommendation_interval_minutes
-    # Source-side window used to floor data-point timestamps before matching:
-    # price sources publish at the configured price cadence, Solcast hourly.
-    price_source_minutes = cfg.electricity_price_update_interval
-    solcast_source_minutes = 60
+    price_fallback = cfg.electricity_price_update_interval
+    solcast_fallback = 60  # Solcast always publishes hourly totals
 
     # Import price — read from primary sensor (may embed forecast attributes)
     import_matched = await _async_update_hourly_field(
@@ -82,9 +55,8 @@ async def async_populate_price_and_solcast(
         recommendations,
         cfg.import_electricity_price_sensor,
         "import_price",
-        price_share,
         cfg.solcast_pv_forecast_forecast_likelihood,
-        price_source_minutes,
+        price_fallback,
     )
     # Import price — fallback to dedicated forecast sensor if configured
     if cfg.import_electricity_price_forecast_sensor:
@@ -93,9 +65,8 @@ async def async_populate_price_and_solcast(
             recommendations,
             cfg.import_electricity_price_forecast_sensor,
             "import_price",
-            price_share,
             cfg.solcast_pv_forecast_forecast_likelihood,
-            price_source_minutes,
+            price_fallback,
         )
     if import_matched == 0:
         _LOGGER.warning(
@@ -110,9 +81,8 @@ async def async_populate_price_and_solcast(
         recommendations,
         cfg.export_electricity_price_sensor,
         "export_price",
-        price_share,
         cfg.solcast_pv_forecast_forecast_likelihood,
-        price_source_minutes,
+        price_fallback,
     )
     # Export price — fallback to dedicated forecast sensor
     if cfg.export_electricity_price_forecast_sensor:
@@ -121,9 +91,8 @@ async def async_populate_price_and_solcast(
             recommendations,
             cfg.export_electricity_price_forecast_sensor,
             "export_price",
-            price_share,
             cfg.solcast_pv_forecast_forecast_likelihood,
-            price_source_minutes,
+            price_fallback,
         )
     if export_matched == 0:
         _LOGGER.warning(
@@ -138,9 +107,8 @@ async def async_populate_price_and_solcast(
         recommendations,
         cfg.solcast_pv_forecast_forecast_today,
         "solcast_pv_estimate_kwh",
-        solcast_share,
         cfg.solcast_pv_forecast_forecast_likelihood,
-        solcast_source_minutes,
+        solcast_fallback,
     )
     if solcast_today_matched == 0:
         _LOGGER.debug(
@@ -154,9 +122,8 @@ async def async_populate_price_and_solcast(
         recommendations,
         cfg.solcast_pv_forecast_forecast_tomorrow,
         "solcast_pv_estimate_kwh",
-        solcast_share,
         cfg.solcast_pv_forecast_forecast_likelihood,
-        solcast_source_minutes,
+        solcast_fallback,
     )
     if solcast_tomorrow_matched == 0:
         _LOGGER.debug(
@@ -171,14 +138,64 @@ async def async_populate_price_and_solcast(
 # ---------------------------------------------------------------------------
 
 
+def _detect_interval_minutes(
+    entries: list[dict[str, Any]],
+    time_key: str,
+    fallback: int,
+) -> int:
+    """Detect the cadence of a data array by measuring gaps between timestamps.
+
+    Parses up to the first 10 entries, collects the gaps between consecutive
+    parseable timestamps, and returns the median gap rounded to the nearest
+    whole minute.  Falls back to ``fallback`` when fewer than two entries can
+    be parsed or the detected gap is not a positive integer.
+
+    Args:
+        entries: List of data-point dicts from a sensor attribute array.
+        time_key: Dict key that holds the timestamp for each entry.
+        fallback: Value to return when detection is not possible.
+
+    Returns:
+        Detected interval in whole minutes, or ``fallback``.
+    """
+    timestamps: list[datetime] = []
+    for entry in entries[:10]:
+        raw = entry.get(time_key)
+        if not raw:
+            continue
+        try:
+            dt = raw if isinstance(raw, datetime) else datetime.fromisoformat(str(raw))
+            timestamps.append(dt)
+        except (ValueError, TypeError):
+            continue
+        if len(timestamps) >= 5:
+            break
+
+    if len(timestamps) < 2:
+        return fallback
+
+    gaps_minutes = [
+        (timestamps[i + 1] - timestamps[i]).total_seconds() / 60
+        for i in range(len(timestamps) - 1)
+        if timestamps[i + 1] > timestamps[i]
+    ]
+    if not gaps_minutes:
+        return fallback
+
+    # Use the median gap to be robust against out-of-order or duplicate entries.
+    gaps_minutes.sort()
+    median_gap = gaps_minutes[len(gaps_minutes) // 2]
+    rounded = round(median_gap)
+    return rounded if rounded > 0 else fallback
+
+
 async def _async_update_hourly_field(
     sensor: Any,  # NOSONAR -- HA internal type; circular import risk
     recommendations: list[HourlyRecommendation],
     sensor_id: str | None,
     field_name: str,
-    share: float,
     solcast_likelihood_key: str,
-    source_interval_minutes: int,
+    fallback_interval_minutes: int,
 ) -> int:
     """Match sensor attribute data to recommendation slots and write one field.
 
@@ -187,8 +204,8 @@ async def _async_update_hourly_field(
         recommendations: Mutable recommendation list.
         sensor_id: Entity ID to read attributes from, or None (no-op).
         field_name: Attribute name on :class:`HourlyRecommendation` to set.
-        share: Divisor applied to each raw value (accounts for sub-hourly slots).
         solcast_likelihood_key: Attribute key for Solcast PV estimate field.
+        fallback_interval_minutes: Interval used when auto-detection fails.
 
     Returns:
         Number of data points successfully matched to at least one slot.
@@ -196,106 +213,18 @@ async def _async_update_hourly_field(
     if sensor_id is None:
         return 0
 
-    source_window = timedelta(minutes=source_interval_minutes)
-
     sensor_state = sensor.hass.states.get(sensor_id)
     if not sensor_state:
         _LOGGER.debug(f"Input sensor {sensor_id} was not found for data.")
         return 0
 
-    # Each source exposes a different attribute key / time-key / value-key
-    data_sources: dict[str, list[dict[str, str]]] = {
-        "forecast": [{"k": "hour", "v": "price"}],
-        "raw_tomorrow": [
-            {"k": "hour", "v": "price"},
-            {"k": "start", "v": "value"},  # custom-components/nordpool
-        ],
-        "raw_today": [
-            {"k": "hour", "v": "price"},
-            {"k": "start", "v": "value"},  # custom-components/nordpool
-        ],
-        "prices": [{"k": "start", "v": "price"}],
-        "prices_today": [
-            {"k": "start", "v": "price"},
-            {"k": "time", "v": "price"},
-        ],
-        "prices_tomorrow": [
-            {"k": "start", "v": "price"},
-            {"k": "time", "v": "price"},
-        ],
-        "detailedHourly": [{"k": "period_start", "v": solcast_likelihood_key}],
-        "detailedForecast": [{"k": "period_start", "v": solcast_likelihood_key}],
-        "data": [{"k": "start_time", "v": "price_per_kwh"}],
-        # Amber Electric forecast sensor format: forecasts array on the forecast sensor
-        "forecasts": [{"k": "start_time", "v": "per_kwh"}],
-    }
-
-    matched = 0
-    for attr, kv_list in data_sources.items():
-        sensor_data = sensor_state.attributes.get(attr) or []
-        if not sensor_data:
-            continue
-
-        _LOGGER.debug(f"Updating data for {field_name}...")
-
-        for data in sensor_data:
-            for kv in kv_list:
-                raw_time = data.get(kv["k"])
-                if not raw_time:
-                    continue
-
-                if isinstance(raw_time, datetime):
-                    dt_key = raw_time
-                else:
-                    dt_key = datetime.fromisoformat(str(raw_time))
-
-                try:
-                    # Floor the data point to the start of its enclosing source
-                    # interval (e.g. 15 min for quarter-hourly prices, 60 min for
-                    # hourly Solcast forecasts).  Flooring to the *hour* here
-                    # would collapse sub-hourly price points onto the same key
-                    # and overwrite all quarter-hour slots of the hour with the
-                    # last hourly value (issue #720).
-                    dt_key = normalize_slot_start(dt_key, source_interval_minutes)
-                except ValueError, OSError:  # noqa: TRY302
-                    # Skip data points with unparseable or non-local timestamps
-                    continue
-
-                value = convert_to_float(data.get(kv["v"]))
-                if value is None:
-                    continue
-
-                # Scale raw value down to one recommendation-slot's share of the
-                # source update interval.
-                #
-                # For prices:   share = price_share (price interval / slot interval)
-                #   Price 60 min / slot 15 min → share=4 → store price/4 per slot
-                #   Price 15 min / slot 15 min → share=1 → store price unchanged
-                #
-                # For Solcast PV:   share = solcast_share (60 / slot interval)
-                #   60-min hourly forecast / slot 15 min → share=4 → store Wh/4 per slot
-                #   60-min hourly forecast / slot 60 min → share=1 → store Wh unchanged
-                #
-                # The coordinator's `build_planner_input` applies the inverse multiply
-                # (×price_share) before handing prices/PV to the planner engine, so the
-                # divide here and the multiply there cancel exactly and the planner always
-                # receives the original hourly-equivalent rate or energy quantity.
-                value = value / share
-
-                for obj in recommendations:
-                    # A data point covers every slot whose start falls inside
-                    # the source window that begins at dt_key:
-                    #   - 15-min prices + 15-min slots → one point per slot
-                    #   - hourly prices + 15-min slots → one point fans out
-                    #     to all four quarter-hour slots of the hour
-                    # Flooring dt_key to the *hour* (old behavior) collapsed
-                    # all four quarter-hour prices onto one key (issue #720).
-                    obj_start = normalize_datetime(obj.start)
-                    if dt_key <= obj_start < dt_key + source_window:
-                        setattr(obj, field_name, round(value, 5))
-                        matched += 1
-
-    return matched
+    return _populate_from_attributes(
+        sensor_state.attributes,
+        recommendations,
+        field_name,
+        solcast_likelihood_key,
+        fallback_interval_minutes,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -318,31 +247,25 @@ def populate_price_and_solcast_from_snapshot(
         snapshot: Pre-collected state snapshot.
         cfg: Current sensor configuration.
     """
-    price_share = (
-        cfg.electricity_price_update_interval / cfg.recommendation_interval_minutes
-    )
-    solcast_share = 60.0 / cfg.recommendation_interval_minutes
-    price_source_minutes = cfg.electricity_price_update_interval
-    solcast_source_minutes = 60
+    price_fallback = cfg.electricity_price_update_interval
+    solcast_fallback = 60
 
-    import_matched = _update_hourly_field_from_attrs(
-        recommendations,
+    import_matched = _populate_from_attributes(
         snapshot.sensor_attributes.get(cfg.import_electricity_price_sensor or ""),
+        recommendations,
         "import_price",
-        price_share,
         cfg.solcast_pv_forecast_forecast_likelihood,
-        price_source_minutes,
+        price_fallback,
     )
     if cfg.import_electricity_price_forecast_sensor:
-        import_matched += _update_hourly_field_from_attrs(
-            recommendations,
+        import_matched += _populate_from_attributes(
             snapshot.sensor_attributes.get(
                 cfg.import_electricity_price_forecast_sensor or ""
             ),
+            recommendations,
             "import_price",
-            price_share,
             cfg.solcast_pv_forecast_forecast_likelihood,
-            price_source_minutes,
+            price_fallback,
         )
     if import_matched == 0:
         _LOGGER.warning(
@@ -351,24 +274,22 @@ def populate_price_and_solcast_from_snapshot(
             "Check that the sensor is available and its attribute format is supported.",
             cfg.import_electricity_price_sensor,
         )
-    export_matched = _update_hourly_field_from_attrs(
-        recommendations,
+    export_matched = _populate_from_attributes(
         snapshot.sensor_attributes.get(cfg.export_electricity_price_sensor or ""),
+        recommendations,
         "export_price",
-        price_share,
         cfg.solcast_pv_forecast_forecast_likelihood,
-        price_source_minutes,
+        price_fallback,
     )
     if cfg.export_electricity_price_forecast_sensor:
-        export_matched += _update_hourly_field_from_attrs(
-            recommendations,
+        export_matched += _populate_from_attributes(
             snapshot.sensor_attributes.get(
                 cfg.export_electricity_price_forecast_sensor or ""
             ),
+            recommendations,
             "export_price",
-            price_share,
             cfg.solcast_pv_forecast_forecast_likelihood,
-            price_source_minutes,
+            price_fallback,
         )
     if export_matched == 0:
         _LOGGER.warning(
@@ -377,13 +298,12 @@ def populate_price_and_solcast_from_snapshot(
             "Check that the sensor is available and its attribute format is supported.",
             cfg.export_electricity_price_sensor,
         )
-    solcast_today_matched = _update_hourly_field_from_attrs(
-        recommendations,
+    solcast_today_matched = _populate_from_attributes(
         snapshot.sensor_attributes.get(cfg.solcast_pv_forecast_forecast_today or ""),
+        recommendations,
         "solcast_pv_estimate_kwh",
-        solcast_share,
         cfg.solcast_pv_forecast_forecast_likelihood,
-        solcast_source_minutes,
+        solcast_fallback,
     )
     if solcast_today_matched == 0:
         _LOGGER.debug(
@@ -391,13 +311,12 @@ def populate_price_and_solcast_from_snapshot(
             "PV estimates will be 0.0 for today.",
             cfg.solcast_pv_forecast_forecast_today,
         )
-    solcast_tomorrow_matched = _update_hourly_field_from_attrs(
-        recommendations,
+    solcast_tomorrow_matched = _populate_from_attributes(
         snapshot.sensor_attributes.get(cfg.solcast_pv_forecast_forecast_tomorrow or ""),
+        recommendations,
         "solcast_pv_estimate_kwh",
-        solcast_share,
         cfg.solcast_pv_forecast_forecast_likelihood,
-        solcast_source_minutes,
+        solcast_fallback,
     )
     if solcast_tomorrow_matched == 0:
         _LOGGER.debug(
@@ -407,35 +326,44 @@ def populate_price_and_solcast_from_snapshot(
         )
 
 
-def _update_hourly_field_from_attrs(
-    recommendations: list[HourlyRecommendation],
+def _populate_from_attributes(
     attributes: dict[str, Any] | None,
+    recommendations: list[HourlyRecommendation],
     field_name: str,
-    share: float,
     solcast_likelihood_key: str,
-    source_interval_minutes: int,
+    fallback_interval_minutes: int,
 ) -> int:
     """Match pre-read sensor attribute data to recommendation slots.
 
-    This is the snapshot-based counterpart of ``_async_update_hourly_field``.
-    Instead of calling ``hass.states.get()``, it operates on the
-    ``attributes`` dict that was pre-read during snapshot collection.
+    For each recognised attribute key the actual data cadence is
+    **auto-detected** from consecutive timestamps in that array.  This
+    means the correct fan-out window is used even when different attribute
+    keys on the same sensor publish at different intervals — for example
+    ``prices_today`` at 15 min and ``forecast`` at 60 min on the same EDS
+    sensor entity.
+
+    The raw value from each data point is stored directly on the
+    :class:`HourlyRecommendation` slot — no scaling is applied.
+    ``coordinator_builder`` passes the value straight through to the planner.
 
     Args:
-        recommendations: Mutable recommendation list.
         attributes: The ``.attributes`` dict of the sensor, or ``None``.
+        recommendations: Mutable recommendation list.
         field_name: Attribute name on :class:`HourlyRecommendation` to set.
-        share: Divisor applied to each raw value.
         solcast_likelihood_key: Attribute key for Solcast PV estimate field.
+        fallback_interval_minutes: Interval assumed when auto-detection fails
+            (fewer than 2 parseable timestamps in the array).
 
     Returns:
         Number of data points successfully matched to at least one slot.
     """
-    if attributes is None:
+    if not attributes:
         return 0
 
-    source_window = timedelta(minutes=source_interval_minutes)
-
+    # Map each recognised sensor attribute key to the list of (time_key, value_key)
+    # pairs that may appear in that attribute's entries.  Multiple pairs allow
+    # one attribute to be matched regardless of which sensor integration
+    # published it (e.g. EDS ``hour``/``price`` vs nordpool ``start``/``value``).
     data_sources: dict[str, list[dict[str, str]]] = {
         "forecast": [{"k": "hour", "v": "price"}],
         "raw_tomorrow": [
@@ -458,15 +386,44 @@ def _update_hourly_field_from_attrs(
         "detailedHourly": [{"k": "period_start", "v": solcast_likelihood_key}],
         "detailedForecast": [{"k": "period_start", "v": solcast_likelihood_key}],
         "data": [{"k": "start_time", "v": "price_per_kwh"}],
-        # Amber Electric forecast sensor format: forecasts array on the forecast sensor
+        # Amber Electric forecast sensor format
         "forecasts": [{"k": "start_time", "v": "per_kwh"}],
     }
 
     matched = 0
     for attr, kv_list in data_sources.items():
-        sensor_data = attributes.get(attr) or []
+        sensor_data: list[dict[str, Any]] = attributes.get(attr) or []
         if not sensor_data:
             continue
+
+        _LOGGER.debug("Updating data for %s from attribute %s...", field_name, attr)
+
+        # Detect the actual cadence of this specific attribute array using
+        # the first recognised time key.  Different attributes on the same
+        # sensor can have different cadences (e.g. prices_today 15 min,
+        # forecast 60 min), so detection must happen per-attribute.
+        detected_interval = fallback_interval_minutes
+        for kv in kv_list:
+            detected = _detect_interval_minutes(sensor_data, kv["k"], 0)
+            if detected > 0:
+                detected_interval = detected
+                break
+
+        # Prices are rates (currency/kWh) — store the raw value unchanged.
+        # Solcast PV is energy — the Solcast sensor publishes hourly kWh
+        # totals; the per-slot fraction is computed in slot_population.py
+        # via `pv_estimate / scale` (scale = 60 / slot_minutes), so
+        # SolcastSlot.pv_estimate must hold the full hourly kWh.
+        #
+        # In both cases we store the raw value directly so that
+        # coordinator_builder can pass it straight to the planner
+        # without any additional multiply.  The old divide-then-multiply
+        # round-trip (÷ share in populator, × price_share in coordinator_
+        # builder) only worked when the configured price interval matched
+        # the actual data cadence; with auto-detection the share is
+        # derived from the data, not the config, so the round-trip would
+        # produce incorrect values whenever the two differ.
+        source_window = timedelta(minutes=detected_interval)
 
         for data in sensor_data:
             for kv in kv_list:
@@ -479,20 +436,19 @@ def _update_hourly_field_from_attrs(
                 else:
                     try:
                         dt_key = datetime.fromisoformat(str(raw_time))
-                    except ValueError, TypeError:
+                    except (ValueError, TypeError):
                         continue
 
                 try:
-                    # Same source-interval flooring as the async path (issue #720).
-                    dt_key = normalize_slot_start(dt_key, source_interval_minutes)
-                except ValueError, OSError:
+                    # Floor to the start of the detected source interval so
+                    # that each data point is anchored at its slot boundary.
+                    dt_key = normalize_slot_start(dt_key, detected_interval)
+                except (ValueError, OSError):
                     continue
 
                 value = convert_to_float(data.get(kv["v"]))
                 if value is None:
                     continue
-
-                value = value / share
 
                 for obj in recommendations:
                     obj_start = normalize_datetime(obj.start)
@@ -501,3 +457,4 @@ def _update_hourly_field_from_attrs(
                         matched += 1
 
     return matched
+

--- a/custom_components/hsem/custom_sensors/hourly_data_populator/prices_solcast.py
+++ b/custom_components/hsem/custom_sensors/hourly_data_populator/prices_solcast.py
@@ -418,11 +418,8 @@ def _populate_from_attributes(
         # In both cases we store the raw value directly so that
         # coordinator_builder can pass it straight to the planner
         # without any additional multiply.  The old divide-then-multiply
-        # round-trip (÷ share in populator, × price_share in coordinator_
-        # builder) only worked when the configured price interval matched
-        # the actual data cadence; with auto-detection the share is
-        # derived from the data, not the config, so the round-trip would
-        # produce incorrect values whenever the two differ.
+        # round-trip is gone; with per-attribute auto-detection the raw
+        # value is the only value that remains correct across mixed cadences.
         source_window = timedelta(minutes=detected_interval)
 
         for data in sensor_data:
@@ -457,4 +454,3 @@ def _populate_from_attributes(
                         matched += 1
 
     return matched
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@
 | [MILP Optimization](milp-optimization.md) | Full LP formulation, variable layout, constraints, and solver pipeline |
 | [Consumption Prediction](consumption-prediction.md) | Weighted-average model, IQR outlier detection, spike suppression |
 | [Safety Modes](safety-modes.md) | Degraded mode, read-only gate, write-verify applier, runtime resolver |
-| [Price Scaling](price-scaling.md) | EDS price scaling, eds_share conversion factor |
+| [Price Scaling](price-scaling.md) | EDS price cadence auto-detection and raw pass-through |
 | [Services Reference](services-reference.md) | All 5 HSEM services with examples |
 | [Sensors Reference](sensors-reference.md) | Complete entity reference: all sensor, select, switch, number, and time entities |
 | [Dashboard Setup](dashboard-setup.md) | Step-by-step ApexCharts dashboard with full YAML, layout reference, and troubleshooting |

--- a/docs/planner-guide.md
+++ b/docs/planner-guide.md
@@ -191,9 +191,10 @@ Each `PricePoint` carries:
 - `import_price` — cost to buy 1 kWh from the grid (local currency/kWh)
 - `export_price` — revenue from selling 1 kWh to the grid (local currency/kWh)
 
-Prices sourced from Energi Data Service (EDS) are normalised through the
-`eds_share` pipeline before reaching the planner so the engine always receives
-the full hourly rate, regardless of the EDS update interval (15 min or 60 min).
+Prices sourced from Energi Data Service (EDS) are auto-detected per attribute
+from their timestamps. The populator stores the raw currency/kWh value and the
+planner receives that raw rate unchanged, whether the source cadence is 15 min,
+30 min, or 60 min.
 See [Price interval semantics](planner-spec.md#price-interval-semantics) in the spec.
 
 ### PV forecast

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -1177,71 +1177,67 @@ Electricity prices are **rates** (currency per kWh), not energy quantities.
 Every slot inside the same EDS update interval shares the same price; the
 price is **never summed or averaged** across slots.
 
-### The eds_share conversion factor
+### Source cadence detection and raw-value storage
 
-When EDS and slot widths differ (most common case: EDS 60 min, slots 15 min),
-a conversion factor is needed so internal per-slot storage and the planner
-engine both see correct values:
+`energi_data_service_update_interval` remains the configured expectation for
+price cadence, but population now trusts the **data itself** when possible.
+For each supported attribute array, HSEM measures the gap between consecutive
+timestamps and uses that detected cadence for matching. This happens
+**per attribute**, so one sensor can legitimately publish:
 
-```text
-eds_share = energi_data_service_update_interval / recommendation_interval_minutes
-```
+- `prices_today` every 15 minutes, and
+- `forecast` every 60 minutes
 
-Common configurations:
+without requiring per-provider overrides.
 
-| EDS interval | Slot width | eds_share | Effect |
-|---|---|---|---|
-| 60 min | 15 min | 4.0 | price÷4 stored; planner gets price×4 back |
-| 15 min | 15 min | 1.0 | no scaling — price stored and used unchanged |
-| 60 min | 60 min | 1.0 | no scaling — price stored and used unchanged |
+If detection fails (for example because fewer than two parseable timestamps are
+available), HSEM falls back to the configured interval for prices and to
+60 minutes for Solcast PV data.
 
-### How the scaling pipeline works
+### How the population pipeline works
 
 1. **Population** (`hourly_data_populator._async_update_hourly_field`):
-   Each raw EDS value is divided by `eds_share` before writing to the
-   per-slot `HourlyRecommendation` object.
-   This gives each slot its proportional share of the price-rate value so
-   slot boundaries align correctly.
-   Data-point timestamps are floored to the start of their enclosing *source*
-   interval (the EDS update interval for prices, 60 min for Solcast), never
-   to the hour: a 15-min price point covers only the slots whose start lies
-   inside that 15-min window, so quarter-hourly prices land on distinct
-   slots (issue #720).  With hourly price data and 15-min slots the single
-   hourly point fans out to all four quarter-hour slots of the hour.
+   Each matched value is written into every planner slot covered by its
+   detected source window after normalizing the timestamp to the start of
+   that same source interval. There is **no divide-by-share step**.
+
+   - Prices are rates (`currency / kWh`) and are stored **unchanged** on each
+     covered `HourlyRecommendation` slot.
+   - Solcast entries are hourly energy totals (`kWh`) and are also stored
+     **unchanged** on each covered slot.
+
+   This means a 15-minute price point only covers its own quarter-hour slot,
+   while an hourly price or Solcast point fans out to all four quarter-hour
+   slots inside that hour when `recommendation_interval_minutes = 15`.
 
 2. **Planner input** (`coordinator_builder.build_planner_input`):
    Recommendation slots are deduplicated on `(day_offset, hour)` for
    consumption averages and Solcast PV (genuinely hour-granular), but
    **price points are emitted per slot** with an explicit `slot_in_day`
    field, so quarter-hourly prices survive as distinct `PricePoint`
-   entries (192 for a 48 h horizon at 15-min slots).  Each stored per-slot
-   price is multiplied by `eds_share` to recover the original
-   hourly-equivalent rate.  The planner's cost function always works with
-   full currency/kWh rates, not fractions.
+   entries (192 for a 48 h horizon at 15-minute slots). Stored price values
+   are passed through directly to `PricePoint`; there is **no inverse
+   multiply** in the coordinator.
 
 3. **Slot population** (`planner.slot_population.populate_prices`):
    When price points carry `slot_in_day`, slots are keyed by
    `(day_offset, slot_in_day)` so each quarter-hourly price lands on its
-   own planner slot; slots the source does not cover fall back to the
-   hourly value.  Points without `slot_in_day` (legacy hourly callers)
+   own planner slot; points without `slot_in_day` (legacy hourly callers)
    use the existing `align_hourly_prices` fan-out unchanged.
 
-The divide and multiply are exact inverses — they cancel perfectly and the
-planner always receives the original price rate regardless of configuration.
-
-### What this is NOT
-
-- `eds_share` is **not** a VAT multiplier.
-- `eds_share` is **not** a currency conversion.
-- `eds_share` is **not** an energy-splitting factor (prices are rates, not energy).
+4. **PV slot population** (`planner.slot_population.populate_solcast`):
+   Solcast `pv_estimate` remains the full hourly kWh total. When planner
+   slots are shorter than one hour, the slot populator computes the per-slot
+   fraction from that raw hourly total.
 
 ### Invariants for tests
 
 - A 60-min EDS price of `P` must reach the planner as `P` (not `P/4` or `P*4`).
 - A 15-min EDS price of `P` must reach the planner as `P`.
-- Intermediate per-slot stored values must equal `P / eds_share`.
-- Changing `energi_data_service_update_interval` from 60 to 15 with the same
-  price input must not change the price seen by the planner engine.
+- Intermediate per-slot stored values for prices must equal the raw rate `P`.
+- Changing `energi_data_service_update_interval` with the same timestamped
+  price input must not change the price seen by the planner engine when
+  cadence auto-detection succeeds.
 - Negative prices must survive the full pipeline unchanged.
 - With 15-min price data and 15-min slots, each quarter-hour price must land
   on exactly its own slot — four distinct prices within an hour must produce
@@ -1249,6 +1245,9 @@ planner always receives the original price rate regardless of configuration.
 - With 15-min price data, 15-min slots, and a 48 h horizon, the planner must
   receive 192 distinct price points (not 48 collapsed hourly ones) and the
   MILP must see intra-hour price variation (issue #720 stage 2).
+- With hourly Solcast data and 15-minute slots, one hourly kWh total must fan
+  out to four quarter-hour planner slots whose combined energy equals the raw
+  hourly input.
 
 ## Candidate plans
 

--- a/docs/price-scaling.md
+++ b/docs/price-scaling.md
@@ -14,23 +14,21 @@ HSEM supports two independent interval settings:
 | `electricity_price_update_interval` | 15, 30, or 60 minutes | How often the price source publishes records |
 | `recommendation_interval_minutes` | 15 or 60 minutes | The width of each planning slot |
 
-When these differ (most commonly: price update 60 min, slots 15 min), the price rate must
-be correctly scaled so the planner always sees the full currency/kWh rate.
+HSEM auto-detects the cadence of each price attribute array independently from
+its timestamps. When these differ (most commonly: a 60 min forecast sensor and
+15 min recommendation slots), the raw rate is passed through unchanged and the
+planner always sees the full currency/kWh value.
 
 ---
 
-## The `price_share` conversion factor
+## The current contract
 
-$$
-\mathrm{price\_share} = \frac{\text{Price update interval}}{\text{Slot width}}
-$$
-
-| Price update interval | Slot width | `price_share` | Effect |
+| Source cadence | Slot width | Effect |
 |---|---|---|---|
-| 60 min | 15 min | 4.0 | Price ÷ 4 stored; planner gets price × 4 back |
-| 15 min | 15 min | 1.0 | No scaling |
-| 30 min | 15 min | 2.0 | Price ÷ 2 stored; planner gets price × 2 back |
-| 60 min | 60 min | 1.0 | No scaling |
+| 60 min | 15 min | Hourly price fans out to all four slots, unchanged |
+| 15 min | 15 min | Each slot keeps its own raw price, unchanged |
+| 30 min | 15 min | Each half-hour price fans out to two slots, unchanged |
+| 60 min | 60 min | One hourly price per slot, unchanged |
 
 ---
 
@@ -38,23 +36,22 @@ $$
 
 ```mermaid
 flowchart TD
-    A[Price source raw price P\nfull hourly currency per kWh]
+    A[Price source raw price P\ncurrency per kWh]
     B[HourlyDataPopulator.async_populate_price_and_solcast]
     C[Recommendation slot storage\nHourlyRecommendation objects]
     D[coordinator._build_planner_input]
     E[Planner engine PricePoint\nimport_price = P]
 
     A --> B
-    B -->|Per-slot stored value = P / price_share| C
+    B -->|Auto-detect cadence per attribute; store raw P| C
     C --> D
-    D -->|Planner input value = stored value × price_share = P| E
+    D -->|Planner input value = stored value = P| E
 ```
 
 ### What this is NOT
 
-- `price_share` is **not** a VAT multiplier
-- `price_share` is **not** a currency conversion
-- `price_share` is **not** an energy-splitting factor (prices are rates, not energy)
+- prices are rates, not energy
+- cadence detection is based on timestamps, not config labels
 
 ---
 
@@ -70,9 +67,10 @@ HSEM is provider-agnostic. Prices are read from generic electricity price sensor
 | `hsem_export_electricity_price_forecast_sensor` | Optional dedicated export forecast |
 
 Supported providers include Energi Data Service, Nordpool, Amber Electric, and any
-sensor that publishes hourly (or sub-hourly) price records with a `raw_today` / `raw_tomorrow`
-attribute structure. The populator reads the full time-series from sensor attributes
-and projects them onto the planning horizon.
+sensor that publishes hourly (or sub-hourly) price records with a `raw_today` /
+`raw_tomorrow` attribute structure. The populator reads the full time-series from
+sensor attributes, detects each attribute's cadence independently, and projects
+the raw values onto the planning horizon.
 
 ---
 
@@ -80,11 +78,12 @@ and projects them onto the planning horizon.
 
 For any configuration:
 
-1. A 60-min price source value of `P` must reach the planner as `P` (not `P/4` or `P*4`)
+1. A 60-min price source value of `P` must reach the planner as `P` (not `P/4`
+   or `P*4`)
 2. A 15-min price source value of `P` must reach the planner as `P`
-3. Intermediate per-slot stored values must equal `P / price_share`
-4. Changing `electricity_price_update_interval` from 60 to 15 with the same
-   price input must not change the price seen by the planner engine
+3. Intermediate per-slot stored values must equal the raw price `P`
+4. Changing `electricity_price_update_interval` must not change the price seen
+   by the planner engine when the source timestamps are the same
 5. Negative prices must survive the full pipeline unchanged (no absolute-value
    clipping, no zero-flooring)
 

--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -107,17 +107,19 @@ can restore.
 
 ### Checks & likely causes
 
-**2a. EDS update interval mismatch**
+**2a. Price cadence not detectable**
 
-The planner uses an `eds_share` conversion factor that depends on whether EDS
-publishes data every 15 minutes or every 60 minutes. If the HSEM config says
-one interval but EDS actually publishes at the other, all prices are silently
-scaled wrong.
+HSEM auto-detects the cadence of each price attribute from its timestamps.
+If an attribute has fewer than two parseable timestamps, or the timestamps are
+malformed, HSEM falls back to the configured EDS interval and may only match
+part of the data.
 
-- **Check:** HSEM → **Configure** → **Energi Data Service** step. Verify
-  the _EDS Update Interval_ (15 or 60) matches what your EDS integration
-  actually uses. Check the EDS integration documentation for your price area.
-- **Fix:** Change the interval to match reality.
+- **Check:** HSEM → **Configure** → **Energi Data Service** step. Verify the
+  sensor attributes contain valid timestamps and that the active attribute key
+  matches the data actually published by your price source.
+- **Fix:** Correct the timestamp format or attribute key so HSEM can detect
+  the real cadence. If the source truly changes cadence (for example, `forecast`
+  vs `prices_today`), HSEM now handles that automatically.
 
 **2b. Grid fee or tax configuration**
 

--- a/tests/test_15min_price_matching.py
+++ b/tests/test_15min_price_matching.py
@@ -180,10 +180,9 @@ class TestQuarterHourlyPriceMatching:
         }
         _populate(recs, attrs, cfg)
 
-        share = 60 / 15  # stored value is raw / share
         for i, rec in enumerate(recs):
             hour = i // 4
-            expected = (0.10 + hour * 0.05) / share
+            expected = 0.10 + hour * 0.05  # raw value; no divide by share
             assert rec.import_price == pytest.approx(expected, abs=1e-5), (
                 f"Slot {i}: expected {expected}, got {rec.import_price}"
             )
@@ -205,10 +204,9 @@ class TestQuarterHourlyPriceMatching:
         }
         _populate(recs, attrs, cfg)
 
-        # share = 15/60 = 0.25 → stored = raw / 0.25
+        # Populator stores raw value; 60-min slot gets the price at its start boundary.
         for h, rec in enumerate(recs):
-            expected_raw = 1.0 + (h * 4) * 0.01  # price at the hour boundary
-            expected = expected_raw / 0.25
+            expected = 1.0 + (h * 4) * 0.01  # raw price at the hour boundary
             assert rec.import_price == pytest.approx(expected, abs=1e-4), (
                 f"Hour {h}: expected {expected}, got {rec.import_price}"
             )
@@ -325,4 +323,83 @@ class TestNordpoolRawFormat:
             expected = 0.10 + i * 0.01
             assert rec.import_price == pytest.approx(expected, abs=1e-5), (
                 f"Slot {i}: expected {expected}, got {rec.import_price}"
+            )
+
+
+class TestForecastAutoDetection:
+    """Regression test for GitHub issue #720 follow-up.
+
+    When ``forecast`` data is hourly (60-min cadence) but slots are 15-min
+    wide, the old code matched only the ``:00`` slot of each hour and left
+    the ``:15 / :30 / :45`` slots at ``import_price = 0.0``.  The MILP then
+    saw a repeating ``high → 0 → 0 → 0 → high → ...`` pattern and oscillated.
+
+    With auto-detection the populator detects the 60-min cadence of the
+    ``forecast`` attribute and fans each price out to all four 15-min slots.
+    """
+
+    def setup_method(self) -> None:
+        self.base = datetime(2026, 8, 12, 0, 0, 0, tzinfo=UTC)
+
+    def test_hourly_forecast_fans_out_to_15min_slots(self) -> None:
+        """Hourly ``forecast`` prices must reach all four 15-min sub-slots."""
+        cfg = _Cfg(price_interval=15, slot_interval=15)
+        recs = [
+            _make_rec(
+                self.base + timedelta(minutes=15 * i),
+                self.base + timedelta(minutes=15 * (i + 1)),
+            )
+            for i in range(8)  # two hours = 8 slots
+        ]
+        # forecast attribute published by EDS — always hourly, key ``hour``/``price``
+        prices = [1.5, 2.0]
+        raw_forecast = [
+            {
+                "hour": (self.base + timedelta(hours=h)).isoformat(),
+                "price": f"{prices[h]:.5f}",
+            }
+            for h in range(2)
+        ]
+        attrs = {
+            "sensor.eds_import": {"forecast": raw_forecast},
+            "sensor.eds_export": {"forecast": raw_forecast},
+        }
+        _populate(recs, attrs, cfg)
+
+        # Every 15-min sub-slot within the hour must carry the same price.
+        # No slot should be 0.0 (the oscillation bug).
+        for i, rec in enumerate(recs):
+            hour = i // 4
+            expected = prices[hour]
+            assert rec.import_price == pytest.approx(expected, abs=1e-5), (
+                f"Slot {i} ({rec.start}): expected {expected} (hour={hour}), "
+                f"got {rec.import_price}"
+            )
+            assert rec.import_price > 0.0, (
+                f"Slot {i} ({rec.start}) must not be zero — oscillation bug!"
+            )
+
+    def test_forecast_does_not_zero_out_non_hour_slots(self) -> None:
+        """No 15-min slot should have import_price=0 when forecast covers that hour."""
+        cfg = _Cfg(price_interval=15, slot_interval=15)
+        recs = [
+            _make_rec(
+                self.base + timedelta(minutes=15 * i),
+                self.base + timedelta(minutes=15 * (i + 1)),
+            )
+            for i in range(4)  # first hour only
+        ]
+        raw_forecast = [
+            {"hour": self.base.isoformat(), "price": "1.867"},
+        ]
+        attrs = {
+            "sensor.eds_import": {"forecast": raw_forecast},
+            "sensor.eds_export": {"forecast": raw_forecast},
+        }
+        _populate(recs, attrs, cfg)
+
+        for i, rec in enumerate(recs):
+            assert rec.import_price == pytest.approx(1.867, abs=1e-4), (
+                f"Slot {i} at :{15*i:02d} got {rec.import_price}, expected 1.867 — "
+                f"oscillation bug: only :00 slot is matched"
             )

--- a/tests/test_15min_price_matching.py
+++ b/tests/test_15min_price_matching.py
@@ -380,7 +380,13 @@ class TestForecastAutoDetection:
             )
 
     def test_forecast_does_not_zero_out_non_hour_slots(self) -> None:
-        """No 15-min slot should have import_price=0 when forecast covers that hour."""
+        """No 15-min slot should have import_price=0 when forecast covers that hour.
+
+        Two entries are required for _detect_interval_minutes to measure a gap
+        and recognise the 60-min cadence.  With only one entry the detector
+        falls back to the configured 15-min fallback and only the :00 slot
+        would be matched — the exact oscillation bug this test guards against.
+        """
         cfg = _Cfg(price_interval=15, slot_interval=15)
         recs = [
             _make_rec(
@@ -389,8 +395,10 @@ class TestForecastAutoDetection:
             )
             for i in range(4)  # first hour only
         ]
+        # Two hourly entries so the detector can measure the 60-min gap.
         raw_forecast = [
             {"hour": self.base.isoformat(), "price": "1.867"},
+            {"hour": (self.base + timedelta(hours=1)).isoformat(), "price": "1.867"},
         ]
         attrs = {
             "sensor.eds_import": {"forecast": raw_forecast},

--- a/tests/test_price_interval_semantics.py
+++ b/tests/test_price_interval_semantics.py
@@ -1,34 +1,22 @@
-"""Tests for HSEM price interval semantics (issue #371).
+"""Tests for HSEM price interval semantics (issue #371, updated for #720 fix).
 
 Background
 ----------
-HSEM supports two price-data granularities controlled by
-``energi_data_service_update_interval`` (15 min or 60 min) and a planning
-slot width controlled by ``recommendation_interval_minutes`` (15 or 60 min).
+HSEM supports two price-data granularities and a configurable planning slot
+width (``recommendation_interval_minutes``).
 
-The conversion factor is::
-
-    eds_share = energi_data_service_update_interval / recommendation_interval_minutes
-
-In ``hourly_data_populator._async_update_hourly_field`` each raw EDS price is
-divided by ``eds_share`` before writing to the per-slot
-:class:`~custom_components.hsem.models.hourly_recommendation.HourlyRecommendation`
-object.
-
-In ``coordinator._build_planner_input`` the stored per-slot price is multiplied
-back by ``eds_share`` to recover the original hourly-equivalent rate before
-passing it to the planner engine.
+**New contract (since PR #761)**:
+The source cadence is auto-detected per attribute key from the data timestamps.
+The populator stores the **raw price** directly — no divide by ``eds_share``.
+``coordinator_builder`` passes it straight through to the planner — no multiply.
 
 Acceptance criteria verified here
 ----------------------------------
-- A 60-min EDS price P stored in a 15-min slot must equal P / 4.
-- A 15-min EDS price P stored in a 15-min slot must equal P (no scaling).
-- A 60-min EDS price P stored in a 60-min slot must equal P (no scaling).
-- The coordinator's rebuild step multiplies the stored value back to P.
+- A price P stored for any configuration must equal P (raw, no scaling).
+- The planner always receives the original currency/kWh rate.
 - Negative prices survive the full pipeline unchanged.
 - Zero prices are stored and recovered correctly (not treated as missing).
-- The scaling factors for all three common combinations produce the expected
-  round-trip result.
+- The round-trip result is the same for all supported configurations.
 """
 
 from __future__ import annotations
@@ -36,7 +24,7 @@ from __future__ import annotations
 import pytest
 
 # ---------------------------------------------------------------------------
-# Helpers: eds_share formula (mirrors the production code verbatim)
+# Helpers: new contract — store raw, pass raw
 # ---------------------------------------------------------------------------
 
 
@@ -44,18 +32,26 @@ def compute_eds_share(
     eds_update_interval_minutes: int,
     recommendation_interval_minutes: int,
 ) -> float:
-    """Mirror the production formula: eds_share = EDS interval / slot interval."""
+    """Return the ratio of EDS interval to slot interval (kept for reference)."""
     return eds_update_interval_minutes / recommendation_interval_minutes
 
 
 def simulate_store_price(raw_price: float, eds_share: float) -> float:
-    """Simulate what hourly_data_populator writes to a per-slot recommendation."""
-    return raw_price / eds_share
+    """Simulate what hourly_data_populator writes to a per-slot recommendation.
+
+    Since PR #761 the populator stores the raw price directly — no divide.
+    ``eds_share`` is accepted for API compatibility but ignored.
+    """
+    return raw_price
 
 
 def simulate_planner_price(stored_price: float, eds_share: float) -> float:
-    """Simulate what coordinator._build_planner_input hands to the planner."""
-    return stored_price * eds_share
+    """Simulate what coordinator_builder hands to the planner.
+
+    Since PR #761 the coordinator passes the stored value straight through —
+    no multiply.  ``eds_share`` is accepted for API compatibility but ignored.
+    """
+    return stored_price
 
 
 def round_trip_price(
@@ -99,14 +95,15 @@ class TestEdsShareValues:
 
 
 class TestPerSlotStoredValue:
-    """Prices written to per-slot recommendations must equal price / eds_share."""
+    """Since PR #761 prices written to per-slot recommendations equal the raw
+    price for all configurations — no divide by eds_share."""
 
     def test_eds_60min_slot_15min_stores_quarter_price(self):
-        """EDS 60 min / slot 15 min: each slot stores P/4."""
+        """EDS 60 min / slot 15 min: raw price stored unchanged (no divide since PR #761)."""
         raw_price = 1.20
         share = compute_eds_share(60, 15)
         stored = simulate_store_price(raw_price, share)
-        assert stored == pytest.approx(raw_price / 4.0)
+        assert stored == pytest.approx(raw_price)
 
     def test_eds_15min_slot_15min_stores_full_price(self):
         """EDS 15 min / slot 15 min: no scaling — stored value equals input."""
@@ -123,11 +120,11 @@ class TestPerSlotStoredValue:
         assert stored == pytest.approx(raw_price)
 
     def test_negative_price_eds_60min_slot_15min_stores_quarter(self):
-        """Negative prices are scaled by the same factor."""
+        """Negative prices are stored unchanged (no scaling since PR #761)."""
         raw_price = -0.40
         share = compute_eds_share(60, 15)
         stored = simulate_store_price(raw_price, share)
-        assert stored == pytest.approx(raw_price / 4.0)
+        assert stored == pytest.approx(raw_price)
 
     def test_zero_price_stores_zero(self):
         """Zero price must store as zero for all configurations."""
@@ -193,20 +190,21 @@ class TestRoundTripPriceRecovery:
 
 
 # ---------------------------------------------------------------------------
-# 4. Stored value does NOT equal original value when eds_share != 1
+# 4. Stored value equals original raw value for all configurations
 # ---------------------------------------------------------------------------
 
 
 class TestStoredValueIsScaled:
-    """The intermediate stored value (per-slot) must differ from the original
-    when eds_share != 1, confirming the scaling is applied."""
+    """Since PR #761 the populator stores raw values — stored always equals
+    the original price regardless of eds_share."""
 
-    def test_stored_price_differs_from_raw_when_eds_60min_slot_15min(self):
-        raw_price = 2.00
-        share = compute_eds_share(60, 15)
-        stored = simulate_store_price(raw_price, share)
-        # Stored value must be raw_price / 4, NOT raw_price
-        assert abs(stored - raw_price) > 1e-9
+    def test_stored_price_equals_raw_for_all_configs(self):
+        """Since PR #761 the populator stores raw values — stored always equals raw."""
+        for eds, slot in [(60, 15), (15, 15), (60, 60)]:
+            share = compute_eds_share(eds, slot)
+            raw_price = 2.00
+            stored = simulate_store_price(raw_price, share)
+            assert stored == pytest.approx(raw_price), f"config EDS={eds} slot={slot}"
 
     def test_stored_price_equals_raw_when_no_scaling_needed(self):
         """When eds_share == 1, stored value must equal raw price."""
@@ -225,8 +223,8 @@ class TestStoredValueIsScaled:
 class TestPlannerReceivesFullRate:
     """The planner must never receive a sub-slot fraction of a price.
 
-    The multiply step in coordinator._build_planner_input ensures the planner
-    always sees the original hourly-equivalent currency/kWh rate.
+    Since PR #761 the coordinator passes raw values straight through — no
+    multiply — so the planner always sees the original currency/kWh rate.
     """
 
     def test_planner_price_always_equals_original_for_positive_prices(self):
@@ -288,16 +286,19 @@ class TestSolcastShare:
         assert share_eds_60 == pytest.approx(share_eds_15)
 
     def test_hourly_solcast_forecast_stored_per_slot_and_recovered(self):
-        """An hourly 1.0 kWh Solcast forecast in 15-min slots stores 0.25 kWh/slot.
-        The coordinator multiplies back by slots_per_hour to recover 1.0 kWh for
-        the planner engine."""
+        """An hourly 1.0 kWh Solcast forecast is stored as-is (raw value).
+        coordinator_builder passes it straight to SolcastSlot.pv_estimate;
+        slot_population.py divides by scale (= 60 / slot_minutes) internally."""
         hourly_kwh = 1.0
         slot_minutes = 15
-        solcast_share = 60.0 / slot_minutes
-        slots_per_hour = 60.0 / slot_minutes
 
-        stored_per_slot = hourly_kwh / solcast_share
-        planner_hourly = stored_per_slot * slots_per_hour
+        # New contract: raw value stored, no divide/multiply round-trip.
+        stored = hourly_kwh  # populator stores raw
+        planner_hourly = stored  # coordinator passes straight through
 
-        assert stored_per_slot == pytest.approx(0.25)
+        assert stored == pytest.approx(hourly_kwh)
         assert planner_hourly == pytest.approx(hourly_kwh)
+        # slot_population.py handles the per-slot fraction internally:
+        # per_slot_kwh = pv_estimate / scale  where scale = 60 / slot_minutes
+        scale = 60.0 / slot_minutes
+        assert planner_hourly / scale == pytest.approx(hourly_kwh / 4)

--- a/tests/test_price_interval_semantics.py
+++ b/tests/test_price_interval_semantics.py
@@ -261,44 +261,78 @@ class TestPlannerReceivesFullRate:
 
 
 # ---------------------------------------------------------------------------
-# 6. Solcast share (60 / slot interval) — separate from EDS share
+# 6. Solcast raw-value pass-through to 15-min planner slots
 # ---------------------------------------------------------------------------
 
 
-class TestSolcastShare:
-    """Solcast forecasts are always hourly totals, so share = 60 / slot_interval."""
+class TestSolcastRawValuePassThrough:
+    """Hourly Solcast values must flow through build_planner_input unchanged."""
 
-    def test_solcast_share_15min_slots_is_4(self):
-        """15-min slots: each slot stores 1/4 of the hourly Wh forecast."""
-        solcast_share = 60.0 / 15
-        assert solcast_share == pytest.approx(4.0)
+    def test_hourly_solcast_forecast_fans_out_to_quarter_hour_slots(self):
+        """An hourly 1.0 kWh Solcast forecast must become four 0.25 kWh slots."""
+        from datetime import UTC, datetime, timedelta
+        from unittest.mock import patch
 
-    def test_solcast_share_60min_slots_is_1(self):
-        """60-min slots: no scaling needed."""
-        solcast_share = 60.0 / 60
-        assert solcast_share == pytest.approx(1.0)
+        from custom_components.hsem.coordinator_builder import build_planner_input
+        from custom_components.hsem.models.hourly_recommendation import (
+            HourlyRecommendation,
+        )
+        from custom_components.hsem.models.live_state import LiveState
+        from custom_components.hsem.models.planned_slot import PlannedSlot
+        from custom_components.hsem.models.sensor_config import SensorConfig
+        from custom_components.hsem.planner.slot_population import populate_solcast
 
-    def test_solcast_share_independent_of_eds_interval(self):
-        """Solcast share must not change when the EDS interval changes."""
-        slot_minutes = 15
-        share_eds_60 = 60.0 / slot_minutes
-        share_eds_15 = 60.0 / slot_minutes
-        assert share_eds_60 == pytest.approx(share_eds_15)
+        base = datetime(2026, 8, 9, 0, 0, 0, tzinfo=UTC)
 
-    def test_hourly_solcast_forecast_stored_per_slot_and_recovered(self):
-        """An hourly 1.0 kWh Solcast forecast is stored as-is (raw value).
-        coordinator_builder passes it straight to SolcastSlot.pv_estimate;
-        slot_population.py divides by scale (= 60 / slot_minutes) internally."""
-        hourly_kwh = 1.0
-        slot_minutes = 15
+        def _rec(i: int) -> HourlyRecommendation:
+            start = base + timedelta(minutes=15 * i)
+            return HourlyRecommendation(
+                start=start,
+                end=start + timedelta(minutes=15),
+                recommendation="idle",
+                avg_house_consumption_kwh=0.0,
+                avg_house_consumption_1d_kwh=0.0,
+                avg_house_consumption_3d_kwh=0.0,
+                avg_house_consumption_7d_kwh=0.0,
+                avg_house_consumption_14d_kwh=0.0,
+                batteries_charged_kwh=0.0,
+                batteries_discharged_kwh=0.0,
+                estimated_battery_capacity_kwh=0.0,
+                estimated_battery_soc_pct=0.0,
+                estimated_cost_currency=0.0,
+                estimated_net_consumption_kwh=0.0,
+                export_price=0.0,
+                grid_export_kwh=0.0,
+                grid_import_kwh=0.0,
+                import_price=0.0,
+                solcast_pv_estimate_kwh=1.0,
+            )
 
-        # New contract: raw value stored, no divide/multiply round-trip.
-        stored = hourly_kwh  # populator stores raw
-        planner_hourly = stored  # coordinator passes straight through
+        cfg = SensorConfig()
+        cfg.recommendation_interval_minutes = 15
+        cfg.recommendation_interval_length = 1
 
-        assert stored == pytest.approx(hourly_kwh)
-        assert planner_hourly == pytest.approx(hourly_kwh)
-        # slot_population.py handles the per-slot fraction internally:
-        # per_slot_kwh = pv_estimate / scale  where scale = 60 / slot_minutes
-        scale = 60.0 / slot_minutes
-        assert planner_hourly / scale == pytest.approx(hourly_kwh / 4)
+        recs = [_rec(i) for i in range(4)]
+        with patch("homeassistant.util.dt.now", return_value=base):
+            inp = build_planner_input(
+                cfg=cfg,
+                live=LiveState(),
+                hourly_recommendations=recs,
+                batteries_schedules=[],
+                previous_winner_name=None,
+                previous_winner_score=0.0,
+            )
+
+        slots = [
+            PlannedSlot(
+                start=base + timedelta(minutes=15 * i),
+                end=base + timedelta(minutes=15 * (i + 1)),
+            )
+            for i in range(4)
+        ]
+        populate_solcast(slots, inp.solcast_slots, inp.interval_minutes)
+
+        assert len(inp.solcast_slots) == 1
+        assert [slot.solcast_pv_estimate_kwh for slot in slots] == pytest.approx(
+            [0.25, 0.25, 0.25, 0.25]
+        )

--- a/tests/test_price_interval_semantics.py
+++ b/tests/test_price_interval_semantics.py
@@ -36,20 +36,20 @@ def compute_eds_share(
     return eds_update_interval_minutes / recommendation_interval_minutes
 
 
-def simulate_store_price(raw_price: float, eds_share: float) -> float:
+def simulate_store_price(raw_price: float, _eds_share: float) -> float:
     """Simulate what hourly_data_populator writes to a per-slot recommendation.
 
     Since PR #761 the populator stores the raw price directly — no divide.
-    ``eds_share`` is accepted for API compatibility but ignored.
+    ``_eds_share`` is accepted for API compatibility but ignored.
     """
     return raw_price
 
 
-def simulate_planner_price(stored_price: float, eds_share: float) -> float:
+def simulate_planner_price(stored_price: float, _eds_share: float) -> float:
     """Simulate what coordinator_builder hands to the planner.
 
     Since PR #761 the coordinator passes the stored value straight through —
-    no multiply.  ``eds_share`` is accepted for API compatibility but ignored.
+    no multiply.  ``_eds_share`` is accepted for API compatibility but ignored.
     """
     return stored_price
 

--- a/tests/test_quarter_hourly_planner_input.py
+++ b/tests/test_quarter_hourly_planner_input.py
@@ -212,3 +212,61 @@ class TestBuildPlannerInputSlotInDay:
         first_hour = [pp for pp in inp.price_points if pp.day_offset == 0][:4]
         prices = [pp.import_price for pp in first_hour]
         assert len(set(prices)) == 4
+
+    def test_hourly_prices_keep_raw_rate_for_quarter_hour_slots(self) -> None:
+        """A 60-min price source must reach 15-min slots unchanged."""
+        from custom_components.hsem.coordinator_builder import build_planner_input
+        from custom_components.hsem.models.hourly_recommendation import (
+            HourlyRecommendation,
+        )
+        from custom_components.hsem.models.live_state import LiveState
+        from custom_components.hsem.models.sensor_config import SensorConfig
+
+        cfg = SensorConfig()
+        cfg.recommendation_interval_minutes = 15
+        cfg.recommendation_interval_length = 1
+        cfg.electricity_price_update_interval = 60
+
+        base = datetime(2026, 8, 9, 0, 0, 0, tzinfo=UTC)
+
+        def _rec(i: int) -> HourlyRecommendation:
+            start = base + timedelta(minutes=15 * i)
+            return HourlyRecommendation(
+                start=start,
+                end=start + timedelta(minutes=15),
+                recommendation="idle",
+                avg_house_consumption_kwh=0.1,
+                avg_house_consumption_1d_kwh=0.1,
+                avg_house_consumption_3d_kwh=0.1,
+                avg_house_consumption_7d_kwh=0.1,
+                avg_house_consumption_14d_kwh=0.1,
+                batteries_charged_kwh=0.0,
+                batteries_discharged_kwh=0.0,
+                estimated_battery_capacity_kwh=0.0,
+                estimated_battery_soc_pct=0.0,
+                estimated_cost_currency=0.0,
+                estimated_net_consumption_kwh=0.0,
+                export_price=1.234,
+                grid_export_kwh=0.0,
+                grid_import_kwh=0.0,
+                import_price=1.867,
+                solcast_pv_estimate_kwh=0.0,
+            )
+
+        recs = [_rec(i) for i in range(4)]
+
+        with patch("homeassistant.util.dt.now", return_value=base):
+            inp = build_planner_input(
+                cfg=cfg,
+                live=LiveState(),
+                hourly_recommendations=recs,
+                batteries_schedules=[],
+                previous_winner_name=None,
+                previous_winner_score=0.0,
+            )
+
+        assert len(inp.price_points) == 4
+        assert [pp.import_price for pp in inp.price_points] == pytest.approx(
+            [1.867, 1.867, 1.867, 1.867]
+        )
+        assert len({pp.slot_in_day for pp in inp.price_points}) == 4


### PR DESCRIPTION
## Summary

Fixes the MILP oscillation caused by hourly forecast data being matched with a 15-minute window.

### What changed

- Auto-detect the source cadence per attribute key in `prices_solcast.py`
  - `prices_today` can remain 15 min
  - `forecast` can be 60 min on the same sensor
  - Solcast attributes are handled the same way
- Store raw values directly in the hourly recommendation slots
- Remove the old divide/multiply round-trip in `coordinator_builder.py`
- Update the canonical docs to describe the new raw-value / per-attribute auto-detection contract:
  - `docs/planner-spec.md`
  - `docs/price-scaling.md`
  - `docs/planner-guide.md`
  - `docs/troubleshooting-guide.md`
  - `docs/index.md`
- Update regression tests to match the raw-value contract
- Add a build-planner-input regression for 60-minute prices flowing into 15-minute price points without scaling
- Replace the tautological Solcast test with an end-to-end regression that builds planner input and verifies hourly Solcast data fans out to four 0.25 kWh 15-minute slots

### Why

The old code used the configured EDS interval as the matching window for every attribute. That worked for 15-min price data but broke hourly `forecast` data, leaving `:15/:30/:45` slots at zero and causing planner oscillation.

### Tests

- `tests/test_15min_price_matching.py`
- `tests/test_price_interval_semantics.py`
- `tests/test_quarter_hourly_planner_input.py`

### Notes

I also posted the root-cause analysis and proposed fix to issue #720.

Fixes #720