### PR TITLE
fix(applier): stop blocking PV export below export_electricity_min_price

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -18,6 +18,12 @@ for the HSEM (Home Smart Energy Management) project. Read this before making any
 | `charge_scheduler.py` | Assigns charge recommendations to slots |
 | `discharge_scheduler.py` | Assigns discharge recommendations to slots; `concentrate_discharge_on_expensive_slots` uses **per-calendar-day** budget pools |
 | `milp_optimizer.py` | Solves the MILP LP problem — variable vector is 8*n base, growing to 8n + 2n·E + E with EV co-optimisation.  Accepts optional `EVConfig` list for EV integration. |
+| `milp/_price_sanitise.py` | Pre-solve price transformations: NaN handling, battery-export floor mask, export-≤-import clamp, negative-import clamp. |
+| `milp/_constraints.py` | Builds LP constraint matrices and variable bounds. |
+| `milp/_objective.py` | Builds LP objective vector. |
+| `milp/_write_results.py` | Translates LP solution back into `PlannedSlot` recommendations and energy flows. |
+| `milp/_diagnostics.py` | Computes MILP diagnostics and violation reports. |
+| `milp/_export_cap.py` | Resolves DNO/inverter grid-export power cap per slot. |
 | `cost_function.py` | Scores a candidate plan — source of truth for cost math |
 | `soc_simulation.py` | Simulates battery SoC forward through a slot plan |
 | `ev_planner.py` | EV-specific planning logic |
@@ -270,26 +276,30 @@ Also in `_build_constraints`, the session-EV AC load is simply
 by definition.  Do not re-introduce a multiply-then-divide by
 `charger_efficiency`.
 
-## Battery Export Minimum Price Floor (Issue #752)
+## Battery Export Minimum Price Floor (Issues #752 and #767)
 
 A third per-slot ed cap, in the same `_build_constraints` loop:
 
-3. **Battery-export-min-price floor** — when `battery_export_min_price > 0`
-   and the slot's RAW export price is strictly below the floor
-   (`p_exp[t] < battery_export_min_price`, evaluated on the raw p_exp
-   BEFORE the `min_export_price` and export-≤-import clamps), apply
-   `ed[t] ≤ base_load / η_dis` to that slot.  This is the per-slot,
-   soft-switch companion to the global `no_export` cap — it blocks
-   *intentional* battery-to-grid export only on slots below the user's
-   explicit floor, not everywhere.  Above the floor the optimizer is
-   free to decide whether exporting is worthwhile; reaching the threshold
-   does NOT auto-trigger export.  The non-MILP `apply_excess_export` path
-   enforces the same floor via
+3. **Battery-export-min-price floor** — the combined floor is
+   `max(min_export_price, battery_export_min_price)`, where
+   `min_export_price` is passed from the engine as
+   `max(export_min_price, recommended_threshold)`.  When the slot's RAW
+   export price is strictly below the combined floor
+   (`p_exp[t] < effective_floor`, evaluated on the raw p_exp BEFORE the
+   export-≤-import clamp), apply `ed[t] ≤ base_load / η_dis` to that slot.
+   This is the per-slot, soft-switch companion to the global `no_export`
+   cap — it blocks *intentional* battery-to-grid export only on slots below
+   the floor, not everywhere.  Above the floor the optimizer is free to
+   decide whether exporting is worthwhile; reaching the threshold does NOT
+   auto-trigger export.  The non-MILP `apply_excess_export` path enforces
+   the same floor via
    `export_price >= max(export_min_price, recommended_threshold, battery_export_min_price)`.
 
-   - The mask is computed in `milp_optimizer.py::solve_milp`
-     (`battery_export_blocked`) and passed to `_build_constraints` via the
-     `battery_export_blocked=` kwarg.  Wire it end-to-end:
+   - The combined mask is computed in
+     `planner/milp/_price_sanitise.py::sanitize_prices`
+     (`battery_export_blocked`) and passed through `solve_milp` to
+     `_build_constraints` via the `battery_export_blocked=` kwarg.
+     Wire it end-to-end:
      `const.py` (`hsem_batteries_export_min_price` default 0.0) →
      `flows/batteries_excess_export.py` schema/validator →
      `models/sensor_config.py::batteries_export_min_price` →
@@ -298,11 +308,20 @@ A third per-slot ed cap, in the same `_build_constraints` loop:
      `coordinator_builder.py::build_planner_input` →
      `planner/candidate_generator.py::generate_candidates` →
      `planner/milp_optimizer.py::solve_milp` (kwarg) →
+     `planner/milp/_price_sanitise.py::sanitize_prices` (mask) →
      `planner/milp/_constraints.py::_build_constraints` (mask).
-   - The cost function mirrors the floor via
+   - The cost function mirrors the `battery_export_min_price` floor via
      `CostWeights.battery_export_min_price`; battery-destined export
      revenue (and discharge-loss export-destined pricing) is zeroed on
