### PR TITLE
docs: mandate GitHub MCP tools, never the gh CLI

### DIFF
--- a/.agents/skills/hsem-pr-workflow/SKILL.md
+++ b/.agents/skills/hsem-pr-workflow/SKILL.md
@@ -57,10 +57,28 @@ fix(planner): correct cycle cost denominator — Fixes #444
 feat(sensor): add temperature-adaptive charge rate — Fixes #123
 ```
 
+## GitHub Operations — Use MCP Tools, Never the `gh` CLI (Mandatory)
+
+- **The `gh` CLI is NOT available in the devcontainer.** Do not shell out to `gh` for any
+  GitHub operation (PRs, issues, reviews, branches, releases, etc.).
+- **Always use the GitHub MCP tools** instead:
+  - Create a PR → `create_pull_request`
+  - Update a PR (title/body/draft/reviewers) → `update_pull_request`
+  - Read a PR / diff / files / reviews / comments → `pull_request_read`
+  - Review a PR → `pull_request_review_write` / `add_comment_to_pending_review`
+  - Create / update / close issues → `issue_write` / `issue_read`
+  - List / search issues & PRs → `list_issues` / `search_issues` / `search_pull_requests`
+  - Merge a PR → `merge_pull_request`
+  - Create / list branches → `create_branch` / `list_branches`
+  - Push files to a branch → `push_files`
+- **Local git is still fine** for `git add` / `git commit` / `git checkout` / `git push`
+  (pushing the branch over SSH). Only the *GitHub API* operations (PRs, issues, reviews)
+  must go through the MCP tools.
+
 ## Creating a PR
 
 ### PR Title
-Must follow Conventional Commits format: `<type>(<scope>): <description>`
+Must follow Conventional Commits format: `<type>(scope): <description>`
 
 ### PR Description Must Include
 - Summary of changes
@@ -91,22 +109,10 @@ After every follow-up commit on a branch that already has an open PR:
 
 ### How to Update a PR
 
-Always use a temp file for the body — never pass multiline body inline:
+Use the **`update_pull_request` MCP tool** — pass the full markdown body as the `body`
+argument. The MCP tool handles multiline content safely (no temp file, no shell escaping).
 
-```bash
-# Write PR body to a temp file first
-cat > /tmp/pr_body.md << 'EOF'
-<markdown body here>
-EOF
-
-# Edit the PR
-gh pr edit <PR_NUMBER> --title "<type>(scope): updated title" --body-file /tmp/pr_body.md
-
-# Clean up
-rm /tmp/pr_body.md
-```
-
-**Never use `--body "..."` with inline multiline text** — PowerShell corrupts newlines and backticks.
+**Never** shell out to `gh pr edit` — the `gh` CLI is not available in the devcontainer.
 
 ## Merge Rules
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,10 +63,26 @@ When asked to solve a GitHub issue, always follow these steps in order:
 12. **Keep the PR up to date** — after every follow-up commit on a branch that already has an open
     PR, update both the PR title and description to reflect the current state of all changes made.
     Tick off any completed acceptance criteria in the PR checklist.
-    - Use `gh pr edit <PR_NUMBER> --title "..." --body-file <file>` — write the PR body
-      to a temp file first, pass it with `--body-file`, then delete the file.
-    - **Never** pass a multiline body inline via `--body "..."`: PowerShell corrupts the
-      content (newlines become `∙` characters; backticks become `\x5c` escapes).
+    - Use the **`update_pull_request` MCP tool** to change the title and/or body. Pass the
+      full markdown body as the `body` argument — the MCP tool handles multiline content
+      safely (no temp file, no shell escaping).
+
+## GitHub Operations — Use MCP Tools, Never the `gh` CLI (Mandatory)
+- **The `gh` CLI is NOT available in the devcontainer.** Do not shell out to `gh` for any
+  GitHub operation (PRs, issues, reviews, branches, releases, etc.).
+- **Always use the GitHub MCP tools** instead:
+  - Create a PR → `create_pull_request`
+  - Update a PR (title/body/draft/reviewers) → `update_pull_request`
+  - Read a PR / diff / files / reviews / comments → `pull_request_read`
+  - Review a PR → `pull_request_review_write` / `add_comment_to_pending_review`
+  - Create / update / close issues → `issue_write` / `issue_read`
+  - List / search issues & PRs → `list_issues` / `search_issues` / `search_pull_requests`
+  - Merge a PR → `merge_pull_request`
+  - Create / list branches → `create_branch` / `list_branches`
+  - Push files to a branch → `push_files`
+- **Local git is still fine** for `git add` / `git commit` / `git checkout` / `git push`
+  (pushing the branch over SSH). Only the *GitHub API* operations (PRs, issues, reviews)
+  must go through the MCP tools.
 
 ## Planner Specification Rule (Mandatory)
 - **Always read `docs/planner-spec.md` before touching any planner code** — engine, cost

--- a/.github/memories.md
+++ b/.github/memories.md
@@ -1062,3 +1062,25 @@ Files involved: `flows/batteries_wait_mode.py`, `config_flow.py`,
 `options_flow.py`, `translations/en.json`, `const.py`,
 `models/sensor_config.py`, `custom_sensors/config_reader.py`,
 `custom_sensors/applier.py`.
+
+## GitHub Operations — MCP Tools Only, Never the `gh` CLI
+
+The `gh` CLI is **not available in the devcontainer**. All GitHub API operations
+must go through the GitHub MCP tools — never shell out to `gh`.
+
+| Operation | MCP tool |
+|---|---|
+| Create a PR | `create_pull_request` |
+| Update a PR (title/body/draft/reviewers) | `update_pull_request` |
+| Read a PR / diff / files / reviews / comments | `pull_request_read` |
+| Review a PR | `pull_request_review_write` / `add_comment_to_pending_review` |
+| Create / update / close issues | `issue_write` / `issue_read` |
+| List / search issues & PRs | `list_issues` / `search_issues` / `search_pull_requests` |
+| Merge a PR | `merge_pull_request` |
+| Create / list branches | `create_branch` / `list_branches` |
+| Push files to a branch | `push_files` |
+
+**Local `git` is still fine** for `git add` / `git commit` / `git checkout` / `git push`
+(pushing the branch over SSH). Only the *GitHub API* operations (PRs, issues, reviews)
+must use the MCP tools. The `update_pull_request` tool accepts the full markdown body
+as the `body` argument — no temp file or shell escaping needed.

--- a/.github/skills/hsem-pr-workflow/SKILL.md
+++ b/.github/skills/hsem-pr-workflow/SKILL.md
@@ -57,10 +57,28 @@ fix(planner): correct cycle cost denominator — Fixes #444
 feat(sensor): add temperature-adaptive charge rate — Fixes #123
 ```
 
