### PR TITLE
fix(forecast): wire DST-aware slots_ahead_for() into solar-correction call sites

### DIFF
--- a/custom_components/hsem/coordinator_cycle.py
+++ b/custom_components/hsem/coordinator_cycle.py
@@ -435,6 +435,13 @@ class CoordinatorCycleMixin(CoordinatorSharedState):
         accepted_plan_state = self._capture_accepted_plan_state()
         now = hsem_now()
 
+        # Anchor the solar corrector's slot-distance math to this cycle's
+        # physical time so DST folds and mid-cycle replans compute the true
+        # elapsed-slot distance, not the list position (issue #815).
+        getattr(self, "_solar_corrector", SolarForecastCorrector()).set_reference_time(
+            now
+        )
+
         try:
             # Phases 1-7: collect live state, populate consumption/prices/solcast.
             consumption_ok, state = await self._async_collect_and_populate(now)

--- a/custom_components/hsem/planner/slot_population.py
+++ b/custom_components/hsem/planner/slot_population.py
@@ -254,7 +254,11 @@ def populate_solcast(
             if corrector is not None and raw_estimate > 0:
                 slot.solcast_pv_estimate_kwh = round(
                     corrector.get_corrected_pv(
-                        slot.start.hour, raw_estimate, slots_ahead=i
+                        slot.start.hour,
+                        raw_estimate,
+                        slots_ahead=corrector.slots_ahead_for(
+                            slot.start, interval_minutes, fallback=i
+                        ),
                     ),
                     3,
                 )
@@ -271,7 +275,11 @@ def populate_solcast(
         if corrector is not None and raw_estimate > 0:
             slot.solcast_pv_estimate_kwh = round(
                 corrector.get_corrected_pv(
-                    slot.start.hour, raw_estimate, slots_ahead=i
+                    slot.start.hour,
+                    raw_estimate,
+                    slots_ahead=corrector.slots_ahead_for(
+                        slot.start, interval_minutes, fallback=i
+                    ),
                 ),
                 3,
             )

--- a/tests/test_solar_corrector.py
+++ b/tests/test_solar_corrector.py
@@ -265,6 +265,65 @@ class TestPhysicalSlotsAhead:
             == 4
         )
 
+    def test_populate_solcast_uses_physical_distance_not_list_position(self) -> None:
+        """Regression: populate_solcast must call slots_ahead_for, not use list index.
+
+        Simulates a mid-cycle replan where the first slot in the list is already
+        4 physical slots ahead of the reference time. The correction must reflect
+        the true physical distance (4 slots), not the list position (0).
+        """
+        from custom_components.hsem.models.planned_slot import PlannedSlot
+        from custom_components.hsem.models.solcast_slot import SolcastSlot
+        from custom_components.hsem.planner.slot_population import populate_solcast
+
+        # Reference time is 15:00 UTC; first slot starts at 16:00 UTC (4 slots ahead at 15-min granularity).
+        corrector = SolarForecastCorrector()
+        corrector.set_reference_time(datetime(2026, 8, 20, 15, 0, tzinfo=UTC))
+        # Seed residual decay so correction differs by slots_ahead.
+        corrector.update_residual(forecast_kwh=2.0, actual_kwh=1.0)
+
+        slots = [
+            PlannedSlot(
+                start=datetime(2026, 8, 20, 16, 0, tzinfo=UTC),
+                end=datetime(2026, 8, 20, 17, 0, tzinfo=UTC),
+            ),
+            PlannedSlot(
+                start=datetime(2026, 8, 20, 17, 0, tzinfo=UTC),
+                end=datetime(2026, 8, 20, 18, 0, tzinfo=UTC),
+            ),
+        ]
+        solcast_data = [
+            SolcastSlot(hour=16, pv_estimate=4.0),
+            SolcastSlot(hour=17, pv_estimate=4.0),
+        ]
+
+        populate_solcast(
+            slots,
+            solcast_data,
+            interval_minutes=15,
+            corrector=corrector,
+        )
+
+        # First slot is at list position i=0 but 4 physical slots ahead.
+        # With slots_ahead=4, the residual factor is closer to 1.0 than with slots_ahead=0.
+        # get_corrected_pv(16, raw, slots_ahead=4) != get_corrected_pv(16, raw, slots_ahead=0).
+        # Note: populate_solcast scales hourly PV by 60/interval_minutes, so raw_estimate = 4.0 / 4 = 1.0.
+        corrected_4ahead = corrector.get_corrected_pv(16, 1.0, slots_ahead=4)
+        corrected_0ahead = corrector.get_corrected_pv(16, 1.0, slots_ahead=0)
+        # The wired-in call must produce the 4-ahead result, not the 0-ahead fallback.
+        assert slots[0].solcast_pv_estimate_kwh == pytest.approx(
+            corrected_4ahead, rel=1e-3
+        )
+        assert slots[0].solcast_pv_estimate_kwh != pytest.approx(
+            corrected_0ahead, rel=1e-3
+        )
+
+        # Second slot is at list position i=1 but 8 physical slots ahead.
+        corrected_8ahead = corrector.get_corrected_pv(17, 1.0, slots_ahead=8)
+        assert slots[1].solcast_pv_estimate_kwh == pytest.approx(
+            corrected_8ahead, rel=1e-3
+        )
+
 
 class TestConfidence:
     """Tests for correction-strength behavior."""


### PR DESCRIPTION
## Summary

Wires the DST-aware `slots_ahead_for()` method into the solar-correction call sites so the intra-hour residual-decay correction reflects the true elapsed-slot distance across DST folds and mid-cycle replans, not the list position.

The `SolarForecastCorrector.set_reference_time()` and `.slots_ahead_for()` methods already existed and were unit-tested in isolation, but were never called in production code. This PR completes the wiring that was ported at the file level but never activated.

## Changes

### 1. Coordinator cycle — anchor reference time (`coordinator_cycle.py`)

Call `set_reference_time(now)` once per coordinator planning cycle, right after `now = hsem_now()` is captured. This anchors the solar corrector's slot-distance math to the physical time of the current cycle.

```python
# Anchor the solar corrector's slot-distance math to this cycle's
# physical time so DST folds and mid-cycle replans compute the true
# elapsed-slot distance, not the list position (issue #815).
getattr(self, "_solar_corrector", SolarForecastCorrector()).set_reference_time(now)
```

### 2. Slot population — use physical distance (`planner/slot_population.py`)

Replace both `slots_ahead=i` call sites in `populate_solcast()` with `corrector.slots_ahead_for(slot.start, interval_minutes, fallback=i)`:

- **Line 257** (TSL-aligned path): `slots_ahead=corrector.slots_ahead_for(slot.start, interval_minutes, fallback=i)`
- **Line 274** (hourly-indexed path): `slots_ahead=corrector.slots_ahead_for(slot.start, interval_minutes, fallback=i)`

The `fallback=i` preserves backward compatibility when `_reference_time` is `None` (e.g., in tests or edge cases), but in production the reference time is now always set before population runs.

### 3. Regression test (`tests/test_solar_corrector.py`)

Add `test_populate_solcast_uses_physical_distance_not_list_position` to the `TestPhysicalSlotsAhead` class. The test simulates a mid-cycle replan where:
- Reference time is 15:00 UTC
- First slot starts at 16:00 UTC (4 physical slots ahead at 15-min granularity, but list position i=0)
- Second slot starts at 17:00 UTC (8 physical slots ahead, but list position i=1)

The test asserts that the corrected PV estimates match `get_corrected_pv(hour, raw, slots_ahead=4)` and `get_corrected_pv(hour, raw, slots_ahead=8)`, **not** the fallback values of 0 and 1 that the raw list indices would produce.

## Acceptance criteria

- [x] `SolarForecastCorrector.set_reference_time()` is called once per coordinator planning cycle with the current time
- [x] `planner/slot_population.py`'s two `get_corrected_pv` call sites use `corrector.slots_ahead_for(...)` instead of the raw loop index
- [x] A test proves the wiring is live (asserts `slots_ahead_for` output, not the `fallback=i` value, drives the correction under a replan scenario)
- [x] Existing solar-corrector and slot-population tests still pass (2793 passed)
- [x] Four quality gates pass: `lint`, `typing`, `quality`, `test`

## Upstream reference

Adapted from Ambilights/hsem-ambilights#11 (commit `c4e7df9`), which wired the same pattern into the fork's monolithic `coordinator.py`. This repo's split `coordinator_cycle.py` / `planner/slot_population.py` layout required placing the `set_reference_time()` call in `_async_run_update_cycle()` after `now = hsem_now()` and before `_async_collect_and_populate(now)`.

Closes #815