### PR TITLE
feat(ocpp): run one dedicated OCPP server per EV

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -1195,3 +1195,13 @@ feature, so removing it is a user-facing breaking change with no upstream
 benefit. Treat OCPP's continued presence as a deliberate divergence, never as an
 unfinished port. The same holds for fixed battery schedules. Only the dead
 seven-bucket charge-rate learner from #7 was taken.
+
+**One OCPP server per EV (2026-08-23).** Each EV gets its own embedded OCPP
+server on its own port (defaults 9000 / 9001): the primary plan drives the
+primary server, the second-EV plan drives the second server. The second
+server's config fields (`hsem_ocpp_second_enabled` / `_port` / `_cpid`) are only
+shown in the ocpp flow step when the second EV is enabled, and the second set
+of diagnostic sensors (`*_second`) only registers when both the second EV and
+the second server are enabled. Sensor name helpers take a `charger_index`
+argument (1 = primary, 2 = second); `CoordinatorData` carries
+`ocpp_second_chargers` / `ocpp_second_sessions` alongside the primary fields.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 ### EV Charging
 - **MILP EV co-optimisation** — EV charging scheduled alongside battery in one LP solve
 - **Session-aware EV demand** — treats actively-charging EV as certain demand for the next 2 hours
-- **Embedded OCPP 1.6 server** — direct EV charger control via WebSocket (Easee, Zaptec, Wallbox, etc.)
+- **Embedded OCPP 1.6 server** — direct EV charger control via WebSocket (Easee, Zaptec, Wallbox, etc.), one server per EV (second EV optional, separate port)
 - **Auto-Full on negative prices** — automatically charges EV at full power when electricity is free
 - **Dual EV support** — independent configuration and planning for two EVs
 

--- a/custom_components/hsem/config_flow.py
+++ b/custom_components/hsem/config_flow.py
@@ -589,7 +589,10 @@ class HSEMConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # pyright: igno
                 self._user_input.update(user_input)
                 return await self.async_step_batteries_schedules()
 