+## GitHub Operations — Use MCP Tools, Never the `gh` CLI (Mandatory)
+
+- **The `gh` CLI is NOT available in the devcontainer.** Do not shell out to `gh` for any
+  GitHub operation (PRs, issues, reviews, branches, releases, etc.).
+- **Always use the GitHub MCP tools** instead:
+  - Create a PR → `create_pull_request`
+  - Update a PR (title/body/draft/reviewers) → `update_pull_request`
+  - Read a PR / diff / files / reviews / comments → `pull_request_read`
+  - Review a PR → `pull_request_review_write` / `add_comment_to_pending_review`
+  - Create / update / close issues → `issue_write` / `issue_read`
+  - List / search issues & PRs → `list_issues` / `search_issues` / `search_pull_requests`
+  - Merge a PR → `merge_pull_request`
+  - Create / list branches → `create_branch` / `list_branches`
+  - Push files to a branch → `push_files`
+- **Local git is still fine** for `git add` / `git commit` / `git checkout` / `git push`
+  (pushing the branch over SSH). Only the *GitHub API* operations (PRs, issues, reviews)
+  must go through the MCP tools.
+
 ## Creating a PR
 
 ### PR Title
-Must follow Conventional Commits format: `<type>(<scope>): <description>`
+Must follow Conventional Commits format: `<type>(scope): <description>`
 
 ### PR Description Must Include
 - Summary of changes
