### PR TITLE
fix(planner): stop double-counting EV load in MILP net_load when EV co-optimisation is active

### DIFF
--- a/custom_components/hsem/models/ev_config.py
+++ b/custom_components/hsem/models/ev_config.py
@@ -98,6 +98,13 @@ class EVConfig:
     #: Only meaningful when ``force_max_discharge_power`` is True; zero is
     #: fail-closed (treated as no permission).
     max_discharge_power_w: float = 0.0
+    #: When True, the live current-slot house projection has already
+    #: subtracted this EV's active session from ``avg_house_consumption_kwh``
+    #: (either because the sensor excludes EV load or because injection
+    #: removed the known session).  Prevents the MILP ``net_load`` rebuild
+    #: from subtracting the heuristic accounted value a second time and
+    #: inventing PV headroom that does not exist.
+    current_session_removed_from_base: bool = False
 
     @property
     def phase_share(self) -> float:

--- a/custom_components/hsem/planner/milp_optimizer.py
+++ b/custom_components/hsem/planner/milp_optimizer.py
@@ -19,7 +19,7 @@ from custom_components.hsem.models.ev_config import EVConfig
 from custom_components.hsem.planner._scipy_probe import (  # noqa: F401
     is_scipy_available,
 )
-from custom_components.hsem.utils.datetime_utils import as_tz
+from custom_components.hsem.utils.datetime_utils import as_tz, slot_contains
 from custom_components.hsem.utils.logger import log_planner
 from custom_components.hsem.utils.misc import clamp_efficiency
 
@@ -325,21 +325,34 @@ def solve_milp(
             ):
                 active_evs.append(ev)
         if active_evs:
-            # Recompute net_load without EV planned loads
-            net_load = np.array(
-                [
-                    slots[i].avg_house_consumption_kwh
-                    - slots[i].solcast_pv_estimate_kwh
-                    for i in future_idx
-                ],
-                dtype=float,
-            )
+            # Recompute the pure-house baseline before adding the MILP's EV
+            # variables.  Accounted heuristic EV load is already embedded in
+            # the house forecast and must be removed, except for a known live
+            # session that current-slot injection already subtracted.
+            active_net_load: list[float] = []
+            for slot_i in future_idx:
+                slot = slots[slot_i]
+                accounted_to_remove = max(slot.ev_accounted_load_kwh, 0.0)
+                if slot_contains(slot.start, slot.end, now) and any(
+                    ev.current_session_removed_from_base for ev in active_evs
+                ):
+                    # Live injection already turned avg_house into a pure-house
+                    # current-slot projection by subtracting every known session.
+                    # The heuristic accounted value may use a different power,
+                    # so subtracting any of it again would invent PV headroom.
+                    accounted_to_remove = 0.0
+                active_net_load.append(
+                    slot.avg_house_consumption_kwh
+                    - accounted_to_remove
+                    - slot.solcast_pv_estimate_kwh
+                )
+            net_load = np.asarray(active_net_load, dtype=float)
             pv_avail = np.maximum(-net_load, 0.0)
             base_load = np.maximum(net_load, 0.0)
             log_planner(
                 "debug",
                 "[milp] EV co-optimisation enabled: %d active EV(s), "
-                "net_load rebuilt without pre-computed EV loads",
+                "net_load rebuilt without double-counted EV loads",
                 len(active_evs),
             )
         else:

--- a/tests/planner/test_milp_ev.py
+++ b/tests/planner/test_milp_ev.py
@@ -1249,3 +1249,123 @@ def test_ev_discharge_guard_partial_pv_slot_is_exact_not_over_conservative():
         f"discharge={s0.batteries_discharged_kwh:.3f} kWh, "
         f"expected ≈ 1.03 kWh DC for the 1.0 kWh AC non-EV unmet load"
     )
