### PR TITLE
fix(config): coerce vol.UNDEFINED for optional battery device IDs

### DIFF
--- a/custom_components/hsem/custom_sensors/config_reader.py
+++ b/custom_components/hsem/custom_sensors/config_reader.py
@@ -32,6 +32,21 @@ from custom_components.hsem.utils.conversion import (
 from custom_components.hsem.utils.misc import get_config_value
 
 
+def _normalize_optional_device_id(value: Any) -> str | None:
+    """Return a valid device ID string or ``None``.
+
+    Existing config entries may store ``vol.UNDEFINED`` for optional device IDs
+    that were added after the entry was created.  This helper coerces those
+    sentinels — along with empty or whitespace-only strings — to ``None`` so
+    downstream code only has to handle a real string or ``None``.
+    """
+    if value is None or value is vol.UNDEFINED:
+        return None
+    if isinstance(value, str) and value.strip() == "":
+        return None
+    return cast(str, value)
+
+
 def build_sensor_config(
     config_entry: Any,
 ) -> SensorConfig:  # NOSONAR -- HA ConfigEntry; circular import risk
@@ -115,26 +130,16 @@ def build_sensor_config(
     cfg.huawei_solar_device_id_inverter_1 = get_config_value(
         config_entry, "hsem_huawei_solar_device_id_inverter_1"
     )
-    cfg.huawei_solar_device_id_inverter_2 = get_config_value(
-        config_entry, "hsem_huawei_solar_device_id_inverter_2"
+    cfg.huawei_solar_device_id_inverter_2 = _normalize_optional_device_id(
+        get_config_value(config_entry, "hsem_huawei_solar_device_id_inverter_2")
     )
-    if (
-        cfg.huawei_solar_device_id_inverter_2 is not None
-        and len(cfg.huawei_solar_device_id_inverter_2) == 0
-    ):
-        cfg.huawei_solar_device_id_inverter_2 = None
 
     cfg.huawei_solar_device_id_batteries = get_config_value(
         config_entry, "hsem_huawei_solar_device_id_batteries"
     )
-    cfg.huawei_solar_device_id_batteries_2 = get_config_value(
-        config_entry, "hsem_huawei_solar_device_id_batteries_2"
+    cfg.huawei_solar_device_id_batteries_2 = _normalize_optional_device_id(
+        get_config_value(config_entry, "hsem_huawei_solar_device_id_batteries_2")
     )
-    if (
-        cfg.huawei_solar_device_id_batteries_2 is not None
-        and len(cfg.huawei_solar_device_id_batteries_2) == 0
-    ):
-        cfg.huawei_solar_device_id_batteries_2 = None
 
     # Huawei Solar entity IDs
     cfg.huawei_solar_batteries_working_mode = get_config_value(

--- a/tests/sensors/test_state_collector.py
+++ b/tests/sensors/test_state_collector.py
@@ -11,6 +11,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+import voluptuous as vol
 
 from custom_components.hsem.custom_sensors.state_collector import (
     _compute_battery_capacities,
@@ -144,6 +145,28 @@ class TestBuildSensorConfig:
             _make_config_entry(hsem_huawei_solar_device_id_batteries_2="bat2")
         )
         assert cfg.huawei_solar_device_id_batteries_2 == "bat2"
+
+    def test_batteries_2_undefined_becomes_none(self):
+        """Regression test for post-merge crash on existing config entries.
+
+        Config entries created before the second battery device ID was
+        introduced store ``vol.UNDEFINED`` for the new key.  The reader must
+        coerce that sentinel to ``None`` instead of calling ``len()`` on it.
+        """
+        cfg = build_sensor_config(
+            _make_config_entry(
+                hsem_huawei_solar_device_id_batteries_2=vol.UNDEFINED
+            )
+        )
+        assert cfg.huawei_solar_device_id_batteries_2 is None
+
+    def test_inverter_2_undefined_becomes_none(self):
+        cfg = build_sensor_config(
+            _make_config_entry(
+                hsem_huawei_solar_device_id_inverter_2=vol.UNDEFINED
+            )
+        )
+        assert cfg.huawei_solar_device_id_inverter_2 is None
 
     def test_recommendation_interval_minutes(self):
         cfg = build_sensor_config(


### PR DESCRIPTION
## Summary

Fixes a runtime crash that occurred after merging the optional second battery device ID feature (#759) for issue #747.

Existing config entries created before the feature store `vol.UNDEFINED` for the new key `hsem_huawei_solar_device_id_batteries_2`. `build_sensor_config()` then called `len()` on that sentinel, raising:

```
TypeError: object of type 'Undefined' has no len()
```

## Changes

- `custom_components/hsem/custom_sensors/config_reader.py`
  - Added `_normalize_optional_device_id()` helper that coerces `vol.UNDEFINED`, `None`, and empty/whitespace strings to `None`.
  - Applied the helper to both `hsem_huawei_solar_device_id_inverter_2` and `hsem_huawei_solar_device_id_batteries_2`.
- `tests/sensors/test_state_collector.py`
  - Added regression tests for `vol.UNDEFINED` on both optional device IDs.

## Verification

- [ ] `tests/sensors/test_state_collector.py` passes
- [ ] `./scripts/quality.sh lint` passes
- [ ] `./scripts/quality.sh typing` passes
- [ ] `./scripts/quality.sh quality` passes
- [ ] `./scripts/quality.sh test` passes

Fixes #747