@@ -91,22 +109,10 @@ After every follow-up commit on a branch that already has an open PR:
 
 ### How to Update a PR
 
-Always use a temp file for the body — never pass multiline body inline:
+Use the **`update_pull_request` MCP tool** — pass the full markdown body as the `body`
+argument. The MCP tool handles multiline content safely (no temp file, no shell escaping).
 
-```bash
-# Write PR body to a temp file first
-cat > /tmp/pr_body.md << 'EOF'
-<markdown body here>
-EOF
-
-# Edit the PR
-gh pr edit <PR_NUMBER> --title "<type>(scope): updated title" --body-file /tmp/pr_body.md
-
-# Clean up
-rm /tmp/pr_body.md
-```
-
-**Never use `--body "..."` with inline multiline text** — PowerShell corrupts newlines and backticks.
+**Never** shell out to `gh pr edit` — the `gh` CLI is not available in the devcontainer.
 
 ## Merge Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,6 +252,24 @@ Before creating a commit, the agent MUST report the result of:
 
 ## Pull Request Guidelines
 
+### GitHub Operations — Use MCP Tools, Never the `gh` CLI (Mandatory)
+
+- **The `gh` CLI is NOT available in the devcontainer.** Do not shell out to `gh` for any
+  GitHub operation (PRs, issues, reviews, branches, releases, etc.).
+- **Always use the GitHub MCP tools** instead:
+  - Create a PR → `create_pull_request`
+  - Update a PR (title/body/draft/reviewers) → `update_pull_request`
+  - Read a PR / diff / files / reviews / comments → `pull_request_read`
+  - Review a PR → `pull_request_review_write` / `add_comment_to_pending_review`
+  - Create / update / close issues → `issue_write` / `issue_read`
+  - List / search issues & PRs → `list_issues` / `search_issues` / `search_pull_requests`
+  - Merge a PR → `merge_pull_request`
+  - Create / list branches → `create_branch` / `list_branches`
+  - Push files to a branch → `push_files`
+- **Local git is still fine** for `git add` / `git commit` / `git checkout` / `git push`
+  (pushing the branch over SSH). Only the *GitHub API* operations (PRs, issues, reviews)
+  must go through the MCP tools.
+
 **REQUIRED: Code Quality Before Submission**
 
 Before submitting a PR, the agent MUST:
@@ -282,10 +300,10 @@ PR after every meaningful commit:
 - **Description** — reflect every change made since the PR was opened: new files, updated logic,
   additional tests, and any acceptance criteria that were added or completed.
 - **Checklist** — tick off acceptance criteria that are now satisfied.
-- Use `gh pr edit --body-file <file>` to apply updates — write the PR body to a
-  temporary file first and pass the path via `--body-file`. **Never** use `--body "..."`
-  with an inline multiline string: this corrupts content in PowerShell (newlines become
-  `∙` and backticks become `\x5c`). Delete the temp file after the command succeeds.
+- Use the **`update_pull_request` MCP tool** to apply updates — pass the full markdown
+  body as the `body` argument. The MCP tool handles multiline content safely (no temp
+  file, no shell escaping). **Never** shell out to `gh pr edit` — the `gh` CLI is not
+  available in the devcontainer.
 - Do NOT leave the PR description stale after follow-up commits.
 
 Before merging any PR, the agent MUST ensure:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,17 +142,18 @@ git status
 # 9. Commit with conventional commit format
 git commit -m "feat(scope): description - Fixes #<ISSUE_NUMBER>"
 
-# 10. Push and create PR (do not merge)
+# 10. Push the branch (local git over SSH)
 git push origin feat/<issue-number>-<description>
 
