### PR TITLE
fix(planner): use per-slot month for seasonal fill

### DIFF
--- a/custom_components/hsem/planner/discharge_scheduler.py
+++ b/custom_components/hsem/planner/discharge_scheduler.py
@@ -487,8 +487,14 @@ def apply_optimization_strategy(
        → ``ForceExport``
     2. Solar surplus → ``BatteriesChargeSolar`` (until battery full)
     3. Future forced export pending and battery above required → ``BatteriesWaitMode``
-    4. Winter month → ``BatteriesWaitMode``
-    5. Summer month with solar → ``BatteriesChargeSolar``; else ``BatteriesDischargeMode``
+    4. Slot's month is a winter month → ``BatteriesWaitMode``
+    5. Slot's month is a summer month with solar → ``BatteriesChargeSolar``;
+       else ``BatteriesDischargeMode``
+
+    The seasonal check (steps 4–5) uses each slot's own calendar month
+    (derived from ``rec.start``), not the month of ``now``.  This means a
+    planning horizon that crosses a season boundary (e.g. Aug 31 → Sep 1)
+    applies the correct seasonal strategy to every slot independently.
 
     Args:
         slots: Mutable list of planned slots.
@@ -511,7 +517,6 @@ def apply_optimization_strategy(
         required_capacity,
         export_min_price,
     )
-    current_month = now.month
     months_summer = [m for m in range(1, 13) if m not in months_winter]
 
     # ForceExport when export > import AND export >= export_min_price (A3 fix)
@@ -564,9 +569,13 @@ def apply_optimization_strategy(
             rec.recommendation = Recommendations.BatteriesWaitMode.value
             continue
 
-        if current_month in months_winter:
+        # Use the slot's own calendar month so that a horizon that
+        # crosses a season boundary (e.g. Aug 31 → Sep 1) applies the
+        # correct seasonal strategy to each slot independently.
+        slot_month = as_tz(rec.start, now.tzinfo).month
+        if slot_month in months_winter:
             rec.recommendation = Recommendations.BatteriesWaitMode.value
-        elif current_month in months_summer:
+        elif slot_month in months_summer:
             # Only charge from solar when there is an actual PV surplus
             # (negative net consumption).  A small positive house load
             # must not be treated as a solar-charging opportunity —

--- a/docs/planner-guide.md
+++ b/docs/planner-guide.md
@@ -443,15 +443,22 @@ recommendation it is not changed by later rules in the same layer.
 | 1 | Export price > import price AND export price ≥ `export_min_price` | `force_export` |
 | 2 | Actual PV surplus (`estimated_net_consumption_kwh < 0`) and battery not full | `batteries_charge_solar` |
 | 3 | Future `force_batteries_discharge` slot exists AND battery > required | `batteries_wait_mode` |
-| 4 | Winter month | `batteries_wait_mode` |
-| 5 | Summer month, actual PV surplus | `batteries_charge_solar` |
-| 5 | Summer month, no PV surplus (zero or positive net consumption) | `batteries_discharge_mode` |
+| 4 | Slot's month is a winter month | `batteries_wait_mode` |
+| 5 | Slot's month is a summer month, actual PV surplus | `batteries_charge_solar` |
+| 5 | Slot's month is a summer month, no PV surplus (zero or positive net consumption) | `batteries_discharge_mode` |
 
 > **Note:** `BatteriesChargeSolar` is only assigned when there is a genuine PV
 > surplus (negative net consumption).  A small positive house load with zero PV
 > must not be mislabeled as solar charging — that would cause the applier to
 > write `MaximizeSelfConsumption` instead of `TimeOfUse` + charge TOU
 > (issue #720).
+
+> **Per-slot season:** the seasonal check (priorities 4–5) uses each slot's own
+> calendar month (derived from the slot's `start` timestamp in the local
+> timezone), **not** the month of `now`.  A planning horizon that crosses a
+> season boundary (e.g. Aug 31 → Sep 1) therefore applies the correct seasonal
+> strategy to every slot independently — summer slots get discharge/solar and
+> winter slots get wait-mode, even within the same 48-hour plan.
 
 > **Wait mode behaviour:** the `batteries_wait_mode` recommendation normally keeps the
 > battery idle.  When `hsem_batteries_wait_mode_behavior` is set to

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -79,14 +79,21 @@ in the same layer must not change it.
 1. Export price > import price AND export price ≥ `export_min_price` → `force_export`
 2. Actual PV surplus (`estimated_net_consumption_kwh < 0`) and battery not full → `batteries_charge_solar`
 3. Future `force_batteries_discharge` AND battery > required → `batteries_wait_mode`
-4. Winter month → `batteries_wait_mode`
-5. Summer month, actual PV surplus → `batteries_charge_solar`; else → `batteries_discharge_mode`
+4. Slot's month is a winter month → `batteries_wait_mode`
+5. Slot's month is a summer month, actual PV surplus → `batteries_charge_solar`; else → `batteries_discharge_mode`
 
 > **Note:** `BatteriesChargeSolar` is only assigned when there is a genuine PV
 > surplus (negative net consumption).  A small positive house load with zero PV
 > must not be mislabeled as solar charging — that would cause the applier to
 > write `MaximizeSelfConsumption` instead of `TimeOfUse` + charge TOU
 > (issue #720).
+
+> **Per-slot season:** the seasonal check (steps 4–5) uses each slot's own
+> calendar month (derived from the slot's `start` timestamp in the local
+> timezone), **not** the month of `now`.  This means a planning horizon that
+> crosses a season boundary (e.g. Aug 31 → Sep 1) applies the correct seasonal
+> strategy to every slot independently — summer slots get discharge/solar and
+> winter slots get wait-mode, even within the same 48-hour plan.
 
 ### Layer 2 — EV planned load labelling (post-simulation)
 

--- a/tests/planner/test_seasonal_boundary.py
+++ b/tests/planner/test_seasonal_boundary.py
@@ -1,0 +1,241 @@
+"""Regression tests: seasonal fill must use each slot's own calendar month.
+
+Before the fix, ``apply_optimization_strategy`` computed ``current_month =
+now.month`` once and applied it to every slot in the horizon.  A 48-hour plan
+starting on Aug 31 (summer) would classify Sep 1 slots (winter) as summer,
+assigning ``BatteriesDischargeMode`` instead of ``BatteriesWaitMode``.
+
+After the fix, each slot's month is derived from ``rec.start`` (via
+``as_tz(rec.start, now.tzinfo).month``), so the seasonal boundary is
+respected mid-horizon.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, time, timedelta
+from zoneinfo import ZoneInfo
+
+from custom_components.hsem.models.battery_schedule_input import BatteryScheduleInput
+from custom_components.hsem.models.hourly_consumption_average import (
+    HourlyConsumptionAverage,
+)
+from custom_components.hsem.models.planned_slot import PlannedSlot
+from custom_components.hsem.models.planner_input import PlannerInput
+from custom_components.hsem.models.price_point import PricePoint
+from custom_components.hsem.models.solcast_slot import SolcastSlot
+from custom_components.hsem.planner import run_planner
+from custom_components.hsem.planner.discharge_scheduler import (
+    apply_optimization_strategy,
+)
+from custom_components.hsem.utils.prices import SlotPrice
+from custom_components.hsem.utils.recommendations import Recommendations
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TZ = ZoneInfo("Europe/Copenhagen")
+# September is winter for this test; August is summer.
+_MONTHS_WINTER = [1, 2, 3, 4, 9, 10, 11, 12]
+
+
+def _make_slot(start: datetime, net_consumption: float = 0.5) -> PlannedSlot:
+    """Return a minimal :class:`PlannedSlot` for unit-testing the seasonal fill."""
+    return PlannedSlot(
+        start=start,
+        end=start + timedelta(hours=1),
+        price=SlotPrice(import_price=0.20, export_price=0.05),
+        estimated_net_consumption_kwh=net_consumption,
+    )
+
+
+def _make_boundary_input() -> PlannerInput:
+    """48-hour plan starting Aug 31 (summer) crossing into Sep 1 (winter).
+
+    Flat prices (import > export), no PV, disabled schedules — the seasonal
+    fill is the only recommendation source.
+    """
+    prices = [
+        PricePoint(hour=h, import_price=0.20, export_price=0.05) for h in range(24)
+    ]
+    solar = [SolcastSlot(hour=h, pv_estimate=0.0) for h in range(24)]
+    consumption = [
+        HourlyConsumptionAverage(
+            hour=h, avg_1d=0.5, avg_3d=0.5, avg_7d=0.5, avg_14d=0.5
+        )
+        for h in range(24)
+    ]
+    disabled_schedules = [
+        BatteryScheduleInput(enabled=False, start=time(7, 0), end=time(9, 0)),
+        BatteryScheduleInput(enabled=False, start=time(17, 0), end=time(21, 0)),
+    ]
+
+    return PlannerInput(
+        now_iso="2024-08-31T00:00:00+02:00",
+        interval_minutes=60,
+        interval_length_hours=48,
+        battery_soc_pct=50.0,
+        battery_rated_capacity_kwh=10.0,
+        battery_end_of_discharge_soc_pct=10.0,
+        battery_max_charge_power_w=5000.0,
+        battery_purchase_price=0.0,
+        battery_expected_cycles=6000,
+        weight_1d=25,
+        weight_3d=30,
+        weight_7d=30,
+        weight_14d=15,
+        consumption_averages=consumption,
+        price_points=prices,
+        solcast_slots=solar,
+        battery_schedules=disabled_schedules,
+        excess_export_enabled=False,
+        excess_export_discharge_buffer_pct=10.0,
+        excess_export_price_threshold=0.10,
+        months_winter=_MONTHS_WINTER,
+        house_power_includes_ev=True,
+        is_read_only=True,
+    )
+
+
+# ===========================================================================
+# Unit tests — apply_optimization_strategy directly
+# ===========================================================================
+
+
+class TestSeasonalBoundaryUnit:
+    """``apply_optimization_strategy`` must use each slot's own calendar month."""
+
+    def test_aug31_summer_sep1_winter(self):
+        """Slots on Aug 31 (summer) → Discharge; Sep 1 (winter) → Wait.
+
+        ``now`` is Aug 31 (month 8, summer).  The old code used
+        ``now.month`` for every slot, so Sep 1 slots (month 9, winter)
+        would incorrectly get ``BatteriesDischargeMode``.
+        """
+        now = datetime(2024, 8, 31, 0, 0, tzinfo=_TZ)
+
+        aug31_slots = [_make_slot(now + timedelta(hours=h)) for h in range(24)]
+        sep1_slots = [_make_slot(now + timedelta(hours=24 + h)) for h in range(24)]
+        slots = aug31_slots + sep1_slots
+
+        apply_optimization_strategy(
+            slots=slots,
+            now=now,
+            current_capacity=5.0,
+            usable_capacity=9.0,
+            required_capacity=0.0,
+            months_winter=_MONTHS_WINTER,
+        )
+
+        for slot in aug31_slots:
+            assert (
+                slot.recommendation == Recommendations.BatteriesDischargeMode.value
+            ), (
+                f"Aug 31 slot {slot.start.isoformat()} should be "
+                f"BatteriesDischargeMode (summer), got {slot.recommendation}"
+            )
+
+        for slot in sep1_slots:
+            assert slot.recommendation == Recommendations.BatteriesWaitMode.value, (
+                f"Sep 1 slot {slot.start.isoformat()} should be "
+                f"BatteriesWaitMode (winter), got {slot.recommendation}"
+            )
+
+    def test_single_day_no_regression(self):
+        """A single-day plan (no boundary crossing) must behave as before.
+
+        All slots on Aug 31 (summer) → ``BatteriesDischargeMode``.
+        """
+        now = datetime(2024, 8, 31, 0, 0, tzinfo=_TZ)
+        slots = [_make_slot(now + timedelta(hours=h)) for h in range(24)]
+
+        apply_optimization_strategy(
+            slots=slots,
+            now=now,
+            current_capacity=5.0,
+            usable_capacity=9.0,
+            required_capacity=0.0,
+            months_winter=_MONTHS_WINTER,
+        )
+
+        for slot in slots:
+            assert (
+                slot.recommendation == Recommendations.BatteriesDischargeMode.value
+            ), (
+                f"Aug 31 slot {slot.start.isoformat()} should be "
+                f"BatteriesDischargeMode (summer), got {slot.recommendation}"
+            )
+
+    def test_winter_to_summer_boundary(self):
+        """Slots crossing from winter (Sep) to summer (Oct is not in this
+        test, but we verify the reverse: Sep winter → Oct would be summer).
+
+        Here we test Sep 30 (winter) → Oct 1 (winter by default, but we
+        override to make Oct summer) to verify the boundary works in both
+        directions.
+        """
+        # Make October summer: months_winter = [1,2,3,4,9,11,12]
+        months_winter = [1, 2, 3, 4, 9, 11, 12]
+        now = datetime(2024, 9, 30, 0, 0, tzinfo=_TZ)
+
+        sep30_slots = [_make_slot(now + timedelta(hours=h)) for h in range(24)]
+        oct1_slots = [_make_slot(now + timedelta(hours=24 + h)) for h in range(24)]
+        slots = sep30_slots + oct1_slots
+
+        apply_optimization_strategy(
+            slots=slots,
+            now=now,
+            current_capacity=5.0,
+            usable_capacity=9.0,
+            required_capacity=0.0,
+            months_winter=months_winter,
+        )
+
+        for slot in sep30_slots:
+            assert slot.recommendation == Recommendations.BatteriesWaitMode.value, (
+                f"Sep 30 slot {slot.start.isoformat()} should be "
+                f"BatteriesWaitMode (winter), got {slot.recommendation}"
+            )
+
+        for slot in oct1_slots:
+            assert (
+                slot.recommendation == Recommendations.BatteriesDischargeMode.value
+            ), (
+                f"Oct 1 slot {slot.start.isoformat()} should be "
+                f"BatteriesDischargeMode (summer), got {slot.recommendation}"
+            )
+
+
+# ===========================================================================
+# Integration tests — full run_planner pipeline
+# ===========================================================================
+
+
+class TestSeasonalBoundaryIntegration:
+    """The full planner pipeline must respect the seasonal boundary."""
+
+    def test_48h_boundary_produces_wait_mode_on_winter_day(self):
+        """A 48-hour plan crossing Aug 31 → Sep 1 must produce
+        ``BatteriesWaitMode`` slots on the winter day (Sep 1).
+
+        Before the fix, all slots were classified as summer (Aug), so
+        Sep 1 slots would all be ``BatteriesDischargeMode``.
+        """
+        result = run_planner(_make_boundary_input())
+        assert len(result.slots) == 48
+
+        sep1_slots = [s for s in result.slots if s.start.month == 9]
+        assert sep1_slots, "Expected Sep 1 slots in the 48-hour horizon"
+
+        wait_slots = [
+            s
+            for s in sep1_slots
+            if s.recommendation == Recommendations.BatteriesWaitMode.value
+        ]
+        assert wait_slots, (
+            "Sep 1 (winter) slots must include BatteriesWaitMode from the "
+            "seasonal fill.  Before the fix, all slots used now.month "
+            f"(Aug = summer) and got BatteriesDischargeMode.  "
+            f"Sep 1 recommendations: "
+            f"{[(s.start.hour, s.recommendation) for s in sep1_slots]}"
+        )


### PR DESCRIPTION
## Summary

The seasonal fill in `apply_optimization_strategy` computed `current_month = now.month` **once** and applied it to every slot in the planning horizon. A 48-hour plan starting **Aug 31 (summer)** classified **Sep 1 (winter)** slots as summer, assigning `BatteriesDischargeMode` instead of `BatteriesWaitMode`.

Each slot now uses its **own calendar month** (`as_tz(rec.start, now.tzinfo).month`), so a horizon that crosses a season boundary applies the correct seasonal strategy to every slot independently.

## Branch

`fix/planner-seasonal-per-slot-month`

## Files changed

| File | Change |
|---|---|
| `custom_components/hsem/planner/discharge_scheduler.py` | Removed single `current_month = now.month`; seasonal fill now derives `slot_month` from each slot's `start`. Updated docstring. |
| `docs/planner-spec.md` | Seasonal fill rules 4–5 now say "slot's month"; added "Per-slot season" note. |
| `docs/planner-guide.md` | Same table update + "Per-slot season" note. |
| `tests/planner/test_seasonal_boundary.py` | **New** — 3 unit tests (direct `apply_optimization_strategy`) + 1 integration test (`run_planner`). |

## What changed and why

**Before:**
```python
current_month = now.month          # computed once
...
if current_month in months_winter:  # same month for every slot
    rec.recommendation = Recommendations.BatteriesWaitMode.value
elif current_month in months_summer:
    ...
```

**After:**
```python
slot_month = as_tz(rec.start, now.tzinfo).month   # per-slot
if slot_month in months_winter:
    rec.recommendation = Recommendations.BatteriesWaitMode.value
elif slot_month in months_summer:
    ...
```

This was the **only** place in the planner where a `now`-derived calendar property was used to classify individual slots. A full scan of `planner/` (including `milp/`) confirmed:
- The MILP subpackage has **no** seasonal/month logic.
- `pre_charge.py`'s `today = now.date()` is a legitimate "current-day battery budget" concept (correct as-is).
- `engine_explanation.py` also reads `now.month`, but only for the human-readable `selected_strategy`/`constraints` summary — it does **not** drive slot recommendations, so it was left untouched to keep the change surgical.

## Tests added

`tests/planner/test_seasonal_boundary.py`:
- **`test_aug31_summer_sep1_winter`** — unit: Aug 31 slots → `BatteriesDischargeMode`, Sep 1 slots → `BatteriesWaitMode` (the exact regression).
- **`test_single_day_no_regression`** — unit: single-day plan behaves as before.
- **`test_winter_to_summer_boundary`** — unit: reverse boundary (Sep winter → Oct summer).
- **`test_48h_boundary_produces_wait_mode_on_winter_day`** — integration: full `run_planner` 48h Aug 31→Sep 1 plan produces `BatteriesWaitMode` on the winter day.

## Test and lint results

All four quality gates pass:

| Gate | Result |
|---|---|
| `./scripts/quality.sh lint` | ✅ 0 remaining |
| `./scripts/quality.sh typing` | ✅ no issues in 292 source files |
| `./scripts/quality.sh quality` | ✅ 0 errors, 0 warnings |
| `./scripts/quality.sh test` | ✅ 2537 passed |

## Known limitations / open questions

- `engine_explanation.py` (display-only `selected_strategy` / `constraints`) still uses `now.month`. For a boundary-crossing plan the summary would still say "summer" even though the winter day is correctly handled. Left untouched to keep this change surgical — can be addressed separately if desired.
- No tracked GitHub issue for this fix (the related #265 was a different string-containment month-matching bug, fixed in #330).

## Configuration changes

None.
