### PR TITLE
fix(safety): reserve phase headroom during OCPP/Huawei write transition

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -1250,3 +1250,13 @@ fraction inline.
 - Config key: `hsem_ev_planned_load_charger_phase_topology` (+ `ev_second_`
   variant), wired const → flows → translations (config AND options steps)
   → sensor_config → planner_input → engine_ev_milp → EVConfig.
+
+## OCPP/Huawei Phase-Headroom Write Ordering (issue #816)
+
+**Race confirmed and fixed (2026-08-25).** When the plan transitions from "EV charging" to "battery discharging", the OCPP anti-flap stop window (180s) means the charger hasn't stopped yet when the Huawei discharge cap is updated. The cap was computed from the **planned** EV power (0 kW), not accounting for the still-running EV draw (e.g., 7 kW), causing a transient phase-fuse overload.
+
+**Fix:** `_ev_phase_headroom_reservation_w()` in `applier_caps.py` computes the reservation: when an EV is live charging but the planned power is 0 (or lower), the reservation is the difference between live and planned draw. The Huawei discharge cap in `applier.py` subtracts the total reservation from the planned cap, preventing the overload.
+
+**Pattern:** Same class of race as Ambilights/hsem-ambilights#32 (PowMr-vs-Huawei), but locally between OCPP EV charger and Huawei battery. The upstream fix tracked `_active_secondary_slot` and `_active_secondary_current_retarget_downward`; the local fix uses live-vs-planned power difference, which is simpler and doesn't require cross-component state tracking.
+
+**Key insight:** The MILP planner's per-phase fuse constraint already allocates headroom correctly, but the **hardware writes** don't happen instantaneously. The reservation bridges the gap between the planner's solved state and the live hardware state during transitions.