-# 11. If the PR already exists and you make further commits, update it
-#     Write the body to a file first, then pass --body-file (shell-agnostic):
-Set-Content -Path pr_body.md -Value @"
-<markdown body here>
-"@
-gh pr edit <PR_NUMBER> --title "<type>(scope): updated title" --body-file pr_body.md
-Remove-Item pr_body.md
+# 11. Create the PR with the GitHub MCP tool (NOT the `gh` CLI — it is not
+#     available in the devcontainer). Pass the full markdown body as the `body`
+#     argument to `create_pull_request`.
 ```
+
+> **GitHub operations use MCP tools, never the `gh` CLI.** The `gh` CLI is not
+> available in the devcontainer. Use `create_pull_request`, `update_pull_request`,
+> `pull_request_read`, `issue_write`/`issue_read`, `search_issues`,
+> `merge_pull_request`, etc. Local `git` (add/commit/checkout/push) is still fine.
 
 ### Keeping an Open PR Up to Date
 
@@ -163,9 +164,10 @@ Whenever you push additional commits to a branch that already has an open PR:
    additional tests, and any newly satisfied acceptance criteria.
 3. Tick off completed items in any checklist inside the PR description.
 4. Never leave the PR description stale after follow-up commits.
-5. **Always write the PR body to a temporary file and use `gh pr edit --body-file`.**
-   Never pass a multiline body inline via `--body "..."` — this corrupts the content
-   in PowerShell (produces `∙` instead of newlines and `\x5c` instead of backticks).
+5. **Use the `update_pull_request` MCP tool** — pass the full markdown body as the `body`
+   argument. The MCP tool handles multiline content safely (no temp file, no shell
+   escaping). **Never** shell out to `gh pr edit` — the `gh` CLI is not available in the
+   devcontainer.
 
 ## Home Assistant Compliance
 


### PR DESCRIPTION
## Summary

The `gh` CLI is **not available in the devcontainer**, yet several agent instruction and memory files still told the agent to shell out to `gh pr edit` (with temp-file workarounds for multiline bodies). This PR updates all of them to **mandate the GitHub MCP tools** for every GitHub API operation, and to keep local `git` only for `add` / `commit` / `checkout` / `push`.

## Branch

`chore/docs-mcp-tools-only`

## Files changed

| File | Change |
|---|---|
| `AGENTS.md` | Added "GitHub Operations — Use MCP Tools, Never the `gh` CLI" rule; replaced `gh pr edit --body-file` guidance with `update_pull_request` MCP tool. |
| `CLAUDE.md` | Replaced the `gh pr edit` workflow step + "How to Update a PR" temp-file guidance with MCP-tool guidance; added a callout. |
| `.github/copilot-instructions.md` | Replaced `gh pr edit` step with `update_pull_request`; added a new mandatory "GitHub Operations" section with the full tool mapping. |
| `.github/memories.md` | Added a "GitHub Operations — MCP Tools Only" section with an operation→tool table. |
| `.agents/skills/hsem-pr-workflow/SKILL.md` | Added the mandatory MCP-tools section; replaced the `gh pr edit` temp-file block with `update_pull_request`. |
| `.github/skills/hsem-pr-workflow/SKILL.md` | Same as above (kept in sync with the `.agents` copy). |

## What changed and why

Every file now states, in one place:

- **The `gh` CLI is NOT available in the devcontainer** — do not shell out to it.
- **Always use the GitHub MCP tools** for PRs, issues, reviews, branches, and releases, with an explicit operation→tool mapping (`create_pull_request`, `update_pull_request`, `pull_request_read`, `pull_request_review_write`, `issue_write`/`issue_read`, `search_issues`, `merge_pull_request`, `create_branch`/`list_branches`, `push_files`).
- **Local `git` is still fine** for `add` / `commit` / `checkout` / `push` (pushing the branch over SSH) — only the GitHub *API* operations must go through MCP.
- The `update_pull_request` tool accepts the full markdown body as the `body` argument, so the old temp-file / `--body-file` / PowerShell-corruption workarounds are no longer needed.

## Tests

Docs/instructions only — no code changes, no test impact.

## Known limitations / open questions

None.

## Configuration changes

None.