-        data_schema = await get_ocpp_step_schema(None)
+        data_schema = await get_ocpp_step_schema(
+            None,
+            second_ev_enabled=bool(self._user_input.get("hsem_ev_second_enabled")),
+        )
 
         return self.async_show_form(
             step_id="ocpp",

--- a/custom_components/hsem/const.py
+++ b/custom_components/hsem/const.py
@@ -138,6 +138,10 @@ DEFAULT_CONFIG_VALUES = {
     "hsem_ocpp_cpid": "",
     "hsem_ocpp_start_window_s": 60,
     "hsem_ocpp_stop_window_s": 180,
+    # Second OCPP server for the optional second EV (separate port).
+    "hsem_ocpp_second_enabled": False,
+    "hsem_ocpp_second_port": 9001,
+    "hsem_ocpp_second_cpid": "",
     # Daily plan-vs-actual tracking — optional energy meter entities.
     # When not configured, the sensor falls back to Riemann-sum estimates
     # from instantaneous power sensors.

--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -271,7 +271,10 @@ class HSEMDataUpdateCoordinator(
         self._capacity_learner: CapacityLearner = CapacityLearner()
 
         # Embedded OCPP 1.6 server for EV charger control (issue #603).
+        # One server per EV: primary EV on ``_ocpp_server``, optional second
+        # EV on ``_ocpp_second_server`` (separate port).
         self._ocpp_server: OCPPServer | None = None
+        self._ocpp_second_server: OCPPServer | None = None
         self._ocpp_sessions: list = []
 
         # ML consumption predictor — cached across cycles so the retrain

--- a/custom_components/hsem/coordinator_cycle.py
+++ b/custom_components/hsem/coordinator_cycle.py
@@ -417,6 +417,14 @@ class CoordinatorCycleMixin(CoordinatorSharedState):
             ocpp_chargers = ocpp.charger_sessions
             ocpp_sessions = list(self._ocpp_sessions)
 
+        # Second EV's OCPP server state.
+        ocpp_second_chargers: dict | None = None
+        ocpp_second_sessions: list | None = None
+        ocpp_second = getattr(self, "_ocpp_second_server", None)
+        if ocpp_second is not None:
+            ocpp_second_chargers = ocpp_second.charger_sessions
+            ocpp_second_sessions = []
+
         data = CoordinatorData(
             cfg=self._cfg,
             live=self._live,
@@ -441,6 +449,8 @@ class CoordinatorCycleMixin(CoordinatorSharedState):
             ),
             ocpp_chargers=ocpp_chargers,
             ocpp_sessions=ocpp_sessions,
+            ocpp_second_chargers=ocpp_second_chargers,
+            ocpp_second_sessions=ocpp_second_sessions,
             capacity_learner=getattr(self, "_capacity_learner", CapacityLearner()),
             solar_hour_factors=dict(
                 getattr(self, "_solar_corrector", SolarForecastCorrector()).hour_factors
@@ -481,19 +491,26 @@ class CoordinatorCycleMixin(CoordinatorSharedState):
                 load_forecast_signature=self._current_load_forecast_signature,
             )
 
-        # Push the accepted EV target only after the freshness gate passes.
+        # Push the accepted EV targets only after the freshness gate passes.
+        # Each EV gets its own OCPP server: the primary plan drives the
+        # primary server, the second plan drives the second server.
+        slot_minutes = self._cfg.recommendation_interval_minutes
+        force_primary = bool(
+            get_config_value(self._config_entry, "hsem_ev_force_charge_now")
+        )
+        force_second = bool(
+            get_config_value(self._config_entry, "hsem_ev_second_force_charge_now")
+        )
+
         ocpp_server = getattr(self, "_ocpp_server", None)
         if ocpp_server is not None and self._cfg.ocpp_enabled:
             cpid = self._cfg.ocpp_cpid or "default"
             target_kw = 0.0
             if self._ev_charging_plan is not None:
                 target_kw = self._ev_charging_plan.current_slot_planned_load_kwh
-                slot_minutes = self._cfg.recommendation_interval_minutes
                 if slot_minutes > 0 and target_kw > 0:
                     target_kw = target_kw / slot_minutes * 60.0
-                if bool(
-                    get_config_value(self._config_entry, "hsem_ev_force_charge_now")
-                ):
+                if force_primary:
                     forced_kw = float(
                         get_config_value(
                             self._config_entry,
@@ -504,5 +521,33 @@ class CoordinatorCycleMixin(CoordinatorSharedState):
                     if forced_kw > 0:
                         target_kw = forced_kw
             await ocpp_server.update_charge_target(cpid, target_kw, now=now)
+
+        ocpp_second_server = getattr(self, "_ocpp_second_server", None)
+        if (
+            ocpp_second_server is not None
+            and self._cfg.ocpp_enabled
+            and self._cfg.ocpp_second_enabled
+        ):
+            second_cpid = self._cfg.ocpp_second_cpid or "default"
+            second_target_kw = 0.0
+            if self._ev_second_charging_plan is not None:
+                second_target_kw = (
+                    self._ev_second_charging_plan.current_slot_planned_load_kwh
+                )
+                if slot_minutes > 0 and second_target_kw > 0:
+                    second_target_kw = second_target_kw / slot_minutes * 60.0
+                if force_second:
+                    forced_kw = float(
+                        get_config_value(
+                            self._config_entry,
+                            "hsem_ev_second_planned_load_charger_power_kw",
+                        )
+                        or 0.0
+                    )
+                    if forced_kw > 0:
+                        second_target_kw = forced_kw
+            await ocpp_second_server.update_charge_target(
+                second_cpid, second_target_kw, now=now
+            )
 
         async_log("debug", "------ HSEM Coordinator: update cycle complete")

--- a/custom_components/hsem/coordinator_data.py
+++ b/custom_components/hsem/coordinator_data.py
@@ -90,3 +90,7 @@ class CoordinatorData:
     ocpp_chargers: dict | None = None
     #: OCPP completed session log for the sessions sensor.
     ocpp_sessions: list | None = None
+    #: Second EV OCPP charger session dict (CPID → ChargerSession).
+    ocpp_second_chargers: dict | None = None
+    #: Second EV OCPP completed session log.
+    ocpp_second_sessions: list | None = None

--- a/custom_components/hsem/coordinator_lifecycle.py
+++ b/custom_components/hsem/coordinator_lifecycle.py
@@ -69,7 +69,9 @@ class CoordinatorLifecycleMixin(CoordinatorSharedState):
         except Exception as e:
             async_log("error", "Failed to initialise financial tracker: %s", e)
 
-        # Start the embedded OCPP 1.6 server if enabled (issue #603).
+        # Start the embedded OCPP 1.6 server(s) if enabled (issue #603).
+        # One server per EV: the primary EV uses the primary server, and the
+        # optional second EV gets its own dedicated server on a separate port.
         cfg = build_sensor_config(self._config_entry)
         if cfg.ocpp_enabled:
             try:
@@ -85,6 +87,26 @@ class CoordinatorLifecycleMixin(CoordinatorSharedState):
             except Exception as e:
                 async_log("error", "Failed to start OCPP server: %s", e)
                 self._ocpp_server = None
+
+        # Second OCPP server — only when the second EV is configured/enabled.
+        if cfg.ev_second_planned_load_enabled and cfg.ocpp_second_enabled:
+            try:
+                self._ocpp_second_server = OCPPServer(
+                    hass=self.hass,
+                    host="0.0.0.0",
+                    port=cfg.ocpp_second_port,
+                    start_window_s=cfg.ocpp_start_window_s,
+                    stop_window_s=cfg.ocpp_stop_window_s,
+                )
+                await self._ocpp_second_server.start()
+                async_log(
+                    "info",
+                    "Second OCPP server started on port %d",
+                    cfg.ocpp_second_port,
+                )
+            except Exception as e:
+                async_log("error", "Failed to start second OCPP server: %s", e)
+                self._ocpp_second_server = None
 
         # Run an immediate first cycle so entities have data before first render.
         await self._async_handle_update(None)
@@ -126,11 +148,15 @@ class CoordinatorLifecycleMixin(CoordinatorSharedState):
                 midnight()
                 daily_tracker._midnight_unsub = None  # type: ignore[attr-defined]
 
-        # Stop the OCPP server if it was started.
+        # Stop the OCPP servers if they were started.
         ocpp = getattr(self, "_ocpp_server", None)
         if ocpp is not None:
             await ocpp.stop()
             self._ocpp_server = None
+        ocpp_second = getattr(self, "_ocpp_second_server", None)
+        if ocpp_second is not None:
+            await ocpp_second.stop()
+            self._ocpp_second_server = None
 
         # Cancel any pending options-update background task and debounce timer.
         task = getattr(self, "_options_update_task", None)

--- a/custom_components/hsem/coordinator_state.py
+++ b/custom_components/hsem/coordinator_state.py
@@ -117,6 +117,7 @@ class CoordinatorSharedState(_Base):
     _net_consumption_ema: float | None
     _next_update: str | None
     _ocpp_server: OCPPServer | None
+    _ocpp_second_server: OCPPServer | None
     _ocpp_sessions: list
     _options_update_debounce_task: asyncio.Task | None
     _options_update_task: asyncio.Task | None

--- a/custom_components/hsem/custom_sensors/config_reader.py
+++ b/custom_components/hsem/custom_sensors/config_reader.py
@@ -534,6 +534,16 @@ def build_sensor_config(
     _stop = convert_to_int(get_config_value(config_entry, "hsem_ocpp_stop_window_s"))
     cfg.ocpp_stop_window_s = _stop if _stop is not None else 180
 
+    # Second OCPP server for the optional second EV (separate port).
+    cfg.ocpp_second_enabled = convert_to_boolean(
+        get_config_value(config_entry, "hsem_ocpp_second_enabled")
+    )
+    _ocpp_second_port = convert_to_int(
+        get_config_value(config_entry, "hsem_ocpp_second_port")
+    )
+    cfg.ocpp_second_port = _ocpp_second_port if _ocpp_second_port is not None else 9001
+    cfg.ocpp_second_cpid = get_config_value(config_entry, "hsem_ocpp_second_cpid") or ""
+
     return cfg
 
 

--- a/custom_components/hsem/custom_sensors/ocpp_sensors.py
+++ b/custom_components/hsem/custom_sensors/ocpp_sensors.py
@@ -1,15 +1,19 @@
 """Diagnostic sensors exposing OCPP charger state to Home Assistant.
 
-Provides four sensors:
+Provides four sensors per OCPP server (one server per EV):
 
 - ``sensor.hsem_ocpp_charger_status`` — Connection status and charging state.
 - ``sensor.hsem_ocpp_charger_power`` — Live charging power (kW).
 - ``sensor.hsem_ocpp_charger_info`` — Vendor, model, firmware, serial.
 - ``sensor.hsem_ocpp_charger_sessions`` — Completed session log.
 
+The second EV's server (when configured) exposes the same four sensors with
+``_second`` entity IDs, reading from the second server's charger state.
+
 All sensors are diagnostic entities that subscribe to the shared
 :class:`~custom_components.hsem.coordinator.HSEMDataUpdateCoordinator`.
-They read charger state from :attr:`CoordinatorData.ocpp_chargers`.
+They read charger state from :attr:`CoordinatorData.ocpp_chargers` and
+:attr:`CoordinatorData.ocpp_second_chargers`.
 """
 
 from __future__ import annotations
@@ -45,6 +49,21 @@ from custom_components.hsem.utils.sensornames.ocpp import (
     get_ocpp_charger_status_sensor_unique_id,
 )
 
+
+def _chargers_for(data: CoordinatorData | None, charger_index: int) -> dict | None:
+    """Return the charger dict for the given EV's OCPP server.
+
+    Args:
+        data: Coordinator data (may be ``None``).
+        charger_index: ``1`` for the primary EV server, ``2`` for the second.
+    """
+    if data is None:
+        return None
+    if charger_index == 2:
+        return data.ocpp_second_chargers
+    return data.ocpp_chargers
+
+
 # ---------------------------------------------------------------------------
 # OCPP Charger Status Sensor
 # ---------------------------------------------------------------------------
@@ -74,22 +93,28 @@ class HSEMOCPPChargerStatusSensor(
         self,
         config_entry: ConfigEntry,
         coordinator: HSEMDataUpdateCoordinator,
+        charger_index: int = 1,
     ) -> None:
         """Initialise the OCPP charger status sensor.
 
         Args:
             config_entry: The HSEM config entry.
             coordinator: The shared coordinator.
+            charger_index: ``1`` for the primary EV server, ``2`` for the
+                second EV's server.
         """
         HSEMCoordinatorEntity.__init__(self, coordinator)
         HSEMEntity.__init__(self, config_entry)
 
         self._config_entry = config_entry
+        self._charger_index = charger_index
         self._attr_unique_id = get_ocpp_charger_status_sensor_unique_id(
-            config_entry.entry_id
+            config_entry.entry_id, charger_index=charger_index
         )
-        self.entity_id = get_ocpp_charger_status_sensor_entity_id()
-        self._name = get_ocpp_charger_status_sensor_name()
+        self.entity_id = get_ocpp_charger_status_sensor_entity_id(
+            charger_index=charger_index
+        )
+        self._name = get_ocpp_charger_status_sensor_name(charger_index)
         self._restored_state: str | None = None
 
     @property
@@ -112,7 +137,7 @@ class HSEMOCPPChargerStatusSensor(
         if data is None:
             return self._restored_state or "disconnected"
 
-        chargers = data.ocpp_chargers or {}
+        chargers = _chargers_for(data, self._charger_index) or {}
         if not chargers:
             return "disconnected"
 
@@ -125,11 +150,12 @@ class HSEMOCPPChargerStatusSensor(
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return per-charger status details."""
         data: CoordinatorData | None = self.coordinator.data
-        if data is None or not data.ocpp_chargers:
+        chargers = _chargers_for(data, self._charger_index)
+        if not chargers:
             return {}
 
         attrs: dict[str, Any] = {}
-        for cpid, session in data.ocpp_chargers.items():
+        for cpid, session in chargers.items():
             attrs[cpid] = {
                 "status": session.status,
                 "power_w": round(session.current_power_w, 1),
@@ -189,22 +215,28 @@ class HSEMOCPPChargerPowerSensor(
         self,
         config_entry: ConfigEntry,
         coordinator: HSEMDataUpdateCoordinator,
+        charger_index: int = 1,
     ) -> None:
         """Initialise the OCPP charger power sensor.
 
         Args:
             config_entry: The HSEM config entry.
             coordinator: The shared coordinator.
+            charger_index: ``1`` for the primary EV server, ``2`` for the
+                second EV's server.
         """
         HSEMCoordinatorEntity.__init__(self, coordinator)
         HSEMEntity.__init__(self, config_entry)
 
         self._config_entry = config_entry
+        self._charger_index = charger_index
         self._attr_unique_id = get_ocpp_charger_power_sensor_unique_id(
-            config_entry.entry_id
+            config_entry.entry_id, charger_index=charger_index
         )
-        self.entity_id = get_ocpp_charger_power_sensor_entity_id()
-        self._name = get_ocpp_charger_power_sensor_name()
+        self.entity_id = get_ocpp_charger_power_sensor_entity_id(
+            charger_index=charger_index
+        )
+        self._name = get_ocpp_charger_power_sensor_name(charger_index)
         self._restored_state: str | None = None
 
     @property
@@ -224,10 +256,11 @@ class HSEMOCPPChargerPowerSensor(
     def state(self) -> float | str:
         """Return the current charging power in kW."""
         data: CoordinatorData | None = self.coordinator.data
-        if data is None or not data.ocpp_chargers:
+        chargers = _chargers_for(data, self._charger_index)
+        if not chargers:
             return self._restored_state or "0.0"
 
-        first = next(iter(data.ocpp_chargers.values()))
+        first = next(iter(chargers.values()))
         return float(round(first.current_power_w / 1000.0, 2))  # type: ignore[no-any-return]
 
     @property
@@ -278,22 +311,28 @@ class HSEMOCPPChargerInfoSensor(
         self,
         config_entry: ConfigEntry,
         coordinator: HSEMDataUpdateCoordinator,
+        charger_index: int = 1,
     ) -> None:
         """Initialise the OCPP charger info sensor.
 
         Args:
             config_entry: The HSEM config entry.
             coordinator: The shared coordinator.
+            charger_index: ``1`` for the primary EV server, ``2`` for the
+                second EV's server.
         """
         HSEMCoordinatorEntity.__init__(self, coordinator)
         HSEMEntity.__init__(self, config_entry)
 
         self._config_entry = config_entry
+        self._charger_index = charger_index
         self._attr_unique_id = get_ocpp_charger_info_sensor_unique_id(
-            config_entry.entry_id
+            config_entry.entry_id, charger_index=charger_index
         )
-        self.entity_id = get_ocpp_charger_info_sensor_entity_id()
-        self._name = get_ocpp_charger_info_sensor_name()
+        self.entity_id = get_ocpp_charger_info_sensor_entity_id(
+            charger_index=charger_index
+        )
+        self._name = get_ocpp_charger_info_sensor_name(charger_index)
         self._restored_state: str | None = None
 
     @property
@@ -313,10 +352,11 @@ class HSEMOCPPChargerInfoSensor(
     def state(self) -> str:
         """Return the charger model or 'disconnected'."""
         data: CoordinatorData | None = self.coordinator.data
-        if data is None or not data.ocpp_chargers:
+        chargers = _chargers_for(data, self._charger_index)
+        if not chargers:
             return self._restored_state or "disconnected"
 
-        first = next(iter(data.ocpp_chargers.values()))
+        first = next(iter(chargers.values()))
         return first.model or "unknown"
 
     @property
@@ -324,10 +364,11 @@ class HSEMOCPPChargerInfoSensor(
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return charger identity details."""
         data: CoordinatorData | None = self.coordinator.data
-        if data is None or not data.ocpp_chargers:
+        chargers = _chargers_for(data, self._charger_index)
+        if not chargers:
             return {}
 
-        first = next(iter(data.ocpp_chargers.values()))
+        first = next(iter(chargers.values()))
         return {
             "vendor": first.vendor,
             "model": first.model,
@@ -384,22 +425,28 @@ class HSEMOCPPChargerSessionsSensor(
         self,
         config_entry: ConfigEntry,
         coordinator: HSEMDataUpdateCoordinator,
+        charger_index: int = 1,
     ) -> None:
         """Initialise the OCPP charger sessions sensor.
 
         Args:
             config_entry: The HSEM config entry.
             coordinator: The shared coordinator.
+            charger_index: ``1`` for the primary EV server, ``2`` for the
+                second EV's server.
         """
         HSEMCoordinatorEntity.__init__(self, coordinator)
         HSEMEntity.__init__(self, config_entry)
 
         self._config_entry = config_entry
+        self._charger_index = charger_index
         self._attr_unique_id = get_ocpp_charger_sessions_sensor_unique_id(
-            config_entry.entry_id
+            config_entry.entry_id, charger_index=charger_index
         )
-        self.entity_id = get_ocpp_charger_sessions_sensor_entity_id()
-        self._name = get_ocpp_charger_sessions_sensor_name()
+        self.entity_id = get_ocpp_charger_sessions_sensor_entity_id(
+            charger_index=charger_index
+        )
+        self._name = get_ocpp_charger_sessions_sensor_name(charger_index)
         self._restored_state: str | None = None
 
     @property
@@ -419,7 +466,12 @@ class HSEMOCPPChargerSessionsSensor(
     def state(self) -> str:
         """Return the session count."""
         data: CoordinatorData | None = self.coordinator.data
-        sessions = data.ocpp_sessions if data is not None else None
+        if data is None:
+            sessions = None
+        elif self._charger_index == 2:
+            sessions = data.ocpp_second_sessions
+        else:
+            sessions = data.ocpp_sessions
         if sessions is None:
             return self._restored_state or "0"
         return str(len(sessions))
@@ -429,7 +481,12 @@ class HSEMOCPPChargerSessionsSensor(
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return session history."""
         data: CoordinatorData | None = self.coordinator.data
-        sessions = data.ocpp_sessions if data is not None else None
+        if data is None:
+            sessions = None
+        elif self._charger_index == 2:
+            sessions = data.ocpp_second_sessions
+        else:
+            sessions = data.ocpp_sessions
         if sessions is None:
             return {}
         return {"sessions": sessions}

--- a/custom_components/hsem/flows/ocpp.py
+++ b/custom_components/hsem/flows/ocpp.py
@@ -16,69 +16,107 @@ from custom_components.hsem.utils.misc import get_config_value
 
 async def get_ocpp_step_schema(
     config_entry: ConfigEntry | None,
+    *,
+    second_ev_enabled: bool = False,
 ) -> vol.Schema:
     """Return the data schema for the OCPP server config flow step.
 
     Args:
         config_entry: Active config entry; ``None`` for the initial config
             flow.
+        second_ev_enabled: When ``True``, include the second OCPP server
+            fields (for the optional second EV).  The second server can only
+            be configured when the second EV is enabled.
 
     Returns:
         A ``vol.Schema`` for the OCPP step.
     """
-    return vol.Schema(
-        {
-            vol.Required(
-                "hsem_ocpp_enabled",
-                default=bool(get_config_value(config_entry, "hsem_ocpp_enabled")),
-            ): selector({"boolean": {}}),
-            vol.Required(
-                "hsem_ocpp_port",
-                default=get_config_value(config_entry, "hsem_ocpp_port"),
-            ): selector(
-                {
-                    "number": {
-                        "min": 1024,
-                        "max": 65535,
-                        "step": 1,
-                        "mode": "box",
-                    }
+    fields: dict = {
+        vol.Required(
+            "hsem_ocpp_enabled",
+            default=bool(get_config_value(config_entry, "hsem_ocpp_enabled")),
+        ): selector({"boolean": {}}),
+        vol.Required(
+            "hsem_ocpp_port",
+            default=get_config_value(config_entry, "hsem_ocpp_port"),
+        ): selector(
+            {
+                "number": {
+                    "min": 1024,
+                    "max": 65535,
+                    "step": 1,
+                    "mode": "box",
                 }
-            ),
+            }
+        ),
+        vol.Optional(
+            "hsem_ocpp_cpid",
+            default=get_config_value(config_entry, "hsem_ocpp_cpid") or "",
+        ): str,
+        vol.Required(
+            "hsem_ocpp_start_window_s",
+            default=get_config_value(config_entry, "hsem_ocpp_start_window_s"),
+        ): selector(
+            {
+                "number": {
+                    "min": 0,
+                    "max": 600,
+                    "step": 10,
+                    "unit_of_measurement": "s",
+                    "mode": "slider",
+                }
+            }
+        ),
+        vol.Required(
+            "hsem_ocpp_stop_window_s",
+            default=get_config_value(config_entry, "hsem_ocpp_stop_window_s"),
+        ): selector(
+            {
+                "number": {
+                    "min": 0,
+                    "max": 1800,
+                    "step": 30,
+                    "unit_of_measurement": "s",
+                    "mode": "slider",
+                }
+            }
+        ),
+    }
+
+    if second_ev_enabled:
+        # Second OCPP server — only configurable when the second EV is
+        # enabled. Runs on its own port so each EV gets a dedicated server.
+        fields[
+            vol.Required(
+                "hsem_ocpp_second_enabled",
+                default=bool(
+                    get_config_value(config_entry, "hsem_ocpp_second_enabled")
+                ),
+            )
+        ] = selector({"boolean": {}})
+        fields[
+            vol.Required(
+                "hsem_ocpp_second_port",
+                default=get_config_value(config_entry, "hsem_ocpp_second_port"),
+            )
+        ] = selector(
+            {
+                "number": {
+                    "min": 1024,
+                    "max": 65535,
+                    "step": 1,
+                    "mode": "box",
+                }
+            }
+        )
+        fields[
             vol.Optional(
-                "hsem_ocpp_cpid",
-                default=get_config_value(config_entry, "hsem_ocpp_cpid") or "",
-            ): str,
-            vol.Required(
-                "hsem_ocpp_start_window_s",
-                default=get_config_value(config_entry, "hsem_ocpp_start_window_s"),
-            ): selector(
-                {
-                    "number": {
-                        "min": 0,
-                        "max": 600,
-                        "step": 10,
-                        "unit_of_measurement": "s",
-                        "mode": "slider",
-                    }
-                }
-            ),
-            vol.Required(
-                "hsem_ocpp_stop_window_s",
-                default=get_config_value(config_entry, "hsem_ocpp_stop_window_s"),
-            ): selector(
-                {
-                    "number": {
-                        "min": 0,
-                        "max": 1800,
-                        "step": 30,
-                        "unit_of_measurement": "s",
-                        "mode": "slider",
-                    }
-                }
-            ),
-        }
-    )
+                "hsem_ocpp_second_cpid",
+                default=get_config_value(config_entry, "hsem_ocpp_second_cpid") or "",
+            )
+        ] = str
+
+    return vol.Schema(fields)
 
 
 async def validate_ocpp_step_input(
@@ -102,6 +140,11 @@ async def validate_ocpp_step_input(
         "hsem_ocpp_stop_window_s",
     ]
 
+    # Second-server fields are only required when submitted; they are only
+    # presented when the second EV is enabled.
+    if "hsem_ocpp_second_enabled" in user_input:
+        required_fields.extend(["hsem_ocpp_second_port"])
+
     for field in required_fields:
         if field not in user_input:
             errors[field] = "required"
@@ -115,5 +158,20 @@ async def validate_ocpp_step_input(
                 errors["hsem_ocpp_port"] = "power_out_of_range"
         except ValueError, TypeError:
             errors["hsem_ocpp_port"] = "invalid_power_value"
+
+    second_port = user_input.get("hsem_ocpp_second_port")
+    if second_port is not None:
+        try:
+            second_port_int = int(second_port)
+            if second_port_int < 1024 or second_port_int > 65535:
+                errors["hsem_ocpp_second_port"] = "power_out_of_range"
+            elif (
+                port is not None
+                and "hsem_ocpp_port" not in errors
+                and second_port_int == int(port)
+            ):
+                errors["hsem_ocpp_second_port"] = "port_conflict"
+        except ValueError, TypeError:
+            errors["hsem_ocpp_second_port"] = "invalid_power_value"
 
     return errors

--- a/custom_components/hsem/models/sensor_config.py
+++ b/custom_components/hsem/models/sensor_config.py
@@ -292,6 +292,10 @@ class SensorConfig:
     ocpp_cpid: str = ""
     ocpp_start_window_s: int = 60
     ocpp_stop_window_s: int = 180
+    # Second OCPP server for the optional second EV (separate port).
+    ocpp_second_enabled: bool = False
+    ocpp_second_port: int = 9001
+    ocpp_second_cpid: str = ""
 
     # Consumption weights
     house_consumption_energy_weight_1d: int = 50

--- a/custom_components/hsem/options_flow.py
+++ b/custom_components/hsem/options_flow.py
@@ -69,6 +69,7 @@ from custom_components.hsem.flows.weighted_values import (
     validate_weighted_values_input,
 )
 from custom_components.hsem.utils.conversion import convert_months_to_int
+from custom_components.hsem.utils.misc import get_config_value
 
 
 class HSEMOptionsFlow(config_entries.OptionsFlow):
@@ -384,7 +385,13 @@ class HSEMOptionsFlow(config_entries.OptionsFlow):
                 self._user_input.update(user_input)
                 return await self.async_step_batteries_schedules()
 
-        data_schema = await get_ocpp_step_schema(self._config_entry)
+        data_schema = await get_ocpp_step_schema(
+            self._config_entry,
+            second_ev_enabled=bool(
+                get_config_value(self._config_entry, "hsem_ev_second_enabled")
+                or bool(self._user_input.get("hsem_ev_second_enabled"))
+            ),
+        )
 
         return self.async_show_form(
             step_id="ocpp",

--- a/custom_components/hsem/sensor.py
+++ b/custom_components/hsem/sensor.py
@@ -97,6 +97,7 @@ from custom_components.hsem.custom_sensors.update_interval_sensor import (
 from custom_components.hsem.custom_sensors.working_mode_sensor import (
     HSEMWorkingModeSensor,
 )
+from custom_components.hsem.utils.misc import get_config_value
 
 
 async def async_setup_entry(  # NOSONAR -- HA platform callback, must be async
@@ -175,12 +176,24 @@ async def async_setup_entry(  # NOSONAR -- HA platform callback, must be async
     savings_sensor = HSEMSavingsSensor(config_entry, coordinator)
 
     # OCPP charger sensors — expose charger state when OCPP server is enabled.
+    # One set per EV: the second set only when the second EV is configured.
     ocpp_charger_status_sensor = HSEMOCPPChargerStatusSensor(config_entry, coordinator)
     ocpp_charger_power_sensor = HSEMOCPPChargerPowerSensor(config_entry, coordinator)
     ocpp_charger_info_sensor = HSEMOCPPChargerInfoSensor(config_entry, coordinator)
     ocpp_charger_sessions_sensor = HSEMOCPPChargerSessionsSensor(
         config_entry, coordinator
     )
+
+    ocpp_second_entities = []
+    if bool(
+        get_config_value(config_entry, "hsem_ev_second_planned_load_enabled")
+    ) and bool(get_config_value(config_entry, "hsem_ocpp_second_enabled")):
+        ocpp_second_entities = [
+            HSEMOCPPChargerStatusSensor(config_entry, coordinator, charger_index=2),
+            HSEMOCPPChargerPowerSensor(config_entry, coordinator, charger_index=2),
+            HSEMOCPPChargerInfoSensor(config_entry, coordinator, charger_index=2),
+            HSEMOCPPChargerSessionsSensor(config_entry, coordinator, charger_index=2),
+        ]
 
     async_add_entities(
         [
@@ -217,6 +230,7 @@ async def async_setup_entry(  # NOSONAR -- HA platform callback, must be async
             ocpp_charger_power_sensor,
             ocpp_charger_info_sensor,
             ocpp_charger_sessions_sensor,
+            *ocpp_second_entities,
         ]
     )
 

--- a/custom_components/hsem/translations/en.json
+++ b/custom_components/hsem/translations/en.json
@@ -24,7 +24,8 @@
       "required": "This field is required.",
       "start_time_after_end_time": "Start time must be before end time.",
       "start_time_equals_end_time": "Start time and end time cannot be the same — this creates a zero-length window. Disable the schedule instead.",
-      "invalid_wait_mode_behavior": "Invalid wait mode behaviour. Choose Strict wait or Self-consumption with reserve."
+      "invalid_wait_mode_behavior": "Invalid wait mode behaviour. Choose Strict wait or Self-consumption with reserve.",
+      "port_conflict": "The second OCPP port must differ from the first OCPP port."
     },
     "step": {
       "batteries_excess_export": {
@@ -83,14 +84,20 @@
           "hsem_ocpp_port": "OCPP Port",
           "hsem_ocpp_cpid": "Charge Point ID",
           "hsem_ocpp_start_window_s": "Start Window (s)",
-          "hsem_ocpp_stop_window_s": "Stop Window (s)"
+          "hsem_ocpp_stop_window_s": "Stop Window (s)",
+          "hsem_ocpp_second_enabled": "Enable Second OCPP Server",
+          "hsem_ocpp_second_port": "Second OCPP Port",
+          "hsem_ocpp_second_cpid": "Second Charge Point ID"
         },
         "data_description": {
           "hsem_ocpp_enabled": "Enable the embedded OCPP 1.6 WebSocket server for direct EV charger control. LAN-only — do not expose the port to the internet.",
           "hsem_ocpp_port": "TCP port for the OCPP WebSocket server. Default: 9000. Must be above 1024.",
           "hsem_ocpp_cpid": "Expected charge-point identifier of the EV charger. Leave empty to accept any charger.",
           "hsem_ocpp_start_window_s": "Seconds of sustained surplus required before starting a charge. Prevents rapid start-stop cycling. Default: 60.",
-          "hsem_ocpp_stop_window_s": "Seconds of sustained shortage required before stopping a charge. Prevents rapid stop-start cycling. Default: 180."
+          "hsem_ocpp_stop_window_s": "Seconds of sustained shortage required before stopping a charge. Prevents rapid stop-start cycling. Default: 180.",
+          "hsem_ocpp_second_enabled": "Enable a second, dedicated OCPP server for the second EV. Only available when EV 2 planned load is enabled.",
+          "hsem_ocpp_second_port": "TCP port for the second OCPP WebSocket server. Default: 9001. Must differ from the first server's port.",
+          "hsem_ocpp_second_cpid": "Expected charge-point identifier of the second EV charger. Leave empty to accept any charger."
         },
         "description": "Configure the embedded OCPP 1.6 server for LAN-only EV charger control. When enabled, HSEM sends SetChargingProfile commands directly to your EV charger based on the charging plan.",
         "title": "OCPP Server"
@@ -514,7 +521,8 @@
       "required": "This field is required.",
       "start_time_after_end_time": "Start time must be before end time.",
       "start_time_equals_end_time": "Start time and end time cannot be the same — this creates a zero-length window. Disable the schedule instead.",
-      "invalid_wait_mode_behavior": "Invalid wait mode behaviour. Choose Strict wait or Self-consumption with reserve."
+      "invalid_wait_mode_behavior": "Invalid wait mode behaviour. Choose Strict wait or Self-consumption with reserve.",
+      "port_conflict": "The second OCPP port must differ from the first OCPP port."
     },
     "step": {
       "batteries_excess_export": {
@@ -573,14 +581,20 @@
           "hsem_ocpp_port": "OCPP Port",
           "hsem_ocpp_cpid": "Charge Point ID",
           "hsem_ocpp_start_window_s": "Start Window (s)",
-          "hsem_ocpp_stop_window_s": "Stop Window (s)"
+          "hsem_ocpp_stop_window_s": "Stop Window (s)",
+          "hsem_ocpp_second_enabled": "Enable Second OCPP Server",
+          "hsem_ocpp_second_port": "Second OCPP Port",
+          "hsem_ocpp_second_cpid": "Second Charge Point ID"
         },
         "data_description": {
           "hsem_ocpp_enabled": "Enable the embedded OCPP 1.6 WebSocket server for direct EV charger control. LAN-only — do not expose the port to the internet.",
           "hsem_ocpp_port": "TCP port for the OCPP WebSocket server. Default: 9000. Must be above 1024.",
           "hsem_ocpp_cpid": "Expected charge-point identifier of the EV charger. Leave empty to accept any charger.",
           "hsem_ocpp_start_window_s": "Seconds of sustained surplus required before starting a charge. Prevents rapid start-stop cycling. Default: 60.",
-          "hsem_ocpp_stop_window_s": "Seconds of sustained shortage required before stopping a charge. Prevents rapid stop-start cycling. Default: 180."
+          "hsem_ocpp_stop_window_s": "Seconds of sustained shortage required before stopping a charge. Prevents rapid stop-start cycling. Default: 180.",
+          "hsem_ocpp_second_enabled": "Enable a second, dedicated OCPP server for the second EV. Only available when EV 2 planned load is enabled.",
+          "hsem_ocpp_second_port": "TCP port for the second OCPP WebSocket server. Default: 9001. Must differ from the first server's port.",
+          "hsem_ocpp_second_cpid": "Expected charge-point identifier of the second EV charger. Leave empty to accept any charger."
         },
         "description": "Configure the embedded OCPP 1.6 server for LAN-only EV charger control. When enabled, HSEM sends SetChargingProfile commands directly to your EV charger based on the charging plan.",
         "title": "OCPP Server"

--- a/custom_components/hsem/utils/sensornames/ocpp.py
+++ b/custom_components/hsem/utils/sensornames/ocpp.py
@@ -1,7 +1,9 @@
 """OCPP-related sensor name generators.
 
 Provides getter functions for OCPP charger status, power, info, and
-sessions sensor names, unique IDs, and entity IDs.
+sessions sensor names, unique IDs, and entity IDs.  Each OCPP server
+(one per EV) exposes its own set of sensors; ``charger_index`` selects
+between the primary (``1``) and second (``2``) EV's server.
 """
 
 from homeassistant.util import slugify as s
@@ -13,23 +15,32 @@ from custom_components.hsem.const import DOMAIN
 # ---------------------------------------------------------------------------
 
 
-def get_ocpp_charger_status_sensor_name() -> str:
+def _suffix(charger_index: int) -> str:
+    """Return the name/entity suffix for a charger index."""
+    return "" if charger_index == 1 else "_second"
+
+
+def get_ocpp_charger_status_sensor_name(charger_index: int = 1) -> str:
     """Return the display name for the OCPP charger status sensor."""
-    return "OCPP Charger Status"
+    suffix = " Second" if charger_index == 2 else ""
+    return f"OCPP Charger{suffix} Status"
 
 
-def get_ocpp_charger_status_sensor_unique_id(entry_id: str) -> str:
+def get_ocpp_charger_status_sensor_unique_id(
+    entry_id: str, charger_index: int = 1
+) -> str:
     """Return a unique ID for the OCPP charger status sensor.
 
     Args:
         entry_id: The config entry ID for uniqueness across entries.
+        charger_index: ``1`` for the primary EV server, ``2`` for the second.
     """
-    return f"{DOMAIN}_{entry_id}_ocpp_charger_status_sensor"
+    return f"{DOMAIN}_{entry_id}_ocpp_charger_status_sensor{_suffix(charger_index)}"
 
 
-def get_ocpp_charger_status_sensor_entity_id() -> str:
+def get_ocpp_charger_status_sensor_entity_id(charger_index: int = 1) -> str:
     """Return the entity_id for the OCPP charger status sensor."""
-    return f"sensor.{s(f'{DOMAIN}_ocpp_charger_status_sensor')}"
+    return f"sensor.{s(f'{DOMAIN}_ocpp_charger_status_sensor{_suffix(charger_index)}')}"
 
 
 # ---------------------------------------------------------------------------
@@ -37,23 +48,27 @@ def get_ocpp_charger_status_sensor_entity_id() -> str:
 # ---------------------------------------------------------------------------
 
 
-def get_ocpp_charger_power_sensor_name() -> str:
+def get_ocpp_charger_power_sensor_name(charger_index: int = 1) -> str:
     """Return the display name for the OCPP charger power sensor."""
-    return "OCPP Charger Power"
+    suffix = " Second" if charger_index == 2 else ""
+    return f"OCPP Charger{suffix} Power"
 
 
-def get_ocpp_charger_power_sensor_unique_id(entry_id: str) -> str:
+def get_ocpp_charger_power_sensor_unique_id(
+    entry_id: str, charger_index: int = 1
+) -> str:
     """Return a unique ID for the OCPP charger power sensor.
 
     Args:
         entry_id: The config entry ID for uniqueness across entries.
+        charger_index: ``1`` for the primary EV server, ``2`` for the second.
     """
-    return f"{DOMAIN}_{entry_id}_ocpp_charger_power_sensor"
+    return f"{DOMAIN}_{entry_id}_ocpp_charger_power_sensor{_suffix(charger_index)}"
 
 
-def get_ocpp_charger_power_sensor_entity_id() -> str:
+def get_ocpp_charger_power_sensor_entity_id(charger_index: int = 1) -> str:
     """Return the entity_id for the OCPP charger power sensor."""
-    return f"sensor.{s(f'{DOMAIN}_ocpp_charger_power_sensor')}"
+    return f"sensor.{s(f'{DOMAIN}_ocpp_charger_power_sensor{_suffix(charger_index)}')}"
 
 
 # ---------------------------------------------------------------------------
@@ -61,23 +76,27 @@ def get_ocpp_charger_power_sensor_entity_id() -> str:
 # ---------------------------------------------------------------------------
 
 
-def get_ocpp_charger_info_sensor_name() -> str:
+def get_ocpp_charger_info_sensor_name(charger_index: int = 1) -> str:
     """Return the display name for the OCPP charger info sensor."""
-    return "OCPP Charger Info"
+    suffix = " Second" if charger_index == 2 else ""
+    return f"OCPP Charger{suffix} Info"
 
 
-def get_ocpp_charger_info_sensor_unique_id(entry_id: str) -> str:
+def get_ocpp_charger_info_sensor_unique_id(
+    entry_id: str, charger_index: int = 1
+) -> str:
     """Return a unique ID for the OCPP charger info sensor.
 
     Args:
         entry_id: The config entry ID for uniqueness across entries.
+        charger_index: ``1`` for the primary EV server, ``2`` for the second.
     """
-    return f"{DOMAIN}_{entry_id}_ocpp_charger_info_sensor"
+    return f"{DOMAIN}_{entry_id}_ocpp_charger_info_sensor{_suffix(charger_index)}"
 
 
-def get_ocpp_charger_info_sensor_entity_id() -> str:
+def get_ocpp_charger_info_sensor_entity_id(charger_index: int = 1) -> str:
     """Return the entity_id for the OCPP charger info sensor."""
-    return f"sensor.{s(f'{DOMAIN}_ocpp_charger_info_sensor')}"
+    return f"sensor.{s(f'{DOMAIN}_ocpp_charger_info_sensor{_suffix(charger_index)}')}"
 
 
 # ---------------------------------------------------------------------------
@@ -85,20 +104,26 @@ def get_ocpp_charger_info_sensor_entity_id() -> str:
 # ---------------------------------------------------------------------------
 
 
-def get_ocpp_charger_sessions_sensor_name() -> str:
+def get_ocpp_charger_sessions_sensor_name(charger_index: int = 1) -> str:
     """Return the display name for the OCPP charger sessions sensor."""
-    return "OCPP Charger Sessions"
+    suffix = " Second" if charger_index == 2 else ""
+    return f"OCPP Charger{suffix} Sessions"
 
 
-def get_ocpp_charger_sessions_sensor_unique_id(entry_id: str) -> str:
+def get_ocpp_charger_sessions_sensor_unique_id(
+    entry_id: str, charger_index: int = 1
+) -> str:
     """Return a unique ID for the OCPP charger sessions sensor.
 
     Args:
         entry_id: The config entry ID for uniqueness across entries.
+        charger_index: ``1`` for the primary EV server, ``2`` for the second.
     """
-    return f"{DOMAIN}_{entry_id}_ocpp_charger_sessions_sensor"
+    return f"{DOMAIN}_{entry_id}_ocpp_charger_sessions_sensor{_suffix(charger_index)}"
 
 
-def get_ocpp_charger_sessions_sensor_entity_id() -> str:
+def get_ocpp_charger_sessions_sensor_entity_id(charger_index: int = 1) -> str:
     """Return the entity_id for the OCPP charger sessions sensor."""
-    return f"sensor.{s(f'{DOMAIN}_ocpp_charger_sessions_sensor')}"
+    return (
+        f"sensor.{s(f'{DOMAIN}_ocpp_charger_sessions_sensor{_suffix(charger_index)}')}"
+    )

--- a/docs/config-flow-reference.md
+++ b/docs/config-flow-reference.md
@@ -171,14 +171,21 @@ Second EV planned load integration (identical fields; only shown when second EV 
 ### Step: `ocpp`
 
 OCPP (Open Charge Point Protocol) integration for EV charger remote control.
+HSEM runs **one OCPP server per EV**: the primary EV's charger connects to the
+primary server, and — when the second EV is enabled — the second EV's charger
+can connect to a dedicated second server on its own port. The second-server
+fields are only shown when the second EV is configured.
 
 | Field | Key | Default | Description |
 |---|---|---|---|
 | OCPP enabled | `hsem_ocpp_enabled` | `False` | Master switch for OCPP integration |
-| OCPP port | `hsem_ocpp_port` | `9000` | TCP port for the OCPP WebSocket server |
+| OCPP port | `hsem_ocpp_port` | `9000` | TCP port for the primary EV's OCPP WebSocket server |
 | OCPP charge point ID | `hsem_ocpp_cpid` | — | Charge point identifier (as configured in the charger) |
 | Start window | `hsem_ocpp_start_window_s` | `300` | Seconds before a scheduled charge slot to send `RemoteStartTransaction` |
 | Stop window | `hsem_ocpp_stop_window_s` | `300` | Seconds before a non-charge slot to send `RemoteStopTransaction` |
+| Second OCPP enabled | `hsem_ocpp_second_enabled` | `False` | Enable the dedicated second-EV server (only shown with second EV) |
+| Second OCPP port | `hsem_ocpp_second_port` | `9001` | TCP port for the second EV's OCPP WebSocket server (must differ from the primary port) |
+| Second charge point ID | `hsem_ocpp_second_cpid` | — | Charge point identifier of the second EV charger |
 
 ### Step: `batteries_schedule_1/2/3`
 

--- a/docs/sensors-reference.md
+++ b/docs/sensors-reference.md
@@ -435,17 +435,20 @@ Controls and reports the effective discharge floor SoC, which the planner uses a
 
 ## OCPP charger sensors
 
-Sensors providing live status and diagnostics for an OCPP-compliant EV charger connected via the integrated OCPP server.
+Sensors providing live status and diagnostics for an OCPP-compliant EV charger connected via the integrated OCPP server. HSEM runs **one OCPP server per EV** (primary EV on port 9000 by default, second EV on port 9001) — the `_second` variants below exist only when the second EV is configured and the second OCPP server is enabled.
 
 **Configuration keys** (set in config flow):
 
 | Key | Description |
 |---|---|
 | `hsem_ocpp_enabled` | Enable the OCPP server |
-| `hsem_ocpp_port` | TCP port for OCPP WebSocket connections |
+| `hsem_ocpp_port` | TCP port for the primary EV's OCPP WebSocket connections |
 | `hsem_ocpp_cpid` | OCPP charge point identifier |
 | `hsem_ocpp_start_window_s` | Seconds before charge deadline to start charging |
 | `hsem_ocpp_stop_window_s` | Seconds after charge deadline to stop charging |
+| `hsem_ocpp_second_enabled` | Enable the dedicated second-EV OCPP server (requires second EV) |
+| `hsem_ocpp_second_port` | TCP port for the second EV's OCPP WebSocket connections |
+| `hsem_ocpp_second_cpid` | Second EV charger's OCPP charge point identifier |
 
 ### `sensor.hsem_ocpp_charger_status`
 
@@ -478,6 +481,19 @@ Sensors providing live status and diagnostics for an OCPP-compliant EV charger c
 | **Type** | `sensor` |
 | **State** | Number of completed sessions |
 | **Attributes** | `sessions` — list of completed session logs (start time, energy, duration) |
+
+### Second-EV variants
+
+When the second EV is configured with its own OCPP server, four additional
+diagnostic sensors are created with `_second` suffixed entity IDs:
+
+- `sensor.hsem_ocpp_charger_status_sensor_second`
+- `sensor.hsem_ocpp_charger_power_sensor_second`
+- `sensor.hsem_ocpp_charger_info_sensor_second`
+- `sensor.hsem_ocpp_charger_sessions_sensor_second`
+
+These mirror the primary sensors but read from the second EV's dedicated
+OCPP server.
 
 **Template example:**
 

--- a/tests/custom_sensors/test_ocpp_per_ev.py
+++ b/tests/custom_sensors/test_ocpp_per_ev.py
@@ -1,0 +1,130 @@
+"""Tests for per-EV OCPP server configuration and sensors (issue #782).
+
+Covers:
+- Sensor name/unique-id/entity-id helpers for charger_index 1 and 2
+- Second-server config fields in the OCPP flow schema (only with second EV)
+- Port-conflict validation between the two OCPP servers
+- Config reader defaults for the second server
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from homeassistant.exceptions import HomeAssistantError  # noqa: F401
+
+from custom_components.hsem.custom_sensors.config_reader import build_sensor_config
+from custom_components.hsem.flows.ocpp import (
+    get_ocpp_step_schema,
+    validate_ocpp_step_input,
+)
+from custom_components.hsem.utils.sensornames.ocpp import (
+    get_ocpp_charger_power_sensor_entity_id,
+    get_ocpp_charger_power_sensor_name,
+    get_ocpp_charger_power_sensor_unique_id,
+    get_ocpp_charger_status_sensor_entity_id,
+    get_ocpp_charger_status_sensor_unique_id,
+)
+
+# ---------------------------------------------------------------------------
+# Sensor name helpers
+# ---------------------------------------------------------------------------
+
+
+def test_primary_sensor_names_unchanged():
+    """charger_index=1 keeps the original entity IDs and unique IDs."""
+    assert (
+        get_ocpp_charger_status_sensor_entity_id()
+        == "sensor.hsem_ocpp_charger_status_sensor"
+    )
+    assert get_ocpp_charger_status_sensor_unique_id("entry") == (
+        "hsem_entry_ocpp_charger_status_sensor"
+    )
+
+
+def test_second_sensor_names_are_distinct():
+    """charger_index=2 produces distinct, slugified second-server entities."""
+    entity_id = get_ocpp_charger_power_sensor_entity_id(charger_index=2)
+    unique_id = get_ocpp_charger_power_sensor_unique_id("entry", charger_index=2)
+    name = get_ocpp_charger_power_sensor_name(2)
+
+    assert entity_id == "sensor.hsem_ocpp_charger_power_sensor_second"
+    assert unique_id == "hsem_entry_ocpp_charger_power_sensor_second"
+    assert name == "OCPP Charger Second Power"
+    assert entity_id != get_ocpp_charger_power_sensor_entity_id()
+
+
+# ---------------------------------------------------------------------------
+# Flow schema gating on second EV
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_schema_without_second_ev_has_no_second_fields():
+    """The second OCPP fields are absent when the second EV is disabled."""
+    schema = await get_ocpp_step_schema(None, second_ev_enabled=False)
+    keys = str(schema)
+    assert "hsem_ocpp_second_enabled" not in keys
+    assert "hsem_ocpp_port" in keys
+
+
+@pytest.mark.asyncio
+async def test_schema_with_second_ev_includes_second_fields():
+    """The second OCPP fields appear when the second EV is enabled."""
+    schema = await get_ocpp_step_schema(None, second_ev_enabled=True)
+    keys = str(schema)
+    assert "hsem_ocpp_second_enabled" in keys
+    assert "hsem_ocpp_second_port" in keys
+    assert "hsem_ocpp_second_cpid" in keys
+
+
+@pytest.mark.asyncio
+async def test_validation_rejects_conflicting_ports():
+    """Second-server port must differ from the primary port."""
+    errors = await validate_ocpp_step_input(
+        MagicMock(),
+        {
+            "hsem_ocpp_enabled": True,
+            "hsem_ocpp_port": 9000,
+            "hsem_ocpp_start_window_s": 60,
+            "hsem_ocpp_stop_window_s": 180,
+            "hsem_ocpp_second_enabled": True,
+            "hsem_ocpp_second_port": 9000,
+        },
+    )
+    assert errors.get("hsem_ocpp_second_port") == "port_conflict"
+
+
+@pytest.mark.asyncio
+async def test_validation_accepts_distinct_ports():
+    """Distinct ports validate cleanly."""
+    errors = await validate_ocpp_step_input(
+        MagicMock(),
+        {
+            "hsem_ocpp_enabled": True,
+            "hsem_ocpp_port": 9000,
+            "hsem_ocpp_start_window_s": 60,
+            "hsem_ocpp_stop_window_s": 180,
+            "hsem_ocpp_second_enabled": True,
+            "hsem_ocpp_second_port": 9001,
+        },
+    )
+    assert errors == {}
+
+
+# ---------------------------------------------------------------------------
+# Config reader defaults
+# ---------------------------------------------------------------------------
+
+
+def test_config_reader_second_server_defaults():
+    """Second-server config falls back to disabled / port 9001 / empty CPID."""
+    entry = MagicMock()
+    entry.options = {}
+    entry.data = {}
+    cfg = build_sensor_config(entry)
+    assert cfg.ocpp_second_enabled is False
+    assert cfg.ocpp_second_port == 9001
+    assert cfg.ocpp_second_cpid == ""


### PR DESCRIPTION
## Summary

Runs **one dedicated embedded OCPP 1.6 server per EV**. The primary EV's charger connects to the primary server (default port 9000); the optional second EV gets its own dedicated server on a separate port (default 9001). Each cycle, every EV's own charging-plan target — including its own force-charge override — is pushed to that EV's server.

Stacked on `fix/782-adapt-planner-safety` (PR #783) — merge #783 first.

Part of #782.

## What changed

### Configuration

- New config keys: `hsem_ocpp_second_enabled` (default `False`), `hsem_ocpp_second_port` (default `9001`), `hsem_ocpp_second_cpid` (default empty).
- The second-server fields are **only shown in the ocpp flow step when the second EV is enabled** — if the second EV is not configured, the second OCPP server cannot be configured or enabled.
- Validation rejects a second port equal to the primary port (`port_conflict` error, translated).
- Wired through `const.py`, `models/sensor_config.py`, and `custom_sensors/config_reader.py`.

### Coordinator

- `coordinator_lifecycle.py`: starts the second server only when **both** the second EV planned load and the second OCPP server are enabled; stops both servers on teardown.
- `coordinator_cycle.py`: packages second-server charger state into `CoordinatorData` (`ocpp_second_chargers` / `ocpp_second_sessions`) and pushes each EV's plan target (kWh → kW for the slot interval, plus per-EV force-charge) to its own server.
- Shared state declared in `coordinator_state.py`; initialised in `coordinator.py`.

### Sensors

- All four OCPP sensor classes take a `charger_index` argument (1 = primary, 2 = second); name/unique-id/entity-id helpers are parameterised by it.
- Four new `*_second` diagnostic sensors (`status`, `power`, `info`, `sessions`) register only when both the second EV and the second server are enabled.
- Primary sensor entity IDs and unique IDs are unchanged — no migration needed for existing installs.

### Docs and translations

- `translations/en.json`: labels/descriptions for the three new fields in both `config` and `options` ocpp steps, plus the `port_conflict` error string.
- `docs/config-flow-reference.md` and `docs/sensors-reference.md`: second-server fields and `_second` sensor variants documented.
- `README.md` and `.github/memories.md`: one-server-per-EV decision recorded.

## Tests

New `tests/custom_sensors/test_ocpp_per_ev.py` (7 regressions):

- Primary sensor names/entity IDs unchanged for `charger_index=1`.
- Second-server names produce distinct slugified entities for `charger_index=2`.
- Flow schema omits second-server fields without the second EV and includes them with it.
- Port-conflict validation rejects equal ports and accepts distinct ones.
- Config-reader defaults: disabled / 9001 / empty CPID.

## Quality gates

- `./scripts/quality.sh lint` — passed
- `./scripts/quality.sh typing` — passed, 0 errors in 324 source files
- `./scripts/quality.sh quality` — passed
- `./scripts/quality.sh test` — passed: **2677 tests**, 4 warnings
- File-size policy verified: no production file exceeds 30 KB or 1000 lines

Fixes #782 and #781 (together with PR #783)