### PR TITLE
fix(workflows): harden fork PR jobs

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -4,9 +4,9 @@
 name: Auto Label PRs from Conventional Commits
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
-    types: [opened, reopened, labeled, unlabeled]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
   workflow_dispatch:
 
 permissions:
@@ -21,8 +21,6 @@ jobs:
       pull-requests: write
     if: github.event.pull_request.merged == false
     steps:
-      - uses: actions/checkout@v7.0.1
-
       - name: Execute assign labels
         id: action-assign-labels
         uses: mauroalderete/action-assign-labels@v1

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Execute assign labels
         id: action-assign-labels
-        uses: mauroalderete/action-assign-labels@v1
+        uses: mauroalderete/action-assign-labels@671a4ca2da0f900464c58b8b5540a1e07133e915
         with:
           pull-request-number: ${{ github.event.pull_request.number }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -33,6 +33,8 @@ jobs:
   MSDO:
     # currently only windows latest is supported
     runs-on: windows-latest
+    # Fork PRs run with a read-only token; this job writes security results.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       security-events: write
     steps:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -16,6 +16,8 @@ jobs:
   sonarqube:
     name: SonarQube
     runs-on: ubuntu-latest
+    # Fork PRs get a read-only token, but this job reports checks back to GitHub.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
## Summary

Hardened the GitHub Actions workflows that were failing on pull requests from forks.

## Branch

- `agents/auto-label-workflow-issue`

## Files changed

- `.github/workflows/auto-label.yml`
- `.github/workflows/defender-for-devops.yml`
- `.github/workflows/sonarcloud.yml`

## What changed and why

- Switched the auto-label workflow to `pull_request_target` so it can add labels on fork PRs.
- Removed the checkout step from auto-label because the job only needs PR metadata/API access.
- Pinned `mauroalderete/action-assign-labels` to the current `v1` tag commit SHA for safer third-party action consumption.
- Added fork guards to Defender for DevOps and SonarCloud so they skip fork PRs instead of failing on read-only tokens.

## Tests / validation

- Reviewed the workflow diffs and final file contents.
- Ran `git diff --check`.
- Could not run the repo YAML validator locally because Python is not available in this environment.

## Known limitations

- Defender for DevOps and SonarCloud will not run on fork PRs; they are skipped to avoid token-permission failures.

## Configuration changes

- No additional repo configuration changes required.

## Follow-up

- Verified the `mauroalderete/action-assign-labels` repository and pinned the workflow to tag commit `671a4ca2da0f900464c58b8b5540a1e07133e915`.