### PR TITLE
fix(ml): align consumption history and tracking time

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -1084,3 +1084,28 @@ must go through the GitHub MCP tools — never shell out to `gh`.
 (pushing the branch over SSH). Only the *GitHub API* operations (PRs, issues, reviews)
 must use the MCP tools. The `update_pull_request` tool accepts the full markdown body
 as the `body` argument — no temp file or shell escaping needed.
+
+## Fork Divergence — `Ambilights/hsem-ambilights` Is Not Back-Portable
+
+The AGPL fork `Ambilights/hsem-ambilights` (v7.x) **diverged** from this repo at
+commit `dd8db6ec` (2026-08-11). It is not a linear descendant, so its numbered
+"fix" PRs cannot be cherry-picked onto `main` — they are layered on fork-only
+architecture that does not exist here. Before re-attempting any port, remember:
+
+| Fork PR | Subject | Status for `main` |
+|---|---|---|
+| #5 | ENTSO-E published-price backup | **Feature**, not a fix; new provider. Not needed — no request. |
+| #7 | Remove unused controls + embedded OCPP | **Removal** — explicitly rejected (upstream ships OCPP, schedules, charge-rate learner). |
+| #9 / #22 | PowMr site-attribution / control stability | **Feature** — `origin/main` has no PowMr/secondary-storage subsystem at all. N/A. |
+| #11 | ML history ↔ tracking time | **Ported** (ML core + DST-fold `slot_key` prerequisite). |
+| #13 | Bound terminal inventory at price boundary | Coupled to fork-only `future_value.py`/`_solver_execution.py`/`secondary_storage.py`/`price_forecast.py`. |
+| #15 | Group export-reserve checkpoints | Refines fork-only `_export_reserve.py`; upstream has no export-reserve concept. N/A. |
+| #17 | Harden MILP bounds layout | Core idea **ported natively** as a `len(bounds) == n_vars` fail-fast guard. |
+| #19 | Reject unavailable load + stale solves | Load fail-closed **ported natively**; the authority-generation rollback requires the fork coordinator rewrite. |
+| #21 | Coalesce boundary price refreshes | Requires the fork's forecast-authority-generation machinery (authority `generation` counter). |
+
+**Decision:** `origin/main` remains the baseline. Port only self-contained,
+upstream-relevant *fixes*; re-implement concrete bugs natively (with regression
+tests), never import the fork's v7 planner/coordinator architecture. ENTSO-E and
+PowMr are provider/hardware *features* and stay out unless an explicit request
+arrives.

--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import math
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
@@ -238,6 +239,100 @@ def _apply_force_charge_now(
             "→ overriding current slot to ev_smart_charging at %dW",
             now_slot.ev_second_charger_calculated_power,
         )
+
+
+# ---------------------------------------------------------------------------
+# Load-forecast fail-closed hold helper
+# ---------------------------------------------------------------------------
+
+#: Live house demand above this wattage is treated as a genuine, non-zero load
+#: that an all-zero consumption profile cannot explain.
+_LOAD_FORECAST_LIVE_DEMAND_THRESHOLD_W = 50.0
+#: Epsilon used to treat a consumption value as numerically zero.
+_LOAD_FORECAST_ZERO_EPSILON_KWH = 1e-9
+
+
+def _apply_load_forecast_hold(
+    recommendations: list[HourlyRecommendation],
+    live: LiveState,
+    now: datetime,
+    *,
+    consumption_ok: bool,
+) -> HourlyRecommendation | None:
+    """Publish a strict current-slot storage hold when load data is unsafe.
+
+    If consumption averages failed to populate, or the entire future profile
+    is numerically zero while live house demand is clearly positive, the
+    planner must not solve or reuse a plan sized on fictional zero load.  In
+    that case the current slot is held in :attr:`BatteriesWaitMode` with zero
+    charge/discharge motion, which the applier treats as a safe storage hold.
+
+    A user-forced working mode always wins over this automatic safety hold.
+
+    Args:
+        recommendations: The hourly recommendations to modify (current slot).
+        live: Live entity state snapshot.
+        now: Current time (timezone-aware).
+        consumption_ok: Whether consumption averages populated successfully.
+
+    Returns:
+        The held current slot, or ``None`` when no hold is applied.
+    """
+    if consumption_ok and _future_consumption_profile_is_nonzero(recommendations, now):
+        return None
+    if str(live.force_working_mode_state).strip().lower() != "auto":
+        return None
+
+    current = next(
+        (
+            rec
+            for rec in recommendations
+            if as_tz(rec.start, now.tzinfo) <= now < as_tz(rec.end, now.tzinfo)
+        ),
+        None,
+    )
+    if current is None:
+        return None
+
+    current.recommendation = Recommendations.BatteriesWaitMode.value
+    current.batteries_charged_kwh = 0.0
+    current.batteries_discharged_kwh = 0.0
+    return current
+
+
+def _future_consumption_profile_is_nonzero(
+    recommendations: list[HourlyRecommendation],
+    now: datetime,
+) -> bool:
+    """Return whether at least one future slot carries a positive load estimate.
+
+    Used to distinguish a legitimate measured-zero night from an all-zero
+    profile produced by a failed or not-yet-ready consumption source.
+    """
+    return any(
+        math.isfinite(rec.avg_house_consumption_kwh)
+        and rec.avg_house_consumption_kwh > _LOAD_FORECAST_ZERO_EPSILON_KWH
+        and as_tz(rec.end, now.tzinfo) > now
+        for rec in recommendations
+    )
+
+
+def _live_demand_contradicts_zero_profile(
+    recommendations: list[HourlyRecommendation],
+    live: LiveState,
+    now: datetime,
+) -> bool:
+    """Return whether live demand disproves an all-zero future load profile."""
+    if _future_consumption_profile_is_nonzero(recommendations, now):
+        return False
+    demand_w = live.house_consumption_power_w
+    if demand_w is None or isinstance(demand_w, bool):
+        return False
+    try:
+        demand = float(demand_w)
+    except TypeError, ValueError:
+        return False
+    return math.isfinite(demand) and demand > _LOAD_FORECAST_LIVE_DEMAND_THRESHOLD_W
 
 
 # ---------------------------------------------------------------------------
@@ -1222,6 +1317,28 @@ class HSEMDataUpdateCoordinator(DataUpdateCoordinator[CoordinatorData]):
                     ev_second_plan=self._ev_second_charging_plan,
                     now=now,
                 )
+
+                # 8d. Load-forecast fail-closed hold.  When consumption data is
+                # unavailable/invalid, or the entire future profile is zero
+                # while live demand is clearly positive, hold the current slot
+                # in BatteriesWaitMode instead of solving or reusing a plan
+                # sized on fictional zero load.  A forced mode always wins.
+                if not consumption_ok or _live_demand_contradicts_zero_profile(
+                    self._hourly_recommendations, live, now
+                ):
+                    held = _apply_load_forecast_hold(
+                        self._hourly_recommendations,
+                        live,
+                        now,
+                        consumption_ok=consumption_ok,
+                    )
+                    if held is not None:
+                        async_log(
+                            "debug",
+                            "[load] consumption_ok=%s → holding current slot in "
+                            "batteries_wait_mode",
+                            consumption_ok,
+                        )
 
                 # 9. Find the current time-slot recommendation.
                 self._hourly_recommendations.sort(key=lambda x: x.start)

--- a/custom_components/hsem/ml/consumption_predictor.py
+++ b/custom_components/hsem/ml/consumption_predictor.py
@@ -5,18 +5,22 @@ regression on mixed categorical (DOW, slot) and continuous (day-of-year,
 temperature) features.  L2 regularization naturally handles data sparsity.
 
 Features (index order):
-  0 .. 6*S-1    one-hot (DOW, slot)     — 672 for 15-min
-  6*S, 6*S+1    sin/cos day-of-year      — seasonality
-  6*S+2         temperature (optional)   — weather-driven load
+  0 .. 7*S-1    one-hot (DOW, slot)     — 672 for 15-min
+  7*S, 7*S+1    sin/cos day-of-year      — seasonality
+  7*S+2         temperature (optional)   — weather-driven load
 """
 
 from __future__ import annotations
 
 import math
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import override
 
 import numpy as np
+
+type _SampleFingerprint = tuple[
+    datetime, int, int, int, float, float | None, float | None
+]
 
 
 class ConsumptionPredictor:
@@ -35,7 +39,8 @@ class ConsumptionPredictor:
         decay_days: Exponential time-decay half-life in days.
         alpha: L2 regularization strength.
         slots_per_day: Number of time slots per 24h day.
-        retrain_min_new_samples: Minimum new samples before refitting.
+        retrain_min_new_samples: Minimum unseen or revised valid samples
+            since the last fit before refitting.
         use_temperature: Whether to include temperature as a feature.
     """
 
@@ -56,10 +61,10 @@ class ConsumptionPredictor:
         self._use_sequential = use_sequential
 
         # Feature layout:
-        #   0 .. 6*S-1  = one-hot DOW×slot
-        #   6*S, 6*S+1  = sin/cos day-of-year
-        #   6*S+2       = temperature (if use_temperature)
-        #   6*S+3       = lag feature (prev slot energy, if use_sequential)
+        #   0 .. 7*S-1  = one-hot DOW×slot
+        #   7*S, 7*S+1  = sin/cos day-of-year
+        #   7*S+2       = temperature (if use_temperature)
+        #   7*S+3       = lag feature (prev slot energy, if use_sequential)
         self._n_onehot = 7 * slots_per_day
         self._doy_offset = self._n_onehot
         self._temp_offset = self._n_onehot + 2
@@ -79,8 +84,16 @@ class ConsumptionPredictor:
 
         self._last_fit_samples: int = 0
         self._last_fit_time: datetime | None = None
+        self._last_fit_fingerprints: set[_SampleFingerprint] = set()
         #: Actual calendar days spanned by the input history (set by populator).
         self.actual_history_days: float = 0.0
+        #: Effective source/configuration used for the fitted coefficients.
+        #: The populator replaces the predictor whenever this changes so the
+        #: retrain gate cannot retain coefficients from another
+        #: entity, net/gross mode, interval, or history context.
+        self.training_context: (
+            tuple[str, str | None, bool, int, int, str | None] | None
+        ) = None
 
     @property
     def days_of_history(self) -> float:
@@ -116,6 +129,18 @@ class ConsumptionPredictor:
         """
         if reference_time is None:
             reference_time = datetime.now().astimezone()
+        reference_aware = (
+            reference_time
+            if reference_time.tzinfo is not None
+            else reference_time.astimezone()
+        )
+
+        def as_aware(timestamp: datetime) -> datetime:
+            return (
+                timestamp
+                if timestamp.tzinfo is not None
+                else timestamp.replace(tzinfo=reference_aware.tzinfo)
+            )
 
         n = len(history)
         if n < 2:
@@ -130,18 +155,28 @@ class ConsumptionPredictor:
         temps = temperatures or {}
         self._raw_groups.clear()
 
-        # For sequential mode: track previous slot's energy as lag feature.
+        # Sequential lag follows physical time, not wall-clock slot order.
+        slot_duration = timedelta(minutes=1440 // self._slots_per_day)
         prev_energy = 0.0
+        prev_timestamp_utc: datetime | None = None
+        valid_fingerprints: set[_SampleFingerprint] = set()
 
         valid = 0
-        for ts, slot, energy in history:
+        ordered_history = sorted(
+            history,
+            key=lambda sample: as_aware(sample[0]).astimezone(UTC),
+        )
+        for ts, slot, energy in ordered_history:
             if slot < 0 or slot >= self._slots_per_day:
                 continue
-            if energy <= 0:
+            if not math.isfinite(energy) or energy <= 0:
                 continue
 
-            ts_aware = ts if ts.tzinfo is not None else ts.astimezone()
-            age_days = (reference_time - ts_aware).total_seconds() / 86400.0
+            ts_aware = as_aware(ts)
+            ts_utc = ts_aware.astimezone(UTC)
+            age_days = (
+                reference_aware.astimezone(UTC) - ts_utc
+            ).total_seconds() / 86400.0
             if age_days < 0:
                 continue
 
@@ -159,6 +194,7 @@ class ConsumptionPredictor:
             X[valid, self._doy_offset + 1] = math.cos(2 * math.pi * doy / 365.0)
 
             # Temperature feature.
+            temperature_value: float | None = None
             if self._use_temperature:
                 # Match temperature by slot-start timestamp (nearest).
                 slot_start = ts_aware.replace(
@@ -167,28 +203,53 @@ class ConsumptionPredictor:
                     second=0,
                     microsecond=0,
                 )
-                temp_val = self._lookup_temperature(temps, slot_start)
-                X[valid, self._temp_offset] = temp_val
+                temperature_value = self._lookup_temperature(temps, slot_start)
+                X[valid, self._temp_offset] = temperature_value
 
-            # Lag feature: previous slot's energy.
+            # A lag is valid only across one exact physical interval.  Reset
+            # after recorder gaps, rejected readings, and accumulator resets.
+            lag_value: float | None = None
             if self._use_sequential:
-                X[valid, self._lag_offset] = prev_energy
+                is_contiguous = (
+                    prev_timestamp_utc is not None
+                    and ts_utc - prev_timestamp_utc == slot_duration
+                )
+                lag_value = prev_energy if is_contiguous else 0.0
+                X[valid, self._lag_offset] = lag_value
+
+            # Fingerprint every input that can change this sample's feature
+            # row or target.  UTC identifies the physical observation while
+            # local calendar fields preserve the model's HA-local features.
+            valid_fingerprints.add(
+                (
+                    ts_utc,
+                    dow,
+                    doy,
+                    slot,
+                    float(energy),
+                    temperature_value,
+                    lag_value,
+                )
+            )
 
             y[valid] = energy
             w[valid] = math.exp(-age_days / max(self._decay_days, 0.5))
             prev_energy = energy
+            prev_timestamp_utc = ts_utc
             valid += 1
 
         if valid < 2:
             self._coef = None
             return
 
-        # Retrain gate.
-        new_samples = valid - self._last_fit_samples
+        # Retrain only after enough genuinely new or revised valid samples.
+        # A rolling history often keeps a constant length, so sample count
+        # alone cannot detect that old observations slid out and new ones in.
+        changed_samples = len(valid_fingerprints - self._last_fit_fingerprints)
         if (
             self._coef is not None
-            and self._last_fit_samples > 0
-            and new_samples < self._retrain_min_new
+            and self._last_fit_fingerprints
+            and changed_samples < self._retrain_min_new
         ):
             self._X = X[:valid]
             self._y = y[:valid]
@@ -203,6 +264,8 @@ class ConsumptionPredictor:
         self._y = y
         self._w = w
         self._fit(X, y, w)
+        self._last_fit_time = reference_aware
+        self._last_fit_fingerprints = valid_fingerprints
 
     def predict(
         self,
@@ -263,38 +326,48 @@ class ConsumptionPredictor:
 
     def predict_sequential(
         self,
-        day_offset: int = 0,
-        reference_time: datetime | None = None,
-        temperatures: dict[int, float] | None = None,
-    ) -> dict[int, float]:
-        """Predict all slots sequentially, feeding each prediction as lag input.
+        slot_starts: list[datetime],
+        temperatures: dict[datetime, float] | None = None,
+    ) -> dict[datetime, float]:
+        """Predict recommendation slots in physical order with a lag chain.
 
-        Slot 0 is predicted with prev_energy=0.  Slot 1 uses slot 0's
-        prediction as its lag feature, and so on.  This captures intra-day
-        momentum that independent per-slot predictions miss.
+        The caller supplies the real HA-local recommendation timestamps.
+        Canonical UTC keys keep both autumn folds distinct, while physical
+        ordering skips nonexistent spring wall slots.  Any physical gap
+        resets the lag instead of joining unrelated observations.
         """
         if self._coef is None:
             return {}
 
-        if reference_time is None:
-            reference_time = datetime.now().astimezone()
-
-        target_date = reference_time.date() + timedelta(days=day_offset)
         temps = temperatures or {}
+        slot_minutes = 1440 // self._slots_per_day
+        slot_duration = timedelta(minutes=slot_minutes)
         prev = 0.0
+        prev_timestamp_utc: datetime | None = None
 