+
+
+def test_ev_accounted_load_subtracted_from_net_load_no_double_count():
+    """Regression: EV load already in avg_house_consumption_kwh is not double-counted.
+
+    Scenario (all future slots, single-hour each):
+      - avg_house_consumption_kwh = 3.0  (includes 1.5 kWh of accounted EV load)
+      - ev_accounted_load_kwh       = 1.5  (heuristic EV already in the forecast)
+      - solcast_pv_estimate_kwh     = 2.0
+
+    Without the fix, the MILP rebuilds net_load as 3.0 - 2.0 = +1.0 kWh
+    (a deficit), so it draws from grid/battery — even though true house-only
+    load is 1.5 kWh and PV of 2.0 kWh leaves 0.5 kWh of genuine surplus.
+
+    With the fix, net_load = 3.0 - 1.5 - 2.0 = -0.5 kWh, i.e. a 0.5 kWh
+    PV surplus that the MILP can allocate to battery charge or EV charge.
+    We assert that grid import is zero (surplus covers house-only load) and
+    the surplus is either stored in the battery or exported — never imported.
+    """
+    # Use low import/export prices so battery discharge for export is unattractive.
+    # _build_slots sets export_price = import_price * 0.8.
+    slots = _build_slots(
+        4, start_hour=15, import_price=0.05, pv_kwh=2.0, consumption_kwh=3.0
+    )
+    for s in slots:
+        s.ev_accounted_load_kwh = 1.5
+        s.ev_total_planned_load_kwh = 1.5
+
+    ev = EVConfig(
+        enabled=True,
+        initial_soc_kwh=25.0,
+        target_kwh=40.0,
+        capacity_kwh=50.0,
+        max_charge_per_slot=5.0,
+        charger_efficiency=0.90,
+        deadline_slot=3,
+        base_load_includes_ev=True,
+    )
+
+    result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=25.0,
+        usable_kwh=10.0,
+        max_charge_per_slot=5.0,
+        max_discharge_per_slot=None,
+        ev_configs=[ev],
+    )
+    assert result is not None
+    out_slots, _diag = result
+
+    # With genuine 0.5 kWh PV surplus and low export price, the MILP should
+    # NOT import grid power.  The surplus (0.5 kWh) is either stored in the
+    # battery or exported — but never imported while also having PV surplus.
+    s0 = out_slots[0]
+    assert s0.grid_import_kwh == pytest.approx(0.0, abs=1e-6), (
+        "Grid import should be zero when PV surplus exists after subtracting "
+        f"accounted EV load; got import={s0.grid_import_kwh:.4f} kWh, "
+        f"charge={s0.batteries_charged_kwh:.4f}, discharge={s0.batteries_discharged_kwh:.4f}"
+    )
+    # The surplus (0.5 kWh) must go somewhere: battery charge or PV export.
+    assert (s0.batteries_charged_kwh + s0.pv_export_kwh) > 1e-6, (
+        "PV surplus must be allocated to battery charge or export; "
+        f"got charge={s0.batteries_charged_kwh:.4f}, pv_export={s0.pv_export_kwh:.4f}"
+    )
+
+
+def test_ev_accounted_load_not_subtracted_when_session_already_removed():
+    """When current_session_removed_from_base=True, accounted load is NOT subtracted again.
+
+    The current slot's avg_house_consumption_kwh has already been stripped
+    of the live session by injection.  Subtracting ev_accounted_load_kwh
+    would over-correct and invent phantom PV headroom.  The guard ensures
+    the MILP sees the already-pure house projection.
+    """
+    slots = _build_slots(
+        4, start_hour=14, import_price=0.30, pv_kwh=1.0, consumption_kwh=2.0
+    )
+    # Current slot (14:00) already has the session removed by live injection,
+    # so its avg_house is the pure-house value (2.0) — no further subtraction.
+    for s in slots:
+        s.ev_accounted_load_kwh = 1.5
+        s.ev_total_planned_load_kwh = 1.5
+
+    ev = EVConfig(
+        enabled=True,
+        initial_soc_kwh=25.0,
+        target_kwh=40.0,
+        capacity_kwh=50.0,
+        max_charge_per_slot=5.0,
+        charger_efficiency=0.90,
+        deadline_slot=3,
+        base_load_includes_ev=True,
+        # Live injection already stripped the current-slot session.
+        current_session_removed_from_base=True,
+        session_charge_kw=3.0,
+    )
+
+    result = solve_milp(
+        slots,
+        _NOW,  # 14:00 — current slot is the first one
+        current_kwh=25.0,
+        usable_kwh=10.0,
+        max_charge_per_slot=5.0,
+        max_discharge_per_slot=None,
+        ev_configs=[ev],
+    )
+    assert result is not None
+    out_slots, _diag = result
+
+    # Current slot: net_load = 2.0 (pure house) - 0 (guarded) - 1.0 (PV)
+    # = +1.0 kWh deficit → must be covered by grid import or battery.
+    s0 = out_slots[0]
+    # The current slot has a genuine 1.0 kWh deficit, so the MILP must
+    # import or discharge — it must NOT see a phantom surplus.
+    assert (s0.grid_import_kwh + s0.batteries_discharged_kwh) > 1e-6, (
+        "Current slot with session already removed should show a deficit, "
+        f"not surplus; got import={s0.grid_import_kwh:.4f}, "
+        f"discharge={s0.batteries_discharged_kwh:.4f}"
+    )