--- a/custom_components/hsem/custom_sensors/applier.py
+++ b/custom_components/hsem/custom_sensors/applier.py
@@ -42,6 +42,7 @@ from custom_components.hsem.const import (
 from custom_components.hsem.custom_sensors.applier_caps import (  # noqa: F401
     _configured_battery_device_ids,
     _ev_is_active_or_planned,
+    _ev_phase_headroom_reservation_w,
     _fmt_live_power_w,
     _held_planned_export_is_authoritative,
     _planned_ev_discharge_cap_w,
@@ -228,6 +229,30 @@ async def async_apply_battery_settings(
                         f"(planned={rec.batteries_discharged_kwh:.3f} kWh, "
                         f"slot={slot_hours:.3f} h)"
                     )
+                    # Phase-headroom reservation (issue #816): when an EV is
+                    # live charging but the planned power is 0 (or lower), the
+                    # OCPP anti-flap stop window means the charger hasn't
+                    # stopped yet. Reserve headroom for the still-running EV
+                    # draw to prevent a transient phase-fuse overload.
+                    total_reservation_w = sum(
+                        _ev_phase_headroom_reservation_w(
+                            ev=ev, planned_power_w=planned_power_w
+                        )
+                        for _, ev, planned_power_w in relevant_evs
+                    )
+                    if total_reservation_w > 0 and cap_w > 0:
+                        reserved_cap_w = max(cap_w - total_reservation_w, 0)
+                        if reserved_cap_w < cap_w:
+                            _LOGGER.debug(
+                                "%s — phase-headroom reservation reduced cap "
+                                "from %d W to %d W (reservation=%d W for "
+                                "still-running EV draw)",
+                                cap_reason,
+                                cap_w,
+                                reserved_cap_w,
+                                total_reservation_w,
+                            )
+                            cap_w = reserved_cap_w
 
             # SoC guard (issue #592, v6.2.0-beta1): never let the EV cap
             # drain the battery below the energy the planner has reserved

--- a/custom_components/hsem/custom_sensors/applier_caps.py
+++ b/custom_components/hsem/custom_sensors/applier_caps.py
@@ -101,6 +101,46 @@ def _ev_is_active_or_planned(
     )
 
 
+def _ev_phase_headroom_reservation_w(
+    *,
+    ev: EVLiveState,
+    planned_power_w: object,
+) -> int:
+    """Return the phase-headroom reservation for an EV that hasn't ramped down yet.
+
+    When an EV is live charging but the planned power is 0 (or significantly
+    lower than the live draw), the OCPP anti-flap stop window means the charger
+    hasn't stopped yet. The Huawei discharge cap must reserve headroom for the
+    still-running EV draw until the stop command verifies.
+
+    This prevents a transient phase-fuse overload when the plan transitions
+    from "EV charging" to "battery discharging" (issue #816).
+
+    Args:
+        ev: Live EV state (includes ``is_charging`` and ``power_w``).
+        planned_power_w: The planner's solved EV charge command for this slot (W).
+
+    Returns:
+        Reservation in watts. 0 when the EV is not charging live, or when the
+        planned power is >= the live draw (no reservation needed).
+    """
+    if not ev.is_charging:
+        return 0
+    live_power_w = ev.power_w
+    if not isinstance(live_power_w, (int, float)) or not math.isfinite(live_power_w):
+        return 0
+    if live_power_w <= 1e-9:
+        return 0
+    planned_w = (
+        float(planned_power_w) if isinstance(planned_power_w, (int, float)) else 0.0
+    )
+    if not math.isfinite(planned_w):
+        planned_w = 0.0
+    # Reservation is the live draw minus the planned draw (if positive).
+    reservation_w = live_power_w - planned_w
+    return max(math.floor(reservation_w + 1e-9), 0) if reservation_w > 1e-9 else 0
+
+
 def _planned_ev_discharge_cap_w(
     *,
     planned_discharge_kwh: float,

--- a/tests/sensors/test_applier.py
+++ b/tests/sensors/test_applier.py
@@ -193,3 +193,83 @@ class TestWaitModeSelfConsumptionCapW:
             max_discharge_power_w=5000,
         )
         assert cap == 0
+
+
+# ---------------------------------------------------------------------------
+# _ev_phase_headroom_reservation_w — phase-headroom reservation (issue #816)
+# ---------------------------------------------------------------------------
+
+
+class TestEvPhaseHeadroomReservationW:
+    """Reservation prevents transient phase-fuse overload when EV hasn't ramped down."""
+
+    @staticmethod
+    def _reservation(**kwargs):
+        from custom_components.hsem.custom_sensors.applier_caps import (
+            _ev_phase_headroom_reservation_w,
+        )
+
+        return _ev_phase_headroom_reservation_w(**kwargs)
+
+    def test_not_charging_returns_zero(self):
+        """No reservation when EV is not live charging."""
+        from custom_components.hsem.models.live_state import EVLiveState
+
+        ev = EVLiveState()
+        ev.is_charging = False
+        ev.power_w = 7000.0
+        assert self._reservation(ev=ev, planned_power_w=0) == 0
+
+    def test_charging_but_planned_matches_live_returns_zero(self):
+        """No reservation when planned power matches live draw."""
+        from custom_components.hsem.models.live_state import EVLiveState
+
+        ev = EVLiveState()
+        ev.is_charging = True
+        ev.power_w = 7000.0
+        assert self._reservation(ev=ev, planned_power_w=7000) == 0
+
+    def test_charging_and_planned_zero_returns_live_draw(self):
+        """Full reservation when EV is charging but planned is 0."""
+        from custom_components.hsem.models.live_state import EVLiveState
+
+        ev = EVLiveState()
+        ev.is_charging = True
+        ev.power_w = 7000.0
+        assert self._reservation(ev=ev, planned_power_w=0) == 7000
+
+    def test_charging_and_planned_lower_returns_difference(self):
+        """Partial reservation when planned is lower than live."""
+        from custom_components.hsem.models.live_state import EVLiveState
+
+        ev = EVLiveState()
+        ev.is_charging = True
+        ev.power_w = 7000.0
+        assert self._reservation(ev=ev, planned_power_w=3000) == 4000
+
+    def test_planned_higher_than_live_returns_zero(self):
+        """No reservation when planned is higher than live (ramping up)."""
+        from custom_components.hsem.models.live_state import EVLiveState
+
+        ev = EVLiveState()
+        ev.is_charging = True
+        ev.power_w = 3000.0
+        assert self._reservation(ev=ev, planned_power_w=7000) == 0
+
+    def test_none_power_w_returns_zero(self):
+        """No reservation when live power is unavailable."""
+        from custom_components.hsem.models.live_state import EVLiveState
+
+        ev = EVLiveState()
+        ev.is_charging = True
+        ev.power_w = None
+        assert self._reservation(ev=ev, planned_power_w=0) == 0
+
+    def test_zero_live_power_returns_zero(self):
+        """No reservation when live power is 0."""
+        from custom_components.hsem.models.live_state import EVLiveState
+
+        ev = EVLiveState()
+        ev.is_charging = True
+        ev.power_w = 0.0
+        assert self._reservation(ev=ev, planned_power_w=0) == 0


### PR DESCRIPTION
## Summary

Investigated the possible race between OCPP EV charge-target write and Huawei discharge-cap write on shared phase headroom (issue #816). **Race confirmed and fixed.**

### Investigation findings

When the plan transitions from "EV charging" to "battery discharging":
1. OCPP write sends 0 kW target → charger enters "stopping" anti-flap state (waits 180s)
2. Huawei writes compute discharge cap from **planned** EV power (0 kW), not **live** EV draw (still 7 kW)
3. **Transient**: EV drawing 7 kW + battery discharging 5 kW + house load = phase fuse exceeded

This is the same class of race as Ambilights/hsem-ambilights#32 (PowMr-vs-Huawei), but locally between OCPP EV charger and Huawei battery.

### Fix

Added `_ev_phase_headroom_reservation_w()` in `applier_caps.py` to compute the reservation: when an EV is live charging but the planned power is 0 (or lower), the reservation is the difference between live and planned draw.

The Huawei discharge cap in `applier.py` subtracts the total reservation from the planned cap, preventing the overload by reserving headroom for the still-running EV until the OCPP stop command verifies.

### Changes

- `custom_components/hsem/custom_sensors/applier_caps.py`: Added `_ev_phase_headroom_reservation_w()` helper
- `custom_components/hsem/custom_sensors/applier.py`: Apply reservation to discharge cap computation
- `tests/sensors/test_applier.py`: Added 7 regression tests for the reservation helper
- `.github/memories.md`: Documented the race and fix under "OCPP/Huawei Phase-Headroom Write Ordering"

### Quality gates

All four quality gates pass:
- ✅ `./scripts/quality.sh lint` — ruff format + ruff check
- ✅ `./scripts/quality.sh typing` — mypy type checking
- ✅ `./scripts/quality.sh quality` — pyright + vulture
- ✅ `./scripts/quality.sh test` — pytest with coverage (7 new tests pass)

Closes #816