-        result: dict[int, float] = {}
-        for s in range(self._slots_per_day):
-            slot_dt = datetime(
-                target_date.year,
-                target_date.month,
-                target_date.day,
-                tzinfo=reference_time.tzinfo,
-            ) + timedelta(minutes=s * (1440 // self._slots_per_day))
-            temp_val = temps.get(s)
-            pred = float(self._predict_from_features(slot_dt, s, temp_val, prev))
-            result[s] = pred
+        # De-duplicate only identical physical instants.  Repeated local wall
+        # slots on an autumn DST day have different UTC keys and survive.
+        physical_slots: dict[datetime, datetime] = {}
+        for timestamp in slot_starts:
+            aware = (
+                timestamp if timestamp.tzinfo is not None else timestamp.astimezone()
+            )
+            physical_slots[aware.astimezone(UTC)] = aware
+
+        result: dict[datetime, float] = {}
+        for physical_start in sorted(physical_slots):
+            slot_dt = physical_slots[physical_start]
+            slot = (slot_dt.hour * 60 + slot_dt.minute) // slot_minutes
+            temp_val = self._lookup_temperature(temps, slot_dt) if temps else None
+            is_contiguous = (
+                prev_timestamp_utc is not None
+                and physical_start - prev_timestamp_utc == slot_duration
+            )
+            lag = prev if is_contiguous else 0.0
+            pred = float(self._predict_from_features(slot_dt, slot, temp_val, lag))
+            result[physical_start] = pred
             prev = pred
+            prev_timestamp_utc = physical_start
         return result
 
     def predict_all_slots(
@@ -350,7 +423,11 @@ class ConsumptionPredictor:
             2 * math.pi * doy / 365.0
         )
 
-        if self._use_temperature and temperature is not None:
+        if (
+            self._use_temperature
+            and temperature is not None
+            and math.isfinite(temperature)
+        ):
             pred += float(self._coef[self._temp_offset]) * temperature
 
         if self._use_sequential:
@@ -439,7 +516,6 @@ class ConsumptionPredictor:
         self._coef = coef
 
         self._last_fit_samples = X.shape[0]
-        self._last_fit_time = datetime.now().astimezone()
 
     def _weighted_std(self, samples: list[tuple[float, float]]) -> float:
         """Compute time-decay weighted standard deviation."""
@@ -462,15 +538,28 @@ class ConsumptionPredictor:
         temperatures: dict[datetime, float],
         target: datetime,
     ) -> float:
-        """Find the temperature closest to the target timestamp."""
-        if not temperatures:
+        """Find the temperature closest to the target physical timestamp."""
+        finite_temperatures = [
+            (timestamp, value)
+            for timestamp, value in temperatures.items()
+            if math.isfinite(value)
+        ]
+        if not finite_temperatures:
             return 0.0
-        best = min(
-            temperatures.keys(),
-            key=lambda t: abs((t - target).total_seconds()),
-            default=target,
-        )
-        return temperatures.get(best, 0.0)
+        target_aware = target if target.tzinfo is not None else target.astimezone()
+        target_utc = target_aware.astimezone(UTC)
+
+        def physical_distance(item: tuple[datetime, float]) -> float:
+            timestamp = item[0]
+            aware = (
+                timestamp
+                if timestamp.tzinfo is not None
+                else timestamp.replace(tzinfo=target_aware.tzinfo)
+            )
+            return abs((aware.astimezone(UTC) - target_utc).total_seconds())
+
+        _best_timestamp, best_value = min(finite_temperatures, key=physical_distance)
+        return best_value
 
     # ------------------------------------------------------------------
     # Properties
@@ -489,6 +578,29 @@ class ConsumptionPredictor:
     @property
     def slots_per_day(self) -> int:
         return self._slots_per_day
+
+    @property
+    def decay_days(self) -> float:
+        """Return the current exponential time-decay half-life in days."""
+        return self._decay_days
+
+    @decay_days.setter
+    def decay_days(self, value: float) -> None:
+        """Refresh decay for a reused predictor before its next training pass."""
+        if not math.isfinite(value) or value <= 0:
+            msg = "decay_days must be finite and positive"
+            raise ValueError(msg)
+        self._decay_days = value
+
+    @property
+    def use_temperature(self) -> bool:
+        """Return whether the fitted feature layout includes temperature."""
+        return self._use_temperature
+
+    @property
+    def use_sequential(self) -> bool:
+        """Return whether the fitted feature layout includes the lag feature."""
+        return self._use_sequential
 
     @property
     def last_fit_time(self) -> datetime | None:

--- a/custom_components/hsem/ml/history_reader.py
+++ b/custom_components/hsem/ml/history_reader.py
@@ -10,6 +10,7 @@ loop responsive.
 
 from __future__ import annotations
 
+import math
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -19,6 +20,13 @@ from homeassistant.components.recorder import (
 from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.core import HomeAssistant
 
+from custom_components.hsem.utils.datetime_utils import (
+    normalize_datetime,
+    normalize_slot_start,
+    now as hsem_now,
+    slot_key,
+    utc_key,
+)
 from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
 
 # ---------------------------------------------------------------------------
@@ -89,8 +97,9 @@ class HistoryReader:
             ``slot_index`` is 0-based within the day (0 = 00:00-00:15 for
             15-min slots, up to 95 = 23:45-00:00).
         """
-        now = datetime.now().astimezone()
-        start_time = now - timedelta(days=max_days)
+        now = hsem_now()
+        end_time = utc_key(now)
+        start_time = end_time - timedelta(days=max_days)
 
         _LOGGER.debug(
             "ML history: fetching states for %s from %s to %s",
@@ -106,7 +115,7 @@ class HistoryReader:
             get_significant_states,
             self._hass,
             start_time,
-            now,
+            end_time,
             [entity_id],
             None,  # no significant_changes_only filter
             True,  # minimal_response
@@ -133,8 +142,10 @@ class HistoryReader:
         readings: list[tuple[datetime, float]] = []
         for state_obj in entity_states:
             try:
-                ts = state_obj.last_updated
+                ts = normalize_datetime(state_obj.last_updated)
                 value = float(state_obj.state)
+                if not math.isfinite(value):
+                    continue
                 readings.append((ts, value))
             except ValueError, TypeError, AttributeError:
                 continue
@@ -149,7 +160,7 @@ class HistoryReader:
             return []
 
         # Sort by timestamp ascending.
-        readings.sort(key=lambda x: x[0])
+        readings.sort(key=lambda item: utc_key(item[0]))
 
         # Compute per-slot consumption deltas from the accumulator.
         slots_per_day = 24 * 60 // slot_minutes
@@ -158,7 +169,7 @@ class HistoryReader:
         # Check minimum history requirement.
         if history:
             earliest = history[0][0]
-            actual_days = (now - earliest).total_seconds() / 86400.0
+            actual_days = (utc_key(now) - utc_key(earliest)).total_seconds() / 86400.0
             if actual_days < days:
                 _LOGGER.info(
                     "ML history: only %.1f days available for %s (need %d). "
@@ -191,8 +202,9 @@ class HistoryReader:
             List of ``(timestamp, value)`` sorted oldest-first.
             Empty list if insufficient history.
         """
-        now = datetime.now().astimezone()
-        start_time = now - timedelta(days=max_days)
+        now = hsem_now()
+        end_time = utc_key(now)
+        start_time = end_time - timedelta(days=max_days)
 
         states: dict[str, list[Any]] = await get_instance(
             self._hass
@@ -200,7 +212,7 @@ class HistoryReader:
             get_significant_states,
             self._hass,
             start_time,
-            now,
+            end_time,
             [entity_id],
             None,
             True,
@@ -217,17 +229,19 @@ class HistoryReader:
         readings: list[tuple[datetime, float]] = []
         for state_obj in entity_states:
             try:
-                ts = state_obj.last_updated
+                ts = normalize_datetime(state_obj.last_updated)
                 value = float(state_obj.state)
+                if not math.isfinite(value):
+                    continue
                 readings.append((ts, value))
             except ValueError, TypeError, AttributeError:
                 continue
 
-        readings.sort(key=lambda x: x[0])
+        readings.sort(key=lambda item: utc_key(item[0]))
 
         if readings:
             earliest = readings[0][0]
-            actual_days = (now - earliest).total_seconds() / 86400.0
+            actual_days = (utc_key(now) - utc_key(earliest)).total_seconds() / 86400.0
             if actual_days < days:
                 _LOGGER.info(
                     "ML history: only %.1f days available for %s (need %d).",
@@ -243,32 +257,44 @@ class HistoryReader:
         self,
         entity_id: str,
         slot_minutes: int = DEFAULT_SLOT_MINUTES,
-    ) -> dict[int, float]:
+    ) -> dict[datetime, float]:
         """Read today's completed-slot actual consumption from the energy sensor.
 
-        Queries the recorder for the last 24 hours of the energy accumulator
-        and computes per-slot deltas for today's slots that have already
-        ended.  In-progress and future slots are excluded.
+        Queries from one physical slot before HA-local midnight through now,
+        then computes deltas for today's completed slots. In-progress and
+        future slots are excluded.
 
         Args:
             entity_id: The energy accumulator entity ID.
             slot_minutes: Slot width in minutes.
 
         Returns:
-            Dict mapping ``slot_index`` → ``actual_kwh`` for completed
-            slots only.  Empty dict if no data is available.
+            Dict mapping canonical UTC slot-start datetime → ``actual_kwh``
+            for completed slots only.  Physical datetime identity is required
+            so both folds of an autumn repeated hour remain distinct.  Empty
+            dict if no data is available.
         """
-        now = datetime.now().astimezone()
-        midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        now = hsem_now()
+        midnight = now.replace(
+            hour=0,
+            minute=0,
+            second=0,
+            microsecond=0,
+            fold=0,
+        )
+        # Include one physical slot before local midnight.  Its final reading
+        # is the left boundary needed to calculate the first slot of today.
+        start_time = utc_key(midnight) - timedelta(minutes=slot_minutes)
+        end_time = utc_key(now)
 
-        # Fetch last 24h of states.
+        # Fetch the DST-safe local-day boundary range.
         states: dict[str, list[Any]] = await get_instance(
             self._hass
         ).async_add_executor_job(
             get_significant_states,
             self._hass,
-            midnight - (midnight.utcoffset() or timedelta(0)),
-            now,
+            start_time,
+            end_time,
             [entity_id],
             None,
             True,
@@ -283,8 +309,10 @@ class HistoryReader:
         readings: list[tuple[datetime, float]] = []
         for state_obj in entity_states:
             try:
-                ts = state_obj.last_updated
+                ts = normalize_datetime(state_obj.last_updated)
                 value = float(state_obj.state)
+                if not math.isfinite(value):
+                    continue
                 readings.append((ts, value))
             except ValueError, TypeError, AttributeError:
                 continue
@@ -292,16 +320,19 @@ class HistoryReader:
         if len(readings) < 2:
             return {}
 
-        readings.sort(key=lambda x: x[0])
+        readings.sort(key=lambda item: utc_key(item[0]))
 
         # Compute per-slot deltas for today only.
         slots_per_day = 24 * 60 // slot_minutes
         history = self._compute_slot_deltas(readings, now, slot_minutes, slots_per_day)
 
-        # Filter to today's completed slots and index by slot number.
-        actuals: dict[int, float] = {}
-        for _ts, slot_idx, energy in history:
-            actuals[slot_idx] = energy
+        # Filter to today's completed slots and key by physical slot identity.
+        # ``_compute_slot_deltas`` has already excluded the in-progress slot.
+        actuals: dict[datetime, float] = {}
+        for slot_start, _slot_idx, energy in history:
+            if slot_start.date() != now.date():
+                continue
+            actuals[slot_key(slot_start, slot_minutes)] = energy
 
         return actuals
 
@@ -327,28 +358,34 @@ class HistoryReader:
             List of ``(slot_start_dt, slot_index, energy_kwh)``.
         """
 
-        # Compute a unique slot key for each reading:
-        #   day_number * slots_per_day + slot_index
-        def slot_key(ts: datetime) -> int:
-            minutes_since_midnight = ts.hour * 60 + ts.minute
-            slot_idx = minutes_since_midnight // slot_minutes
-            return ts.toordinal() * slots_per_day + slot_idx
+        # ``slots_per_day`` remains part of the private signature for callers
+        # that already pre-compute it, but physical slot identity comes from a
+        # canonical UTC datetime rather than ``ordinal * slots_per_day``.  A
+        # wall-clock integer would collapse both folds of an autumn repeated
+        # hour and cannot represent a 92/100-slot DST day.
+        del slots_per_day
 
-        # Group readings by slot key.
-        slot_groups: dict[int, list[tuple[datetime, float]]] = {}
+        # Group readings by physical slot identity after converting recorder
+        # UTC timestamps to Home Assistant local time.  Calendar features
+        # (date, DOW, and wall slot) must be derived from the local timestamp;
+        # ordering and identity must remain UTC-based.
+        slot_groups: dict[datetime, list[tuple[datetime, float]]] = {}
         for ts, val in readings:
-            key = slot_key(ts)
-            slot_groups.setdefault(key, []).append((ts, val))
+            if not math.isfinite(val):
+                continue
+            local_ts = normalize_datetime(ts)
+            key = slot_key(local_ts, slot_minutes)
+            slot_groups.setdefault(key, []).append((local_ts, val))
 
         # Get the last reading of each slot.
-        slot_ends: list[tuple[int, datetime, float]] = []
+        slot_ends: list[tuple[datetime, datetime, float]] = []
         for key in sorted(slot_groups.keys()):
             group = slot_groups[key]
-            last_ts, last_val = max(group, key=lambda x: x[0])
+            last_ts, last_val = max(group, key=lambda x: utc_key(x[0]))
             slot_ends.append((key, last_ts, last_val))
 
         # Compute the slot key for "now" and skip incomplete current slot.
-        now_key = slot_key(now)
+        now_key = slot_key(now, slot_minutes)
         slot_ends = [(k, ts, v) for k, ts, v in slot_ends if k < now_key]
 
         if len(slot_ends) < 2:
@@ -357,24 +394,29 @@ class HistoryReader:
         # Compute deltas between consecutive slots.
         history: list[tuple[datetime, int, float]] = []
         for i in range(1, len(slot_ends)):
-            _prev_key, prev_ts, prev_val = slot_ends[i - 1]
-            _curr_key, _curr_ts, curr_val = slot_ends[i]
+            prev_key, _prev_ts, prev_val = slot_ends[i - 1]
+            curr_key, curr_ts, curr_val = slot_ends[i]
+
+            # Never turn a recorder outage into one oversized slot.  Only
+            # adjacent physical slots have compatible accumulator boundaries.
+            if curr_key - prev_key != timedelta(minutes=slot_minutes):
+                continue
+
             delta_kwh = curr_val - prev_val
 
-            # Skip negative deltas (accumulator resets) and zero deltas.
-            if delta_kwh <= 0:
+            # Skip non-finite, negative, reset, and zero deltas.
+            if not math.isfinite(delta_kwh) or delta_kwh <= 0:
                 continue
 
             # Cap unreasonably large deltas.
             if delta_kwh > MAX_SLOT_KWH:
                 continue
 
-            # Compute slot start time and slot index within the day.
-            slot_start = prev_ts.replace(
-                minute=(prev_ts.minute // slot_minutes) * slot_minutes,
-                second=0,
-                microsecond=0,
-            )
+            # Consecutive end-of-slot readings delimit the *current* slot.
+            # Labelling the delta with ``prev_ts`` shifts every observation one
+            # interval early.  Keep the local timestamp (including DST fold)
+            # for calendar features and expose the wall slot separately.
+            slot_start = normalize_slot_start(curr_ts, slot_minutes)
             slot_index = (slot_start.hour * 60 + slot_start.minute) // slot_minutes
 
             history.append((slot_start, slot_index, round(delta_kwh, 4)))

--- a/custom_components/hsem/ml/populator.py
+++ b/custom_components/hsem/ml/populator.py
@@ -12,7 +12,8 @@ but uses ML predictions instead of rolling-average sensor states.
 
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta
+import math
+from datetime import datetime, timedelta
 
 from homeassistant.core import HomeAssistant
 
@@ -23,14 +24,28 @@ from custom_components.hsem.ml.history_reader import (
 )
 from custom_components.hsem.models.hourly_recommendation import HourlyRecommendation
 from custom_components.hsem.models.sensor_config import SensorConfig
+from custom_components.hsem.utils.datetime_utils import (
+    normalize_datetime,
+    now as hsem_now,
+    slot_key,
+    utc_key,
+)
 from custom_components.hsem.utils.logger import HSEM_LOGGER
 
-# Cache for full history fetch — avoids querying 90 days of recorder
-# data on every 1–5 minute coordinator cycle.
-_last_history_fetch: datetime | None = None
-_cached_history: list[tuple[datetime, int, float]] | None = None
-_last_temp_fetch: datetime | None = None
-_cached_temps: dict[datetime, float] | None = None
+type _HistorySample = tuple[datetime, int, float]
+type _HistoryCacheKey = tuple[int, str, str | None, bool, int, int]
+type _TemperatureCacheKey = tuple[int, str, int]
+type _PredictorContext = tuple[str, str | None, bool, int, int, str | None]
+
+# Cache final, fully processed history rather than an import-only intermediate.
+# The effective configuration is part of the key so another config entry,
+# source entity, cadence, history window, or net/gross mode cannot reuse it.
+_processed_history_cache: dict[
+    _HistoryCacheKey, tuple[datetime, list[_HistorySample]]
+] = {}
+_temperature_history_cache: dict[
+    _TemperatureCacheKey, tuple[datetime, dict[datetime, float]]
+] = {}
 _MIN_HISTORY_REFRESH = timedelta(minutes=60)
 
 
@@ -72,24 +87,35 @@ async def populate_ml_house_consumption(
 
     reader = HistoryReader(hass)
 
-    # Full history fetch — cached for 60 minutes to avoid hammering the
-    # recorder database on every 1–5 minute coordinator cycle.
-    global _last_history_fetch, _cached_history
-    now_ts = datetime.now().astimezone()
-    cache_valid = (
-        _last_history_fetch is not None
-        and _cached_history is not None
-        and (now_ts - _last_history_fetch) < _MIN_HISTORY_REFRESH
+    # Full history fetch — cache the processed series for 60 minutes to avoid
+    # hammering the recorder database on every 1–5 minute coordinator cycle.
+    now_ts = hsem_now()
+    net_enabled = cfg.ml_consumption_net_consumption
+    if net_enabled and not cfg.grid_export_energy_entity:
+        HSEM_LOGGER.warning(
+            "ML populator: net consumption is enabled but no grid export "
+            "energy entity is configured. Falling back to legacy avg sensors."
+        )
+        return False, None
+    export_entity = cfg.grid_export_energy_entity if net_enabled else None
+    cache_key: _HistoryCacheKey = (
+        id(hass),
+        energy_entity,
+        export_entity,
+        net_enabled,
+        slot_minutes,
+        min_days,
     )
+    cached = _processed_history_cache.get(cache_key)
+    cache_valid = cached is not None and _cache_is_fresh(cached[0], now_ts)
 
-    if cache_valid:
-        assert _cached_history is not None  # guarded by cache_valid
-        assert _last_history_fetch is not None  # guarded by cache_valid
-        import_history = _cached_history
+    history: list[_HistorySample]
+    if cache_valid and cached is not None:
+        history = cached[1]
         HSEM_LOGGER.debug(
             "ML populator: using cached history (%d samples, age %.0f min).",
-            len(import_history),
-            (now_ts - _last_history_fetch).total_seconds() / 60,
+            len(history),
+            _physical_elapsed(now_ts, cached[0]).total_seconds() / 60,
         )
     else:
         import_history = await reader.read_energy_history(
@@ -98,72 +124,114 @@ async def populate_ml_house_consumption(
             slot_minutes=slot_minutes,
             max_days=DEFAULT_MAX_HISTORY_DAYS,
         )
-        if import_history:
-            _cached_history = import_history
-            _last_history_fetch = now_ts
-            HSEM_LOGGER.debug(
-                "ML populator: fetched fresh history (%d samples).",
-                len(import_history),
+        if not import_history:
+            HSEM_LOGGER.info(
+                "ML populator: insufficient history for %s (need %d days). "
+                "Falling back to legacy avg sensors.",
+                energy_entity,
+                min_days,
             )
+            return False, None
 
-    if not import_history:
-        HSEM_LOGGER.info(
-            "ML populator: insufficient history for %s (need %d days). "
-            "Falling back to legacy avg sensors.",
-            energy_entity,
-            min_days,
-        )
-        return False, None
-
-    # Build per-slot consumption history.
-    # When using cached import, also skip the export fetch.
-    if cfg.ml_consumption_net_consumption and cfg.grid_export_energy_entity:
-        if cache_valid:
-            # Use cached import directly — export fetch is also skipped.
-            history = import_history
-        else:
+        history = import_history
+        if net_enabled and export_entity is not None:
             export_history = await reader.read_energy_history(
-                entity_id=cfg.grid_export_energy_entity,
+                entity_id=export_entity,
                 days=min_days,
                 slot_minutes=slot_minutes,
                 max_days=DEFAULT_MAX_HISTORY_DAYS,
             )
             if export_history:
                 history = _compute_net_consumption(import_history, export_history)
+                if not _history_meets_minimum_span(history, now_ts, min_days):
+                    HSEM_LOGGER.info(
+                        "ML populator: aligned import/export history is "
+                        "insufficient for %d days. Falling back to legacy "
+                        "avg sensors.",
+                        min_days,
+                    )
+                    return False, None
             else:
                 HSEM_LOGGER.info(
-                    "ML populator: export history unavailable,"
-                    " using import-only consumption."
+                    "ML populator: export history unavailable while net "
+                    "consumption is enabled. Falling back to legacy avg sensors."
                 )
-                history = import_history
-    else:
-        history = import_history
+                return False, None
+
+        if history:
+            _processed_history_cache[cache_key] = (now_ts, history)
+        HSEM_LOGGER.debug(
+            "ML populator: fetched fresh processed history (%d samples).",
+            len(history),
+        )
 
     if not history:
         HSEM_LOGGER.warning("ML populator: empty history after processing")
         return False, None
 
-    # Create or reuse predictor.
-    reference_time = datetime.now().astimezone()
-    use_temp = bool(cfg.ml_consumption_temperature_entity)
+    # Create or reuse predictor.  Calendar calculations use HA local time;
+    # physical sample ages remain correct because all timestamps are aware.
+    reference_time = now_ts
 
     # Compute decay from the actual data span, not the configured window.
     # Half-life = actual_span / 2 gives the oldest data ~14% weight.
-    if history:
-        oldest_age = max(
-            (
-                reference_time - ts.replace(tzinfo=reference_time.tzinfo)
-                if ts.tzinfo is None
-                else reference_time - ts
-            ).total_seconds()
-            / 86400.0
-            for ts, _slot, _energy in history
-        )
-        decay_days = max(oldest_age, 1.0) / 2.0
-    else:
-        decay_days = float(min_days) / 2.0
+    oldest_age = max(
+        _physical_elapsed(reference_time, ts).total_seconds() / 86400.0
+        for ts, _slot, _energy in history
+    )
+    decay_days = max(oldest_age, 1.0) / 2.0
 
-    if predictor is None:
+    # Read temperature history before creating the predictor.  If a configured
+    # sensor has insufficient history, disable the feature safely rather than
+    # fitting a temperature column and then omitting it during inference.
+    temperatures: dict[datetime, float] | None = None
+    temperature_entity = cfg.ml_consumption_temperature_entity
+    if temperature_entity:
+        temp_cache_key: _TemperatureCacheKey = (
+            id(hass),
+            temperature_entity,
+            min_days,
+        )
+        cached_temps = _temperature_history_cache.get(temp_cache_key)
+        temp_cache_valid = cached_temps is not None and _cache_is_fresh(
+            cached_temps[0], now_ts
+        )
+        if temp_cache_valid and cached_temps is not None:
+            temperatures = cached_temps[1]
+        else:
+            temperatures = await _read_temperature_history(
+                reader, temperature_entity, min_days
+            )
+            if temperatures:
+                _temperature_history_cache[temp_cache_key] = (
+                    now_ts,
+                    temperatures,
+                )
+
+    use_temp = bool(temperatures)
+    if not use_temp:
+        temperatures = None
+    if temperature_entity and not use_temp:
+        HSEM_LOGGER.info(
+            "ML populator: temperature history unavailable;"
+            " fitting without temperature."
+        )
+
+    training_context: _PredictorContext = (
+        energy_entity,
+        export_entity,
+        net_enabled,
+        slot_minutes,
+        min_days,
+        temperature_entity if use_temp else None,
+    )
+    if (
+        predictor is None
+        or predictor.slots_per_day != slots_per_day
+        or predictor.use_temperature != use_temp
+        or predictor.use_sequential != cfg.ml_consumption_sequential
+        or predictor.training_context != training_context
+    ):
         predictor = ConsumptionPredictor(
             decay_days=decay_days,
             alpha=1.0,
@@ -171,32 +239,12 @@ async def populate_ml_house_consumption(
             use_temperature=use_temp,
             use_sequential=cfg.ml_consumption_sequential,
         )
+    # A reused predictor must not retain the half-life from its initial fit.
+    predictor.decay_days = decay_days
+    predictor.training_context = training_context
 
     # Store the actual history span so it can be exposed to the user.
-    predictor.actual_history_days = max(oldest_age, 0.0) if history else 0.0
-
-    # Read temperature history if configured.
-    # Expects an outdoor (ambient) temperature sensor in °C.
-    # Indoor thermostats will NOT help predict weather-driven load.
-    # Cached for 60 minutes (temperature changes slowly).
-    temperatures: dict[datetime, float] | None = None
-    if use_temp:
-        global _last_temp_fetch, _cached_temps
-        temp_cache_valid = (
-            _last_temp_fetch is not None
-            and _cached_temps is not None
-            and (now_ts - _last_temp_fetch) < _MIN_HISTORY_REFRESH
-        )
-        if temp_cache_valid:
-            temperatures = _cached_temps
-        else:
-            assert cfg.ml_consumption_temperature_entity is not None
-            temperatures = await _read_temperature_history(
-                reader, cfg.ml_consumption_temperature_entity, min_days
-            )
-            if temperatures:
-                _cached_temps = temperatures
-                _last_temp_fetch = now_ts
+    predictor.actual_history_days = max(oldest_age, 0.0)
 
     # Train — retrain gate skips fitting when no new data has arrived.
     # The fit is CPU-bound (numpy ridge solve), so run it in HA's executor
@@ -205,6 +253,13 @@ async def populate_ml_house_consumption(
     await hass.async_add_executor_job(
         predictor.train, history, reference_time, temperatures
     )
+
+    if not predictor.trained:
+        HSEM_LOGGER.info(
+            "ML populator: history did not produce a trained model;"
+            " falling back to legacy avg sensors."
+        )
+        return False, None
 
     if predictor.trained and not was_fitted_before:
         HSEM_LOGGER.info(
@@ -238,59 +293,80 @@ async def populate_ml_house_consumption(
     buffer_1 = 0
 
     # Read today's actual consumption for completed slots.
-    today_actuals: dict[int, float] = {}
-    today_actuals = await reader.read_today_actuals(
+    today_actuals: dict[datetime, float] = await reader.read_today_actuals(
         entity_id=energy_entity,
         slot_minutes=slot_minutes,
     )
+    today_actuals = {
+        key: value for key, value in today_actuals.items() if math.isfinite(value)
+    }
     if cfg.ml_consumption_net_consumption and cfg.grid_export_energy_entity:
         export_actuals = await reader.read_today_actuals(
             entity_id=cfg.grid_export_energy_entity,
             slot_minutes=slot_minutes,
         )
-        # Subtract export from import per slot.
-        for slot_idx in list(today_actuals.keys()):
-            today_actuals[slot_idx] = max(
-                today_actuals[slot_idx] - export_actuals.get(slot_idx, 0.0),
+        # A missing channel key is unknown, not zero.  Use only physical
+        # slots observed in both meters so recorder gaps cannot silently
+        # become import-only labels in a net-consumption model.
+        aligned_actuals: dict[datetime, float] = {}
+        for physical_key, import_energy in today_actuals.items():
+            if physical_key not in export_actuals:
+                continue
+            export_energy = export_actuals[physical_key]
+            if not math.isfinite(export_energy):
+                continue
+            aligned_actuals[physical_key] = max(
+                import_energy - export_energy,
                 0.01,
             )
+        today_actuals = aligned_actuals
 
     actual_count = 0
     predicted_count = 0
 
-    # In sequential mode, precompute per-day predictions (each slot feeds
-    # its output as lag input to the next).  Independent mode predicts
-    # each slot separately.
-    seq_predictions: dict[int, dict[int, float]] = {}
+    # Sequential mode follows the real recommendation instants in UTC order.
+    # This naturally skips spring's nonexistent hour and preserves both
+    # physical folds of autumn's repeated wall hour.
+    seq_predictions: dict[datetime, float] = {}
+    prediction_temperature = _nearest_temperature(temperatures, reference_time)
     if cfg.ml_consumption_sequential:
-        seen_day_offsets: set[int] = set()
-        for rec in recommendations:
-            seen_day_offsets.add((rec.start.date() - reference_time.date()).days)
-        for day_offset in sorted(seen_day_offsets):
-            seq_predictions[day_offset] = predictor.predict_sequential(
-                day_offset, reference_time
-            )
+        sequence_keys = sorted(
+            {
+                slot_key(normalize_datetime(rec.start), slot_minutes)
+                for rec in recommendations
+            }
+        )
+        sequence_starts = [normalize_datetime(key) for key in sequence_keys]
+        sequential_temperatures = (
+            {key: prediction_temperature for key in sequence_keys}
+            if prediction_temperature is not None
+            else None
+        )
+        seq_predictions = predictor.predict_sequential(
+            sequence_starts, sequential_temperatures
+        )
 
     for rec in recommendations:
-        rec_day_offset = (rec.start.date() - reference_time.date()).days
-        slot_index = (rec.start.hour * 60 + rec.start.minute) // slot_minutes
+        rec_start = normalize_datetime(rec.start)
+        rec_day_offset = (rec_start.date() - reference_time.date()).days
+        slot_index = (rec_start.hour * 60 + rec_start.minute) // slot_minutes
+        physical_key = slot_key(rec_start, slot_minutes)
 
         # Use actual consumption for past slots (day_offset == 0 and slot has ended).
-        if rec_day_offset == 0 and slot_index in today_actuals:
-            per_slot_kwh = round(today_actuals[slot_index], 4)
+        if rec_day_offset == 0 and physical_key in today_actuals:
+            per_slot_kwh = round(today_actuals[physical_key], 4)
             actual_count += 1
         else:
             # Future slot: ML prediction.
             if seq_predictions:
                 # Sequential mode: use precomputed chained prediction.
-                day_preds = seq_predictions.get(rec_day_offset, {})
-                mean = day_preds.get(slot_index, 0.0)
+                mean = seq_predictions.get(physical_key, 0.0)
                 # Safety buffer: use DOW-slot std from raw groups.
                 std = 0.0
                 if predictor.trained:
-                    target_date = reference_time.date() + timedelta(days=rec_day_offset)
-                    dow = target_date.weekday()
-                    group = predictor._raw_groups.get((dow, slot_index), [])
+                    group = predictor._raw_groups.get(
+                        (rec_start.weekday(), slot_index), []
+                    )
                     if len(group) >= 2:
                         std = predictor._weighted_std(group)
                     elif mean > 0:
@@ -298,7 +374,10 @@ async def populate_ml_house_consumption(
             else:
                 # Independent mode: predict each slot separately.
                 mean, std = predictor.predict_with_std(
-                    slot_index, rec_day_offset, reference_time
+                    slot_index,
+                    rec_day_offset,
+                    reference_time,
+                    prediction_temperature,
                 )
             rel_uncertainty = std / mean if mean > 0 else 0.0
             if rel_uncertainty < 0.1:
@@ -344,24 +423,86 @@ async def populate_ml_house_consumption(
     return True, predictor
 
 
-def _compute_net_consumption(
-    import_history: list[tuple[datetime, int, float]],
-    export_history: list[tuple[datetime, int, float]],
-) -> list[tuple[datetime, int, float]]:
-    """Compute net consumption by subtracting export from import per slot."""
-    export_map: dict[tuple[date, int], float] = {}
-    for ts, slot, energy in export_history:
-        key = (ts.date(), slot)
-        export_map[key] = energy
+def _physical_elapsed(later: datetime, earlier: datetime) -> timedelta:
+    """Return elapsed time by UTC instant, retaining local calendar timestamps."""
+    later_aware = later if later.tzinfo is not None else later.astimezone()
+    earlier_aware = (
+        earlier
+        if earlier.tzinfo is not None
+        else earlier.replace(tzinfo=later_aware.tzinfo)
+    )
+    return utc_key(later_aware) - utc_key(earlier_aware)
 
-    net: list[tuple[datetime, int, float]] = []
+
+def _cache_is_fresh(cached_at: datetime, current: datetime) -> bool:
+    """Return whether a cache timestamp is within the physical refresh window."""
+    age = _physical_elapsed(current, cached_at)
+    return timedelta(0) <= age < _MIN_HISTORY_REFRESH
+
+
+def _history_meets_minimum_span(
+    history: list[_HistorySample],
+    reference_time: datetime,
+    min_days: int,
+) -> bool:
+    """Return whether aligned history can train and spans the configured window."""
+    if len(history) < 2:
+        return False
+    oldest_age_days = max(
+        _physical_elapsed(reference_time, timestamp).total_seconds() / 86400.0
+        for timestamp, _slot, _energy in history
+    )
+    return oldest_age_days >= min_days
+
+
+def _compute_net_consumption(
+    import_history: list[_HistorySample],
+    export_history: list[_HistorySample],
+) -> list[_HistorySample]:
+    """Compute net consumption for physical slots present in both channels."""
+    export_map = {
+        utc_key(ts): energy
+        for ts, _slot, energy in export_history
+        if math.isfinite(energy)
+    }
+
+    net: list[_HistorySample] = []
     for ts, slot, import_energy in import_history:
-        key = (ts.date(), slot)
-        export_energy = export_map.get(key, 0.0)
+        if not math.isfinite(import_energy):
+            continue
+        physical_key = utc_key(ts)
+        if physical_key not in export_map:
+            continue
+        export_energy = export_map[physical_key]
         net_energy = max(import_energy - export_energy, 0.01)
         net.append((ts, slot, round(net_energy, 4)))
 
     return net
+
+
+def _nearest_temperature(
+    temperatures: dict[datetime, float] | None,
+    target: datetime,
+) -> float | None:
+    """Return the temperature nearest to *target* by physical time.
+
+    The configured entity provides history rather than a future weather
+    forecast, so inference deliberately persists the newest nearby reading
+    through the prediction horizon.
+    """
+    finite_temperatures = {
+        timestamp: value
+        for timestamp, value in (temperatures or {}).items()
+        if math.isfinite(value)
+    }
+    if not finite_temperatures:
+        return None
+    target_key = utc_key(target)
+    nearest = min(
+        finite_temperatures,
+        key=lambda timestamp: abs((utc_key(timestamp) - target_key).total_seconds()),
+    )
+    return finite_temperatures[nearest]
 
 
 async def _read_temperature_history(
@@ -388,4 +529,10 @@ async def _read_temperature_history(
     if not raw_states:
         return {}
 
-    return dict(raw_states)
+    # Canonical UTC keys preserve both folds of an autumn repeated hour;
+    # local ZoneInfo datetimes with identical wall fields compare equal.
+    return {
+        utc_key(timestamp): value
+        for timestamp, value in raw_states
+        if math.isfinite(value)
+    }

--- a/custom_components/hsem/models/price_source.py
+++ b/custom_components/hsem/models/price_source.py
@@ -1,0 +1,25 @@
+"""Price-source provenance shared by coordinator and planner models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+type PriceSource = Literal["primary", "entsoe", "forecast"]
+
+
+@dataclass(frozen=True)
+class PriceBackupStatus:
+    """Safe per-cycle status for the paired published-price backup."""
+
+    configured: bool = False
+    matched_slots: int = 0
+    rejection_reason: str | None = None
+
+    def as_dict(self) -> dict[str, bool | int | str | None]:
+        """Return a JSON-safe diagnostic representation."""
+        return {
+            "configured": self.configured,
+            "matched_slots": self.matched_slots,
+            "rejection_reason": self.rejection_reason,
+        }

--- a/custom_components/hsem/planner/milp_optimizer.py
+++ b/custom_components/hsem/planner/milp_optimizer.py
@@ -535,6 +535,19 @@ def solve_milp(
     b_ub = constraints["b_ub"]
     bounds = constraints["bounds"]
 
+    # Fail fast if the positional bounds list is not exactly one entry per
+    # LP variable.  A wrong-width or missing block would otherwise silently
+    # misalign the bounds array handed to linprog and produce either an
+    # opaque solver failure or, worse, bounds applied to the wrong variables.
+    if len(bounds) != n_vars:
+        log_planner(
+            "error",
+            "[milp] bounds layout mismatch: %d bounds for %d variables",
+            len(bounds),
+            n_vars,
+        )
+        return None
+
     # ------------------------------------------------------------------
     # Solve using HiGHS
     # ------------------------------------------------------------------

--- a/custom_components/hsem/utils/datetime_utils.py
+++ b/custom_components/hsem/utils/datetime_utils.py
@@ -105,8 +105,9 @@ def slot_key(value: datetime, interval_minutes: int) -> datetime:
     inside HSEM.  Using it on both sides of a lookup guarantees that:
 
     - Slots from different timezones (e.g. ``ZoneInfo('Europe/Copenhagen')``
-      vs a fixed ``+02:00`` offset) that represent the same wall-clock instant
+      vs a fixed ``+02:00`` offset) that represent the same physical instant
       produce the same key.
+    - The two occurrences of an autumn repeated wall-clock hour remain distinct.
     - Sub-second jitter (microseconds) from ``dt_util.now()`` is stripped.
     - Timestamps with seconds != 0 (e.g. from ``dt_util.now()``) are floored
       to the interval boundary so they match planner slots anchored at midnight.
@@ -119,7 +120,18 @@ def slot_key(value: datetime, interval_minutes: int) -> datetime:
         A timezone-aware :class:`~datetime.datetime` that uniquely identifies
         the slot containing *value* under the given interval width.
     """
-    return normalize_slot_start(value, interval_minutes)
+    return utc_key(normalize_slot_start(value, interval_minutes))
+
+
+def slot_contains(start: datetime, end: datetime, value: datetime) -> bool:
+    """Return whether *value* is inside the half-open slot ``[start, end)``.
+
+    All operands are compared by UTC instant.  Direct comparisons between two
+    datetimes carrying the same :class:`zoneinfo.ZoneInfo` object compare their
+    wall-clock fields and can treat the two occurrences of an autumn repeated
+    hour as equal.
+    """
+    return utc_key(start) <= utc_key(value) < utc_key(end)
 
 
 def as_tz(value: datetime, tz: tzinfo | None) -> datetime:

--- a/custom_components/hsem/utils/forecast_tracker.py
+++ b/custom_components/hsem/utils/forecast_tracker.py
@@ -14,9 +14,17 @@ from __future__ import annotations
 
 import math
 import statistics
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
+
+from custom_components.hsem.utils.persistence import (
+    aware_datetime_from_iso,
+    finite_float,
+)
+
+_MAX_RESTORED_ENERGY_KWH = 1_000_000.0
 
 # ---------------------------------------------------------------------------
 # Slot record stored in the tracker
@@ -33,13 +41,25 @@ class ForecastSlotRecord:
         end:
             Timezone-aware end of the slot.
         forecast_pv_kwh:
-            Predicted PV production for this slot (kWh).
+            Corrected PV prediction for this slot (kWh).
+        raw_forecast_pv_kwh:
+            Raw, pre-correction PV prediction frozen before the slot starts.
         forecast_load_kwh:
             Predicted house load for this slot (kWh).
+        forecast_soc_pct:
+            Predicted end-of-slot battery SoC frozen before the slot starts.
+        forecast_action:
+            Predicted action label frozen before the slot starts.
         actual_pv_kwh:
             Accumulated actual PV production during this slot (kWh).
         actual_load_kwh:
             Accumulated actual house load during this slot (kWh).
+        forecast_frozen:
+            Whether the pre-slot baseline has been frozen.
+        actual_coverage_seconds:
+            Seconds of the physical slot covered by trusted power samples.
+            ``None`` retains compatibility with records created by older
+            versions and direct callers.
         finalised:
             ``True`` once the slot's end time has passed and error metrics
             have been computed and frozen.
@@ -66,6 +86,33 @@ class ForecastSlotRecord:
     mae_load: float | None = None
     bias_pv: float | None = None
     bias_load: float | None = None
+    raw_forecast_pv_kwh: float | None = None
+    forecast_soc_pct: float | None = None
+    forecast_action: str | None = None
+    forecast_frozen: bool = False
+    actual_coverage_seconds: float | None = None
+
+    @property
+    def accuracy_eligible(self) -> bool:
+        """Return whether this record has an uncontaminated full-slot baseline."""
+        if not self.forecast_frozen or self.raw_forecast_pv_kwh is None:
+            return False
+        if self.actual_coverage_seconds is None:
+            return True
+        duration_seconds = (_utc_key(self.end) - _utc_key(self.start)).total_seconds()
+        return (
+            duration_seconds > 0
+            and self.actual_coverage_seconds >= duration_seconds - 1.0
+        )
+
+    @property
+    def prediction_eligible(self) -> bool:
+        """Return whether all frozen PredictionTracker inputs are available."""
+        return (
+            self.accuracy_eligible
+            and self.forecast_soc_pct is not None
+            and self.forecast_action is not None
+        )
 
     def accumulate_pv(self, energy_kwh: float) -> None:
         """Add *energy_kwh* of measured PV to the slot accumulator.
@@ -114,9 +161,14 @@ class ForecastSlotRecord:
             "start": self.start.isoformat(),
             "end": self.end.isoformat(),
             "forecast_pv_kwh": self.forecast_pv_kwh,
+            "raw_forecast_pv_kwh": self.raw_forecast_pv_kwh,
             "forecast_load_kwh": self.forecast_load_kwh,
+            "forecast_soc_pct": self.forecast_soc_pct,
+            "forecast_action": self.forecast_action,
             "actual_pv_kwh": self.actual_pv_kwh,
             "actual_load_kwh": self.actual_load_kwh,
+            "forecast_frozen": self.forecast_frozen,
+            "actual_coverage_seconds": self.actual_coverage_seconds,
             "finalised": self.finalised,
             "mae_pv": self.mae_pv,
             "mae_load": self.mae_load,
@@ -125,7 +177,7 @@ class ForecastSlotRecord:
         }
 
     @staticmethod
-    def from_dict(data: dict[str, Any]) -> ForecastSlotRecord:
+    def from_dict(data: Mapping[str, Any]) -> ForecastSlotRecord:
         """Deserialize a record from a dictionary produced by :meth:`to_dict`.
 
         Args:
@@ -134,21 +186,80 @@ class ForecastSlotRecord:
         Returns:
             A reconstructed :class:`ForecastSlotRecord`.
         """
-        from datetime import datetime as dt
+        start = aware_datetime_from_iso(data.get("start"))
+        end = aware_datetime_from_iso(data.get("end"))
+        if start is None or end is None:
+            raise ValueError("forecast record timestamps must be timezone-aware")
+        duration_seconds = (_utc_key(end) - _utc_key(start)).total_seconds()
+        if (
+            duration_seconds <= 0
+            or duration_seconds > timedelta(hours=1).total_seconds()
+        ):
+            raise ValueError("forecast record timestamps are not an ordered slot")
 
-        return ForecastSlotRecord(
-            start=dt.fromisoformat(data["start"]),
-            end=dt.fromisoformat(data["end"]),
-            forecast_pv_kwh=data.get("forecast_pv_kwh", 0.0),
-            forecast_load_kwh=data.get("forecast_load_kwh", 0.0),
-            actual_pv_kwh=data.get("actual_pv_kwh", 0.0),
-            actual_load_kwh=data.get("actual_load_kwh", 0.0),
-            finalised=data.get("finalised", False),
-            mae_pv=data.get("mae_pv"),
-            mae_load=data.get("mae_load"),
-            bias_pv=data.get("bias_pv"),
-            bias_load=data.get("bias_load"),
+        forecast_pv_kwh = _required_finite(
+            data.get("forecast_pv_kwh", 0.0),
+            minimum=0.0,
+            maximum=_MAX_RESTORED_ENERGY_KWH,
         )
+        forecast_load_kwh = _required_finite(
+            data.get("forecast_load_kwh", 0.0),
+            minimum=0.0,
+            maximum=_MAX_RESTORED_ENERGY_KWH,
+        )
+        actual_pv_kwh = _required_finite(
+            data.get("actual_pv_kwh", 0.0),
+            minimum=0.0,
+            maximum=_MAX_RESTORED_ENERGY_KWH,
+        )
+        actual_load_kwh = _required_finite(
+            data.get("actual_load_kwh", 0.0),
+            minimum=0.0,
+            maximum=_MAX_RESTORED_ENERGY_KWH,
+        )
+        raw_forecast_pv_kwh = _optional_finite(
+            data.get("raw_forecast_pv_kwh"),
+            minimum=0.0,
+            maximum=_MAX_RESTORED_ENERGY_KWH,
+        )
+        forecast_soc_pct = _optional_finite(
+            data.get("forecast_soc_pct"), minimum=0.0, maximum=100.0
+        )
+        actual_coverage_seconds = _optional_finite(
+            data.get("actual_coverage_seconds"),
+            minimum=0.0,
+            maximum=duration_seconds + 1.0,
+        )
+
+        forecast_action = data.get("forecast_action")
+        if forecast_action is not None and (
+            not isinstance(forecast_action, str) or len(forecast_action) > 128
+        ):
+            raise ValueError("forecast action must be a bounded string")
+
+        forecast_frozen = data.get("forecast_frozen", False)
+        finalised = data.get("finalised", False)
+        if not isinstance(forecast_frozen, bool) or not isinstance(finalised, bool):
+            raise TypeError("forecast lifecycle flags must be booleans")
+
+        record = ForecastSlotRecord(
+            start=start,
+            end=end,
+            forecast_pv_kwh=forecast_pv_kwh,
+            raw_forecast_pv_kwh=raw_forecast_pv_kwh,
+            forecast_load_kwh=forecast_load_kwh,
+            forecast_soc_pct=forecast_soc_pct,
+            forecast_action=forecast_action,
+            actual_pv_kwh=actual_pv_kwh,
+            actual_load_kwh=actual_load_kwh,
+            forecast_frozen=forecast_frozen,
+            actual_coverage_seconds=actual_coverage_seconds,
+        )
+        # Error fields are derived state. Recompute them instead of trusting
+        # persisted MAE/bias values that could be stale or non-finite.
+        if finalised:
+            record.finalise()
+        return record
 
 
 # ---------------------------------------------------------------------------
@@ -246,6 +357,7 @@ class ForecastTracker:
         self._max_slots = max_slots
         # Sorted by start time, oldest first.
         self._records: list[ForecastSlotRecord] = []
+        self._restored_unfinalised_keys: set[datetime] = set()
 
     @property
     def records(self) -> list[ForecastSlotRecord]:
@@ -253,9 +365,14 @@ class ForecastTracker:
         return list(self._records)
 
     @property
+    def restored_unfinalised_keys(self) -> set[datetime]:
+        """Return every restored slot whose lifecycle was not finalised."""
+        return set(self._restored_unfinalised_keys)
+
+    @property
     def summary(self) -> ForecastErrorSummary:
         """Compute and return a summary of all finalised records."""
-        finalised = [r for r in self._records if r.finalised]
+        finalised = [r for r in self._records if r.finalised and r.accuracy_eligible]
         if not finalised:
             return ForecastErrorSummary(window_slots=len(self._records))
 
@@ -343,6 +460,7 @@ class ForecastTracker:
 
         rec = ForecastSlotRecord(start=start, end=end)
         self._records.append(rec)
+        self._records.sort(key=lambda record: _utc_key(record.start))
         self._prune()
         return rec
 
@@ -359,6 +477,33 @@ class ForecastTracker:
             if _same_slot(rec.start, start):
                 return rec
         return None
+
+    def reconcile_unfinalised_layout(
+        self,
+        expected_slots: Iterable[tuple[datetime, datetime]],
+        *,
+        now: datetime,
+    ) -> bool:
+        """Discard an incompatible live layout while keeping finalised history.
+
+        Returns ``True`` when active/future records did not match the current
+        recommendation starts and ends.  Callers use that signal to reset
+        instantaneous-power endpoints so no interval bridges the change.
+        """
+        expected = {_utc_key(start): _utc_key(end) for start, end in expected_slots}
+        now_key = _utc_key(now)
+        incompatible = any(
+            expected.get(_utc_key(record.start)) != _utc_key(record.end)
+            for record in self._records
+            if not record.finalised and _utc_key(record.end) > now_key
+        )
+        if not incompatible:
+            return False
+
+        self._records = [record for record in self._records if record.finalised]
+        retained = {_utc_key(record.start) for record in self._records}
+        self._restored_unfinalised_keys.intersection_update(retained)
+        return True
 
     def finalise_record(self, start: datetime) -> bool:
         """Finalise the record at *start* if it exists and is not yet finalised.
@@ -389,8 +534,23 @@ class ForecastTracker:
         """
         count = 0
         for rec in self._records:
-            if not rec.finalised and rec.end <= now:
+            if not rec.finalised and _utc_key(rec.end) <= _utc_key(now):
                 rec.finalise()
+                count += 1
+        return count
+
+    def freeze_forecasts(self, now: datetime) -> int:
+        """Freeze baselines for slots that have physically started."""
+        count = 0
+        now_key = _utc_key(now)
+        for rec in self._records:
+            if (
+                not rec.finalised
+                and not rec.forecast_frozen
+                and rec.raw_forecast_pv_kwh is not None
+                and _utc_key(rec.start) <= now_key
+            ):
+                rec.forecast_frozen = True
                 count += 1
         return count
 
@@ -399,26 +559,88 @@ class ForecastTracker:
         start: datetime,
         pv_kwh: float,
         load_kwh: float,
+        *,
+        raw_pv_kwh: float | None = None,
+        forecast_soc_pct: float | None = None,
+        forecast_action: str | None = None,
+        observed_at: datetime | None = None,
     ) -> bool:
-        """Set the forecast values for the slot at *start*.
+        """Set an eligible pre-slot forecast baseline.
 
-        Only sets forecast if the record has not been finalised yet.
+        Production callers pass ``observed_at`` and may update a future slot
+        until its physical start.  Direct callers that omit it retain the
+        legacy one-shot behaviour and freeze the baseline immediately.
 
         Args:
             start: Slot start time.
-            pv_kwh: Forecast PV energy (kWh).
+            pv_kwh: Corrected forecast PV energy (kWh).
             load_kwh: Forecast load energy (kWh).
+            raw_pv_kwh: Raw PV forecast before correction.
+            forecast_soc_pct: Predicted end-of-slot battery SoC (%).
+            forecast_action: Predicted action label.
+            observed_at: Time at which this forecast was observed.
 
         Returns:
             ``True`` if the forecast was set, ``False`` if no matching
-            record exists or it is already finalised.
+            record exists, the baseline is frozen, or the slot has started.
         """
         rec = self.find_record(start)
-        if rec is None or rec.finalised:
+        if rec is None or rec.finalised or rec.forecast_frozen:
+            return False
+        if observed_at is not None and _utc_key(observed_at) >= _utc_key(rec.start):
             return False
         rec.forecast_pv_kwh = pv_kwh
+        rec.raw_forecast_pv_kwh = pv_kwh if raw_pv_kwh is None else raw_pv_kwh
         rec.forecast_load_kwh = load_kwh
+        rec.forecast_soc_pct = forecast_soc_pct
+        rec.forecast_action = forecast_action
+        if observed_at is None:
+            rec.forecast_frozen = True
+        elif rec.actual_coverage_seconds is None:
+            rec.actual_coverage_seconds = 0.0
         return True
+
+    def accumulate_power_interval(
+        self,
+        start: datetime,
+        end: datetime,
+        *,
+        pv_power_w: float,
+        load_power_w: float,
+        max_gap_seconds: float,
+    ) -> float:
+        """Allocate prior-sample power over ``[start, end)`` by UTC overlap.
+
+        Long gaps are rejected rather than treating a stale power sample as
+        representative.  The return value is the allocated number of seconds.
+        """
+        start_key = _utc_key(start)
+        end_key = _utc_key(end)
+        elapsed_seconds = (end_key - start_key).total_seconds()
+        if (
+            elapsed_seconds <= 0
+            or max_gap_seconds <= 0
+            or elapsed_seconds > max_gap_seconds
+        ):
+            return 0.0
+
+        assigned_seconds = 0.0
+        for rec in self._records:
+            if rec.finalised or not rec.forecast_frozen:
+                continue
+            overlap_start = max(start_key, _utc_key(rec.start))
+            overlap_end = min(end_key, _utc_key(rec.end))
+            overlap_seconds = (overlap_end - overlap_start).total_seconds()
+            if overlap_seconds <= 0:
+                continue
+            rec.accumulate_pv(compute_accumulated_energy(pv_power_w, overlap_seconds))
+            rec.accumulate_load(
+                compute_accumulated_energy(load_power_w, overlap_seconds)
+            )
+            if rec.actual_coverage_seconds is not None:
+                rec.actual_coverage_seconds += overlap_seconds
+            assigned_seconds += overlap_seconds
+        return assigned_seconds
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -444,18 +666,126 @@ class ForecastTracker:
             "records": [r.to_dict() for r in self._records],
         }
 
-    def load_from_dict(self, data: dict[str, Any]) -> None:
-        """Restore tracker records from a dictionary previously produced
-        by :meth:`to_dict`.
+    def to_persistence_dict(
+        self,
+        *,
+        now: datetime,
+        max_records: int = 24,
+    ) -> dict[str, Any]:
+        """Serialize the bounded records that matter across a restart.
 
-        This replaces the current record list.  Call once on startup
-        after deserializing from HA storage.
-
-        Args:
-            data: A dictionary previously produced by :meth:`to_dict`.
+        The active/frozen slot is retained first, followed by the newest
+        eligible finalised records and then the nearest future baselines.
+        This prevents a long pre-created planning horizon from filling HA's
+        attribute budget with only the farthest-future slots.
         """
+        if now.tzinfo is None or now.utcoffset() is None:
+            raise ValueError("persistence reference time must be timezone-aware")
+        if max_records <= 0:
+            return {"records": []}
+
+        now_key = _utc_key(now)
+        active = sorted(
+            (
+                record
+                for record in self._records
+                if not record.finalised
+                and _utc_key(record.start) <= now_key < _utc_key(record.end)
+            ),
+            key=lambda record: _utc_key(record.start),
+            reverse=True,
+        )
+        frozen = sorted(
+            (
+                record
+                for record in self._records
+                if not record.finalised
+                and record.forecast_frozen
+                and record not in active
+            ),
+            key=lambda record: _utc_key(record.start),
+            reverse=True,
+        )
+        finalised = sorted(
+            (
+                record
+                for record in self._records
+                if record.finalised and record.accuracy_eligible
+            ),
+            key=lambda record: _utc_key(record.start),
+            reverse=True,
+        )
+        future = sorted(
+            (
+                record
+                for record in self._records
+                if not record.finalised
+                and not record.forecast_frozen
+                and record.raw_forecast_pv_kwh is not None
+                and _utc_key(record.start) > now_key
+            ),
+            key=lambda record: _utc_key(record.start),
+        )
+
+        selected: list[ForecastSlotRecord] = []
+        selected_keys: set[datetime] = set()
+        for category in (active, frozen, finalised, future):
+            for record in category:
+                key = _utc_key(record.start)
+                if key in selected_keys:
+                    continue
+                selected.append(record)
+                selected_keys.add(key)
+                if len(selected) >= max_records:
+                    break
+            if len(selected) >= max_records:
+                break
+
+        selected.sort(key=lambda record: _utc_key(record.start))
+        return {"records": [record.to_dict() for record in selected]}
+
+    def load_from_dict(
+        self,
+        data: Any,
+    ) -> None:
+        """Restore valid tracker records without trusting persisted values.
+
+        Invalid records are skipped. The retained records are UTC-sorted,
+        de-duplicated by physical start, and bounded by ``max_slots``.
+        """
+        self._records = []
+        self._restored_unfinalised_keys.clear()
+        if not isinstance(data, Mapping):
+            return
         raw_records = data.get("records", [])
-        self._records = [ForecastSlotRecord.from_dict(r) for r in raw_records]
+        if not isinstance(raw_records, list):
+            return
+
+        parsed_records: list[ForecastSlotRecord] = []
+        for raw_record in raw_records:
+            if not isinstance(raw_record, Mapping):
+                continue
+            try:
+                record = ForecastSlotRecord.from_dict(raw_record)
+            except TypeError, ValueError, OverflowError:
+                continue
+            parsed_records.append(record)
+
+        parsed_records.sort(key=lambda record: _utc_key(record.start))
+        seen: set[datetime] = set()
+        for record in parsed_records:
+            key = _utc_key(record.start)
+            if key in seen:
+                continue
+            seen.add(key)
+            self._records.append(record)
+            if not record.finalised:
+                self._restored_unfinalised_keys.add(key)
+
+        if len(self._records) > self._max_slots:
+            self._records = self._records[-self._max_slots :]
+            retained = {_utc_key(record.start) for record in self._records}
+            self._restored_unfinalised_keys.intersection_update(retained)
 
 
 # ---------------------------------------------------------------------------
@@ -465,7 +795,37 @@ class ForecastTracker:
 
 def _same_slot(a: datetime, b: datetime) -> bool:
     """Return ``True`` when *a* and *b* represent the same slot start."""
-    return a == b
+    return _utc_key(a) == _utc_key(b)
+
+
+def _utc_key(value: datetime) -> datetime:
+    """Return a pure-Python UTC identity without importing HA utilities."""
+    return value.astimezone(UTC).replace(microsecond=0)
+
+
+def _required_finite(
+    value: Any,
+    *,
+    minimum: float | None = None,
+    maximum: float | None = None,
+) -> float:
+    """Return a finite restored value or raise for the caller to skip it."""
+    parsed = finite_float(value, minimum=minimum, maximum=maximum)
+    if parsed is None:
+        raise ValueError("restored numeric value is invalid")
+    return parsed
+
+
+def _optional_finite(
+    value: Any,
+    *,
+    minimum: float | None = None,
+    maximum: float | None = None,
+) -> float | None:
+    """Return a finite optional restored value or reject invalid state."""
+    if value is None:
+        return None
+    return _required_finite(value, minimum=minimum, maximum=maximum)
 
 
 def compute_accumulated_energy(power_w: float, elapsed_seconds: float) -> float:

--- a/custom_components/hsem/utils/persistence.py
+++ b/custom_components/hsem/utils/persistence.py
@@ -18,7 +18,7 @@ def finite_float(
         return None
     try:
         parsed = float(value)
-    except (TypeError, ValueError, OverflowError):
+    except TypeError, ValueError, OverflowError:
         return None
     if not math.isfinite(parsed):
         return None
@@ -35,12 +35,12 @@ def aware_datetime_from_iso(value: Any) -> datetime | None:
         return None
     try:
         parsed = datetime.fromisoformat(value)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return None
     if parsed.tzinfo is None or parsed.utcoffset() is None:
         return None
     try:
         parsed.astimezone(UTC)
-    except (OverflowError, ValueError):
+    except OverflowError, ValueError:
         return None
     return parsed

--- a/custom_components/hsem/utils/persistence.py
+++ b/custom_components/hsem/utils/persistence.py
@@ -1,0 +1,46 @@
+"""Pure validation helpers for JSON-restored integration state."""
+
+from __future__ import annotations
+
+import math
+from datetime import UTC, datetime
+from typing import Any
+
+
+def finite_float(
+    value: Any,
+    *,
+    minimum: float | None = None,
+    maximum: float | None = None,
+) -> float | None:
+    """Return a bounded finite float, or ``None`` for invalid state."""
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if not math.isfinite(parsed):
+        return None
+    if minimum is not None and parsed < minimum:
+        return None
+    if maximum is not None and parsed > maximum:
+        return None
+    return parsed
+
+
+def aware_datetime_from_iso(value: Any) -> datetime | None:
+    """Parse an aware ISO datetime, returning ``None`` when invalid."""
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        return None
+    try:
+        parsed.astimezone(UTC)
+    except (OverflowError, ValueError):
+        return None
+    return parsed

--- a/custom_components/hsem/utils/solar_corrector.py
+++ b/custom_components/hsem/utils/solar_corrector.py
@@ -10,10 +10,18 @@ plain ``pytest``.
 
 from __future__ import annotations
 
+import math
 import statistics
+from collections.abc import Mapping
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
 
 from custom_components.hsem.utils.logger import log_planner
+from custom_components.hsem.utils.persistence import (
+    aware_datetime_from_iso,
+    finite_float,
+)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -23,7 +31,7 @@ from custom_components.hsem.utils.logger import log_planner
 FACTOR_MIN: float = 0.3
 FACTOR_MAX: float = 1.5
 
-# Maximum number of (forecast, actual) samples retained per hour.
+# Four eligible samples are retained per wall-clock hour.
 MAX_HISTORY_PER_HOUR: int = 4
 
 # Maximum number of recent closed-slot residuals retained.
@@ -34,8 +42,15 @@ RESIDUAL_DECAY_SLOTS: int = 8
 
 CONFIDENCE_DEFAULT: float = 0.50
 
+# Versions before 3 did not persist the exact rolling buffers or replay
+# watermark, so restoring their factors could not preserve learning semantics.
+SOLAR_CORRECTOR_STATE_VERSION: int = 3
+
 # Threshold below which forecast kWh is treated as zero to avoid division by zero.
 _FORECAST_EPS: float = 1e-9
+
+# A deliberately generous per-slot ceiling keeps restored arithmetic finite.
+_MAX_ENERGY_KWH: float = 1_000_000.0
 
 
 @dataclass
@@ -44,17 +59,18 @@ class SolarForecastCorrector:
 
     Two-layer correction:
     1. **Per-hour accuracy factor**: Rolling mean of (actual PV / forecast PV)
-       over the last ~4 days per hour-of-day, clamped to [0.3, 1.5].
+       over the last four eligible samples for that wall-clock
+       hour, clamped to [0.3, 1.5].
     2. **Intra-hour residual correction**: Mean of (actual / forecast) over the
-       last 4 closed 15-min slots, linearly decayed to 1.0 over the next 2 hours
-       (8 slots).
+       last four eligible closed physical slots, linearly decayed to 1.0 over
+       the next eight physical slots (two hours at 15-minute cadence).
 
     Attributes:
         hour_factors: Per-hour accuracy factors keyed by hour (0-23).
             Defaults to 1.0 for all hours.
-        confidence: Confidence percentile (0.10-0.90).  At 0.50 the learned
-            factor is used as-is; lower values reduce the correction toward
-            1.0 (more conservative PV estimate).
+        confidence: Internal correction strength (0.10-0.90).  At 0.50 the
+            learned factor is used as-is; lower values reduce the correction
+            toward the raw forecast.
     """
 
     # Per-hour accuracy factor [0.3, 1.5], keyed by hour (0-23).
@@ -71,14 +87,76 @@ class SolarForecastCorrector:
         default_factory=list, repr=False
     )
 
-    # Confidence percentile (0.10-0.90, default 0.50).
+    # Internal correction strength (0.10-0.90, default 0.50).
     # At 0.50 the learned factor is applied fully; lower values push toward 1.0
-    # (more conservative — less PV expected).
+    # (toward the uncorrected raw forecast).
     confidence: float = CONFIDENCE_DEFAULT
+
+    # Physical planning instant used to derive residual distance.  Ephemeral:
+    # it is refreshed each coordinator cycle and deliberately not persisted.
+    _reference_time: datetime | None = field(default=None, repr=False)
+
+    # Latest UTC slot start consumed by the rolling buffers. Persisted so a
+    # restored finalised tracker record cannot be learned a second time.
+    _processed_through: datetime | None = field(default=None, repr=False)
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
+
+    def set_reference_time(self, now: datetime) -> None:
+        """Set the physical instant from which future-slot distance is measured."""
+        if now.tzinfo is None:
+            raise ValueError("reference time must be timezone-aware")
+        self._reference_time = now
+
+    @property
+    def processed_through(self) -> datetime | None:
+        """Return the latest physical slot consumed by the rolling buffers."""
+        return self._processed_through
+
+    def mark_processed(self, slot_start: datetime) -> None:
+        """Advance the replay watermark to an aware physical slot start."""
+        if slot_start.tzinfo is None or slot_start.utcoffset() is None:
+            raise ValueError("processed slot start must be timezone-aware")
+        key = slot_start.astimezone(UTC).replace(microsecond=0)
+        if self._processed_through is None or key > self._processed_through:
+            self._processed_through = key
+
+    def was_processed(self, slot_start: datetime) -> bool:
+        """Return whether a physical slot is at or before the replay watermark."""
+        if slot_start.tzinfo is None or slot_start.utcoffset() is None:
+            return False
+        return (
+            self._processed_through is not None
+            and slot_start.astimezone(UTC).replace(microsecond=0)
+            <= self._processed_through
+        )
+
+    def slots_ahead_for(
+        self,
+        slot_start: datetime,
+        interval_minutes: int,
+        *,
+        fallback: int,
+    ) -> int:
+        """Return a UTC-based physical slot distance from the current slot.
+
+        The ceiling keeps an in-progress slot at ``0`` while mapping the next
+        whole-hour boundaries correctly (for example +4 and +8 at 15-minute
+        granularity).  UTC arithmetic preserves both identities in a DST fold.
+        """
+        if self._reference_time is None:
+            return max(0, fallback)
+        if slot_start.tzinfo is None:
+            raise ValueError("slot start must be timezone-aware")
+        if interval_minutes <= 0:
+            raise ValueError("interval_minutes must be positive")
+
+        delta_seconds = (
+            slot_start.astimezone(UTC) - self._reference_time.astimezone(UTC)
+        ).total_seconds()
+        return max(0, math.ceil(delta_seconds / (interval_minutes * 60.0)))
 
     def update_hour(self, hour: int, forecast_kwh: float, actual_kwh: float) -> None:
         """Update the per-hour accuracy factor for a given hour.
@@ -103,14 +181,16 @@ class SolarForecastCorrector:
             )
             return
 
-        if abs(forecast_kwh) < _FORECAST_EPS:
+        sample = _valid_energy_pair(forecast_kwh, actual_kwh)
+        if sample is None or sample[0] < _FORECAST_EPS:
             log_planner(
                 "debug",
-                "[solar_corrector] update_hour(h=%d) skipped — forecast_kwh=%.4f near zero",
+                "[solar_corrector] update_hour(h=%d) skipped — invalid or "
+                "near-zero sample",
                 hour,
-                forecast_kwh,
             )
             return
+        forecast_kwh, actual_kwh = sample
 
         if hour not in self._hour_history:
             self._hour_history[hour] = []
@@ -149,7 +229,11 @@ class SolarForecastCorrector:
             forecast_kwh: Forecast PV energy for the slot in kWh.
             actual_kwh: Actual PV energy for the slot in kWh.
         """
-        self._recent_residuals.append((forecast_kwh, actual_kwh))
+        sample = _valid_energy_pair(forecast_kwh, actual_kwh)
+        if sample is None or sample[0] < _FORECAST_EPS:
+            return
+
+        self._recent_residuals.append(sample)
         while len(self._recent_residuals) > MAX_RESIDUALS:
             self._recent_residuals.pop(0)
 
@@ -165,7 +249,7 @@ class SolarForecastCorrector:
         """Return the corrected PV estimate for a slot.
 
         Applies:
-        1. Per-hour accuracy factor (scaled by confidence percentile).
+        1. Per-hour accuracy factor (scaled by correction strength).
         2. Intra-hour residual factor (decayed by ``slots_ahead``).
 
         The two corrections multiply::
@@ -211,41 +295,118 @@ class SolarForecastCorrector:
     # Serialization (reboot persistence)
     # ------------------------------------------------------------------
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize the corrector state to a JSON-safe dictionary.
 
         Returns:
-            A dictionary with hour_factors and confidence.
+            A versioned dictionary with the exact bounded rolling state.
         """
         return {
-            "hour_factors": dict(self.hour_factors),
+            "schema_version": SOLAR_CORRECTOR_STATE_VERSION,
+            "hour_factors": {
+                str(hour): factor for hour, factor in sorted(self.hour_factors.items())
+            },
+            "hour_history": {
+                str(hour): [list(sample) for sample in history]
+                for hour, history in sorted(self._hour_history.items())
+            },
+            "recent_residuals": [list(sample) for sample in self._recent_residuals],
             "confidence": self.confidence,
+            "processed_through": (
+                self._processed_through.isoformat()
+                if self._processed_through is not None
+                else None
+            ),
         }
 
-    def load_from_dict(self, data: dict) -> None:
-        """Restore corrector state from a previously-serialized dictionary.
+    def load_from_dict(
+        self,
+        data: Any,
+        *,
+        restored_at: datetime | None = None,
+    ) -> None:
+        """Restore a validated corrector state or intentionally cold-reset.
+
+        Versions before 3 lack the exact rolling buffers and replay watermark,
+        so their learned state cannot be resumed faithfully. Malformed current
+        payloads are rejected atomically. A valid bounded confidence control is
+        retained across either kind of cold reset.
 
         Args:
-            data: A dictionary previously produced by :meth:`to_dict`.
+            data: A value previously produced by :meth:`to_dict`.
         """
-        if "hour_factors" in data:
-            self.hour_factors = {
-                int(k): float(v) for k, v in data["hour_factors"].items()
-            }
-        if "confidence" in data:
-            self.confidence = float(data["confidence"])
+        safe_confidence = (
+            finite_float(self.confidence, minimum=0.10, maximum=0.90)
+            or CONFIDENCE_DEFAULT
+        )
+        if isinstance(data, Mapping):
+            restored_confidence = finite_float(
+                data.get("confidence"), minimum=0.10, maximum=0.90
+            )
+            if restored_confidence is not None:
+                safe_confidence = restored_confidence
+
+        self.hour_factors.clear()
+        self._hour_history.clear()
+        self._recent_residuals.clear()
+        self._processed_through = None
+        self.confidence = safe_confidence
+
+        if (
+            not isinstance(data, Mapping)
+            or type(data.get("schema_version")) is not int
+            or data.get("schema_version") != SOLAR_CORRECTOR_STATE_VERSION
+        ):
+            log_planner(
+                "debug",
+                "[solar_corrector] discarded pre-v3 learned state; rebuilding "
+                "from frozen forecast baselines",
+            )
+            return
+
+        restore_reference = restored_at or datetime.now(UTC)
+        if restore_reference.tzinfo is None or restore_reference.utcoffset() is None:
+            log_planner(
+                "warning",
+                "[solar_corrector] discarded v3 state without an aware "
+                "restore reference",
+            )
+            return
+        try:
+            restore_reference_utc = restore_reference.astimezone(UTC)
+        except OverflowError, ValueError:
+            return
+
+        restored = _parse_current_state(
+            data,
+            restored_at=restore_reference_utc,
+        )
+        if restored is None:
+            log_planner(
+                "warning",
+                "[solar_corrector] discarded malformed v3 persisted state",
+            )
+            return
+
+        (
+            self.hour_factors,
+            self._hour_history,
+            self._recent_residuals,
+            self.confidence,
+            self._processed_through,
+        ) = restored
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
 
     def _apply_confidence(self, raw_factor: float) -> float:
-        """Scale the per-hour factor by the confidence percentile.
+        """Scale the per-hour factor by the correction strength.
 
         At ``confidence = 0.50`` the raw factor is applied at full strength.
-        Below 0.50 the correction is dampened toward 1.0 (more conservative
-        — less PV expected).  Above 0.50 the correction is still applied at
-        full strength but never amplified beyond the raw factor.
+        Below 0.50 the correction is dampened toward 1.0 (toward the raw
+        forecast). Above 0.50 the correction is still applied at full strength
+        but never amplified beyond the raw factor.
 
         Args:
             raw_factor: The raw learned factor for the hour.
@@ -291,3 +452,150 @@ class SolarForecastCorrector:
 
         decay = 1.0 - (slots_ahead / RESIDUAL_DECAY_SLOTS)
         return 1.0 + (mean_residual - 1.0) * decay
+
+
+def _valid_energy_pair(
+    forecast_kwh: Any,
+    actual_kwh: Any,
+) -> tuple[float, float] | None:
+    """Return a finite, non-negative, bounded energy pair."""
+    forecast = finite_float(
+        forecast_kwh,
+        minimum=0.0,
+        maximum=_MAX_ENERGY_KWH,
+    )
+    actual = finite_float(
+        actual_kwh,
+        minimum=0.0,
+        maximum=_MAX_ENERGY_KWH,
+    )
+    if forecast is None or actual is None:
+        return None
+    return forecast, actual
+
+
+def _parse_hour_key(value: Any) -> int | None:
+    """Parse one canonical JSON hour key."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        hour = value
+    elif isinstance(value, str) and value.isdigit() and str(int(value)) == value:
+        hour = int(value)
+    else:
+        return None
+    return hour if 0 <= hour <= 23 else None
+
+
+def _parse_energy_history(
+    value: Any,
+    *,
+    maximum_length: int,
+) -> list[tuple[float, float]] | None:
+    """Parse a bounded ordered list of valid forecast/actual pairs."""
+    if not isinstance(value, list) or len(value) > maximum_length:
+        return None
+    parsed: list[tuple[float, float]] = []
+    for raw_pair in value:
+        if not isinstance(raw_pair, (list, tuple)) or len(raw_pair) != 2:
+            return None
+        pair = _valid_energy_pair(raw_pair[0], raw_pair[1])
+        if pair is None or pair[0] < _FORECAST_EPS:
+            return None
+        parsed.append(pair)
+    return parsed
+
+
+def _factor_from_history(history: list[tuple[float, float]]) -> float:
+    """Recompute the exact bounded factor represented by a history buffer."""
+    mean_ratio = statistics.mean(actual / forecast for forecast, actual in history)
+    return max(FACTOR_MIN, min(FACTOR_MAX, mean_ratio))
+
+
+def _parse_current_state(
+    data: Mapping[str, Any],
+    *,
+    restored_at: datetime,
+) -> (
+    tuple[
+        dict[int, float],
+        dict[int, list[tuple[float, float]]],
+        list[tuple[float, float]],
+        float,
+        datetime | None,
+    ]
+    | None
+):
+    """Parse v3 state atomically, rejecting partial or poisoned payloads."""
+    required_keys = {
+        "hour_factors",
+        "hour_history",
+        "recent_residuals",
+        "confidence",
+        "processed_through",
+    }
+    if not required_keys.issubset(data):
+        return None
+
+    raw_factors = data.get("hour_factors")
+    raw_history = data.get("hour_history")
+    raw_residuals = data.get("recent_residuals")
+    if not isinstance(raw_factors, Mapping) or not isinstance(raw_history, Mapping):
+        return None
+
+    factors: dict[int, float] = {}
+    for raw_hour, raw_factor in raw_factors.items():
+        hour = _parse_hour_key(raw_hour)
+        factor = finite_float(raw_factor, minimum=FACTOR_MIN, maximum=FACTOR_MAX)
+        if hour is None or hour in factors or factor is None:
+            return None
+        factors[hour] = factor
+
+    history_by_hour: dict[int, list[tuple[float, float]]] = {}
+    for raw_hour, raw_samples in raw_history.items():
+        hour = _parse_hour_key(raw_hour)
+        samples = _parse_energy_history(
+            raw_samples,
+            maximum_length=MAX_HISTORY_PER_HOUR,
+        )
+        if hour is None or hour in history_by_hour or samples is None or not samples:
+            return None
+        history_by_hour[hour] = samples
+
+    if factors.keys() != history_by_hour.keys():
+        return None
+    if any(
+        not math.isclose(
+            factors[hour],
+            _factor_from_history(samples),
+            rel_tol=1e-9,
+            abs_tol=1e-9,
+        )
+        for hour, samples in history_by_hour.items()
+    ):
+        return None
+
+    residuals = _parse_energy_history(
+        raw_residuals,
+        maximum_length=MAX_RESIDUALS,
+    )
+    confidence = finite_float(
+        data.get("confidence"),
+        minimum=0.10,
+        maximum=0.90,
+    )
+    if residuals is None or confidence is None:
+        return None
+
+    raw_processed_through = data.get("processed_through")
+    if raw_processed_through is None:
+        processed_through = None
+    else:
+        parsed_timestamp = aware_datetime_from_iso(raw_processed_through)
+        if parsed_timestamp is None:
+            return None
+        processed_through = parsed_timestamp.astimezone(UTC).replace(microsecond=0)
+        if processed_through > restored_at:
+            return None
+
+    return factors, history_by_hour, residuals, confidence, processed_through

--- a/tests/ml/test_consumption_predictor.py
+++ b/tests/ml/test_consumption_predictor.py
@@ -4,7 +4,9 @@ Uses lazy imports to avoid triggering the numpy/bcrypt native module
 conflict during pytest collection in CI environments.
 """
 
-from datetime import datetime, timedelta
+import math
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -122,3 +124,223 @@ class TestConsumptionPredictor:
             history.append((NOW - timedelta(days=offset), 32, 5.0))
         p.train(history, NOW)
         assert p.predict(32, 2, NOW) > p.predict(32, 4, NOW)
+
+    def test_same_length_rolling_history_retrains_at_unseen_threshold(self) -> None:
+        """A sliding window must refit even when its sample count stays constant."""
+        tz = NOW.tzinfo
+        assert tz is not None
+
+        def sample(month: int, day: int, energy: float) -> tuple[datetime, int, float]:
+            return datetime(2026, month, day, 12, 0, tzinfo=tz), 48, energy
+
+        initial_reference = datetime(2026, 7, 16, 13, 0, tzinfo=tz)
+        initial_history = [
+            sample(6, 25, 1.0),
+            sample(7, 2, 1.0),
+            sample(7, 9, 1.0),
+            sample(7, 16, 1.0),
+        ]
+        p = _predictor(
+            decay_days=30.0,
+            alpha=0.1,
+            slots_per_day=96,
+            retrain_min_new_samples=2,
+        )
+
+        p.train(initial_history, initial_reference)
+        baseline_prediction = p.predict(48, 0, initial_reference)
+        assert p.last_fit_time == initial_reference
+
+        # Truly unchanged history retains the cheap gate even as time advances.
+        p.train(initial_history, initial_reference + timedelta(minutes=15))
+        assert p.last_fit_time == initial_reference
+        assert p.predict(48, 0, initial_reference) == pytest.approx(baseline_prediction)
+
+        # One unseen physical sample is below the configured threshold.
+        one_new_reference = datetime(2026, 7, 23, 13, 0, tzinfo=tz)
+        one_new_sample = [
+            sample(7, 2, 1.0),
+            sample(7, 9, 1.0),
+            sample(7, 16, 1.0),
+            sample(7, 23, 4.0),
+        ]
+        p.train(one_new_sample, one_new_reference)
+        assert p.last_fit_time == initial_reference
+        assert p.predict(48, 0, initial_reference) == pytest.approx(baseline_prediction)
+
+        # The second unseen sample reaches the threshold.  Length is still
+        # four, but the fitted coefficients and prediction must update.
+        two_new_reference = datetime(2026, 7, 30, 13, 0, tzinfo=tz)
+        two_new_samples = [
+            sample(7, 9, 1.0),
+            sample(7, 16, 1.0),
+            sample(7, 23, 4.0),
+            sample(7, 30, 6.0),
+        ]
+        p.train(two_new_samples, two_new_reference)
+
+        assert p.last_fit_samples == len(initial_history)
+        assert p.last_fit_time == two_new_reference
+        assert p.predict(48, 0, initial_reference) > baseline_prediction
+
+    def test_revised_sample_fingerprint_triggers_same_length_refit(self) -> None:
+        """A corrected value at an existing physical slot counts as changed."""
+        tz = NOW.tzinfo
+        assert tz is not None
+        reference = datetime(2026, 7, 30, 13, 0, tzinfo=tz)
+        first_timestamp = datetime(2026, 7, 23, 12, 0, tzinfo=tz)
+        revised_timestamp = datetime(2026, 7, 30, 12, 0, tzinfo=tz)
+        history = [
+            (first_timestamp, 48, 1.0),
+            (revised_timestamp, 48, 1.0),
+        ]
+        p = _predictor(
+            decay_days=30.0,
+            alpha=0.1,
+            slots_per_day=96,
+            retrain_min_new_samples=1,
+        )
+
+        p.train(history, reference)
+        baseline_prediction = p.predict(48, 0, reference)
+
+        revised_history = [
+            history[0],
+            (revised_timestamp, 48, 5.0),
+        ]
+        revised_reference = reference + timedelta(minutes=15)
+        p.train(revised_history, revised_reference)
+
+        assert p.last_fit_samples == len(history)
+        assert p.last_fit_time == revised_reference
+        assert p.predict(48, 0, reference) > baseline_prediction
+
+    def test_sequential_training_resets_lag_across_recorder_gap(self) -> None:
+        """A missing physical interval must not become another sample's lag."""
+        tz = ZoneInfo("Europe/Stockholm")
+        reference = datetime(2026, 8, 20, 1, 0, tzinfo=tz)
+        slot_zero = datetime(2026, 8, 20, 0, 0, tzinfo=tz)
+        slot_one = datetime(2026, 8, 20, 0, 15, tzinfo=tz)
+        slot_three = datetime(2026, 8, 20, 0, 45, tzinfo=tz)
+        predictor = _predictor(
+            slots_per_day=96,
+            retrain_min_new_samples=1,
+            use_sequential=True,
+        )
+
+        # Recorder order is deliberately scrambled; physical UTC order wins.
+        predictor.train(
+            [
+                (slot_three, 3, 4.0),
+                (slot_zero, 0, 1.0),
+                (slot_one, 1, 2.0),
+            ],
+            reference,
+        )
+
+        assert predictor._X is not None
+        assert predictor._y is not None
+        assert predictor._y.tolist() == pytest.approx([1.0, 2.0, 4.0])
+        assert predictor._X[:, predictor._lag_offset].tolist() == pytest.approx(
+            [0.0, 1.0, 0.0]
+        )
+
+    def test_sequential_inference_skips_nonexistent_spring_slots(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The lag chain follows physical slots across the spring jump."""
+        tz = ZoneInfo("Europe/Stockholm")
+        predictor = _predictor(slots_per_day=96, use_sequential=True)
+        predictor.train([_mk(2, 0, 1.0), _mk(1, 0, 1.0)], NOW)
+        seen: list[tuple[int, int, int, float]] = []
+
+        def fake_predict(
+            timestamp: datetime,
+            _slot: int,
+            _temperature: float | None,
+            prev_energy: float,
+        ) -> float:
+            seen.append((timestamp.hour, timestamp.minute, timestamp.fold, prev_energy))
+            return prev_energy + 1.0
+
+        monkeypatch.setattr(predictor, "_predict_from_features", fake_predict)
+        starts = [
+            datetime(2026, 3, 29, 3, 15, tzinfo=tz),
+            datetime(2026, 3, 29, 1, 45, tzinfo=tz),
+            datetime(2026, 3, 29, 3, 0, tzinfo=tz),
+        ]
+
+        result = predictor.predict_sequential(starts)
+
+        assert list(result) == [
+            datetime(2026, 3, 29, 0, 45, tzinfo=UTC),
+            datetime(2026, 3, 29, 1, 0, tzinfo=UTC),
+            datetime(2026, 3, 29, 1, 15, tzinfo=UTC),
+        ]
+        assert list(result.values()) == pytest.approx([1.0, 2.0, 3.0])
+        assert seen == [
+            (1, 45, 0, 0.0),
+            (3, 0, 0, 1.0),
+            (3, 15, 0, 2.0),
+        ]
+
+    def test_sequential_inference_keeps_both_autumn_folds(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Repeated wall slots remain distinct members of one physical chain."""
+        tz = ZoneInfo("Europe/Stockholm")
+        predictor = _predictor(slots_per_day=96, use_sequential=True)
+        predictor.train([_mk(2, 0, 1.0), _mk(1, 0, 1.0)], NOW)
+
+        def fake_predict(
+            _timestamp: datetime,
+            _slot: int,
+            _temperature: float | None,
+            prev_energy: float,
+        ) -> float:
+            return prev_energy + 1.0
+
+        monkeypatch.setattr(predictor, "_predict_from_features", fake_predict)
+        first_fold = [
+            datetime(2026, 10, 25, 2, minute, tzinfo=tz, fold=0)
+            for minute in (0, 15, 30, 45)
+        ]
+        second_fold_start = datetime(2026, 10, 25, 2, 0, tzinfo=tz, fold=1)
+
+        result = predictor.predict_sequential(
+            [second_fold_start, *reversed(first_fold)]
+        )
+
+        assert len(result) == 5
+        assert result[first_fold[0].astimezone(UTC)] == pytest.approx(1.0)
+        assert result[second_fold_start.astimezone(UTC)] == pytest.approx(5.0)
+
+    def test_nonfinite_energy_and_temperature_never_contaminate_fit(self) -> None:
+        predictor = _predictor(
+            slots_per_day=96,
+            retrain_min_new_samples=1,
+            use_temperature=True,
+        )
+        bad_history = [
+            (_mk(2, 0, 1.0)[0], 0, float("nan")),
+            (_mk(1, 1, 1.0)[0], 1, float("inf")),
+        ]
+        predictor.train(
+            bad_history,
+            NOW,
+            {bad_history[0][0]: float("nan")},
+        )
+        assert predictor.trained is False
+
+        good_history = [_mk(2, 0, 1.0), _mk(1, 1, 2.0)]
+        predictor.train(
+            good_history,
+            NOW,
+            {timestamp: float("-inf") for timestamp, _slot, _energy in good_history},
+        )
+
+        assert predictor.trained is True
+        assert predictor.last_fit_samples == 2
+        assert math.isfinite(predictor.predict(0, 0, NOW, float("nan")))

--- a/tests/ml/test_history_reader.py
+++ b/tests/ml/test_history_reader.py
@@ -1,0 +1,311 @@
+"""Regression tests for recorder-history time and physical-slot alignment."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from custom_components.hsem.ml.history_reader import HistoryReader
+from custom_components.hsem.utils.datetime_utils import utc_key
+
+STOCKHOLM = ZoneInfo("Europe/Stockholm")
+ENTITY_ID = "sensor.house_consumption_energy_total"
+
+
+@pytest.fixture(autouse=True)
+def _ha_local_timezone():
+    """Make HA-local conversion deterministic without a running HA instance."""
+
+    def as_stockholm(value: datetime) -> datetime:
+        if value.tzinfo is None:
+            return value.replace(tzinfo=STOCKHOLM)
+        return value.astimezone(STOCKHOLM)
+
+    with patch(
+        "custom_components.hsem.utils.datetime_utils.dt_util.as_local",
+        side_effect=as_stockholm,
+    ):
+        yield
+
+
+def _state(timestamp: datetime, value: float) -> SimpleNamespace:
+    return SimpleNamespace(last_updated=timestamp, state=str(value))
+
+
+def _deltas(
+    readings: list[tuple[datetime, float]],
+    now: datetime,
+) -> list[tuple[datetime, int, float]]:
+    return HistoryReader._compute_slot_deltas(readings, now, 15, 96)
+
+
+@pytest.mark.parametrize(
+    ("readings", "now"),
+    [
+        (
+            [
+                (datetime(2026, 8, 20, 7, 44, 50, tzinfo=UTC), 100.0),
+                (datetime(2026, 8, 20, 7, 59, 50, tzinfo=UTC), 100.25),
+            ],
+            datetime(2026, 8, 20, 8, 15, tzinfo=UTC),
+        ),
+        (
+            [
+                (datetime(2026, 1, 20, 8, 44, 50, tzinfo=UTC), 100.0),
+                (datetime(2026, 1, 20, 8, 59, 50, tzinfo=UTC), 100.25),
+            ],
+            datetime(2026, 1, 20, 9, 15, tzinfo=UTC),
+        ),
+    ],
+)
+def test_delta_is_attributed_to_current_ha_local_slot_in_cest_and_cet(
+    readings: list[tuple[datetime, float]],
+    now: datetime,
+) -> None:
+    """The same 09:45 local load must not move with the UTC offset."""
+    history = _deltas(readings, now)
+
+    assert len(history) == 1
+    slot_start, slot_index, energy = history[0]
+    assert (slot_start.hour, slot_start.minute) == (9, 45)
+    assert slot_index == 39
+    assert energy == pytest.approx(0.25)
+
+
+def test_recorder_gap_is_not_converted_into_one_slot() -> None:
+    readings = [
+        (datetime(2026, 8, 20, 7, 44, 50, tzinfo=UTC), 100.0),
+        # The 07:45 UTC physical slot has no readings.
+        (datetime(2026, 8, 20, 8, 14, 50, tzinfo=UTC), 100.5),
+    ]
+
+    assert _deltas(readings, datetime(2026, 8, 20, 8, 30, tzinfo=UTC)) == []
+
+
+def test_spring_forward_skips_nonexistent_wall_hour() -> None:
+    readings = [
+        (datetime(2026, 3, 29, 0, 44, 50, tzinfo=UTC), 100.0),
+        (datetime(2026, 3, 29, 0, 59, 50, tzinfo=UTC), 100.1),
+        (datetime(2026, 3, 29, 1, 14, 50, tzinfo=UTC), 100.2),
+        (datetime(2026, 3, 29, 1, 29, 50, tzinfo=UTC), 100.3),
+    ]
+
+    history = _deltas(readings, datetime(2026, 3, 29, 1, 45, tzinfo=UTC))
+
+    assert [(slot.hour, slot.minute, slot.fold) for slot, _idx, _energy in history] == [
+        (1, 45, 0),
+        (3, 0, 0),
+        (3, 15, 0),
+    ]
+    assert [idx for _slot, idx, _energy in history] == [7, 12, 13]
+
+
+def test_autumn_fallback_preserves_both_physical_folds() -> None:
+    readings = [
+        (datetime(2026, 10, 25, 0, 44, 50, tzinfo=UTC), 100.0),
+        (datetime(2026, 10, 25, 0, 59, 50, tzinfo=UTC), 100.1),
+        (datetime(2026, 10, 25, 1, 14, 50, tzinfo=UTC), 100.2),
+        (datetime(2026, 10, 25, 1, 29, 50, tzinfo=UTC), 100.3),
+    ]
+
+    history = _deltas(readings, datetime(2026, 10, 25, 1, 45, tzinfo=UTC))
+    starts = [slot for slot, _idx, _energy in history]
+
+    assert [(slot.hour, slot.minute, slot.fold) for slot in starts] == [
+        (2, 45, 0),
+        (2, 0, 1),
+        (2, 15, 1),
+    ]
+    assert [utc_key(slot) for slot in starts] == sorted(
+        utc_key(slot) for slot in starts
+    )
+
+
+async def _read_actuals(
+    *,
+    now: datetime,
+    states: list[SimpleNamespace],
+) -> tuple[dict[datetime, float], AsyncMock]:
+    executor = AsyncMock(return_value={ENTITY_ID: states})
+    recorder = SimpleNamespace(async_add_executor_job=executor)
+    with (
+        patch(
+            "custom_components.hsem.ml.history_reader.get_instance",
+            return_value=recorder,
+        ),
+        patch(
+            "custom_components.hsem.ml.history_reader.hsem_now",
+            return_value=now,
+        ),
+    ):
+        actuals = await HistoryReader(MagicMock()).read_today_actuals(ENTITY_ID)
+    return actuals, executor
+
+
+@pytest.mark.asyncio
+async def test_today_actuals_use_local_midnight_and_exclude_current_or_prior_day() -> (
+    None
+):
+    now = datetime(2026, 8, 20, 0, 40, tzinfo=STOCKHOLM)
+    states = [
+        _state(datetime(2026, 8, 19, 21, 44, 50, tzinfo=UTC), 99.9),
+        _state(datetime(2026, 8, 19, 21, 59, 50, tzinfo=UTC), 100.0),
+        _state(datetime(2026, 8, 19, 22, 14, 50, tzinfo=UTC), 100.2),
+        _state(datetime(2026, 8, 19, 22, 29, 50, tzinfo=UTC), 100.5),
+        # In-progress local 00:30 slot must be excluded.
+        _state(datetime(2026, 8, 19, 22, 34, 50, tzinfo=UTC), 100.6),
+    ]
+
+    actuals, executor = await _read_actuals(now=now, states=states)
+
+    assert actuals == {
+        datetime(2026, 8, 19, 22, 0, tzinfo=UTC): pytest.approx(0.2),
+        datetime(2026, 8, 19, 22, 15, tzinfo=UTC): pytest.approx(0.3),
+    }
+    assert executor.await_args is not None
+    call_args = executor.await_args.args
+    assert call_args[2] == datetime(2026, 8, 19, 21, 45, tzinfo=UTC)
+    assert call_args[3] == datetime(2026, 8, 19, 22, 40, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_today_actuals_keep_repeated_hour_folds_as_distinct_keys() -> None:
+    now = datetime(2026, 10, 25, 3, 0, tzinfo=STOCKHOLM)
+    states = [
+        _state(datetime(2026, 10, 25, 0, 44, 50, tzinfo=UTC), 100.0),
+        _state(datetime(2026, 10, 25, 0, 59, 50, tzinfo=UTC), 100.1),
+        _state(datetime(2026, 10, 25, 1, 14, 50, tzinfo=UTC), 100.2),
+        _state(datetime(2026, 10, 25, 1, 29, 50, tzinfo=UTC), 100.3),
+    ]
+
+    actuals, _executor = await _read_actuals(now=now, states=states)
+
+    assert datetime(2026, 10, 25, 0, 45, tzinfo=UTC) in actuals
+    assert datetime(2026, 10, 25, 1, 0, tzinfo=UTC) in actuals
+    assert len(actuals) == 3
+
+
+@pytest.mark.asyncio
+async def test_instantaneous_history_orders_repeated_hour_by_physical_time() -> None:
+    now = datetime(2026, 10, 25, 3, 0, tzinfo=STOCKHOLM)
+    # Recorder order is deliberately reversed.  Both normalize to local
+    # 02:00, but they are one physical hour apart.
+    states = [
+        _state(datetime(2026, 10, 25, 1, 0, tzinfo=UTC), 20.0),
+        _state(datetime(2026, 10, 25, 0, 0, tzinfo=UTC), 10.0),
+    ]
+    executor = AsyncMock(return_value={ENTITY_ID: states})
+    recorder = SimpleNamespace(async_add_executor_job=executor)
+
+    with (
+        patch(
+            "custom_components.hsem.ml.history_reader.get_instance",
+            return_value=recorder,
+        ),
+        patch(
+            "custom_components.hsem.ml.history_reader.hsem_now",
+            return_value=now,
+        ),
+    ):
+        readings = await HistoryReader(MagicMock()).read_instantaneous_history(
+            ENTITY_ID,
+            days=0,
+        )
+
+    assert [(timestamp.fold, value) for timestamp, value in readings] == [
+        (0, 10.0),
+        (1, 20.0),
+    ]
+    assert [utc_key(timestamp) for timestamp, _value in readings] == sorted(
+        utc_key(timestamp) for timestamp, _value in readings
+    )
+
+
+@pytest.mark.parametrize("bad_value", [float("nan"), float("inf"), float("-inf")])
+def test_nonfinite_boundary_is_dropped_without_bridging_recorder_gap(
+    bad_value: float,
+) -> None:
+    readings = [
+        (datetime(2026, 8, 20, 7, 44, 50, tzinfo=UTC), 100.0),
+        (datetime(2026, 8, 20, 7, 59, 50, tzinfo=UTC), bad_value),
+        (datetime(2026, 8, 20, 8, 14, 50, tzinfo=UTC), 100.5),
+    ]
+
+    assert _deltas(readings, datetime(2026, 8, 20, 8, 30, tzinfo=UTC)) == []
+
+
+@pytest.mark.asyncio
+async def test_energy_history_with_nonfinite_states_falls_back() -> None:
+    now = datetime(2026, 8, 20, 10, 0, tzinfo=STOCKHOLM)
+    states = [
+        _state(datetime(2026, 8, 20, 7, 29, 50, tzinfo=UTC), 100.0),
+        _state(datetime(2026, 8, 20, 7, 44, 50, tzinfo=UTC), float("nan")),
+        _state(datetime(2026, 8, 20, 7, 59, 50, tzinfo=UTC), float("inf")),
+    ]
+    executor = AsyncMock(return_value={ENTITY_ID: states})
+    recorder = SimpleNamespace(async_add_executor_job=executor)
+
+    with (
+        patch(
+            "custom_components.hsem.ml.history_reader.get_instance",
+            return_value=recorder,
+        ),
+        patch(
+            "custom_components.hsem.ml.history_reader.hsem_now",
+            return_value=now,
+        ),
+    ):
+        history = await HistoryReader(MagicMock()).read_energy_history(
+            ENTITY_ID,
+            days=0,
+        )
+
+    assert history == []
+
+
+@pytest.mark.asyncio
+async def test_today_actuals_do_not_publish_nonfinite_boundary() -> None:
+    now = datetime(2026, 8, 20, 10, 0, tzinfo=STOCKHOLM)
+    states = [
+        _state(datetime(2026, 8, 20, 7, 29, 50, tzinfo=UTC), 100.0),
+        _state(datetime(2026, 8, 20, 7, 44, 50, tzinfo=UTC), float("nan")),
+        _state(datetime(2026, 8, 20, 7, 59, 50, tzinfo=UTC), 100.5),
+    ]
+
+    actuals, _executor = await _read_actuals(now=now, states=states)
+
+    assert actuals == {}
+
+
+@pytest.mark.asyncio
+async def test_instantaneous_history_filters_nonfinite_temperature() -> None:
+    now = datetime(2026, 8, 20, 10, 0, tzinfo=STOCKHOLM)
+    finite_timestamp = datetime(2026, 8, 20, 7, 45, tzinfo=UTC)
+    states = [
+        _state(datetime(2026, 8, 20, 7, 30, tzinfo=UTC), float("nan")),
+        _state(finite_timestamp, 18.5),
+        _state(datetime(2026, 8, 20, 8, 0, tzinfo=UTC), float("-inf")),
+    ]
+    executor = AsyncMock(return_value={ENTITY_ID: states})
+    recorder = SimpleNamespace(async_add_executor_job=executor)
+
+    with (
+        patch(
+            "custom_components.hsem.ml.history_reader.get_instance",
+            return_value=recorder,
+        ),
+        patch(
+            "custom_components.hsem.ml.history_reader.hsem_now",
+            return_value=now,
+        ),
+    ):
+        readings = await HistoryReader(MagicMock()).read_instantaneous_history(
+            ENTITY_ID,
+            days=0,
+        )
+
+    assert readings == [(finite_timestamp.astimezone(STOCKHOLM), 18.5)]

--- a/tests/ml/test_populator_time_alignment.py
+++ b/tests/ml/test_populator_time_alignment.py
@@ -1,0 +1,859 @@
+"""Regression tests for ML populator source, cache, and physical-time safety."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.hsem.ml import populator
+from custom_components.hsem.ml.consumption_predictor import ConsumptionPredictor
+from custom_components.hsem.ml.history_reader import HistoryReader
+from custom_components.hsem.models.hourly_recommendation import HourlyRecommendation
+from custom_components.hsem.models.sensor_config import SensorConfig
+from custom_components.hsem.utils.datetime_utils import slot_key, utc_key
+
+STOCKHOLM = ZoneInfo("Europe/Stockholm")
+NOW = datetime(2026, 8, 20, 12, 0, tzinfo=STOCKHOLM)
+
+type _HistorySample = tuple[datetime, int, float]
+type _TrainingContext = tuple[str, str | None, bool, int, int, str | None]
+
+
+class _FakeHass:
+    async def async_add_executor_job(
+        self,
+        target: Callable[..., Any],
+        *args: Any,
+    ) -> Any:
+        return target(*args)
+
+
+class _FakeReader:
+    def __init__(
+        self,
+        histories: dict[str, list[_HistorySample]],
+        *,
+        actuals: dict[str, dict[datetime, float]] | None = None,
+        temperatures: dict[str, list[tuple[datetime, float]]] | None = None,
+    ) -> None:
+        self.histories = histories
+        self.actuals = actuals or {}
+        self.temperatures = temperatures or {}
+        self.energy_calls: list[str] = []
+        self.actual_calls: list[str] = []
+        self.temperature_calls: list[str] = []
+
+    async def read_energy_history(
+        self,
+        entity_id: str,
+        **_kwargs: object,
+    ) -> list[_HistorySample]:
+        self.energy_calls.append(entity_id)
+        return list(self.histories.get(entity_id, []))
+
+    async def read_today_actuals(
+        self,
+        entity_id: str,
+        **_kwargs: object,
+    ) -> dict[datetime, float]:
+        self.actual_calls.append(entity_id)
+        return dict(self.actuals.get(entity_id, {}))
+
+    async def read_instantaneous_history(
+        self,
+        entity_id: str,
+        **_kwargs: object,
+    ) -> list[tuple[datetime, float]]:
+        self.temperature_calls.append(entity_id)
+        return list(self.temperatures.get(entity_id, []))
+
+
+class _FakePredictor:
+    def __init__(
+        self,
+        decay_days: float = 7.0,
+        alpha: float = 1.0,
+        slots_per_day: int = 96,
+        retrain_min_new_samples: int = 4,
+        use_temperature: bool = False,
+        use_sequential: bool = False,
+        *,
+        trained: bool = False,
+        remain_untrained: bool = False,
+    ) -> None:
+        del alpha, retrain_min_new_samples
+        self.decay_days = decay_days
+        self.slots_per_day = slots_per_day
+        self.use_temperature = use_temperature
+        self.use_sequential = use_sequential
+        self.trained = trained
+        self.remain_untrained = remain_untrained
+        self.training_context: _TrainingContext | None = None
+        self.actual_history_days = 0.0
+        self.last_fit_samples = 0
+        self.group_count = 0
+        self.last_fit_time: datetime | None = NOW if trained else None
+        self._raw_groups: dict[tuple[int, int], list[tuple[float, float]]] = {}
+        self.training_histories: list[list[_HistorySample]] = []
+        self.training_temperatures: list[dict[datetime, float] | None] = []
+        self.prediction_temperatures: list[float | None] = []
+        self.prediction_requests: list[tuple[int, int]] = []
+        self.sequential_requests: list[list[datetime]] = []
+        self.sequential_temperature_requests: list[dict[datetime, float] | None] = []
+
+    def train(
+        self,
+        history: list[_HistorySample],
+        reference_time: datetime,
+        temperatures: dict[datetime, float] | None,
+    ) -> None:
+        self.training_histories.append(list(history))
+        self.training_temperatures.append(
+            dict(temperatures) if temperatures is not None else None
+        )
+        if self.remain_untrained:
+            return
+        self.trained = True
+        self.last_fit_samples = len(history)
+        self.group_count = len(
+            {(timestamp.weekday(), slot) for timestamp, slot, _ in history}
+        )
+        self.last_fit_time = reference_time
+
+    def predict_with_std(
+        self,
+        _slot: int,
+        _day_offset: int,
+        _reference_time: datetime,
+        temperature: float | None,
+    ) -> tuple[float, float]:
+        self.prediction_temperatures.append(temperature)
+        self.prediction_requests.append((_slot, _day_offset))
+        return 0.5, 0.0
+
+    def predict_sequential(
+        self,
+        slot_starts: list[datetime],
+        temperatures: dict[datetime, float] | None,
+    ) -> dict[datetime, float]:
+        self.sequential_requests.append(list(slot_starts))
+        self.sequential_temperature_requests.append(
+            dict(temperatures) if temperatures is not None else None
+        )
+        return {
+            utc_key(start): (index + 1) / 10 for index, start in enumerate(slot_starts)
+        }
+
+    @staticmethod
+    def _weighted_std(_samples: list[tuple[float, float]]) -> float:
+        return 0.0
+
+
+@pytest.fixture(autouse=True)
+def _ha_local_timezone():
+    def as_stockholm(value: datetime) -> datetime:
+        if value.tzinfo is None:
+            return value.replace(tzinfo=STOCKHOLM)
+        return value.astimezone(STOCKHOLM)
+
+    with patch(
+        "custom_components.hsem.utils.datetime_utils.dt_util.as_local",
+        side_effect=as_stockholm,
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _clear_ml_caches():
+    populator._processed_history_cache.clear()
+    populator._temperature_history_cache.clear()
+    yield
+    populator._processed_history_cache.clear()
+    populator._temperature_history_cache.clear()
+
+
+def _history(now: datetime, base: float = 1.0) -> list[_HistorySample]:
+    return [
+        (now - timedelta(days=15), 0, base),
+        (now - timedelta(days=14, minutes=15), 1, base + 0.2),
+    ]
+
+
+def _cfg(
+    *,
+    energy_entity: str = "sensor.import",
+    export_entity: str | None = None,
+    net: bool = False,
+    temperature_entity: str | None = None,
+    history_days: int = 14,
+    sequential: bool = False,
+) -> SensorConfig:
+    cfg = SensorConfig()
+    cfg.recommendation_interval_minutes = 15
+    cfg.ml_consumption_energy_entity = energy_entity
+    cfg.grid_export_energy_entity = export_entity
+    cfg.ml_consumption_net_consumption = net
+    cfg.ml_consumption_temperature_entity = temperature_entity
+    cfg.ml_consumption_history_days = history_days
+    cfg.ml_consumption_sequential = sequential
+    return cfg
+
+
+def _training_context(
+    cfg: SensorConfig,
+    *,
+    use_temperature: bool,
+) -> _TrainingContext:
+    energy_entity = cfg.ml_consumption_energy_entity or cfg.grid_import_energy_entity
+    assert energy_entity is not None
+    return (
+        energy_entity,
+        cfg.grid_export_energy_entity if cfg.ml_consumption_net_consumption else None,
+        cfg.ml_consumption_net_consumption,
+        cfg.recommendation_interval_minutes,
+        cfg.ml_consumption_history_days,
+        cfg.ml_consumption_temperature_entity if use_temperature else None,
+    )
+
+
+def _recommendation(start: datetime, consumption: float = 9.9) -> HourlyRecommendation:
+    return HourlyRecommendation(
+        start=start,
+        end=start + timedelta(minutes=15),
+        avg_house_consumption_kwh=consumption,
+        avg_house_consumption_1d_kwh=consumption,
+        avg_house_consumption_3d_kwh=consumption,
+        avg_house_consumption_7d_kwh=consumption,
+        avg_house_consumption_14d_kwh=consumption,
+        batteries_charged_kwh=0.0,
+        batteries_discharged_kwh=0.0,
+        estimated_battery_capacity_kwh=0.0,
+        estimated_battery_soc_pct=0.0,
+        estimated_cost_currency=0.0,
+        estimated_net_consumption_kwh=0.0,
+        export_price=0.0,
+        grid_export_kwh=0.0,
+        grid_import_kwh=0.0,
+        import_price=0.0,
+        recommendation=None,
+        solcast_pv_estimate_kwh=0.0,
+    )
+
+
+async def _populate(
+    hass: _FakeHass,
+    reader: _FakeReader,
+    cfg: SensorConfig,
+    recommendations: list[HourlyRecommendation],
+    *,
+    now: datetime = NOW,
+    predictor: _FakePredictor | None = None,
+) -> tuple[bool, _FakePredictor | None]:
+    with (
+        patch.object(populator, "HistoryReader", return_value=reader),
+        patch.object(populator, "ConsumptionPredictor", _FakePredictor),
+        patch.object(populator, "hsem_now", return_value=now),
+    ):
+        result = await populator.populate_ml_house_consumption(
+            cast(HomeAssistant, hass),
+            recommendations,
+            cfg,
+            cast(ConsumptionPredictor | None, predictor),
+        )
+    return cast(tuple[bool, _FakePredictor | None], result)
+
+
+@pytest.mark.asyncio
+async def test_processed_cache_is_config_keyed_and_predictor_resets_with_source() -> (
+    None
+):
+    hass = _FakeHass()
+    reader = _FakeReader(
+        {
+            "sensor.import": [
+                *_history(NOW, 1.0),
+                (NOW - timedelta(days=1), 2, 3.0),
+            ],
+            "sensor.export": _history(NOW, 0.2),
+            "sensor.other": _history(NOW, 2.0),
+        }
+    )
+    net_cfg = _cfg(export_entity="sensor.export", net=True)
+
+    success, net_predictor = await _populate(hass, reader, net_cfg, [])
+
+    assert success is True
+    assert net_predictor is not None
+    assert [sample[2] for sample in net_predictor.training_histories[-1]] == [
+        0.8,
+        0.8,
+    ]
+    assert reader.energy_calls == ["sensor.import", "sensor.export"]
+
+    success, cached_predictor = await _populate(
+        hass,
+        reader,
+        net_cfg,
+        [],
+        predictor=net_predictor,
+    )
+
+    assert success is True
+    assert cached_predictor is net_predictor
+    assert cached_predictor is not None
+    assert [sample[2] for sample in cached_predictor.training_histories[-1]] == [
+        0.8,
+        0.8,
+    ]
+    assert reader.energy_calls == ["sensor.import", "sensor.export"]
+
+    gross_cfg = _cfg()
+    success, gross_predictor = await _populate(
+        hass,
+        reader,
+        gross_cfg,
+        [],
+        predictor=net_predictor,
+    )
+
+    assert success is True
+    assert gross_predictor is not None
+    assert gross_predictor is not net_predictor
+    assert [sample[2] for sample in gross_predictor.training_histories[-1]] == [
+        1.0,
+        1.2,
+        3.0,
+    ]
+    assert reader.energy_calls == [
+        "sensor.import",
+        "sensor.export",
+        "sensor.import",
+    ]
+
+    other_cfg = _cfg(energy_entity="sensor.other")
+    success, other_predictor = await _populate(
+        hass,
+        reader,
+        other_cfg,
+        [],
+        predictor=gross_predictor,
+    )
+
+    assert success is True
+    assert other_predictor is not None
+    assert other_predictor is not gross_predictor
+    assert [sample[2] for sample in other_predictor.training_histories[-1]] == [
+        2.0,
+        2.2,
+    ]
+    assert reader.energy_calls[-1] == "sensor.other"
+
+
+@pytest.mark.asyncio
+async def test_net_mode_fails_closed_when_export_history_is_unavailable() -> None:
+    cfg = _cfg(export_entity="sensor.export", net=True)
+    reader = _FakeReader({"sensor.import": _history(NOW)})
+    recommendation = _recommendation(NOW + timedelta(minutes=15))
+
+    success, predictor = await _populate(
+        _FakeHass(),
+        reader,
+        cfg,
+        [recommendation],
+    )
+
+    assert success is False
+    assert predictor is None
+    assert recommendation.avg_house_consumption_kwh == 9.9
+    assert reader.energy_calls == ["sensor.import", "sensor.export"]
+    assert reader.actual_calls == []
+
+
+@pytest.mark.asyncio
+async def test_net_mode_fails_closed_without_export_entity_configuration() -> None:
+    cfg = _cfg(net=True)
+    reader = _FakeReader({"sensor.import": _history(NOW)})
+
+    success, predictor = await _populate(_FakeHass(), reader, cfg, [])
+
+    assert success is False
+    assert predictor is None
+    assert reader.energy_calls == []
+
+
+@pytest.mark.asyncio
+async def test_temperature_history_is_used_for_training_and_inference() -> None:
+    temperature_history = [
+        (NOW - timedelta(days=15), 4.0),
+        (NOW - timedelta(minutes=5), 11.5),
+    ]
+    reader = _FakeReader(
+        {"sensor.import": _history(NOW)},
+        temperatures={"sensor.temperature": temperature_history},
+    )
+    cfg = _cfg(temperature_entity="sensor.temperature")
+    recommendation = _recommendation(NOW + timedelta(minutes=15))
+
+    success, predictor = await _populate(
+        _FakeHass(),
+        reader,
+        cfg,
+        [recommendation],
+    )
+
+    assert success is True
+    assert predictor is not None
+    assert predictor.use_temperature is True
+    assert predictor.training_temperatures[-1] == {
+        utc_key(timestamp): value for timestamp, value in temperature_history
+    }
+    assert predictor.prediction_temperatures == [11.5]
+    assert recommendation.avg_house_consumption_kwh == 0.5
+
+
+@pytest.mark.asyncio
+async def test_missing_temperature_history_disables_feature_safely() -> None:
+    reader = _FakeReader({"sensor.import": _history(NOW)})
+    cfg = _cfg(temperature_entity="sensor.temperature")
+    recommendation = _recommendation(NOW + timedelta(minutes=15))
+
+    success, predictor = await _populate(
+        _FakeHass(),
+        reader,
+        cfg,
+        [recommendation],
+    )
+
+    assert success is True
+    assert predictor is not None
+    assert predictor.use_temperature is False
+    assert predictor.training_temperatures[-1] is None
+    assert predictor.prediction_temperatures == [None]
+
+
+@pytest.mark.asyncio
+async def test_untrained_predictor_falls_back_without_mutating_recommendations() -> (
+    None
+):
+    cfg = _cfg()
+    reader = _FakeReader({"sensor.import": _history(NOW)})
+    predictor = _FakePredictor(remain_untrained=True)
+    predictor.training_context = _training_context(cfg, use_temperature=False)
+    recommendation = _recommendation(NOW + timedelta(minutes=15))
+
+    success, returned_predictor = await _populate(
+        _FakeHass(),
+        reader,
+        cfg,
+        [recommendation],
+        predictor=predictor,
+    )
+
+    assert success is False
+    assert returned_predictor is None
+    assert recommendation.avg_house_consumption_kwh == 9.9
+    assert len(predictor.training_histories) == 1
+    assert reader.actual_calls == []
+
+
+@pytest.mark.asyncio
+async def test_today_actuals_match_each_autumn_fold_by_physical_slot() -> None:
+    now = datetime(2026, 10, 25, 3, 0, tzinfo=STOCKHOLM)
+    fold_zero = datetime(2026, 10, 25, 2, 0, tzinfo=STOCKHOLM, fold=0)
+    fold_one = datetime(2026, 10, 25, 2, 0, tzinfo=STOCKHOLM, fold=1)
+    cfg = _cfg()
+    reader = _FakeReader(
+        {"sensor.import": _history(now)},
+        actuals={
+            "sensor.import": {
+                slot_key(fold_zero, 15): 0.4,
+                slot_key(fold_one, 15): 0.9,
+            }
+        },
+    )
+
+    recommendations = [_recommendation(fold_zero), _recommendation(fold_one)]
+    success, _predictor = await _populate(
+        _FakeHass(),
+        reader,
+        cfg,
+        recommendations,
+        now=now,
+    )
+
+    assert success is True
+    assert fold_zero.utcoffset() != fold_one.utcoffset()
+    assert [
+        recommendation.avg_house_consumption_kwh for recommendation in recommendations
+    ] == [0.4, 0.9]
+
+
+@pytest.mark.asyncio
+async def test_cache_expires_by_physical_time_across_autumn_fold() -> None:
+    fold_zero_now = datetime(2026, 10, 25, 2, 45, tzinfo=STOCKHOLM, fold=0)
+    fold_one_now = datetime(2026, 10, 25, 2, 45, tzinfo=STOCKHOLM, fold=1)
+    cfg = _cfg()
+    reader = _FakeReader({"sensor.import": _history(fold_zero_now)})
+    hass = _FakeHass()
+
+    success, predictor = await _populate(
+        hass,
+        reader,
+        cfg,
+        [],
+        now=fold_zero_now,
+    )
+    assert success is True
+    assert predictor is not None
+
+    success, returned_predictor = await _populate(
+        hass,
+        reader,
+        cfg,
+        [],
+        now=fold_one_now,
+        predictor=predictor,
+    )
+
+    assert success is True
+    assert returned_predictor is predictor
+    assert reader.energy_calls == ["sensor.import", "sensor.import"]
+
+
+def test_predictor_uses_physical_age_and_temperature_identity_across_fold() -> None:
+    fold_zero = datetime(2026, 10, 25, 2, 0, tzinfo=STOCKHOLM, fold=0)
+    fold_one = datetime(2026, 10, 25, 2, 0, tzinfo=STOCKHOLM, fold=1)
+    reference = datetime(2026, 10, 25, 3, 0, tzinfo=STOCKHOLM)
+    temperatures = {utc_key(fold_zero): 10.0, utc_key(fold_one): 20.0}
+    assert len(temperatures) == 2
+    predictor = ConsumptionPredictor(
+        retrain_min_new_samples=1,
+        use_temperature=True,
+    )
+
+    assert predictor._lookup_temperature(temperatures, fold_one) == 20.0
+
+    predictor.train(
+        [(fold_zero, 8, 1.0), (fold_one, 8, 1.1)],
+        reference,
+        temperatures,
+    )
+
+    ages = [age for age, _energy in predictor._raw_groups[(6, 8)]]
+    assert ages == pytest.approx([2 / 24, 1 / 24])
+    assert predictor.last_fit_time == reference
+
+
+@pytest.mark.asyncio
+async def test_partially_misaligned_net_history_falls_back_and_is_not_cached() -> None:
+    import_history = _history(NOW)
+    export_history = [
+        (import_history[0][0], import_history[0][1], 0.2),
+        (NOW - timedelta(days=13), 3, 0.3),
+    ]
+    cfg = _cfg(export_entity="sensor.export", net=True)
+    reader = _FakeReader(
+        {
+            "sensor.import": import_history,
+            "sensor.export": export_history,
+        }
+    )
+    hass = _FakeHass()
+
+    first_success, first_predictor = await _populate(hass, reader, cfg, [])
+    second_success, second_predictor = await _populate(hass, reader, cfg, [])
+
+    assert first_success is False
+    assert first_predictor is None
+    assert second_success is False
+    assert second_predictor is None
+    assert reader.energy_calls == [
+        "sensor.import",
+        "sensor.export",
+        "sensor.import",
+        "sensor.export",
+    ]
+    assert populator._processed_history_cache == {}
+
+
+@pytest.mark.asyncio
+async def test_net_today_actuals_require_both_physical_meter_slots() -> None:
+    missing_export_slot = NOW - timedelta(minutes=30)
+    aligned_slot = NOW - timedelta(minutes=15)
+    recommendations = [
+        _recommendation(missing_export_slot),
+        _recommendation(aligned_slot),
+    ]
+    cfg = _cfg(export_entity="sensor.export", net=True)
+    reader = _FakeReader(
+        {
+            "sensor.import": _history(NOW, 1.0),
+            "sensor.export": _history(NOW, 0.2),
+        },
+        actuals={
+            "sensor.import": {
+                slot_key(missing_export_slot, 15): 0.4,
+                slot_key(aligned_slot, 15): 0.8,
+            },
+            "sensor.export": {
+                slot_key(aligned_slot, 15): 0.2,
+            },
+        },
+    )
+
+    success, predictor = await _populate(
+        _FakeHass(),
+        reader,
+        cfg,
+        recommendations,
+    )
+
+    assert success is True
+    assert predictor is not None
+    assert [rec.avg_house_consumption_kwh for rec in recommendations] == [0.5, 0.6]
+    assert reader.actual_calls == ["sensor.import", "sensor.export"]
+
+
+@pytest.mark.asyncio
+async def test_history_window_change_replaces_predictor_with_same_sample_count() -> (
+    None
+):
+    hass = _FakeHass()
+    reader = _FakeReader({"sensor.import": _history(NOW)})
+    initial_cfg = _cfg(history_days=14)
+
+    initial_success, initial_predictor = await _populate(
+        hass,
+        reader,
+        initial_cfg,
+        [],
+    )
+    assert initial_success is True
+    assert initial_predictor is not None
+
+    changed_cfg = _cfg(history_days=21)
+    changed_success, changed_predictor = await _populate(
+        hass,
+        reader,
+        changed_cfg,
+        [],
+        predictor=initial_predictor,
+    )
+
+    assert changed_success is True
+    assert changed_predictor is not None
+    assert changed_predictor is not initial_predictor
+    assert reader.energy_calls == ["sensor.import", "sensor.import"]
+
+
+@pytest.mark.asyncio
+async def test_temperature_history_preserves_both_autumn_fold_keys() -> None:
+    fold_zero = datetime(2026, 10, 25, 2, 0, tzinfo=STOCKHOLM, fold=0)
+    fold_one = datetime(2026, 10, 25, 2, 0, tzinfo=STOCKHOLM, fold=1)
+    reader = _FakeReader(
+        {},
+        temperatures={"sensor.temperature": [(fold_zero, 10.0), (fold_one, 20.0)]},
+    )
+
+    temperatures = await populator._read_temperature_history(
+        cast(HistoryReader, reader),
+        "sensor.temperature",
+        14,
+    )
+
+    assert temperatures == {
+        utc_key(fold_zero): 10.0,
+        utc_key(fold_one): 20.0,
+    }
+    assert len(temperatures) == 2
+
+
+@pytest.mark.asyncio
+async def test_recommendation_calendar_features_are_ha_local_not_source_timezone() -> (
+    None
+):
+    # 22:15 UTC is 00:15 on the next HA-local day during CEST.
+    source_timestamp = datetime(2026, 8, 20, 22, 15, tzinfo=UTC)
+    reader = _FakeReader({"sensor.import": _history(NOW)})
+
+    success, predictor = await _populate(
+        _FakeHass(),
+        reader,
+        _cfg(),
+        [_recommendation(source_timestamp)],
+    )
+
+    assert success is True
+    assert predictor is not None
+    assert predictor.prediction_requests == [(1, 1)]
+
+
+@pytest.mark.asyncio
+async def test_sequential_predictions_follow_real_spring_slots() -> None:
+    now = datetime(2026, 3, 29, 1, 30, tzinfo=STOCKHOLM)
+    starts = [
+        datetime(2026, 3, 29, 3, 15, tzinfo=STOCKHOLM),
+        datetime(2026, 3, 29, 1, 45, tzinfo=STOCKHOLM),
+        datetime(2026, 3, 29, 3, 0, tzinfo=STOCKHOLM),
+    ]
+    recommendations = [_recommendation(start) for start in starts]
+    reader = _FakeReader({"sensor.import": _history(now)})
+
+    success, predictor = await _populate(
+        _FakeHass(),
+        reader,
+        _cfg(sequential=True),
+        recommendations,
+        now=now,
+    )
+
+    assert success is True
+    assert predictor is not None
+    request = predictor.sequential_requests[-1]
+    assert [(start.hour, start.minute) for start in request] == [
+        (1, 45),
+        (3, 0),
+        (3, 15),
+    ]
+    assert [utc_key(start) for start in request] == sorted(
+        utc_key(start) for start in request
+    )
+    populated = {
+        slot_key(rec.start, 15): rec.avg_house_consumption_kwh
+        for rec in recommendations
+    }
+    assert populated == {
+        slot_key(datetime(2026, 3, 29, 1, 45, tzinfo=STOCKHOLM), 15): 0.11,
+        slot_key(datetime(2026, 3, 29, 3, 0, tzinfo=STOCKHOLM), 15): 0.22,
+        slot_key(datetime(2026, 3, 29, 3, 15, tzinfo=STOCKHOLM), 15): 0.33,
+    }
+
+
+@pytest.mark.asyncio
+async def test_sequential_predictions_keep_autumn_folds_distinct() -> None:
+    now = datetime(2026, 10, 25, 1, 30, tzinfo=STOCKHOLM)
+    first_fold = [
+        datetime(2026, 10, 25, 2, minute, tzinfo=STOCKHOLM, fold=0)
+        for minute in (0, 15, 30, 45)
+    ]
+    second_fold_start = datetime(2026, 10, 25, 2, 0, tzinfo=STOCKHOLM, fold=1)
+    starts = [second_fold_start, *reversed(first_fold)]
+    recommendations = [_recommendation(start) for start in starts]
+    reader = _FakeReader({"sensor.import": _history(now)})
+
+    success, predictor = await _populate(
+        _FakeHass(),
+        reader,
+        _cfg(sequential=True),
+        recommendations,
+        now=now,
+    )
+
+    assert success is True
+    assert predictor is not None
+    request = predictor.sequential_requests[-1]
+    assert [(start.hour, start.minute, start.fold) for start in request] == [
+        (2, 0, 0),
+        (2, 15, 0),
+        (2, 30, 0),
+        (2, 45, 0),
+        (2, 0, 1),
+    ]
+    populated = {
+        slot_key(rec.start, 15): rec.avg_house_consumption_kwh
+        for rec in recommendations
+    }
+    assert len(populated) == 5
+    assert populated[slot_key(first_fold[0], 15)] == 0.11
+    assert populated[slot_key(second_fold_start, 15)] == 0.55
+
+
+@pytest.mark.asyncio
+async def test_nonfinite_temperature_history_disables_feature_safely() -> None:
+    reader = _FakeReader(
+        {"sensor.import": _history(NOW)},
+        temperatures={
+            "sensor.temperature": [
+                (NOW - timedelta(days=15), float("nan")),
+                (NOW - timedelta(minutes=5), float("inf")),
+            ]
+        },
+    )
+
+    success, predictor = await _populate(
+        _FakeHass(),
+        reader,
+        _cfg(temperature_entity="sensor.temperature"),
+        [_recommendation(NOW + timedelta(minutes=15))],
+    )
+
+    assert success is True
+    assert predictor is not None
+    assert predictor.use_temperature is False
+    assert predictor.training_temperatures[-1] is None
+    assert predictor.prediction_temperatures == [None]
+
+
+@pytest.mark.asyncio
+async def test_nonfinite_today_actual_is_replaced_by_finite_prediction() -> None:
+    completed_slot = NOW - timedelta(minutes=15)
+    reader = _FakeReader(
+        {"sensor.import": _history(NOW)},
+        actuals={"sensor.import": {slot_key(completed_slot, 15): float("nan")}},
+    )
+    recommendation = _recommendation(completed_slot)
+
+    success, predictor = await _populate(_FakeHass(), reader, _cfg(), [recommendation])
+
+    assert success is True
+    assert predictor is not None
+    assert recommendation.avg_house_consumption_kwh == 0.5
+    assert reader.actual_calls == ["sensor.import"]
+
+
+@pytest.mark.asyncio
+async def test_reused_predictor_refreshes_decay_as_history_grows() -> None:
+    hass = _FakeHass()
+    reader = _FakeReader({"sensor.import": _history(NOW)})
+    cfg = _cfg()
+
+    first_success, predictor = await _populate(
+        hass,
+        reader,
+        cfg,
+        [],
+        now=NOW,
+    )
+
+    assert first_success is True
+    assert predictor is not None
+    assert predictor.decay_days == pytest.approx(7.5)
+
+    later = NOW + timedelta(minutes=61)
+    reader.histories["sensor.import"] = [
+        (later - timedelta(days=30), 0, 1.0),
+        (later - timedelta(days=14), 1, 1.2),
+    ]
+
+    second_success, reused_predictor = await _populate(
+        hass,
+        reader,
+        cfg,
+        [],
+        now=later,
+        predictor=predictor,
+    )
+
+    assert second_success is True
+    assert reused_predictor is predictor
+    assert reused_predictor is not None
+    assert reused_predictor.decay_days == pytest.approx(15.0)
+    assert reused_predictor.actual_history_days == pytest.approx(30.0)
+    assert reader.energy_calls == ["sensor.import", "sensor.import"]

--- a/tests/test_forecast_tracker.py
+++ b/tests/test_forecast_tracker.py
@@ -12,7 +12,8 @@ Covers:
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -29,6 +30,25 @@ NEVER = datetime(2099, 1, 1, tzinfo=UTC)
 def _slot_start(hour: int, minute: int = 0) -> datetime:
     """Create a timezone-aware slot start time."""
     return datetime(2024, 6, 15, hour, minute, tzinfo=UTC)
+
+
+def test_repeated_hour_folds_create_distinct_forecast_records() -> None:
+    copenhagen = ZoneInfo("Europe/Copenhagen")
+    first = datetime(2026, 10, 25, 2, 0, tzinfo=copenhagen, fold=0)
+    second = datetime(2026, 10, 25, 2, 0, tzinfo=copenhagen, fold=1)
+    tracker = ForecastTracker()
+
+    first_record = tracker.get_or_create_record(
+        first,
+        (first.astimezone(UTC) + timedelta(minutes=15)).astimezone(copenhagen),
+    )
+    second_record = tracker.get_or_create_record(
+        second,
+        (second.astimezone(UTC) + timedelta(minutes=15)).astimezone(copenhagen),
+    )
+
+    assert first_record is not second_record
+    assert len(tracker.records) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -262,8 +282,12 @@ class _SummaryTracker(ForecastTracker):
         start = _slot_start(hour)
         end = _slot_start(hour + 1)
         rec = self.get_or_create_record(start, end)
-        rec.forecast_pv_kwh = forecast_pv
-        rec.forecast_load_kwh = forecast_load
+        assert self.set_forecasts(
+            start,
+            forecast_pv,
+            forecast_load,
+            raw_pv_kwh=forecast_pv,
+        )
         rec.actual_pv_kwh = actual_pv
         rec.actual_load_kwh = actual_load
         rec.finalise()
@@ -588,7 +612,13 @@ class TestForecastTrackerSerialization:
         """Unfinalised serialized records restore correctly (with zero bias)."""
         tracker = ForecastTracker()
         tracker.get_or_create_record(_slot_start(10), _slot_start(11))
-        tracker.set_forecasts(_slot_start(10), 4.0, 2.0)
+        tracker.set_forecasts(
+            _slot_start(10),
+            4.0,
+            2.0,
+            forecast_soc_pct=78.0,
+            forecast_action="charge",
+        )
         # Accumulate but do NOT finalise
 
         data = tracker.to_dict()
@@ -602,3 +632,448 @@ class TestForecastTrackerSerialization:
         assert rec is not None
         assert rec.finalised is False
         assert rec.forecast_pv_kwh == pytest.approx(4.0)
+        assert rec.forecast_soc_pct == pytest.approx(78.0)
+        assert rec.forecast_action == "charge"
+        assert rec.prediction_eligible is True
+
+    def test_legacy_payload_is_restored_but_excluded_from_accuracy(self) -> None:
+        """Pre-baseline-schema records must not train or skew metrics."""
+        legacy_record = {
+            "start": _slot_start(10).isoformat(),
+            "end": _slot_start(11).isoformat(),
+            "forecast_pv_kwh": 9.0,
+            "forecast_load_kwh": 7.0,
+            "actual_pv_kwh": 1.0,
+            "actual_load_kwh": 2.0,
+            "finalised": True,
+            "mae_pv": 8.0,
+            "mae_load": 5.0,
+            "bias_pv": 8.0,
+            "bias_load": 5.0,
+        }
+        tracker = ForecastTracker()
+
+        tracker.load_from_dict({"records": [legacy_record]})
+
+        rec = tracker.records[0]
+        assert rec.forecast_pv_kwh == pytest.approx(9.0)
+        assert rec.actual_pv_kwh == pytest.approx(1.0)
+        assert rec.raw_forecast_pv_kwh is None
+        assert rec.forecast_frozen is False
+        assert rec.actual_coverage_seconds is None
+        assert rec.accuracy_eligible is False
+        assert rec.forecast_soc_pct is None
+        assert rec.forecast_action is None
+        assert rec.prediction_eligible is False
+        assert tracker.summary.finalised_count == 0
+
+    def test_persistence_prioritises_lifecycle_records_over_future_tail(
+        self,
+    ) -> None:
+        """A long horizon keeps current/history and the nearest future slots."""
+        tracker = ForecastTracker(max_slots=96)
+        now = datetime(2026, 8, 20, 10, 5, tzinfo=UTC)
+
+        final_start = now - timedelta(minutes=35)
+        final_end = final_start + timedelta(minutes=15)
+        final = tracker.get_or_create_record(final_start, final_end)
+        assert tracker.set_forecasts(
+            final_start,
+            1.0,
+            1.0,
+            raw_pv_kwh=1.2,
+            observed_at=final_start - timedelta(minutes=1),
+        )
+        tracker.freeze_forecasts(final_start)
+        final.actual_coverage_seconds = 900.0
+        final.finalise()
+
+        active_start = datetime(2026, 8, 20, 10, 0, tzinfo=UTC)
+        active = tracker.get_or_create_record(
+            active_start,
+            active_start + timedelta(minutes=15),
+        )
+        assert tracker.set_forecasts(
+            active_start,
+            2.0,
+            1.0,
+            raw_pv_kwh=2.2,
+            observed_at=active_start - timedelta(minutes=1),
+        )
+        tracker.freeze_forecasts(now)
+        assert active.forecast_frozen is True
+
+        future_starts: list[datetime] = []
+        for index in range(30):
+            start = active.end + timedelta(minutes=15 * index)
+            future_starts.append(start)
+            tracker.get_or_create_record(start, start + timedelta(minutes=15))
+            assert tracker.set_forecasts(
+                start,
+                3.0,
+                1.0,
+                raw_pv_kwh=3.2,
+                observed_at=now,
+            )
+
+        payload = tracker.to_persistence_dict(now=now, max_records=24)
+        persisted_starts = {
+            datetime.fromisoformat(record["start"]) for record in payload["records"]
+        }
+
+        assert len(payload["records"]) == 24
+        assert final_start in persisted_starts
+        assert active_start in persisted_starts
+        assert future_starts[0] in persisted_starts
+        assert future_starts[-1] not in persisted_starts
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("forecast_pv_kwh", float("nan")),
+            ("forecast_load_kwh", float("inf")),
+            ("actual_pv_kwh", -1.0),
+            ("actual_load_kwh", 1e308),
+            ("raw_forecast_pv_kwh", 1e308),
+            ("forecast_soc_pct", 101.0),
+            ("actual_coverage_seconds", 902.0),
+        ],
+    )
+    def test_restore_skips_nonfinite_or_out_of_bounds_records(
+        self,
+        field: str,
+        value: float,
+    ) -> None:
+        """Malformed numerics cannot poison summaries or learned state."""
+        record = ForecastSlotRecord(
+            start=_slot_start(10),
+            end=_slot_start(10, 15),
+            forecast_pv_kwh=1.0,
+            raw_forecast_pv_kwh=1.0,
+            forecast_load_kwh=1.0,
+            forecast_soc_pct=50.0,
+            actual_pv_kwh=1.0,
+            actual_load_kwh=1.0,
+            forecast_frozen=True,
+            actual_coverage_seconds=900.0,
+        ).to_dict()
+        record[field] = value
+        tracker = ForecastTracker()
+
+        tracker.load_from_dict({"records": [record]})
+
+        assert tracker.records == []
+        assert tracker.summary.finalised_count == 0
+
+    def test_restore_sorts_deduplicates_and_bounds_after_validation(self) -> None:
+        """Only the newest valid unique physical starts survive the bound."""
+        valid = [
+            ForecastSlotRecord(
+                start=_slot_start(hour),
+                end=_slot_start(hour + 1),
+            ).to_dict()
+            for hour in (13, 10, 12, 11)
+        ]
+        duplicate = dict(valid[0])
+        duplicate["start"] = duplicate["start"].replace("+00:00", "Z")
+        invalid = dict(valid[1])
+        invalid["start"] = "2024-06-15T10:00:00"
+        tracker = ForecastTracker(max_slots=2)
+
+        tracker.load_from_dict(
+            {"records": [invalid, *valid, duplicate, "not-a-record"]}
+        )
+
+        assert [record.start for record in tracker.records] == [
+            _slot_start(12),
+            _slot_start(13),
+        ]
+
+    def test_nearer_record_inserted_after_restore_preserves_order(self) -> None:
+        """A newly available gap baseline is inserted by physical start."""
+        farther = ForecastSlotRecord(
+            start=_slot_start(12),
+            end=_slot_start(13),
+        )
+        tracker = ForecastTracker()
+        tracker.load_from_dict({"records": [farther.to_dict()]})
+
+        tracker.get_or_create_record(_slot_start(11), _slot_start(12))
+
+        assert [record.start for record in tracker.records] == [
+            _slot_start(11),
+            _slot_start(12),
+        ]
+
+    def test_every_restored_unfinalised_start_is_excluded(self) -> None:
+        """Even a near-end active slot is unsafe for post-restart SoC scoring."""
+        start = datetime(2026, 8, 20, 10, 0, tzinfo=UTC)
+        record = ForecastSlotRecord(
+            start=start,
+            end=start + timedelta(minutes=15),
+            forecast_pv_kwh=1.0,
+            raw_forecast_pv_kwh=1.0,
+            forecast_load_kwh=1.0,
+            forecast_soc_pct=70.0,
+            forecast_action="idle",
+            forecast_frozen=True,
+            actual_coverage_seconds=899.0,
+        )
+        tracker = ForecastTracker()
+
+        tracker.load_from_dict({"records": [record.to_dict()]})
+
+        assert tracker.restored_unfinalised_keys == {start}
+
+
+class TestForecastLayoutReconciliation:
+    """Live cadence changes use physical UTC layout identities."""
+
+    @pytest.mark.parametrize(
+        ("old_minutes", "new_minutes"),
+        [(15, 60), (60, 15)],
+    )
+    def test_same_start_different_end_discards_only_unfinalised(
+        self,
+        old_minutes: int,
+        new_minutes: int,
+    ) -> None:
+        start = datetime(2026, 8, 20, 10, 0, tzinfo=UTC)
+        tracker = ForecastTracker()
+        historical = tracker.get_or_create_record(
+            start - timedelta(hours=2),
+            start - timedelta(hours=1),
+        )
+        historical.finalise()
+        tracker.get_or_create_record(
+            start,
+            start + timedelta(minutes=old_minutes),
+        )
+
+        changed = tracker.reconcile_unfinalised_layout(
+            [(start, start + timedelta(minutes=new_minutes))],
+            now=start - timedelta(minutes=1),
+        )
+
+        assert changed is True
+        assert tracker.records == [historical]
+
+    def test_dst_fold_and_spring_skip_layouts_do_not_false_trigger(self) -> None:
+        stockholm = ZoneInfo("Europe/Stockholm")
+        fold_starts = [
+            datetime(2026, 10, 25, 2, 0, tzinfo=stockholm, fold=0),
+            datetime(2026, 10, 25, 2, 0, tzinfo=stockholm, fold=1),
+        ]
+        spring_starts = [
+            datetime(2026, 3, 29, 0, 45, tzinfo=UTC).astimezone(stockholm),
+            datetime(2026, 3, 29, 1, 0, tzinfo=UTC).astimezone(stockholm),
+        ]
+
+        for starts in (fold_starts, spring_starts):
+            tracker = ForecastTracker()
+            expected: list[tuple[datetime, datetime]] = []
+            for start in starts:
+                end = (start.astimezone(UTC) + timedelta(minutes=15)).astimezone(
+                    stockholm
+                )
+                tracker.get_or_create_record(start, end)
+                expected.append((start, end))
+
+            changed = tracker.reconcile_unfinalised_layout(
+                expected,
+                now=(starts[0].astimezone(UTC) - timedelta(minutes=1)),
+            )
+
+            assert changed is False
+            assert len(tracker.records) == 2
+
+
+class TestPhysicalIntervalAccumulation:
+    """Actual power is allocated by physical overlap, never cycle timestamp."""
+
+    @staticmethod
+    def _add_frozen_slot(
+        tracker: ForecastTracker,
+        start: datetime,
+        end: datetime,
+    ) -> ForecastSlotRecord:
+        rec = tracker.get_or_create_record(start, end)
+        observed_at = start.astimezone(UTC) - timedelta(minutes=1)
+        assert tracker.set_forecasts(
+            start,
+            pv_kwh=1.0,
+            load_kwh=1.0,
+            raw_pv_kwh=1.2,
+            observed_at=observed_at,
+        )
+        assert tracker.freeze_forecasts(start) == 1
+        return rec
+
+    def test_boundary_crossing_is_split_between_slots(self) -> None:
+        tracker = ForecastTracker()
+        first = self._add_frozen_slot(
+            tracker,
+            _slot_start(10),
+            _slot_start(10, 15),
+        )
+        second = self._add_frozen_slot(
+            tracker,
+            _slot_start(10, 15),
+            _slot_start(10, 30),
+        )
+
+        assigned = tracker.accumulate_power_interval(
+            _slot_start(10, 14) + timedelta(seconds=55),
+            _slot_start(10, 15) + timedelta(seconds=5),
+            pv_power_w=3600.0,
+            load_power_w=7200.0,
+            max_gap_seconds=1800.0,
+        )
+
+        assert assigned == pytest.approx(10.0)
+        assert first.actual_pv_kwh == pytest.approx(0.005)
+        assert second.actual_pv_kwh == pytest.approx(0.005)
+        assert first.actual_load_kwh == pytest.approx(0.010)
+        assert second.actual_load_kwh == pytest.approx(0.010)
+        assert first.actual_coverage_seconds == pytest.approx(5.0)
+        assert second.actual_coverage_seconds == pytest.approx(5.0)
+
+    def test_multi_slot_gap_is_distributed_by_overlap(self) -> None:
+        tracker = ForecastTracker()
+        records = [
+            self._add_frozen_slot(
+                tracker,
+                _slot_start(10, minute),
+                _slot_start(10, minute + 15),
+            )
+            for minute in (0, 15, 30)
+        ]
+
+        assigned = tracker.accumulate_power_interval(
+            _slot_start(10, 10),
+            _slot_start(10, 35),
+            pv_power_w=3600.0,
+            load_power_w=7200.0,
+            max_gap_seconds=1800.0,
+        )
+
+        assert assigned == pytest.approx(1500.0)
+        assert [rec.actual_pv_kwh for rec in records] == pytest.approx([0.3, 0.9, 0.3])
+        assert [rec.actual_load_kwh for rec in records] == pytest.approx(
+            [0.6, 1.8, 0.6]
+        )
+        assert [rec.actual_coverage_seconds for rec in records] == pytest.approx(
+            [300.0, 900.0, 300.0]
+        )
+
+    def test_gap_over_twice_five_minute_cadence_is_rejected(self) -> None:
+        tracker = ForecastTracker()
+        rec = self._add_frozen_slot(
+            tracker,
+            _slot_start(10),
+            _slot_start(10, 15),
+        )
+
+        assigned = tracker.accumulate_power_interval(
+            _slot_start(10),
+            _slot_start(10, 10) + timedelta(seconds=1),
+            pv_power_w=3600.0,
+            load_power_w=7200.0,
+            max_gap_seconds=600.0,
+        )
+        tracker.finalise_past_records(_slot_start(11))
+
+        assert assigned == pytest.approx(0.0)
+        assert rec.actual_pv_kwh == pytest.approx(0.0)
+        assert rec.actual_load_kwh == pytest.approx(0.0)
+        assert rec.actual_coverage_seconds == pytest.approx(0.0)
+        assert rec.accuracy_eligible is False
+        assert tracker.summary.finalised_count == 0
+
+    def test_replans_update_future_baseline_but_live_injection_cannot(self) -> None:
+        tracker = ForecastTracker()
+        start = _slot_start(10)
+        tracker.get_or_create_record(start, _slot_start(10, 15))
+
+        assert tracker.set_forecasts(
+            start,
+            pv_kwh=4.0,
+            load_kwh=2.0,
+            raw_pv_kwh=5.0,
+            forecast_soc_pct=80.0,
+            forecast_action="charge",
+            observed_at=_slot_start(9),
+        )
+        assert tracker.set_forecasts(
+            start,
+            pv_kwh=3.0,
+            load_kwh=1.5,
+            raw_pv_kwh=4.5,
+            forecast_soc_pct=65.0,
+            forecast_action="discharge",
+            observed_at=_slot_start(9, 30),
+        )
+        assert tracker.freeze_forecasts(start) == 1
+
+        assert not tracker.set_forecasts(
+            start,
+            pv_kwh=99.0,
+            load_kwh=99.0,
+            raw_pv_kwh=99.0,
+            forecast_soc_pct=99.0,
+            forecast_action="idle",
+            observed_at=_slot_start(10) + timedelta(seconds=5),
+        )
+        rec = tracker.find_record(start)
+        assert rec is not None
+        assert rec.forecast_pv_kwh == pytest.approx(3.0)
+        assert rec.raw_forecast_pv_kwh == pytest.approx(4.5)
+        assert rec.forecast_load_kwh == pytest.approx(1.5)
+        assert rec.forecast_soc_pct == pytest.approx(65.0)
+        assert rec.forecast_action == "discharge"
+        assert rec.prediction_eligible is False  # actual coverage is not complete yet
+
+    def test_autumn_fold_slots_keep_distinct_physical_energy(self) -> None:
+        stockholm = ZoneInfo("Europe/Stockholm")
+        first_start = datetime(
+            2026,
+            10,
+            25,
+            2,
+            45,
+            tzinfo=stockholm,
+            fold=0,
+        )
+        first_end = (first_start.astimezone(UTC) + timedelta(minutes=15)).astimezone(
+            stockholm
+        )
+        second_start = datetime(
+            2026,
+            10,
+            25,
+            2,
+            0,
+            tzinfo=stockholm,
+            fold=1,
+        )
+        second_end = (second_start.astimezone(UTC) + timedelta(minutes=15)).astimezone(
+            stockholm
+        )
+        tracker = ForecastTracker()
+        first = self._add_frozen_slot(tracker, first_start, first_end)
+        second = self._add_frozen_slot(tracker, second_start, second_end)
+
+        assigned = tracker.accumulate_power_interval(
+            datetime(2026, 10, 25, 0, 55, tzinfo=UTC),
+            datetime(2026, 10, 25, 1, 5, tzinfo=UTC),
+            pv_power_w=1000.0,
+            load_power_w=2000.0,
+            max_gap_seconds=1800.0,
+        )
+
+        assert assigned == pytest.approx(600.0)
+        assert first is not second
+        assert first.actual_pv_kwh == pytest.approx(5.0 / 60.0)
+        assert second.actual_pv_kwh == pytest.approx(5.0 / 60.0)
+        assert first.actual_coverage_seconds == pytest.approx(300.0)
+        assert second.actual_coverage_seconds == pytest.approx(300.0)

--- a/tests/test_load_forecast_hold.py
+++ b/tests/test_load_forecast_hold.py
@@ -1,0 +1,116 @@
+"""Regression tests for the load-forecast fail-closed hold in the coordinator."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from custom_components.hsem.coordinator import (
+    _apply_load_forecast_hold,
+    _future_consumption_profile_is_nonzero,
+    _live_demand_contradicts_zero_profile,
+)
+from custom_components.hsem.models.hourly_recommendation import HourlyRecommendation
+from custom_components.hsem.models.live_state import LiveState
+from custom_components.hsem.utils.recommendations import Recommendations
+
+_NOW = datetime(2026, 8, 20, 12, 0, tzinfo=UTC)
+
+
+def _rec(
+    *,
+    start_minutes: int = 0,
+    duration_minutes: int = 15,
+    load_kwh: float = 1.0,
+) -> HourlyRecommendation:
+    """Build a current-slot recommendation with explicit load and timestamps."""
+    start = _NOW + timedelta(minutes=start_minutes)
+    return HourlyRecommendation(
+        start=start,
+        end=start + timedelta(minutes=duration_minutes),
+        avg_house_consumption_kwh=load_kwh,
+        avg_house_consumption_1d_kwh=load_kwh,
+        avg_house_consumption_3d_kwh=load_kwh,
+        avg_house_consumption_7d_kwh=load_kwh,
+        avg_house_consumption_14d_kwh=load_kwh,
+        batteries_charged_kwh=0.0,
+        batteries_discharged_kwh=0.0,
+        estimated_battery_capacity_kwh=0.0,
+        estimated_battery_soc_pct=0.0,
+        estimated_cost_currency=0.0,
+        estimated_net_consumption_kwh=load_kwh,
+        export_price=0.0,
+        grid_export_kwh=0.0,
+        grid_import_kwh=0.0,
+        import_price=1.0,
+        recommendation=Recommendations.BatteriesDischargeMode.value,
+        solcast_pv_estimate_kwh=0.0,
+    )
+
+
+def _live(house_demand_w: float | None = None, force: str = "auto") -> LiveState:
+    """Build a minimal live state snapshot."""
+    live = LiveState()
+    live.force_working_mode_state = force
+    live.house_consumption_power_w = house_demand_w
+    return live
+
+
+def test_future_profile_is_nonzero_when_any_future_slot_has_load() -> None:
+    """A future slot with positive load means the profile is not all-zero."""
+    recs = [_rec(start_minutes=0, load_kwh=0.0), _rec(start_minutes=15, load_kwh=0.5)]
+    assert _future_consumption_profile_is_nonzero(recs, _NOW) is True
+
+
+def test_future_profile_is_zero_when_no_future_load() -> None:
+    """A profile with only past slots is treated as zero (nothing future)."""
+    recs = [_rec(start_minutes=-30, load_kwh=1.0)]
+    assert _future_consumption_profile_is_nonzero(recs, _NOW) is False
+
+
+def test_live_demand_contradicts_zero_profile() -> None:
+    """Live positive demand disproves an all-zero future load profile."""
+    recs = [_rec(start_minutes=15, load_kwh=0.0)]
+    assert _live_demand_contradicts_zero_profile(recs, _live(500.0), _NOW) is True
+
+
+def test_live_demand_below_threshold_does_not_contradict() -> None:
+    """A near-zero live demand is consistent with a measured-zero night."""
+    recs = [_rec(start_minutes=15, load_kwh=0.0)]
+    assert _live_demand_contradicts_zero_profile(recs, _live(10.0), _NOW) is False
+
+
+def test_nonzero_future_profile_never_contradicts() -> None:
+    """Even strong live demand does not contradict a populated future profile."""
+    recs = [_rec(start_minutes=15, load_kwh=2.0)]
+    assert _live_demand_contradicts_zero_profile(recs, _live(5000.0), _NOW) is False
+
+
+def test_hold_publishes_wait_mode_and_zero_motion() -> None:
+    """Unavailable consumption holds the current slot with no storage motion."""
+    recs = [_rec(start_minutes=0, load_kwh=0.0)]
+    recs[0].batteries_charged_kwh = 1.0
+    recs[0].batteries_discharged_kwh = 2.0
+
+    held = _apply_load_forecast_hold(recs, _live(500.0), _NOW, consumption_ok=False)
+
+    assert held is recs[0]
+    assert held.recommendation == Recommendations.BatteriesWaitMode.value
+    assert held.batteries_charged_kwh == 0.0
+    assert held.batteries_discharged_kwh == 0.0
+
+
+def test_hold_does_not_override_forced_mode() -> None:
+    """A user-forced working mode always wins over the automatic hold."""
+    recs = [_rec(start_minutes=0, load_kwh=0.0)]
+    held = _apply_load_forecast_hold(
+        recs, _live(500.0, force="batteries_charge_grid"), _NOW, consumption_ok=False
+    )
+    assert held is None
+    assert recs[0].recommendation == Recommendations.BatteriesDischargeMode.value
+
+
+def test_no_hold_when_consumption_ok_and_profile_populated() -> None:
+    """Healthy consumption with future load does not trigger a hold."""
+    recs = [_rec(start_minutes=15, load_kwh=1.0)]
+    held = _apply_load_forecast_hold(recs, _live(500.0), _NOW, consumption_ok=True)
+    assert held is None

--- a/tests/test_solar_corrector.py
+++ b/tests/test_solar_corrector.py
@@ -4,13 +4,16 @@ Covers:
 - Per-hour factor update and rolling window
 - Factor clamping [0.3, 1.5]
 - Intra-hour residual decay over 8 slots
-- Confidence percentile behavior
+- Correction-strength behavior
 - get_corrected_pv with various slots_ahead values
 - Backward compatibility (corrector=None)
 - Edge cases: zero forecast, empty buffers, division by zero
 """
 
 from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -21,6 +24,7 @@ from custom_components.hsem.utils.solar_corrector import (
     MAX_HISTORY_PER_HOUR,
     MAX_RESIDUALS,
     RESIDUAL_DECAY_SLOTS,
+    SOLAR_CORRECTOR_STATE_VERSION,
     SolarForecastCorrector,
 )
 
@@ -35,7 +39,7 @@ class TestUpdateHour:
         assert c.hour_factors[12] == pytest.approx(0.8)
 
     def test_rolling_window_limit(self) -> None:
-        """Only the last MAX_HISTORY_PER_HOUR samples are kept."""
+        """Keep four eligible quarter-slot samples per wall-clock hour."""
         c = SolarForecastCorrector()
         # Feed 10 updates for hour 10, only last 4 should be used.
         for i in range(10):
@@ -225,8 +229,45 @@ class TestCorrectedPV:
         assert c.get_corrected_pv(12, 3.0) == pytest.approx(3.6)
 
 
+class TestPhysicalSlotsAhead:
+    """Residual decay is anchored to the current physical slot."""
+
+    def test_current_plus_four_plus_eight_slots(self) -> None:
+        corrector = SolarForecastCorrector()
+        corrector.set_reference_time(datetime(2026, 8, 20, 15, 37, tzinfo=UTC))
+        corrector.update_residual(forecast_kwh=2.0, actual_kwh=1.0)
+
+        current = datetime(2026, 8, 20, 15, 30, tzinfo=UTC)
+        plus_four = datetime(2026, 8, 20, 16, 30, tzinfo=UTC)
+        plus_eight = datetime(2026, 8, 20, 17, 30, tzinfo=UTC)
+
+        assert corrector.slots_ahead_for(current, 15, fallback=62) == 0
+        assert corrector.slots_ahead_for(plus_four, 15, fallback=66) == 4
+        assert corrector.slots_ahead_for(plus_eight, 15, fallback=70) == 8
+        assert corrector.get_corrected_pv(15, 1.0, slots_ahead=0) == pytest.approx(0.5)
+        assert corrector.get_corrected_pv(16, 1.0, slots_ahead=4) == pytest.approx(0.75)
+        assert corrector.get_corrected_pv(17, 1.0, slots_ahead=8) == pytest.approx(1.0)
+
+    def test_repeated_local_hour_is_four_physical_slots_apart(self) -> None:
+        stockholm = ZoneInfo("Europe/Stockholm")
+        first_fold = datetime(2026, 10, 25, 2, 0, tzinfo=stockholm, fold=0)
+        second_fold = datetime(2026, 10, 25, 2, 0, tzinfo=stockholm, fold=1)
+        corrector = SolarForecastCorrector()
+        corrector.set_reference_time(first_fold)
+
+        assert first_fold.hour == second_fold.hour == 2
+        assert (
+            corrector.slots_ahead_for(
+                second_fold,
+                15,
+                fallback=0,
+            )
+            == 4
+        )
+
+
 class TestConfidence:
-    """Tests for the confidence percentile behavior."""
+    """Tests for correction-strength behavior."""
 
     def test_default_confidence_uses_full_factor(self) -> None:
         """At default 0.50 confidence, the factor is applied fully."""
@@ -268,11 +309,43 @@ class TestSerialization:
         c.confidence = 0.30
 
         data = c.to_dict()
+        assert data["schema_version"] == SOLAR_CORRECTOR_STATE_VERSION
         restored = SolarForecastCorrector()
         restored.load_from_dict(data)
 
         assert restored.hour_factors == c.hour_factors
         assert restored.confidence == pytest.approx(c.confidence)
+
+    def test_round_trip_preserves_exact_buffers_and_replay_watermark(self) -> None:
+        """Restart resumes the same rolling window without replaying old slots."""
+        corrector = SolarForecastCorrector()
+        for actual in (0.5, 0.75, 1.0, 1.25):
+            corrector.update_hour(12, forecast_kwh=1.0, actual_kwh=actual)
+            corrector.update_residual(forecast_kwh=1.0, actual_kwh=actual)
+        processed = datetime(2026, 8, 20, 12, 45, tzinfo=UTC)
+        corrector.mark_processed(processed)
+
+        payload = corrector.to_dict()
+        restored = SolarForecastCorrector()
+        restored.load_from_dict(
+            payload,
+            restored_at=processed + timedelta(minutes=1),
+        )
+
+        assert restored.to_dict() == payload
+        assert restored._hour_history == corrector._hour_history
+        assert restored._recent_residuals == corrector._recent_residuals
+        assert restored.processed_through == processed
+        assert restored.was_processed(processed) is True
+
+        restored.update_hour(12, forecast_kwh=1.0, actual_kwh=1.5)
+        assert restored._hour_history[12] == [
+            (1.0, 0.75),
+            (1.0, 1.0),
+            (1.0, 1.25),
+            (1.0, 1.5),
+        ]
+        assert restored.hour_factors[12] == pytest.approx(1.125)
 
     def test_load_empty_data_is_noop(self) -> None:
         """Loading an empty dict should leave defaults unchanged."""
@@ -281,6 +354,129 @@ class TestSerialization:
         c.load_from_dict({})
         assert c.confidence == pytest.approx(0.42)
         assert c.hour_factors == {}
+
+    def test_legacy_state_intentionally_discards_contaminated_learning(self) -> None:
+        """Unversioned v7.1.1 factors cold-reset while confidence survives."""
+        corrector = SolarForecastCorrector()
+        corrector.hour_factors = {12: 0.4}
+        corrector._hour_history = {12: [(5.0, 2.0)]}
+        corrector._recent_residuals = [(1.0, 0.5)]
+
+        corrector.load_from_dict(
+            {
+                "hour_factors": {"12": 0.4},
+                "confidence": 0.3,
+            }
+        )
+
+        assert corrector.hour_factors == {}
+        assert corrector._hour_history == {}
+        assert corrector._recent_residuals == []
+        assert corrector.confidence == pytest.approx(0.3)
+
+    def test_v2_state_cold_resets_incomplete_rolling_state(self) -> None:
+        """v2 factors cannot resume because their source buffers were not stored."""
+        corrector = SolarForecastCorrector()
+
+        corrector.load_from_dict(
+            {
+                "schema_version": 2,
+                "hour_factors": {"12": 0.8},
+                "confidence": 0.3,
+            }
+        )
+
+        assert corrector.hour_factors == {}
+        assert corrector._hour_history == {}
+        assert corrector._recent_residuals == []
+        assert corrector.processed_through is None
+        assert corrector.confidence == pytest.approx(0.3)
+
+    def test_malformed_v3_payloads_fail_closed_without_poisoning(self) -> None:
+        """Partial, non-finite, huge, and naive persisted values cold-reset."""
+        valid = {
+            "schema_version": SOLAR_CORRECTOR_STATE_VERSION,
+            "hour_factors": {"12": 0.8},
+            "hour_history": {"12": [[1.0, 0.8]]},
+            "recent_residuals": [[1.0, 0.8]],
+            "confidence": 0.5,
+            "processed_through": "2026-08-20T12:00:00+00:00",
+        }
+        malformed_payloads = [
+            {**valid, "hour_factors": []},
+            {**valid, "hour_factors": {"12": float("nan")}},
+            {
+                **valid,
+                "hour_factors": {"24": 0.8},
+                "hour_history": {"24": [[1.0, 0.8]]},
+            },
+            {**valid, "hour_history": {"12": [[1e308, 0.8]]}},
+            {**valid, "recent_residuals": [[1.0, float("inf")]]},
+            {**valid, "confidence": float("nan")},
+            {**valid, "processed_through": "2026-08-20T12:00:00"},
+            {**valid, "processed_through": "0001-01-01T00:00:00+14:00"},
+            {key: value for key, value in valid.items() if key != "hour_history"},
+        ]
+
+        for payload in malformed_payloads:
+            corrector = SolarForecastCorrector()
+            corrector.update_hour(8, 1.0, 0.7)
+            corrector.update_residual(1.0, 0.7)
+            corrector.mark_processed(datetime(2026, 8, 20, 8, 0, tzinfo=UTC))
+
+            corrector.load_from_dict(payload)
+
+            assert corrector.hour_factors == {}
+            assert corrector._hour_history == {}
+            assert corrector._recent_residuals == []
+            assert corrector.processed_through is None
+            assert 0.10 <= corrector.confidence <= 0.90
+
+    def test_future_replay_watermark_cold_resets_valid_v3_payload(self) -> None:
+        """A poisoned future watermark cannot suppress solar learning."""
+        corrector = SolarForecastCorrector()
+        payload = {
+            "schema_version": SOLAR_CORRECTOR_STATE_VERSION,
+            "hour_factors": {"12": 0.8},
+            "hour_history": {"12": [[1.0, 0.8]]},
+            "recent_residuals": [[1.0, 0.8]],
+            "confidence": 0.5,
+            "processed_through": "2099-01-01T00:00:00+00:00",
+        }
+
+        corrector.load_from_dict(
+            payload,
+            restored_at=datetime(2026, 8, 20, 12, 0, tzinfo=UTC),
+        )
+
+        assert corrector.hour_factors == {}
+        assert corrector._hour_history == {}
+        assert corrector._recent_residuals == []
+        assert corrector.processed_through is None
+
+    @pytest.mark.parametrize(
+        ("forecast_kwh", "actual_kwh"),
+        [
+            (float("nan"), 1.0),
+            (1.0, float("inf")),
+            (-1.0, 1.0),
+            (1e308, 1.0),
+        ],
+    )
+    def test_runtime_samples_reject_nonfinite_or_unbounded_energy(
+        self,
+        forecast_kwh: float,
+        actual_kwh: float,
+    ) -> None:
+        """Bad live samples cannot enter either persisted rolling buffer."""
+        corrector = SolarForecastCorrector()
+
+        corrector.update_hour(12, forecast_kwh, actual_kwh)
+        corrector.update_residual(forecast_kwh, actual_kwh)
+
+        assert corrector.hour_factors == {}
+        assert corrector._hour_history == {}
+        assert corrector._recent_residuals == []
 
 
 class TestBackwardCompatibility:


### PR DESCRIPTION
## Summary

Port of the self-contained, upstream-relevant portions of the ML accuracy and forecast-tracking hardening from `Ambilights/hsem-ambilights` (AGPL fork), applied onto the current `main` baseline without importing the fork's planner/coordinator rewrite. Plus two native fail-closed/hardening fixes adapted from the fork's intent, and a record of the port decision.

### What changed

- **ML consumption history ↔ tracking time alignment** (`fix #11` core)
  - Align recorder-backed consumption history to Home Assistant-local calendar slots while preserving UTC identity, DST folds, and physical gaps.
  - Harden ML cache/source isolation, net-meter alignment, and rolling-window retraining.
  - Make forecast/prediction/solar-correction learning coverage-aware and restart-safe.

- **DST-fold correctness prerequisite**
  - `utils/datetime_utils.py`: `slot_key()` now returns a UTC identity so the two occurrences of an autumn repeated hour remain distinct; added `slot_contains()`.

- **Forecast tracker / solar corrector hardening**
  - `utils/solar_corrector.py` → versioned v3 persistence with a replay watermark (`processed_through`), `slots_ahead_for()`, `set_reference_time()`, and validated restore.
  - `utils/forecast_tracker.py` → UTC-aware record identity, `freeze_forecasts()`, `accumulate_power_interval()`, `reconcile_unfinalised_layout()`.
  - New pure validation helpers in `utils/persistence.py`.
  - New `models/price_source.py` (`PriceSource` + `PriceBackupStatus`) — a shared provenance type introduced here for forward compatibility.

- **Load-forecast fail-closed hold** (native adaptation of fork `#19`)
  - When consumption averages fail to populate, or the entire future profile is numerically zero while live house demand is clearly positive, the current slot is held in `batteries_wait_mode` with zero charge/discharge motion instead of solving or reusing a plan sized on fictional zero load.
  - A user-forced working mode always wins over the automatic hold.

- **MILP bounds-layout fail-fast** (native adaptation of fork `#17`)
  - `milp_optimizer.py` now verifies `len(bounds) == n_vars` before handing bounds to `linprog`, failing closed with a clear log line rather than silently misaligning a wrong-width/missing block.

### Not included (by design)

The full PR set from the fork (#13, #15, #17, #19, #21) is coupled to the fork's v7 planner/coordinator architecture (`_solver_execution.py`, `_layout.py`, `future_value.py`, `secondary_storage.py`, authority-generation rewrite, price authority model) that does not exist on `main`. ENTSO-E (#5) and PowMr (#9, #22) are new providers/hardware features, not fixes, and #7 removes functionality. #15 refines an export-reserve feature that upstream does not have at all.

A decision record was added to `.github/memories.md` documenting this divergence and the per-PR portability status.

### Validation

- `./scripts/quality.sh lint` — clean (Ruff format + check)
- `./scripts/quality.sh typing` — clean (297 source files)
- Full test suite: 2616 passed (coverage plugin disabled to avoid a numpy/Python 3.14 segfault in this environment)
- New `tests/test_load_forecast_hold.py` — 8 tests covering the hold, live-demand contradiction, and forced-mode precedence

## Configuration changes

None.