-     blocked slots so scored costs match the optimisation.
+     blocked slots so scored costs match the optimisation.  The legacy
+     blanket `export_min_price` clamp on all export revenue has been
+     removed (issue #767).
+   - The applier (`custom_sensors/applier.py::async_apply_inverter_power_control`)
+     MUST NOT express a battery-export price floor by writing the grid
+     feed-in limit.  Doing so blocks surplus PV export as well as battery
+     export once the battery is full (issue #767).  The applier keeps the
+     grid connection point at unlimited/100% and lets the planner gate the
+     battery path.
    - The guard applies ONLY to intentional battery-to-grid export
      (`force_batteries_discharge`).  It does NOT affect normal battery
      self-consumption, PV export, or PV charging.  With the default

--- a/.github/memories.md
+++ b/.github/memories.md
@@ -318,10 +318,13 @@ A third per-slot ed cap, in the same `_build_constraints` loop:
      removed (issue #767).
    - The applier (`custom_sensors/applier.py::async_apply_inverter_power_control`)
      MUST NOT express a battery-export price floor by writing the grid
-     feed-in limit.  Doing so blocks surplus PV export as well as battery
-     export once the battery is full (issue #767).  The applier keeps the
-     grid connection point at unlimited/100% and lets the planner gate the
-     battery path.
+     feed-in limit for non-negative export prices.  Doing so blocks surplus
+     PV export as well as battery export once the battery is full
+     (issue #767).  The applier keeps the grid connection point at
+     unlimited/100% for non-negative prices and lets the planner gate the
+     battery path.  **Negative export prices are the exception:** when
+     exporting costs money, the applier still writes a physical watt limit
+     to block all grid export.
    - The guard applies ONLY to intentional battery-to-grid export
      (`force_batteries_discharge`).  It does NOT affect normal battery
      self-consumption, PV export, or PV charging.  With the default

--- a/custom_components/hsem/custom_sensors/applier.py
+++ b/custom_components/hsem/custom_sensors/applier.py
@@ -40,7 +40,6 @@ from custom_components.hsem.const import (
     DEFAULT_HSEM_BATTERIES_WAIT_MODE,
     DEFAULT_HSEM_EV_CHARGER_TOU_MODES,
     DEFAULT_HSEM_TOU_MODES_FORCE_CHARGE,
-    GRID_EXPORT_LIMIT_WATT,
 )
 from custom_components.hsem.models.hourly_recommendation import HourlyRecommendation
 from custom_components.hsem.models.live_state import LiveState
@@ -54,7 +53,6 @@ from custom_components.hsem.utils.ha_helpers import (
 from custom_components.hsem.utils.huawei import (
     async_set_forcible_discharge,
     async_set_grid_export_power_pct,
-    async_set_grid_export_power_watt,
     async_set_tou_periods,
     async_stop_forcible_discharge,
     extract_tou_periods,
@@ -213,12 +211,16 @@ async def async_apply_inverter_power_control(
     cfg: SensorConfig,
     live: LiveState,
 ) -> CycleApplySummary:
-    """Set the grid-export power percentage on all inverters.
+    """Set the grid-export power percentage on all inverters to unlimited.
 
-    Decides whether to allow full export (100%) or block export (0%) based on
-    the current export price, the minimum price threshold, and EV connection
-    state.  Only issues a hardware write when the value differs from the current
-    inverter state.
+    Keeps the inverter grid connection point at full export (100%) so that
+    surplus PV is never curtailed by a price threshold.  Battery-to-grid
+    export below ``export_electricity_min_price`` is gated by the planner
+    (MILP / discharge scheduler) through battery working-mode and TOU
+    settings, not by throttling the whole grid feed-in limit.
+
+    Only issues a hardware write when the inverter is not already at
+    unlimited/100%.
 
     Each write is wrapped with :func:`~utils.inverter_verify.async_write_and_verify`
     so that the inverter is polled after the write and the result is verified
@@ -260,15 +262,22 @@ async def async_apply_inverter_power_control(
     if not isinstance(min_price, (int, float)):
         return summary
 
-    export_pct = 100 if export_price >= min_price else 0
+    export_pct = 100
 
-    # Allow export if EV is connected and needs charging
-    if export_pct == 0 and _should_force_export_for_ev(live.ev, cfg.ev, live):
-        export_pct = 100
-    if export_pct == 0 and _should_force_export_for_ev(
-        live.ev_second, cfg.ev_second, live
-    ):
-        export_pct = 100
+    # The export-electricity-min-price threshold is intentionally a planner-side
+    # battery-export floor, not a physical grid limit.  Writing a watt-mode feed-
+    # in limit (e.g. 100 W) below this price blocks surplus PV export as well as
+    # battery export, which silently curtails free solar energy once the battery
+    # is full (issue #767).  The planner still avoids battery-to-grid discharge
+    # below this price via the MILP and discharge_scheduler.
+    if export_price < min_price:
+        _LOGGER.warning(
+            "Export price %.4f is below export_electricity_min_price %.4f; "
+            "leaving grid feed-in limit unlimited so PV surplus can still export. "
+            "Battery-to-grid export is gated by the planner.",
+            export_price,
+            min_price,
+        )
 
     _LOGGER.debug(
         f"Determined export power percentage: {export_pct}% "
@@ -293,44 +302,29 @@ async def async_apply_inverter_power_control(
             else None
         )
 
-        if export_pct == 0:
-            # Block export → set a soft floor at GRID_EXPORT_LIMIT_WATT.
-            desired = GRID_EXPORT_LIMIT_WATT
-            if current_pct is not None and current_is_watt and current_pct == desired:
-                continue  # already at the watt limit
+        # Always allow full export.  Restore unlimited/100% if the inverter is
+        # currently in a watt-based limit mode (legacy state from before this fix).
+        if (
+            current_pct is not None
+            and not current_is_watt
+            and current_pct == export_pct
+        ):
+            continue  # already at unlimited / 100 %
 
-            result = await async_write_and_verify(
-                entity_id=inv_entity or f"inverter:{inv_id}",
-                desired=desired,
-                writer=lambda _id=inv_id, _w=desired: async_set_grid_export_power_watt(  # type: ignore[misc]  # mypy cannot infer lambda types with default parameters
-                    sensor, _id, _w
-                ),
-                reader=reader_fn,
-            )
-        else:
-            # export_pct == 100 — Allow full export.
-            if (
-                current_pct is not None
-                and not current_is_watt
-                and current_pct == export_pct
-            ):
-                continue  # already at unlimited / 100 %
-
-            result = await async_write_and_verify(
-                entity_id=inv_entity or f"inverter:{inv_id}",
-                desired=export_pct,
-                writer=lambda _id=inv_id, _pct=export_pct: (  # type: ignore[misc]  # mypy cannot infer lambda types with default parameters
-                    async_set_grid_export_power_pct(sensor, _id, _pct)
-                ),
-                reader=reader_fn,
-            )
+        result = await async_write_and_verify(
+            entity_id=inv_entity or f"inverter:{inv_id}",
+            desired=export_pct,
+            writer=lambda _id=inv_id, _pct=export_pct: (  # type: ignore[misc]  # mypy cannot infer lambda types with default parameters
+                async_set_grid_export_power_pct(sensor, _id, _pct)
+            ),
+            reader=reader_fn,
+        )
 
         summary.results.append(result)
 
         if result.status == ApplyStatus.FAILED:
-            mode = "W" if export_pct == 0 else "%"
             _LOGGER.debug(
-                f"Export power {mode} write FAILED for inverter {inv_id} after all retries. "
+                f"Export power % write FAILED for inverter {inv_id} after all retries. "
                 f"Blocking further writes this cycle.",
                 "error",
             )

--- a/custom_components/hsem/custom_sensors/applier.py
+++ b/custom_components/hsem/custom_sensors/applier.py
@@ -40,6 +40,7 @@ from custom_components.hsem.const import (
     DEFAULT_HSEM_BATTERIES_WAIT_MODE,
     DEFAULT_HSEM_EV_CHARGER_TOU_MODES,
     DEFAULT_HSEM_TOU_MODES_FORCE_CHARGE,
+    GRID_EXPORT_LIMIT_WATT,
 )
 from custom_components.hsem.models.hourly_recommendation import HourlyRecommendation
 from custom_components.hsem.models.live_state import LiveState
@@ -53,6 +54,7 @@ from custom_components.hsem.utils.ha_helpers import (
 from custom_components.hsem.utils.huawei import (
     async_set_forcible_discharge,
     async_set_grid_export_power_pct,
+    async_set_grid_export_power_watt,
     async_set_tou_periods,
     async_stop_forcible_discharge,
     extract_tou_periods,
@@ -211,16 +213,21 @@ async def async_apply_inverter_power_control(
     cfg: SensorConfig,
     live: LiveState,
 ) -> CycleApplySummary:
-    """Set the grid-export power percentage on all inverters to unlimited.
+    """Set the grid-export power limit on all inverters.
 
-    Keeps the inverter grid connection point at full export (100%) so that
-    surplus PV is never curtailed by a price threshold.  Battery-to-grid
-    export below ``export_electricity_min_price`` is gated by the planner
-    (MILP / discharge scheduler) through battery working-mode and TOU
-    settings, not by throttling the whole grid feed-in limit.
+    The inverter grid connection point is controlled by price:
 
-    Only issues a hardware write when the inverter is not already at
-    unlimited/100%.
+    - Negative export price → block all export with a soft watt floor
+      (``GRID_EXPORT_LIMIT_WATT``), because exporting then costs money.
+    - Non-negative export price → allow unlimited/100% export.  Battery-to-grid
+      export below ``export_electricity_min_price`` is gated planner-side by the
+      MILP and discharge scheduler, not by throttling the whole connection point.
+
+    This avoids the issue described in #767, where a positive-but-low export
+    price caused the applier to write a 100 W connection-point limit that
+    blocked surplus PV export once the battery was full.
+
+    Only issues a hardware write when the inverter state actually needs to change.
 
     Each write is wrapped with :func:`~utils.inverter_verify.async_write_and_verify`
     so that the inverter is polled after the write and the result is verified
@@ -262,27 +269,40 @@ async def async_apply_inverter_power_control(
     if not isinstance(min_price, (int, float)):
         return summary
 
-    export_pct = 100
-
-    # The export-electricity-min-price threshold is intentionally a planner-side
-    # battery-export floor, not a physical grid limit.  Writing a watt-mode feed-
-    # in limit (e.g. 100 W) below this price blocks surplus PV export as well as
-    # battery export, which silently curtails free solar energy once the battery
-    # is full (issue #767).  The planner still avoids battery-to-grid discharge
-    # below this price via the MILP and discharge_scheduler.
-    if export_price < min_price:
-        _LOGGER.warning(
-            "Export price %.4f is below export_electricity_min_price %.4f; "
-            "leaving grid feed-in limit unlimited so PV surplus can still export. "
-            "Battery-to-grid export is gated by the planner.",
+    # Negative export prices are the only case where we physically block the
+    # whole grid connection point.  When exporting costs money we must not
+    # allow any export, including surplus PV.  For all non-negative prices we
+    # keep the connection point unlimited and let the planner gate battery-to-grid
+    # export via export_electricity_min_price (issue #767).
+    if export_price < 0.0:
+        desired = GRID_EXPORT_LIMIT_WATT
+        desired_is_watt = True
+        _LOGGER.debug(
+            "Export price %.4f is negative; blocking all grid export with %d W limit.",
             export_price,
-            min_price,
+            desired,
         )
+    else:
+        desired = 100
+        desired_is_watt = False
+        if export_price < min_price:
+            _LOGGER.debug(
+                "Export price %.4f is below export_electricity_min_price %.4f; "
+                "leaving grid feed-in limit unlimited so PV surplus can export. "
+                "Battery-to-grid export is gated by the planner.",
+                export_price,
+                min_price,
+            )
 
     _LOGGER.debug(
-        f"Determined export power percentage: {export_pct}% "
-        f"(export={export_price}, min={min_price}, "
-        f"ev1_connected={live.ev.is_connected}, ev2_connected={live.ev_second.is_connected})",
+        "Determined export power limit: %s%s (export=%s, min=%s, "
+        "ev1_connected=%s, ev2_connected=%s)",
+        desired,
+        "W" if desired_is_watt else "%",
+        export_price,
+        min_price,
+        live.ev.is_connected,
+        live.ev_second.is_connected,
     )
 
     current_pct = _parse_power_control_pct(live.huawei_inverter_active_power_control)
@@ -302,29 +322,39 @@ async def async_apply_inverter_power_control(
             else None
         )
 
-        # Always allow full export.  Restore unlimited/100% if the inverter is
-        # currently in a watt-based limit mode (legacy state from before this fix).
+        # Skip if the inverter already matches the desired state.
         if (
             current_pct is not None
-            and not current_is_watt
-            and current_pct == export_pct
+            and current_is_watt == desired_is_watt
+            and current_pct == desired
         ):
-            continue  # already at unlimited / 100 %
+            continue
 
-        result = await async_write_and_verify(
-            entity_id=inv_entity or f"inverter:{inv_id}",
-            desired=export_pct,
-            writer=lambda _id=inv_id, _pct=export_pct: (  # type: ignore[misc]  # mypy cannot infer lambda types with default parameters
-                async_set_grid_export_power_pct(sensor, _id, _pct)
-            ),
-            reader=reader_fn,
-        )
+        if desired_is_watt:
+            result = await async_write_and_verify(
+                entity_id=inv_entity or f"inverter:{inv_id}",
+                desired=desired,
+                writer=lambda _id=inv_id, _w=desired: async_set_grid_export_power_watt(  # type: ignore[misc]  # mypy cannot infer lambda types with default parameters
+                    sensor, _id, _w
+                ),
+                reader=reader_fn,
+            )
+        else:
+            result = await async_write_and_verify(
+                entity_id=inv_entity or f"inverter:{inv_id}",
+                desired=desired,
+                writer=lambda _id=inv_id, _pct=desired: (  # type: ignore[misc]  # mypy cannot infer lambda types with default parameters
+                    async_set_grid_export_power_pct(sensor, _id, _pct)
+                ),
+                reader=reader_fn,
+            )
 
         summary.results.append(result)
 
         if result.status == ApplyStatus.FAILED:
+            mode = "W" if desired_is_watt else "%"
             _LOGGER.debug(
-                f"Export power % write FAILED for inverter {inv_id} after all retries. "
+                f"Export power {mode} write FAILED for inverter {inv_id} after all retries. "
                 f"Blocking further writes this cycle.",
                 "error",
             )

--- a/custom_components/hsem/planner/cost_function.py
+++ b/custom_components/hsem/planner/cost_function.py
@@ -343,20 +343,16 @@ def score_plan(
             import_cost += cost
             import_cost_disc += cost * discount
 
-        # 2. Export revenue — clamp export prices below export_min_price
-        #    to 0 to match the applier's physical export block and the
-        #    MILP's clamping (milp_optimizer.py).  Additionally zero
-        #    battery-destined export revenue when the slot is below the
-        #    user's ``battery_export_min_price`` floor (issue #752): the
-        #    MILP forbids ``force_batteries_discharge`` there, so that
-        #    export can never be realised by the battery.
+        # 2. Export revenue — PV export is always counted at the live
+        #    export price.  Battery-destined export revenue is zeroed when
+        #    the slot is below the user's ``battery_export_min_price`` floor
+        #    (issue #752): the MILP caps ``ed[t]`` there, so that export can
+        #    never be realised by the battery.  The legacy
+        #    ``export_min_price`` blanket clamp has been removed because the
+        #    applier no longer physically blocks all grid export (issue
+        #    #767); it is now a battery-export floor enforced by the MILP.
         if slot.grid_export_kwh > 1e-9:
             effective_exp_price = exp_price
-            if (
-                weights.export_min_price > 1e-9
-                and effective_exp_price < weights.export_min_price
-            ):
-                effective_exp_price = 0.0
             if (
                 weights.battery_export_min_price > 1e-9
                 and effective_exp_price < weights.battery_export_min_price
@@ -410,11 +406,6 @@ def score_plan(
             # net-exporter → price loss at export price; otherwise import price.
             if slot.grid_export_kwh > 1e-9:
                 p_loss = exp_price
-                if (
-                    weights.export_min_price > 1e-9
-                    and p_loss < weights.export_min_price
-                ):
-                    p_loss = 0.0
                 # Battery-destined export floored by battery_export_min_price
                 # (issue #752): when the slot's raw export price is below
                 # the user's floor and the discharge is battery-destined (no

--- a/custom_components/hsem/planner/cost_types.py
+++ b/custom_components/hsem/planner/cost_types.py
@@ -112,9 +112,11 @@ class CostWeights:
     charge_efficiency_pct: float = 100.0
     discharge_efficiency_pct: float = 100.0
 
-    # Minimum export price — exports below this are physically blocked by the
-    # applier (inverter set to GRID_EXPORT_LIMIT_WATT).  Mirrors the clamping
-    # in milp_optimizer.py so that cost_function scores match MILP assumptions.
+    # Minimum export price — legacy battery-export floor.  The applier no
+    # longer physically blocks grid export below this value (issue #767); it
+    # is now enforced by the MILP/discharge scheduler as a battery-export
+    # floor.  Kept in weights for backward compatibility with callers and
+    # diagnostics.
     export_min_price: float = 0.0
 
     # Per-slot hard floor for intentional battery-to-grid export (issue #752).

--- a/custom_components/hsem/planner/discharge_scheduler.py
+++ b/custom_components/hsem/planner/discharge_scheduler.py
@@ -221,9 +221,9 @@ def apply_excess_export(
     the next solar surplus.  Grid-charged batteries require a minimum price
     difference; solar-charged batteries export opportunistically but still
     require ``export_price >= max(export_min_price, recommended_threshold,
-    battery_export_min_price)`` — the highest of the user-configured minimum
-    (inverter physical floor), the cycle-wear cost, and the per-slot hard
-    floor for intentional battery-to-grid export (issue #752).
+    battery_export_min_price)`` — the highest of the user-configured
+    battery-export floor, the cycle-wear cost, and the per-slot hard floor
+    for intentional battery-to-grid export (issue #752).
 
     Args:
         slots: Mutable list of planned slots.
@@ -234,8 +234,9 @@ def apply_excess_export(
             grid-charged batteries.
         warnings: Mutable list to append diagnostic messages to.
         export_min_price: Minimum export price (local currency/kWh) below
-            which forced discharge is never triggered.  Sourced from
-            ``hsem_export_electricity_min_price``.
+            which intentional battery-to-grid discharge is never triggered.
+            Sourced from ``hsem_export_electricity_min_price``.  This is a
+            battery-export floor, not a physical grid limit (issue #767).
         recommended_threshold: Battery cycle-wear cost per kWh (depreciation)
             from :func:`~custom_components.hsem.utils.misc.calculate_recommended_threshold`.
             Used as a floor — exporting below this price costs more in

--- a/custom_components/hsem/planner/milp/_price_sanitise.py
+++ b/custom_components/hsem/planner/milp/_price_sanitise.py
@@ -1,0 +1,101 @@
+"""Price sanitisation helpers for the MILP.
+
+Centralises the pre-solve price transformations that keep the LP bounded
+and consistent with the physical system:
+
+- NaN handling
+- Battery-export floor mask (issues #752 and #767)
+- Export-≤-import clamp (issue #635)
+- Negative-import clamp for objective coefficients (issue #655)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from custom_components.hsem.utils.logger import log_planner
+
+if TYPE_CHECKING:
+    import numpy as np
+
+
+def sanitize_prices(
+    p_imp: np.ndarray,  # type: ignore[name-defined]
+    p_exp: np.ndarray,  # type: ignore[name-defined]
+    min_export_price: float,
+    battery_export_min_price: float,
+) -> tuple[
+    np.ndarray,  # type: ignore[name-defined]
+    np.ndarray,  # type: ignore[name-defined]
+    np.ndarray,  # type: ignore[name-defined]
+]:
+    """Return sanitized import/export arrays and the battery-export block mask.
+
+    The battery-export floor is the maximum of ``min_export_price`` (which
+    already includes the depreciation-based ``recommended_threshold`` from
+    the engine) and ``battery_export_min_price``.  Slots whose raw export
+    price is strictly below the combined floor get ``ed[t]`` capped to
+    ``base_load[t] / discharge_eff`` so the battery can serve house load
+    but cannot intentionally export to the grid.  PV export is intentionally
+    left unrestricted (issue #767).
+
+    The export-≤-import clamp prevents an unbounded LP when
+    ``p_exp > p_imp`` in any slot.  Negative import prices are clamped to
+    0 for objective coefficients only; the raw ``p_imp`` is preserved for
+    the export-≤-import clamp and penalty scaling.
+
+    Args:
+        p_imp: Raw import prices per active slot.
+        p_exp: Raw export prices per active slot.
+        min_export_price: User-configured battery-export floor (combined
+            with the engine's recommended threshold by the caller).
+        battery_export_min_price: Dedicated per-slot battery-export floor.
+
+    Returns:
+        ``(p_imp_obj, p_exp_sanitized, battery_export_blocked)`` where
+        ``p_imp_obj`` is the non-negative import price used in the
+        objective, ``p_exp_sanitized`` is the export price after the
+        export-≤-import clamp, and ``battery_export_blocked`` is a bool
+        mask of slots below the combined battery-export floor.
+    """
+    import numpy as np
+
+    # Replace NaN prices with 0 to prevent solver numerical issues.
+    p_imp = np.nan_to_num(p_imp, nan=0.0)
+    p_exp = np.nan_to_num(p_exp, nan=0.0)
+
+    # Combined battery-export floor (issues #752, #767).
+    effective_floor = max(min_export_price, battery_export_min_price)
+    battery_export_blocked = np.zeros(len(p_exp), dtype=bool)
+    if effective_floor > 1e-9:
+        battery_export_blocked = p_exp < effective_floor
+        n_blocked = int(np.sum(battery_export_blocked))
+        if n_blocked > 0:
+            log_planner(
+                "debug",
+                "[milp] Blocking battery export on %d slots below combined floor "
+                "(%.4f) (max blocked=%.4f)",
+                n_blocked,
+                effective_floor,
+                float(np.max(p_exp[battery_export_blocked])),
+            )
+
+    # Export-≤-import clamp prevents an unbounded LP (issue #635).
+    export_exceeds_import = p_exp > p_imp
+    n_clamped = int(np.sum(export_exceeds_import))
+    if n_clamped > 0:
+        deltas = p_exp[export_exceeds_import] - p_imp[export_exceeds_import]
+        log_planner(
+            "debug",
+            "[milp] Clamping %d export prices that exceed import price "
+            "(max delta=%.4f)",
+            n_clamped,
+            float(np.max(deltas)),
+        )
+        p_exp = np.minimum(p_exp, p_imp)
+
+    # Clamp negative import prices to 0 for objective coefficients
+    # (issue #655).  Keep raw p_imp for the clamp above and penalties.
+    p_imp_obj = np.maximum(p_imp, 0.0)
+
+    return p_imp_obj, p_exp, battery_export_blocked

--- a/custom_components/hsem/planner/milp_optimizer.py
+++ b/custom_components/hsem/planner/milp_optimizer.py
@@ -12,7 +12,7 @@ Objective: Σ p_imp·gi - p_exp·ge + cycle_cost·m + p_soc·penalties.
 Constraints: SoC recurrence, SoC soft bounds, charge/discharge limits,
 mutex, energy balance (with efficiencies), EV co-optimisation, fuse limit.
 
-Price sanitisation: export<min_export→0, export≤import, import_obj≥0.
+Price sanitisation: battery-export floors, export≤import, import_obj≥0.
 Curtailment variable ``curt[t]`` allows explicit PV shedding.
 
 Pure Python, no HA imports — testable with plain pytest.
@@ -141,13 +141,14 @@ def solve_milp(
             ``None`` disables the terminal-SoC credit term.
         min_export_price:
             Minimum export price (local currency/kWh) for the combined
-            threshold below which export is not worthwhile.  Set by the
-            caller to ``max(export_min_price, recommended_threshold)``
-            where ``export_min_price`` is the inverter's physical block
-            threshold and ``recommended_threshold`` is the
-            depreciation-based discharge minimum.  Used for:
-            - Clamping export prices to 0 before the LP solves (export
-              below this price is physically blocked).
+            battery-export floor.  Set by the caller to
+            ``max(export_min_price, recommended_threshold)`` where
+            ``export_min_price`` is the user-configured battery-export
+            floor and ``recommended_threshold`` is the depreciation-based
+            discharge minimum.  Used for:
+            - Capping ``ed[t]`` to ``base_load[t] / discharge_eff`` on
+              slots where ``p_exp < min_export_price``, preventing
+              intentional battery-to-grid discharge below the floor.
             - Deciding between ``ForceBatteriesDischarge`` and
               ``BatteriesDischargeMode`` in post-processing.
             Defaults to 0.0.
@@ -265,77 +266,14 @@ def solve_milp(
     p_imp = np.array([slots[i].price.import_price for i in future_idx], dtype=float)
     p_exp = np.array([slots[i].price.export_price for i in future_idx], dtype=float)
 
-    # Replace NaN prices with 0 to prevent solver numerical issues
-    p_imp = np.nan_to_num(p_imp, nan=0.0)
-    p_exp = np.nan_to_num(p_exp, nan=0.0)
+    from custom_components.hsem.planner.milp._price_sanitise import sanitize_prices
 
-    # Per-slot hard floor for intentional battery-to-grid export (issue
-    # #752). 0.0 (default) → mask all-False, backward compatible.
-    battery_export_blocked = np.zeros(len(future_idx), dtype=bool)
-    if battery_export_min_price > 1e-9:
-        battery_export_blocked = p_exp < battery_export_min_price
-
-    # Clamp export prices below min_export_price to 0.
-    # The applier physically sets the inverter to GRID_EXPORT_LIMIT_WATT
-    # for these slots, blocking export entirely.  The LP must not optimise
-    # around a price signal that will never be realised.
-    #
-    # Negative export prices are NOT clamped — the LP has a curt[t]
-    # variable with zero objective cost that naturally handles them:
-    # when p_exp < 0, export costs money (p_exp is negative, so
-    # -p_exp·ge becomes a positive cost), and the LP prefers curtailment
-    # (cost 0) over export (cost > 0).
-    if min_export_price > 1e-9:
-        blocked = p_exp < min_export_price
-        n_blocked = int(np.sum(blocked))
-        if n_blocked > 0:
-            log_planner(
-                "debug",
-                "[milp] Clamping %d export prices below min_price (%.4f) to 0 "
-                "(max clamped=%.4f)",
-                n_blocked,
-                min_export_price,
-                float(np.max(p_exp[blocked])),
-            )
-        p_exp = np.where(blocked, 0.0, p_exp)
-
-    # Clamp export price to never exceed import price for the same slot.
-    # Without this, slots where p_exp[t] > p_imp[t] create an unbounded LP
-    # (HiGHS status=3): both gi[t] and ge[t] are [0, ∞) and linked only
-    # through the energy-balance equality, so the LP can drive both to
-    # infinity (import cheap, export expensive) while the terms cancel in
-    # the balance equation.  This is economically correct — no rational
-    # agent imports and exports the same commodity in the same instant for
-    # profit — and capping the achievable arbitrage spread removes the
-    # unbounded direction without changing any other behavior.
-    export_exceeds_import = p_exp > p_imp
-    n_clamped = int(np.sum(export_exceeds_import))
-    if n_clamped > 0:
-        deltas = p_exp[export_exceeds_import] - p_imp[export_exceeds_import]
-        log_planner(
-            "debug",
-            "[milp] Clamping %d export prices that exceed import price "
-            "(max delta=%.4f)",
-            n_clamped,
-            float(np.max(deltas)),
-        )
-        p_exp = np.minimum(p_exp, p_imp)
-
-    # Clamp negative import prices to 0 for objective coefficients.
-    # When p_imp[t] < 0, the gi[t] objective coefficient becomes
-    # negative, incentivising the LP to import infinite energy
-    # (HiGHS status=3, unbounded LP).  curt[t] has zero objective
-    # cost but participates in the energy balance, so the LP can
-    # import-and-curtail for unbounded profit even without p_exp>p_imp.
-    #
-    # Clamping to 0 here removes that unbounded direction while
-    # keeping the original p_imp for the export-≤-import clamp and
-    # penalty scaling (both need the real market signal).
-    #
-    # This is the companion to the export-≤-import clamp above:
-    # together they close both unbounded-LP directions identified in
-    # issue #635.
-    p_imp_obj = np.maximum(p_imp, 0.0)
+    p_imp_obj, p_exp, battery_export_blocked = sanitize_prices(
+        p_imp,
+        p_exp,
+        min_export_price=min_export_price,
+        battery_export_min_price=battery_export_min_price,
+    )
 
     # Net load = house consumption + EV extra load − PV estimate.
     # A positive value means the battery/grid must supply extra energy.

--- a/custom_components/hsem/planner/slot_population.py
+++ b/custom_components/hsem/planner/slot_population.py
@@ -418,15 +418,15 @@ def populate_estimated_cost(
     Net consumption >= 0 → cost = net × import_price.
     Net consumption < 0  → revenue = net × export_price (negative cost).
 
-    When ``export_min_price > 0``, export prices below the threshold are
-    treated as 0 to match the physical inverter behaviour (the applier
-    blocks all export below ``export_min_price`` via
-    ``GRID_EXPORT_LIMIT_WATT``).
+    ``export_min_price`` is kept as a parameter for API compatibility but is
+    no longer used to clamp export prices.  The applier no longer physically
+    blocks grid export below the threshold (issue #767); surplus PV export is
+    always allowed and is valued at the live export price.
 
     Args:
         slots: Mutable list of planned slots to update.
-        export_min_price: Minimum export price for grid power control.
-            Export prices below this are clamped to 0.  Defaults to 0.0.
+        export_min_price: Deprecated compatibility parameter.  No longer
+            affects estimated cost calculation.  Defaults to 0.0.
     """
     log_planner(
         "debug",
@@ -440,10 +440,9 @@ def populate_estimated_cost(
             slot.estimated_cost_currency = round(net * slot.price.import_price, 4)
         else:
             exp_price = slot.price.export_price
-            # Clamp to match MILP + cost_function behaviour (issue #483)
+            # Negative export prices are treated as zero for estimation
+            # (curtailment is preferred to paying to export).
             if exp_price < 0.0:
-                exp_price = 0.0
-            if export_min_price > 1e-9 and exp_price < export_min_price:
                 exp_price = 0.0
             slot.estimated_cost_currency = round(net * exp_price, 4)
 

--- a/docs/config-flow-reference.md
+++ b/docs/config-flow-reference.md
@@ -51,7 +51,7 @@ Energi Data Service, Nordpool, Amber Electric, and any other price source.
 | Export price sensor | `hsem_export_electricity_price_sensor` | `sensor.energi_data_service_produktion` | HA entity for export price |
 | Import price forecast sensor | `hsem_import_electricity_price_forecast_sensor` | — | Optional dedicated import forecast sensor |
 | Export price forecast sensor | `hsem_export_electricity_price_forecast_sensor` | — | Optional dedicated export forecast sensor |
-| Export min price | `hsem_export_electricity_min_price` | 0.0 | Minimum export price for intentional battery-to-grid discharge. The inverter no longer throttles the grid feed-in limit; surplus PV export is always allowed (issue #767). |
+| Export min price | `hsem_export_electricity_min_price` | 0.0 | Minimum export price for intentional battery-to-grid discharge. The inverter no longer throttles the grid feed-in limit for positive prices; surplus PV export is always allowed (issue #767). Negative export prices still trigger a physical block because exporting then costs money. |
 | Price update interval | `hsem_electricity_price_update_interval` | 15 minutes | How often the price source publishes (15, 30, or 60) |
 
 ### Step: `months`

--- a/docs/config-flow-reference.md
+++ b/docs/config-flow-reference.md
@@ -51,7 +51,7 @@ Energi Data Service, Nordpool, Amber Electric, and any other price source.
 | Export price sensor | `hsem_export_electricity_price_sensor` | `sensor.energi_data_service_produktion` | HA entity for export price |
 | Import price forecast sensor | `hsem_import_electricity_price_forecast_sensor` | — | Optional dedicated import forecast sensor |
 | Export price forecast sensor | `hsem_export_electricity_price_forecast_sensor` | — | Optional dedicated export forecast sensor |
-| Export min price | `hsem_export_electricity_min_price` | 0.0 | Below this, inverter throttles export to zero |
+| Export min price | `hsem_export_electricity_min_price` | 0.0 | Minimum export price for intentional battery-to-grid discharge. The inverter no longer throttles the grid feed-in limit; surplus PV export is always allowed (issue #767). |
 | Price update interval | `hsem_electricity_price_update_interval` | 15 minutes | How often the price source publishes (15, 30, or 60) |
 
 ### Step: `months`

--- a/docs/milp-optimization.md
+++ b/docs/milp-optimization.md
@@ -151,7 +151,7 @@ Where:
 |---|---|
 | $\delta_t$ | Time discount per slot: $\delta_t = r^{\Delta t}$ where $\Delta t$ is hours from now |
 | $p_{\mathrm{imp}}[t]$ | Grid import price (currency/kWh).  Sanitised to `max(p_imp_raw[t], 0)` (issue #655).  Also used as a **conservative approximation** for the LP's discharge-side conversion loss coefficient (see note below). |
-| $p_{\mathrm{exp}}[t]$ | Grid export price (currency/kWh). Before solving, `p_exp` is sanitised: (1) clamped to 0 when below `min_export_price` (physically blocked export), and (2) clamped to `min(p_exp, p_imp)` to prevent an unbounded LP when `p_exp > p_imp` in any slot (issue #635). |
+| $p_{\mathrm{exp}}[t]$ | Grid export price (currency/kWh). Before solving, `p_exp` is sanitised by clamping to `min(p_exp, p_imp)` to prevent an unbounded LP when `p_exp > p_imp` in any slot (issue #635).  The legacy `min_export_price` clamp has been removed because the applier no longer physically blocks grid export below this price (issue #767). |
 | $\alpha$ | Battery cycle cost per kWh: $\alpha = \frac{P \cdot L_{pct}/100}{2 \cdot N \cdot C_u}$ |
 | $\epsilon_{\mathrm{chg}}$ | Charge-side loss fraction: $\epsilon_{\mathrm{chg}} = 1 - \eta_{\mathrm{chg}}$ |
 | $\epsilon_{\mathrm{dis}}$ | Discharge-side loss fraction: $\epsilon_{\mathrm{dis}} = 1 - \eta_{\mathrm{dis}}$ |
@@ -291,7 +291,7 @@ This is the **per-slot, soft-switch companion to the global `no_export` cap**. W
 
 Scope: the floor applies only to intentional battery-to-grid export (`ForceBatteriesDischarge`). It does not affect normal battery self-consumption, battery discharge for house load, direct PV export (`ge` is not capped — only `ed` is), or PV charging of the battery.
 
-Evaluation on the **raw** `p_exp` is essential: the user's `battery_export_min_price` floor must be honoured even when the `recommended_threshold` (auto-calculated cycle wear) or the inverter's `export_min_price` physical floor are lower.  Selecting the larger of the three floors would force every user to overwrite their own threshold when they want a stricter guard, defeating the purpose of the dedicated setting.
+Evaluation on the **raw** `p_exp` is essential: the user's `battery_export_min_price` floor must be honoured even when the `recommended_threshold` (auto-calculated cycle wear) or the `export_min_price` battery-export floor are lower.  Selecting the larger of the three floors would force every user to overwrite their own threshold when they want a stricter guard, defeating the purpose of the dedicated setting.
 
 The non-MILP `apply_excess_export` path enforces the same floor by requiring `export_price >= max(export_min_price, recommended_threshold, battery_export_min_price)` for any slot it would otherwise label `ForceBatteriesDischarge`.
 
@@ -303,9 +303,16 @@ When `battery_export_min_price = 0` (default), no slot is ever blocked by the fl
 
 Before the LP is built, two sanitisation steps are applied to `p_exp` to prevent solver instability and maintain consistency with physical constraints:
 
-### 1. Min-export-price clamp
+### 1. Battery export floor (replaces min-export-price clamp)
 
-Slots where `p_exp < min_export_price` are clamped to 0. The applier physically blocks export for these slots by setting the inverter to `GRID_EXPORT_LIMIT_WATT`, so the LP must not optimise around a price signal that will never be realised. Negative export prices are **not** clamped — the `curt[t]` variable (zero objective cost) naturally handles them.
+Slots where `p_exp < max(min_export_price, battery_export_min_price)` do
+not have their export price clamped to 0.  Instead, the battery discharge
+variable `ed[t]` is capped to `base_load[t] / η_dis` so the battery can
+serve house load but cannot intentionally export to the grid.  This keeps
+surplus PV export possible (the applier no longer throttles the grid
+feed-in limit, issue #767) while still preventing battery-to-grid discharge
+below the configured floor.  Negative export prices are **not** clamped —
+the `curt[t]` variable (zero objective cost) naturally handles them.
 
 ### 2. Export-≤-import clamp (issue #635)
 

--- a/docs/milp-optimization.md
+++ b/docs/milp-optimization.md
@@ -310,9 +310,10 @@ not have their export price clamped to 0.  Instead, the battery discharge
 variable `ed[t]` is capped to `base_load[t] / η_dis` so the battery can
 serve house load but cannot intentionally export to the grid.  This keeps
 surplus PV export possible (the applier no longer throttles the grid
-feed-in limit, issue #767) while still preventing battery-to-grid discharge
-below the configured floor.  Negative export prices are **not** clamped —
-the `curt[t]` variable (zero objective cost) naturally handles them.
+feed-in limit for non-negative prices, issue #767) while still preventing
+battery-to-grid discharge below the configured floor.  Negative export
+prices are handled by the applier, which writes a physical watt limit to
+block all grid export when exporting costs money.
 
 ### 2. Export-≤-import clamp (issue #635)
 

--- a/docs/planner-guide.md
+++ b/docs/planner-guide.md
@@ -272,7 +272,7 @@ The pre-charge window ends at `schedule.start` and is sized to fill the battery 
 | `excess_export_enabled` | `False` | Enable forced battery → grid export during high-price slots |
 | `excess_export_discharge_buffer_pct` | `10.0` | Safety SoC buffer kept before forced export |
 | `excess_export_price_threshold` | Auto-calculated | Computed at runtime from battery depreciation settings (purchase price, expected cycles, usable capacity) via `calculate_recommended_threshold()`. |
-| `export_min_price` | `0.0` | Minimum export price for intentional battery-to-grid discharge. The inverter no longer throttles the grid feed-in limit; surplus PV export is always allowed (issue #767). |
+| `export_min_price` | `0.0` | Minimum export price for intentional battery-to-grid discharge. The inverter no longer throttles the grid feed-in limit for positive prices; surplus PV export is always allowed (issue #767). Negative export prices still trigger a physical block because exporting then costs money. |
 | `battery_export_min_price` | `0.0` | Per-slot hard floor for intentional battery-to-grid export (issue #752). When > 0 and a slot's raw `export_price` is strictly below this value, the MILP caps `ed[t]` so the battery can only serve house load (no grid export) for that slot — `force_batteries_discharge` is never labelled there. Reaching the threshold does NOT auto-trigger export; the optimizer still decides. Applies only to intentional battery-to-grid export, not to normal battery self-consumption, PV export, or PV charging. Set to 0 to disable. |
 
 ### Seasonal configuration
@@ -822,12 +822,17 @@ Revenue is subtracted from total cost (it reduces the net expense).
 
 **Export price floor:** ``export_min_price`` is a battery-export floor,
 not a physical grid limit.  The applier no longer throttles the grid
-feed-in limit below this price (issue #767), so surplus PV export is
-always allowed.  The MILP and discharge scheduler prevent intentional
-battery-to-grid discharge on slots where ``export_price < export_min_price``.
-The cost function counts PV export revenue at the live export price and
-only zeroes battery-destined export revenue on slots blocked by
+feed-in limit below this price when the export price is non-negative
+(issue #767), so surplus PV export is always allowed.  The MILP and
+discharge scheduler prevent intentional battery-to-grid discharge on
+slots where ``export_price < export_min_price``.  The cost function
+counts PV export revenue at the live export price and only zeroes
+battery-destined export revenue on slots blocked by
 ``battery_export_min_price``.
+
+**Negative export prices** are the exception: when exporting costs
+money, the applier still writes a physical watt limit to block all
+grid export, including surplus PV.
 
 ### Conversion loss cost
 
@@ -1488,9 +1493,10 @@ current SoC but does not retroactively account for the morning shortfall.
 ### Battery export floor, not a grid throttle
 
 `export_min_price` now gates intentional battery-to-grid discharge, not
-the entire grid connection point.  Surplus PV export is always allowed;
-the planner avoids discharging the battery to the grid when the export
-price is below the configured floor.
+the entire grid connection point.  Surplus PV export is always allowed
+when the export price is non-negative.  The exception is negative export
+prices, where the applier still writes a physical block because
+exporting then costs money.
 
 ### Single-zone tariff model
 

--- a/docs/planner-guide.md
+++ b/docs/planner-guide.md
@@ -272,7 +272,7 @@ The pre-charge window ends at `schedule.start` and is sized to fill the battery 
 | `excess_export_enabled` | `False` | Enable forced battery → grid export during high-price slots |
 | `excess_export_discharge_buffer_pct` | `10.0` | Safety SoC buffer kept before forced export |
 | `excess_export_price_threshold` | Auto-calculated | Computed at runtime from battery depreciation settings (purchase price, expected cycles, usable capacity) via `calculate_recommended_threshold()`. |
-| `export_min_price` | `0.0` | Below this export price the inverter throttles export to zero |
+| `export_min_price` | `0.0` | Minimum export price for intentional battery-to-grid discharge. The inverter no longer throttles the grid feed-in limit; surplus PV export is always allowed (issue #767). |
 | `battery_export_min_price` | `0.0` | Per-slot hard floor for intentional battery-to-grid export (issue #752). When > 0 and a slot's raw `export_price` is strictly below this value, the MILP caps `ed[t]` so the battery can only serve house load (no grid export) for that slot — `force_batteries_discharge` is never labelled there. Reaching the threshold does NOT auto-trigger export; the optimizer still decides. Applies only to intentional battery-to-grid export, not to normal battery self-consumption, PV export, or PV charging. Set to 0 to disable. |
 
 ### Seasonal configuration
@@ -820,14 +820,14 @@ export_revenue = Σ (grid_export_kwh[slot] × export_price[slot])
 
 Revenue is subtracted from total cost (it reduces the net expense).
 
-**Export price clamping:** When ``export_min_price > 0``, the applier
-blocks all grid export for slots where ``export_price < export_min_price``
-by setting the inverter to ``GRID_EXPORT_LIMIT_WATT``.  To keep the
-planner consistent with this physical behaviour, both the MILP and the
-cost function treat ``export_price`` as 0 for any slot where
-``export_price < export_min_price`` — no revenue is counted for exports
-that can never happen.  See *Excess export and grid controls* for the
-configuration fields.
+**Export price floor:** ``export_min_price`` is a battery-export floor,
+not a physical grid limit.  The applier no longer throttles the grid
+feed-in limit below this price (issue #767), so surplus PV export is
+always allowed.  The MILP and discharge scheduler prevent intentional
+battery-to-grid discharge on slots where ``export_price < export_min_price``.
+The cost function counts PV export revenue at the live export price and
+only zeroes battery-destined export revenue on slots blocked by
+``battery_export_min_price``.
 
 ### Conversion loss cost
 
@@ -1485,10 +1485,12 @@ Slots marked `time_passed` are frozen. If the morning plan assumed 5 kWh of PV
 that didn't materialise (cloudy day), the afternoon plan starts fresh from the
 current SoC but does not retroactively account for the morning shortfall.
 
-### Grid export throttle is a binary threshold
+### Battery export floor, not a grid throttle
 
-The `export_min_price` threshold turns grid export on or off below a price level.
-There is no proportional throttle or ramp — the switch is instantaneous.
+`export_min_price` now gates intentional battery-to-grid discharge, not
+the entire grid connection point.  Surplus PV export is always allowed;
+the planner avoids discharging the battery to the grid when the export
+price is below the configured floor.
 
 ### Single-zone tariff model
 

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -502,18 +502,17 @@ bounds** on the discharge variable `ed[t]` (implemented as variable bounds in
    cap: instead of blocking battery export everywhere, the floor blocks
    it only on slots whose raw export price is below the user's explicit
    guard.  The mask is evaluated on the RAW `p_exp` (before the
-   `export_min_price` and export-≤-import clamps) so the user's explicit
-   price signal is honoured even when the recommended threshold or
-   inverter physical floor are lower.  Above the floor the optimiser is
-   free to decide whether exporting is worthwhile — reaching the
-   threshold does NOT auto-trigger export.  The guard applies only to
-   intentional battery-to-grid export (`ForceBatteriesDischarge`); it
-   does NOT restrict normal battery self-consumption, battery discharge
-   for house load, direct PV export, or PV charging of the battery.  The
-   non-MILP `apply_excess_export` path applies the same floor by
-   requiring `export_price >= max(export_min_price,
-   recommended_threshold, battery_export_min_price)` for any slot it
-   would otherwise label `ForceBatteriesDischarge`.
+   export-≤-import clamp) so the user's explicit price signal is honoured
+   even when the recommended threshold or the `export_min_price` floor
+   are lower.  Above the floor the optimiser is free to decide whether
+   exporting is worthwhile — reaching the threshold does NOT auto-trigger
+   export.  The guard applies only to intentional battery-to-grid export
+   (`ForceBatteriesDischarge`); it does NOT restrict normal battery
+   self-consumption, battery discharge for house load, direct PV export,
+   or PV charging of the battery.  The non-MILP `apply_excess_export`
+   path applies the same floor by requiring `export_price >=
+   max(export_min_price, recommended_threshold, battery_export_min_price)`
+   for any slot it would otherwise label `ForceBatteriesDischarge`.
 
 When any apply, the tighter cap wins.  When the battery cannot export on
 a slot (`no_export` or a blocked-by-floor slot), the MILP labels
@@ -939,26 +938,31 @@ is negative — exporting costs money rather than earning it.  The
 ``total_cost`` formula ``import_cost − export_revenue`` correctly handles
 this: subtracting a negative adds the cost.
 
-**Export price clamping (``export_min_price``):**  When
-``export_min_price > 0``, the inverter physically blocks all export for
-slots where ``export_price < export_min_price`` (applier sets
-``GRID_EXPORT_LIMIT_WATT``).  To keep the planner model consistent with
-this physical behaviour:
+**Battery export floor (``export_min_price``):**  ``export_min_price`` is
+a battery-export floor, not a physical grid limit.  The applier no longer
+sets the inverter's grid feed-in limit to block export below this price;
+surplus PV export is always allowed (issue #767).  The planner enforces
+the floor by preventing intentional battery-to-grid discharge on slots
+where ``export_price < export_min_price``:
 
-- The MILP clamps ``export_price`` to 0 for all slots where
-  ``export_price < export_min_price`` *before* solving the LP.
-- The cost function (``score_plan``) applies the same clamping via
-  ``CostWeights.export_min_price``.
-- This clamping only affects the planner's decision-making; the raw slot
-  ``export_price`` is preserved for diagnostics.
+- The MILP caps ``ed[t]`` to ``base_load[t] / discharge_eff`` on blocked
+  slots, so the battery can serve house load but cannot export to the grid.
+- The non-MILP ``apply_excess_export`` path requires
+  ``export_price >= max(export_min_price, recommended_threshold,
+  battery_export_min_price)`` before labelling a slot
+  ``ForceBatteriesDischarge``.
+- The cost function counts PV export revenue at the live export price. It
+  zeroes only battery-destined export revenue on slots blocked by
+  ``battery_export_min_price``.
 
 Negative export prices are **not** clamped — the LP's ``curt[t]``
 variable (zero objective cost) naturally handles them: when
 ``p_exp < 0``, exporting costs money (``−p_exp·ge`` becomes a positive
 cost) and the LP prefers curtailment (cost 0) over export (cost > 0).
 
-Invariant: ``export_price < export_min_price`` → planner treats export
-revenue as 0 in both optimisation and scoring.
+Invariant: ``export_price < export_min_price`` → intentional battery-to-grid
+export is forbidden; PV export is unaffected and is valued at the live
+export price.
 
 **Battery export minimum price floor (``battery_export_min_price``, issue
 #752):** When ``battery_export_min_price > 0`` and a slot's raw

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -955,14 +955,15 @@ where ``export_price < export_min_price``:
   zeroes only battery-destined export revenue on slots blocked by
   ``battery_export_min_price``.
 
-Negative export prices are **not** clamped — the LP's ``curt[t]``
-variable (zero objective cost) naturally handles them: when
-``p_exp < 0``, exporting costs money (``−p_exp·ge`` becomes a positive
-cost) and the LP prefers curtailment (cost 0) over export (cost > 0).
+**Negative export prices** are a separate case: when ``p_exp < 0``,
+exporting costs money, so the applier still writes a physical watt
+limit (``GRID_EXPORT_LIMIT_WATT``) to block all grid export, including
+surplus PV.  This is the only price regime where the connection point is
+physically throttled.
 
-Invariant: ``export_price < export_min_price`` → intentional battery-to-grid
-export is forbidden; PV export is unaffected and is valued at the live
-export price.
+Invariant: ``export_price < export_min_price`` AND ``export_price >= 0``
+→ intentional battery-to-grid export is forbidden; PV export is
+unaffected and is valued at the live export price.
 
 **Battery export minimum price floor (``battery_export_min_price``, issue
 #752):** When ``battery_export_min_price > 0`` and a slot's raw

--- a/tests/planner/test_battery_export_min_price.py
+++ b/tests/planner/test_battery_export_min_price.py
@@ -1,4 +1,4 @@
-"""Regression tests for the battery_export_min_price floor (issue #752).
+"""Regression tests for the battery export price floor (issues #752 and #767).
 
 Covers the optional per-slot hard floor for *intentional* battery-to-grid
 export.  When ``battery_export_min_price > 0`` and a slot's RAW export
@@ -249,13 +249,13 @@ class TestMilpBatteryExportMinPrice:
             assert s.batteries_discharged_kwh <= 1e-6
 
     def test_floor_evaluated_on_raw_export_price(self) -> None:
-        """Floor uses raw export_price, not the min_export_price-clamped one.
+        """Floor uses raw export_price, not any post-clamp value.
 
-        If the floor were evaluated AFTER the min_export_price clamp
-        (which sets p_exp < min_export_price to 0), slots with
-        0 < export_price < battery_export_min_price would NOT be blocked
-        because min_export_price=0 doesn't clamp them.  This test ensures
-        the floor is independent of that clamp.
+        The battery export floor must be evaluated on the raw export
+        price (before the export-≤-import clamp).  This ensures the
+        user's explicit floor is honoured regardless of other price
+        guards.  Issue #767 removed the legacy min_export_price clamp,
+        but the floor must still work on the raw price.
         """
         # min_export_price is 0 (disabled), but battery_export_min_price
         # is 0.15.  Slot export_price = 0.10 must still be blocked.
@@ -505,6 +505,34 @@ class TestCostFunctionFloor:
         weights = CostWeights(
             export_min_price=0.0,
             battery_export_min_price=0.15,
+        )
+        bd = score_plan(
+            [slot],
+            initial_battery_kwh=10.0,
+            weights=weights,
+        )
+        assert bd.export_revenue == pytest.approx(0.10, rel=1e-6)
+
+    def test_pv_export_below_legacy_min_price_still_counts(self) -> None:
+        """export_min_price no longer zeroes PV export revenue (issue #767).
+
+        Previously the cost function treated all export below
+        export_min_price as 0.  After issue #767, only battery-destined
+        export below battery_export_min_price is zeroed; PV export is
+        counted at the live export price even when export_min_price is
+        higher.
+        """
+        slot = _slot_with_export(
+            hour=12,
+            export_price=0.10,
+            grid_export_kwh=1.0,
+            pv_kwh=1.5,
+            batteries_discharged_kwh=0.0,
+        )
+
+        weights = CostWeights(
+            export_min_price=0.20,
+            battery_export_min_price=0.0,
         )
         bd = score_plan(
             [slot],

--- a/tests/planner/test_cost_function.py
+++ b/tests/planner/test_cost_function.py
@@ -373,12 +373,14 @@ class TestConversionLoss:
         )
         assert bd.conversion_loss_cost == pytest.approx(0.0)
 
-    def test_discharge_loss_export_below_min_price_uses_zero(self):
-        """Export below min_export_price: loss priced at 0 for export slots.
+    def test_discharge_loss_export_below_legacy_min_price_uses_live_price(self):
+        """export_min_price no longer clamps export-destined discharge loss.
 
-        When the applier blocks export (export < min_export_price), the
-        effective export price is 0.  An export-destined discharge in such
-        a slot should have its loss priced at 0.
+        Since issue #767, the applier does not block grid export below
+        export_min_price; surplus PV export is always allowed.  The legacy
+        blanket clamp on discharge-loss pricing has been removed, so an
+        export-destined discharge below the old min price is priced at the
+        live export price.
         """
         slot = _make_slot(
             import_price=0.20,
@@ -394,9 +396,9 @@ class TestConversionLoss:
                 export_min_price=0.05,
             ),
         )
-        # export_price 0.02 < min 0.05 -> clamped to 0.0
-        # lost_kwh = 0.10, cost = 0.10 * 0.0 = 0.0
-        assert bd.conversion_loss_cost == pytest.approx(0.0)
+        # export_price 0.02 is no longer clamped to 0.0 by export_min_price
+        # lost_kwh = 1.0 * (1 - 0.9) = 0.10, cost = 0.10 * 0.02 = 0.002
+        assert bd.conversion_loss_cost == pytest.approx(0.002, rel=1e-6)
 
 
 # ===========================================================================

--- a/tests/sensors/test_state_collector.py
+++ b/tests/sensors/test_state_collector.py
@@ -154,17 +154,13 @@ class TestBuildSensorConfig:
         coerce that sentinel to ``None`` instead of calling ``len()`` on it.
         """
         cfg = build_sensor_config(
-            _make_config_entry(
-                hsem_huawei_solar_device_id_batteries_2=vol.UNDEFINED
-            )
+            _make_config_entry(hsem_huawei_solar_device_id_batteries_2=vol.UNDEFINED)
         )
         assert cfg.huawei_solar_device_id_batteries_2 is None
 
     def test_inverter_2_undefined_becomes_none(self):
         cfg = build_sensor_config(
-            _make_config_entry(
-                hsem_huawei_solar_device_id_inverter_2=vol.UNDEFINED
-            )
+            _make_config_entry(hsem_huawei_solar_device_id_inverter_2=vol.UNDEFINED)
         )
         assert cfg.huawei_solar_device_id_inverter_2 is None
 

--- a/tests/test_safety_gates.py
+++ b/tests/test_safety_gates.py
@@ -304,6 +304,55 @@ class TestInverterPowerControlSafetyGate:
         mock_watt_write.assert_not_called()
         mock_wv.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_negative_export_price_blocks_all_export(self):
+        """Negative export price must write a watt limit to avoid paying to export.
+
+        This preserves the original physical protection that issue #767 was
+        not meant to remove: when exporting costs money, the connection
+        point must be blocked.
+        """
+        sensor = _make_sensor()
+        cfg = _make_cfg(read_only=False)
+        cfg.huawei_solar_device_id_inverter_1 = "device_abc"
+        cfg.huawei_solar_inverter_active_power_control = (
+            "sensor.inverter_active_power_control"
+        )
+        cfg.export_electricity_min_price = 0.22
+
+        live = _make_live(degraded_mode=DegradedMode.OK)
+        live.export_electricity_price = -0.05
+        # Inverter currently unlimited; must switch to watt limit.
+        live.huawei_inverter_active_power_control = "Unlimited"
+
+        mock_state = MagicMock()
+        mock_state.state = "Unlimited"
+        sensor.hass.states.get.return_value = mock_state
+
+        with (
+            patch(_LOGGER_PATCH, new_callable=MagicMock),
+            patch(
+                "custom_components.hsem.utils.huawei.async_set_grid_export_power_pct"
+            ) as mock_pct_write,
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_write_and_verify",
+                new_callable=AsyncMock,
+            ) as mock_wv,
+        ):
+            from custom_components.hsem.utils.inverter_verify import ApplyResult
+
+            mock_wv.return_value = ApplyResult(
+                entity_id="sensor.inverter_active_power_control",
+                desired=100,
+                actual=100,
+                status=ApplyStatus.OK,
+                attempts=1,
+            )
+            _summary = await async_apply_inverter_power_control(sensor, cfg, live)
+
+        mock_pct_write.assert_not_called()
+        mock_wv.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # async_apply_battery_settings — safety gate

--- a/tests/test_safety_gates.py
+++ b/tests/test_safety_gates.py
@@ -139,8 +139,9 @@ class TestInverterPowerControlSafetyGate:
         live = _make_live(degraded_mode=DegradedMode.Degraded)
         # Set a numeric export price so the function can compute export_pct.
         live.export_electricity_price = 0.5
-        # Set current inverter state to force a write (100 → 0 would write).
-        live.huawei_inverter_active_power_control = "Unlimited"
+        # Set current inverter state to a watt-based limit so the applier must
+        # restore unlimited/100% export (issue #767).
+        live.huawei_inverter_active_power_control = "Limited to 100W"
 
         # Set up an inverter device ID so the write loop has something to call.
         cfg.huawei_solar_device_id_inverter_1 = "device_123"
@@ -149,9 +150,9 @@ class TestInverterPowerControlSafetyGate:
         )
         cfg.export_electricity_min_price = 1.0
 
-        # Make the HA state read return an entity indicating "Unlimited" (100 %).
+        # Make the HA state read return the same watt-limited entity.
         mock_state = MagicMock()
-        mock_state.state = "Unlimited"
+        mock_state.state = "Limited to 100W"
         sensor.hass.states.get.return_value = mock_state
 
         with (
@@ -165,8 +166,8 @@ class TestInverterPowerControlSafetyGate:
 
             mock_wv.return_value = ApplyResult(
                 entity_id="sensor.inverter_active_power_control",
-                desired=0,
-                actual=0,
+                desired=100,
+                actual=100,
                 status=ApplyStatus.OK,
                 attempts=1,
             )
@@ -188,10 +189,11 @@ class TestInverterPowerControlSafetyGate:
 
         live = _make_live(degraded_mode=DegradedMode.OK)
         live.export_electricity_price = 0.5
-        live.huawei_inverter_active_power_control = "Unlimited"
+        # Force a write by starting from a watt-limited state (legacy state).
+        live.huawei_inverter_active_power_control = "Limited to 100W"
 
         mock_state = MagicMock()
-        mock_state.state = "Unlimited"
+        mock_state.state = "Limited to 100W"
         sensor.hass.states.get.return_value = mock_state
 
         with (
@@ -205,13 +207,101 @@ class TestInverterPowerControlSafetyGate:
 
             mock_wv.return_value = ApplyResult(
                 entity_id="sensor.inverter_active_power_control",
-                desired=0,
-                actual=0,
+                desired=100,
+                actual=100,
                 status=ApplyStatus.OK,
                 attempts=1,
             )
             _summary = await async_apply_inverter_power_control(sensor, cfg, live)
 
+        mock_wv.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_low_export_price_does_not_block_pv_export(self):
+        """Below export_electricity_min_price the applier must not write a watt limit.
+
+        Regression test for issue #767: writing a grid feed-in limit of 0 W
+        (or any small watt value) below the price threshold blocks surplus PV
+        export as well as battery export.  The fix keeps the connection point
+        at unlimited/100% and gates battery export in the planner.
+        """
+        sensor = _make_sensor()
+        cfg = _make_cfg(read_only=False)
+        cfg.huawei_solar_device_id_inverter_1 = "device_abc"
+        cfg.huawei_solar_inverter_active_power_control = (
+            "sensor.inverter_active_power_control"
+        )
+        cfg.export_electricity_min_price = 0.22
+
+        live = _make_live(degraded_mode=DegradedMode.OK)
+        live.export_electricity_price = 0.10
+        # Inverter currently at unlimited; no write should happen.
+        live.huawei_inverter_active_power_control = "Unlimited"
+
+        mock_state = MagicMock()
+        mock_state.state = "Unlimited"
+        sensor.hass.states.get.return_value = mock_state
+
+        with (
+            patch(_LOGGER_PATCH, new_callable=MagicMock),
+            patch(
+                "custom_components.hsem.utils.huawei.async_set_grid_export_power_watt"
+            ) as mock_watt_write,
+            patch(
+                "custom_components.hsem.utils.huawei.async_set_grid_export_power_pct"
+            ) as mock_pct_write,
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_write_and_verify",
+                new_callable=AsyncMock,
+            ) as mock_wv,
+        ):
+            _summary = await async_apply_inverter_power_control(sensor, cfg, live)
+
+        mock_watt_write.assert_not_called()
+        mock_pct_write.assert_not_called()
+        mock_wv.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_low_export_price_restores_unlimited_from_watt_limit(self):
+        """If the inverter is stuck at a watt limit, restore unlimited even below min price."""
+        sensor = _make_sensor()
+        cfg = _make_cfg(read_only=False)
+        cfg.huawei_solar_device_id_inverter_1 = "device_abc"
+        cfg.huawei_solar_inverter_active_power_control = (
+            "sensor.inverter_active_power_control"
+        )
+        cfg.export_electricity_min_price = 0.22
+
+        live = _make_live(degraded_mode=DegradedMode.OK)
+        live.export_electricity_price = 0.10
+        live.huawei_inverter_active_power_control = "Limited to 0W"
+
+        mock_state = MagicMock()
+        mock_state.state = "Limited to 0W"
+        sensor.hass.states.get.return_value = mock_state
+
+        with (
+            patch(_LOGGER_PATCH, new_callable=MagicMock),
+            patch(
+                "custom_components.hsem.utils.huawei.async_set_grid_export_power_watt"
+            ) as mock_watt_write,
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_write_and_verify",
+                new_callable=AsyncMock,
+            ) as mock_wv,
+        ):
+            from custom_components.hsem.utils.inverter_verify import ApplyResult
+
+            mock_wv.return_value = ApplyResult(
+                entity_id="sensor.inverter_active_power_control",
+                desired=100,
+                actual=100,
+                status=ApplyStatus.OK,
+                attempts=1,
+            )
+            _summary = await async_apply_inverter_power_control(sensor, cfg, live)
+
+        mock_watt_write.assert_not_called()
         mock_wv.assert_called_once()
 
 
@@ -400,9 +490,7 @@ class TestBatterySettingsSafetyGate:
 
         rec = _make_rec(Recommendations.ForceBatteriesDischarge.value)
 
-        async def _run_writer_then_ok(
-            entity_id, desired, writer, reader, **kwargs
-        ):  # type: ignore[no-untyped-def]  # local test shim mirrors async_write_and_verify signature
+        async def _run_writer_then_ok(entity_id, desired, writer, reader, **kwargs):  # type: ignore[no-untyped-def]  # local test shim mirrors async_write_and_verify signature
             await writer()
             return ApplyResult(
                 entity_id=entity_id,
@@ -449,9 +537,7 @@ class TestBatterySettingsSafetyGate:
 
         rec = _make_rec(Recommendations.BatteriesChargeGrid.value)
 
-        async def _run_writer_then_ok(
-            entity_id, desired, writer, reader, **kwargs
-        ):  # type: ignore[no-untyped-def]  # local test shim mirrors async_write_and_verify signature
+        async def _run_writer_then_ok(entity_id, desired, writer, reader, **kwargs):  # type: ignore[no-untyped-def]  # local test shim mirrors async_write_and_verify signature
             await writer()
             return ApplyResult(
                 entity_id=entity_id,


### PR DESCRIPTION
## Summary

Fixes #767.

Below `export_electricity_min_price`, the applier was writing the inverter's grid feed-in limit to `GRID_EXPORT_LIMIT_WATT` (100 W). Because that register governs the **whole grid connection point**, it blocked surplus PV export as well as battery-to-grid export. Once the battery was full, generated solar energy had nowhere to go and was effectively curtailed.

This PR removes the physical grid throttle for **non-negative** prices. `export_electricity_min_price` becomes a planner-side battery-export floor only. The original protection against paying to export is preserved for **negative export prices**.

## What changed

### Applier (`custom_components/hsem/custom_sensors/applier.py`)
- `export_price < 0` → write a physical watt limit (`GRID_EXPORT_LIMIT_WATT`) to block all grid export, because exporting then costs money.
- `export_price >= 0` → keep the inverter at unlimited/100% export. Battery-to-grid export below `export_electricity_min_price` is gated planner-side.
- Restores unlimited/100% if the inverter is currently stuck in a watt limit (legacy state from before this fix).
- Logs a debug message when the price is below `export_electricity_min_price` but non-negative, making clear that PV export is still allowed.

### Planner
- `milp_optimizer.py` + new `planner/milp/_price_sanitise.py`: removed the blanket `export_min_price` clamp on all export prices. The combined floor `max(export_min_price, battery_export_min_price)` now only caps `ed[t]` on blocked slots.
- `cost_function.py`: removed the `export_min_price` blanket clamp on export revenue. PV export is counted at the live export price; only battery-destined export below `battery_export_min_price` is zeroed.
- `slot_population.py`: removed the `export_min_price` clamp in `populate_estimated_cost`.
- Updated docstrings/comments in `cost_types.py` and `discharge_scheduler.py`.

### Refactor for file-size compliance
- Extracted the MILP price-sanitisation block (NaN handling, battery-export floor mask, export-≤-import clamp, negative-import clamp) into a new submodule `planner/milp/_price_sanitise.py`. This keeps `milp_optimizer.py` under the 30 KB hard limit.

### Documentation
- Updated `docs/planner-spec.md`, `docs/planner-guide.md`, `docs/milp-optimization.md`, `docs/config-flow-reference.md`, and `.github/memories.md` to reflect that `export_min_price` is now a battery-export floor for non-negative prices, while negative prices still trigger a physical block.

### Tests
- Updated `tests/test_safety_gates.py` to expect unlimited/100% writes for non-negative prices and added a regression test for negative-price blocking.
- Updated `tests/planner/test_cost_function.py` for the new discharge-loss pricing behaviour.
- Added `test_pv_export_below_legacy_min_price_still_counts` in `tests/planner/test_battery_export_min_price.py`.

## Test results

```text
./scripts/quality.sh lint    → passed
./scripts/quality.sh typing  → passed
./scripts/quality.sh quality → passed
./scripts/quality.sh test    → 2529 passed, 4 warnings
```

File size check:
```text
27626 custom_components/hsem/planner/milp_optimizer.py
```

## Backward compatibility

- The default `export_electricity_min_price` is `-0.00`, so out-of-the-box behaviour is unchanged.
- Users who set a positive `export_electricity_min_price` will now see surplus PV export continue below that price when prices are non-negative.
- Negative export prices still trigger the physical block, preserving the original cost-protection intent.
- `battery_export_min_price` (issue #752) continues to work as a dedicated per-slot hard floor for intentional battery-to-grid export.

Fixes #767