### PR TITLE
feat(sensor): expose EV planned-load diagnostics in working-mode sensor

### DIFF
--- a/custom_components/hsem/custom_sensors/working_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/working_mode_sensor.py
@@ -38,7 +38,10 @@ from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
 from custom_components.hsem.utils.degraded_mode import hardware_writes_allowed
 from custom_components.hsem.utils.inverter_verify import ApplyStatus, CycleApplySummary
 from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
-from custom_components.hsem.utils.misc import calculate_recommended_threshold
+from custom_components.hsem.utils.misc import (
+    calculate_recommended_threshold,
+    get_config_value,
+)
 from custom_components.hsem.utils.recommendations import Recommendations
 from custom_components.hsem.utils.sensornames.diagnostics import (
     get_working_mode_sensor_entity_id,
@@ -241,7 +244,52 @@ class HSEMWorkingModeSensor(HSEMCoordinatorEntity, SensorEntity, HSEMEntity):
             "ev_past_target_confidence_factor": cfg.ev.past_target_confidence_factor,
             "ev_charger_max_discharge_power_state": live.ev.max_discharge_power_w,
             "ev_charger_force_max_discharge_power": live.ev.force_max_discharge_power,
+            # EV planned-load configuration — gates whether the planner/MILP
+            # schedules EV charging at all. Exposed so missing charging can be
+            # diagnosed directly from the working-mode sensor attributes.
+            "ev_planned_load_enabled": cfg.ev_planned_load_enabled,
+            "ev_planned_load_smart_charging_enabled": live.ev_planned_load_smart_charging_enabled,
+            "ev_planned_load_battery_capacity_kwh": cfg.ev_planned_load_battery_capacity_kwh,
+            "ev_planned_load_charger_power_kw": cfg.ev_planned_load_charger_power_kw,
+            "ev_planned_load_charger_efficiency_pct": cfg.ev_planned_load_charger_efficiency_pct,
+            "ev_planned_load_charger_min_power_w": cfg.ev_planned_load_charger_min_power_w,
+            "ev_planned_load_charger_phase_topology": cfg.ev_planned_load_charger_phase_topology,
+            "ev_planned_load_deadline": (
+                live.ev_planned_load_deadline.isoformat()
+                if live.ev_planned_load_deadline
+                else None
+            ),
+            # Effective SoC = reported SoC + bounded delivered-energy credit.
+            # The planner uses this value, not the raw reported SoC above —
+            # when they diverge the plan may show fully_charged/waiting even
+            # though the car reports below target.
+            "ev_effective_soc_state": live.ev.effective_soc_pct,
+            "ev_delivered_energy_credit_kwh": round(
+                live.ev.delivered_energy_credit_kwh, 3
+            ),
+            "ev_force_charge_now": bool(
+                get_config_value(self._config_entry, "hsem_ev_force_charge_now")
+            ),
             "ev_second_enabled": cfg.ev_second_enabled,
+            "ev_second_planned_load_enabled": cfg.ev_second_planned_load_enabled,
+            "ev_second_planned_load_battery_capacity_kwh": cfg.ev_second_planned_load_battery_capacity_kwh,
+            "ev_second_planned_load_charger_power_kw": cfg.ev_second_planned_load_charger_power_kw,
+            "ev_second_planned_load_smart_charging_enabled": live.ev_second_planned_load_smart_charging_enabled,
+            "ev_second_planned_load_deadline": (
+                live.ev_second_planned_load_deadline.isoformat()
+                if live.ev_second_planned_load_deadline
+                else None
+            ),
+            "ev_second_effective_soc_state": live.ev_second.effective_soc_pct,
+            "ev_second_delivered_energy_credit_kwh": round(
+                live.ev_second.delivered_energy_credit_kwh, 3
+            ),
+            "ev_second_force_charge_now": bool(
+                get_config_value(self._config_entry, "hsem_ev_second_force_charge_now")
+            ),
+            "ev_second_planned_load_charger_efficiency_pct": cfg.ev_second_planned_load_charger_efficiency_pct,
+            "ev_second_planned_load_charger_min_power_w": cfg.ev_second_planned_load_charger_min_power_w,
+            "ev_second_planned_load_charger_phase_topology": cfg.ev_second_planned_load_charger_phase_topology,
             "ev_second_charger_power_state": live.ev_second.power_w,
             "ev_second_charger_status_state": live.ev_second.is_charging,
             "ev_second_soc_state": live.ev_second.soc_pct,


### PR DESCRIPTION
## Summary

Exposes the EV planned-load configuration and effective-SoC state as attributes on the working-mode sensor, so "why is the MILP not charging my EV?" can be diagnosed directly from Home Assistant without log access.

## Background

When debugging a report of the planner not scheduling EV charging despite the EV being below its target SoC, the root cause (`hsem_ev_planned_load_enabled` still `false`) was invisible in the working-mode sensor attributes — none of the planned-load settings were exposed. The basic EV charger sensors (`ev_connected`, `ev_soc`, charger power/status) are legacy inputs and do **not** activate planned-load scheduling on their own; the feature is gated by separate config that was previously unobservable from the dashboard.

## Changes

`custom_components/hsem/custom_sensors/working_mode_sensor.py` — added to `extra_state_attributes`:

**Primary EV:**
- `ev_planned_load_enabled` — the master gate for planner/MILP EV scheduling
- `ev_planned_load_smart_charging_enabled`
- `ev_planned_load_battery_capacity_kwh`, `ev_planned_load_charger_power_kw`, `ev_planned_load_charger_efficiency_pct`, `ev_planned_load_charger_min_power_w`, `ev_planned_load_charger_phase_topology`
- `ev_planned_load_deadline`
- `ev_effective_soc_state` + `ev_delivered_energy_credit_kwh` — the planner uses effective SoC (reported + bounded delivered-energy credit), not the raw reported value; divergence between them is the other common cause of "below target but not charging"
- `ev_force_charge_now`

**Second EV:** the same set (`ev_second_planned_load_*`, `ev_second_effective_soc_state`, `ev_second_delivered_energy_credit_kwh`, `ev_second_force_charge_now`).

Also imports `get_config_value` from `utils/misc.py` (canonical helper) for reading the force-charge switches.

## Checklist

- [x] Smallest safe change — attributes only, no behaviour change
- [x] Uses canonical helpers (`get_config_value`)
- [x] Lint: `ruff check` + `ruff format --check` clean
- [x] Tests: 25 working-mode sensor tests pass
