### PR TITLE
ci: auto-approve Dependabot PRs and auto-merge patch/minor updates

### DIFF
--- a/.github/workflows/dependabot-auto.yml
+++ b/.github/workflows/dependabot-auto.yml
@@ -1,0 +1,44 @@
+name: Dependabot Auto-Approve and Merge
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+
+      # Approve all Dependabot PRs so held workflow runs are released and CI executes.
+      - name: Approve PR
+        run: gh pr review "$PR_URL" --approve --body "Auto-approved by dependabot-auto workflow; CI will validate this change."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Auto-merge patch/minor only — majors get approved but wait for a human.
+      - name: Enable auto-merge (patch & minor)
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Flag major update for manual review
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: |
+          gh pr edit "$PR_URL" --add-label "dependencies:major"
+          gh pr comment "$PR_URL" --body ":warning: Major version bump — auto-merge skipped. Please review the changelog and breaking changes before merging."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a new workflow, `.github/workflows/dependabot-auto.yml`, that automates handling of Dependabot pull requests:

- **Approves every Dependabot PR** — this releases the "workflows awaiting approval" hold GitHub applies to first-time/external contributors (including `dependabot[bot]`), so CI runs without manual intervention.
- **Auto-merges patch and minor updates** via squash auto-merge, gated on required status checks.
- **Flags major updates for manual review** — they are approved so checks run, but labeled `dependencies:major` with a warning comment; a human must merge.

## Behavior

| Update type | Approved | Auto-merge | Extra |
|---|---|---|---|
| patch / minor | ✅ | ✅ squash | — |
| major | ✅ (CI runs) | ❌ | label + warning comment |

## Implementation notes

- Uses `pull_request_target` so the job itself is never subject to the workflow-approval gate.
- Gates on `github.actor == 'dependabot[bot]'`.
- Uses `GH_TOKEN` (not `GITHUB_TOKEN`) since the `gh` CLI ignores the latter.
- `fetch-metadata@v2` for update-type detection.
- Re-runs on `synchronize` to re-arm approval/auto-merge after new commits.

## Prerequisites (repo settings)

- **Settings → General → Pull Requests → Allow auto-merge** must be enabled.
- Branch protection on `main` should require status checks so `--auto --squash` waits for quality gates.
- The `dependencies:major` label must exist (add it manually or via `.github/sync-labels.yml`).
- If `GITHUB_TOKEN` approvals do not release held workflow runs in practice, swap `secrets.GITHUB_TOKEN` for a PAT secret.