### PR DESCRIPTION
## Summary

Fixes double-counting of EV load in MILP `net_load` when EV co-optimisation is active.

When `base_load_includes_ev=True`, `ev_accounted_load_kwh` represents EV charging load already embedded in `avg_house_consumption_kwh`. The MILP rebuilds `net_load` for co-optimisation as `avg_house_consumption_kwh − solcast_pv_estimate_kwh` **without** subtracting the accounted EV load — causing the EV load to be counted twice: once implicitly in the house forecast, and again explicitly through the MILP's `ev_c[t]` decision variable. This understates true PV surplus and produces systematically pessimistic plans whenever a co-optimised EV is charging.

## Changes

### `custom_components/hsem/models/ev_config.py`
- Added `current_session_removed_from_base: bool = False` field to `EVConfig`. When `True`, the live current-slot house projection has already subtracted this EV's active session, preventing the MILP from subtracting the heuristic accounted value a second time.

### `custom_components/hsem/planner/milp_optimizer.py`
- Imported `slot_contains` from `utils.datetime_utils`.
- Replaced the `net_load` rebuild block in the EV co-optimisation path. The new logic:
  1. Computes `accounted_to_remove = max(slot.ev_accounted_load_kwh, 0.0)` per slot.
  2. Guards against double-removal: if the slot is the current slot AND any active EV has `current_session_removed_from_base=True`, sets `accounted_to_remove = 0.0` (live injection already stripped the session).
  3. Rebuilds `net_load = avg_house_consumption_kwh − accounted_to_remove − solcast_pv_estimate_kwh`.

### `tests/planner/test_milp_ev.py`
- Added `test_ev_accounted_load_subtracted_from_net_load_no_double_count`: regression test with non-zero `ev_accounted_load_kwh` (1.5 kWh) asserting that grid import is zero when genuine PV surplus exists after subtracting accounted EV load.
- Added `test_ev_accounted_load_not_subtracted_when_session_already_removed`: verifies the `current_session_removed_from_base` guard prevents over-correction when live injection has already stripped the current slot's session.

## Acceptance criteria

- [x] `net_load` in the MILP solve never double-counts EV load that's already folded into `avg_house_consumption_kwh` when EV co-optimisation is active
- [x] `EVConfig.current_session_removed_from_base` prevents double-removal when live-injection has already stripped the current slot's session
- [x] New regression test with non-zero `ev_accounted_load_kwh` asserts correct (non-double-counted) surplus
- [x] Existing MILP EV tests still pass (27/27)
- [x] All 822 planner tests pass
- [x] Quality gates pass: `ruff format`, `ruff check`, `mypy`, `pyright`

Closes #814