### PR TITLE
fix(sensors): wire restore-safety methods into forecast_accuracy_sensor.py and solar_confidence_sensor.py

### DIFF
--- a/custom_components/hsem/custom_sensors/forecast_accuracy_sensor.py
+++ b/custom_components/hsem/custom_sensors/forecast_accuracy_sensor.py
@@ -16,6 +16,8 @@ are exposed as flat state attributes, plus:
 - ``latest_load_actual_kwh`` — most recent finalised slot load actual.
 - ``latest_bias_pv_kwh`` — bias for the most recent finalised slot.
 - ``latest_bias_load_kwh`` — bias for the most recent finalised slot.
+- ``restored_unfinalised_count`` — number of restored slots whose lifecycle
+  was not finalised before the previous HA session ended.
 - ``_forecast_tracker_data`` — serialised tracker record list (not displayed
   in UI; used internally to restore state across HA restarts).
 
@@ -28,12 +30,7 @@ from typing import Any, cast, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    STATE_UNAVAILABLE,
-    STATE_UNKNOWN,
-    EntityCategory,
-    UnitOfEnergy,
-)
+from homeassistant.const import EntityCategory, UnitOfEnergy
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from custom_components.hsem.coordinator import (
@@ -41,7 +38,10 @@ from custom_components.hsem.coordinator import (
     HSEMDataUpdateCoordinator,
 )
 from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
+from custom_components.hsem.utils.datetime_utils import now as hsem_now
 from custom_components.hsem.utils.forecast_tracker import ForecastTracker
+from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+from custom_components.hsem.utils.persistence import finite_float
 from custom_components.hsem.utils.sensornames.diagnostics import (
     get_forecast_accuracy_sensor_entity_id,
     get_forecast_accuracy_sensor_name,
@@ -154,12 +154,16 @@ class HSEMForecastAccuracySensor(
                 round(latest.bias_load, 4) if latest.bias_load is not None else None
             )
 
-        # Include serialized tracker data for reboot persistence.
-        # Limit to most recent 24 records to stay under HA's 16 KB attribute limit.
-        _data = tracker.to_dict()
-        if _data:
-            _data["records"] = _data.get("records", [])[-24:]
-        attrs["_forecast_tracker_data"] = _data
+        # Number of restored slots whose lifecycle was not finalised before
+        # the previous HA session ended (issue #832).
+        attrs["restored_unfinalised_count"] = len(tracker.restored_unfinalised_keys)
+
+        # Include serialized tracker data for reboot persistence. Bounded to
+        # the slots that matter across a restart to stay under HA's 16 KB
+        # attribute limit (active/frozen/finalised/nearest-future slots).
+        attrs["_forecast_tracker_data"] = tracker.to_persistence_dict(
+            now=hsem_now(), max_records=24
+        )
 
         return cast(dict[str, Any], attrs)
 
@@ -181,8 +185,9 @@ class HSEMForecastAccuracySensor(
         if restored is None:
             return
 
-        # Restore sensor state
-        if restored.state not in {STATE_UNAVAILABLE, STATE_UNKNOWN, None}:
+        # Restore sensor state — only trust it when it parses as a finite
+        # float, since `native_value` calls `float()` on it unconditionally.
+        if finite_float(restored.state) is not None:
             self._restored_state = restored.state
 
         tracker_data = restored.attributes.get("_forecast_tracker_data")
@@ -192,5 +197,19 @@ class HSEMForecastAccuracySensor(
         tracker: ForecastTracker | None = getattr(
             self.coordinator, "_forecast_tracker", None
         )
-        if tracker is not None:
+        if tracker is None:
+            return
+
+        try:
             tracker.load_from_dict(tracker_data)
+        except Exception:
+            _LOGGER.exception(
+                "Failed to restore forecast tracker state from previous session"
+            )
+            return
+
+        if tracker.restored_unfinalised_keys:
+            _LOGGER.debug(
+                "Restored %d unfinalised forecast slot(s) from previous session",
+                len(tracker.restored_unfinalised_keys),
+            )

--- a/custom_components/hsem/custom_sensors/solar_confidence_sensor.py
+++ b/custom_components/hsem/custom_sensors/solar_confidence_sensor.py
@@ -10,6 +10,8 @@ Attributes
 - ``hour_factors`` — JSON-serialized dict of per-hour factors (0–23).
 - ``confidence`` — Configured confidence percentile.
 - ``residual_count`` — Number of intra-hour residuals in the buffer.
+- ``processed_through`` — ISO timestamp of the newest slot the corrector has
+  already learned from, or ``None`` before any slot has been processed.
 - ``_solar_corrector_data`` — Serialised corrector state for reboot persistence.
 
 The sensor is a *diagnostic* entity (``EntityCategory.DIAGNOSTIC``).
@@ -22,11 +24,7 @@ from typing import Any, cast, override
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    STATE_UNAVAILABLE,
-    STATE_UNKNOWN,
-    EntityCategory,
-)
+from homeassistant.const import EntityCategory
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from custom_components.hsem.coordinator import (
@@ -34,6 +32,9 @@ from custom_components.hsem.coordinator import (
     HSEMDataUpdateCoordinator,
 )
 from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
+from custom_components.hsem.utils.datetime_utils import now as hsem_now
+from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+from custom_components.hsem.utils.persistence import finite_float
 from custom_components.hsem.utils.sensornames.diagnostics import (
     get_solar_confidence_sensor_entity_id,
     get_solar_confidence_sensor_name,
@@ -127,6 +128,11 @@ class HSEMSolarConfidenceSensor(
             "residual_count": (
                 len(corrector._recent_residuals) if corrector is not None else 0
             ),
+            "processed_through": (
+                corrector.processed_through.isoformat()
+                if corrector is not None and corrector.processed_through is not None
+                else None
+            ),
         }
 
         # Include serialised corrector state for reboot persistence.
@@ -153,8 +159,9 @@ class HSEMSolarConfidenceSensor(
         if restored is None:
             return
 
-        # Restore sensor state
-        if restored.state not in {STATE_UNAVAILABLE, STATE_UNKNOWN, None}:
+        # Restore sensor state — only trust it when it parses as a finite
+        # float, since `native_value` calls `float()` on it unconditionally.
+        if finite_float(restored.state) is not None:
             self._restored_state = restored.state
 
         corrector_data = restored.attributes.get("_solar_corrector_data")
@@ -164,5 +171,12 @@ class HSEMSolarConfidenceSensor(
         corrector: SolarForecastCorrector | None = getattr(
             self.coordinator, "_solar_corrector", None
         )
-        if corrector is not None:
-            corrector.load_from_dict(corrector_data)
+        if corrector is None:
+            return
+
+        try:
+            corrector.load_from_dict(corrector_data, restored_at=hsem_now())
+        except Exception:
+            _LOGGER.exception(
+                "Failed to restore solar corrector state from previous session"
+            )

--- a/tests/custom_sensors/test_forecast_accuracy_sensor.py
+++ b/tests/custom_sensors/test_forecast_accuracy_sensor.py
@@ -1,0 +1,184 @@
+"""Restart/restore-correctness tests for HSEMForecastAccuracySensor (issue #832).
+
+Covers:
+- Restored sensor state is only trusted when it parses as a finite float
+  (replacing the naive STATE_UNAVAILABLE/STATE_UNKNOWN gating).
+- Tracker restore failures are caught and do not crash entity setup.
+- ``restored_unfinalised_count`` is surfaced via extra_state_attributes.
+- ``_forecast_tracker_data`` is built from ``to_persistence_dict`` (bounded
+  persistence), not the unbounded ``to_dict``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from custom_components.hsem.custom_sensors.forecast_accuracy_sensor import (
+    HSEMForecastAccuracySensor,
+)
+from custom_components.hsem.entity import HSEMCoordinatorEntity
+from custom_components.hsem.utils.forecast_tracker import ForecastTracker
+
+
+def _sensor(*, tracker: ForecastTracker | None) -> HSEMForecastAccuracySensor:
+    sensor = object.__new__(HSEMForecastAccuracySensor)
+    sensor.coordinator = SimpleNamespace(  # type: ignore[assignment]
+        _forecast_tracker=tracker,
+        data=SimpleNamespace(),
+        last_update_success=True,
+    )
+    sensor._restored_state = None
+    return sensor
+
+
+async def _add_to_hass(sensor: HSEMForecastAccuracySensor, restored: Any) -> None:
+    sensor.async_get_last_state = AsyncMock(return_value=restored)  # type: ignore[method-assign]
+    with patch.object(HSEMCoordinatorEntity, "async_added_to_hass", new=AsyncMock()):
+        await sensor.async_added_to_hass()
+
+
+class TestRestoredStateValidation:
+    """Only finite-float restored states should be trusted (DoD bullet 2)."""
+
+    @pytest.mark.asyncio
+    async def test_unavailable_state_is_rejected(self) -> None:
+        tracker = ForecastTracker()
+        sensor = _sensor(tracker=tracker)
+        restored = SimpleNamespace(state="unavailable", attributes={})
+
+        await _add_to_hass(sensor, restored)
+
+        assert sensor._restored_state is None
+
+    @pytest.mark.asyncio
+    async def test_non_numeric_garbage_state_is_rejected(self) -> None:
+        """A corrupted/garbage restored state must not crash native_value later."""
+        tracker = ForecastTracker()
+        sensor = _sensor(tracker=tracker)
+        restored = SimpleNamespace(state="not-a-number", attributes={})
+
+        await _add_to_hass(sensor, restored)
+
+        assert sensor._restored_state is None
+
+    @pytest.mark.asyncio
+    async def test_valid_numeric_state_is_trusted(self) -> None:
+        tracker = ForecastTracker()
+        sensor = _sensor(tracker=tracker)
+        restored = SimpleNamespace(state="1.234", attributes={})
+
+        await _add_to_hass(sensor, restored)
+
+        assert sensor._restored_state == "1.234"
+
+
+class TestTrackerRestoreFailureHandling:
+    """Restore failures must be caught and never propagate (DoD bullet 3)."""
+
+    @pytest.mark.asyncio
+    async def test_load_from_dict_exception_does_not_crash_setup(self) -> None:
+        tracker = ForecastTracker()
+
+        def _raise(data: object) -> None:
+            raise RuntimeError("boom")
+
+        tracker.load_from_dict = _raise  # type: ignore[method-assign]
+        sensor = _sensor(tracker=tracker)
+        restored = SimpleNamespace(
+            state="unknown",
+            attributes={"_forecast_tracker_data": {"records": []}},
+        )
+
+        with patch(
+            "custom_components.hsem.custom_sensors.forecast_accuracy_sensor._LOGGER"
+        ) as mock_logger:
+            await _add_to_hass(sensor, restored)
+            mock_logger.exception.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_missing_tracker_data_is_a_noop(self) -> None:
+        tracker = ForecastTracker()
+        sensor = _sensor(tracker=tracker)
+        restored = SimpleNamespace(state="unknown", attributes={})
+
+        await _add_to_hass(sensor, restored)
+
+        assert tracker.records == []
+
+    @pytest.mark.asyncio
+    async def test_no_tracker_on_coordinator_is_a_noop(self) -> None:
+        sensor = _sensor(tracker=None)
+        restored = SimpleNamespace(
+            state="unknown",
+            attributes={"_forecast_tracker_data": {"records": []}},
+        )
+
+        # Must not raise even though the coordinator has no tracker yet.
+        await _add_to_hass(sensor, restored)
+
+
+class TestRestoredUnfinalisedSurfacing:
+    """restored_unfinalised_keys must reach the entity's attributes."""
+
+    @pytest.mark.asyncio
+    async def test_restored_unfinalised_count_reflects_tracker(self) -> None:
+        start = datetime(2026, 8, 20, 10, 0, tzinfo=UTC)
+        end = datetime(2026, 8, 20, 10, 15, tzinfo=UTC)
+        source = ForecastTracker()
+        source.get_or_create_record(start, end)
+        source.set_forecasts(start, 4.0, 2.0)
+        # Deliberately left unfinalised to simulate an interrupted slot.
+        payload = source.to_persistence_dict(now=end, max_records=24)
+
+        tracker = ForecastTracker()
+        sensor = _sensor(tracker=tracker)
+        restored = SimpleNamespace(
+            state="unknown",
+            attributes={"_forecast_tracker_data": payload},
+        )
+
+        await _add_to_hass(sensor, restored)
+
+        assert tracker.restored_unfinalised_keys == {start}
+
+        attrs = sensor.extra_state_attributes
+        assert attrs is not None
+        assert attrs["restored_unfinalised_count"] == 1
+
+    def test_restored_unfinalised_count_is_zero_by_default(self) -> None:
+        tracker = ForecastTracker()
+        sensor = _sensor(tracker=tracker)
+
+        attrs = sensor.extra_state_attributes
+
+        assert attrs is not None
+        assert attrs["restored_unfinalised_count"] == 0
+
+
+class TestPersistenceDictUsage:
+    """extra_state_attributes must serialise via to_persistence_dict."""
+
+    def test_forecast_tracker_data_matches_to_persistence_dict(self) -> None:
+        fixed_now = datetime(2026, 8, 20, 12, 0, tzinfo=UTC)
+        tracker = ForecastTracker()
+        tracker.get_or_create_record(
+            datetime(2026, 8, 20, 10, 0, tzinfo=UTC),
+            datetime(2026, 8, 20, 10, 15, tzinfo=UTC),
+        )
+        sensor = _sensor(tracker=tracker)
+
+        with patch(
+            "custom_components.hsem.custom_sensors.forecast_accuracy_sensor.hsem_now",
+            return_value=fixed_now,
+        ):
+            attrs = sensor.extra_state_attributes
+
+        assert attrs is not None
+        assert attrs["_forecast_tracker_data"] == tracker.to_persistence_dict(
+            now=fixed_now, max_records=24
+        )

--- a/tests/custom_sensors/test_solar_confidence_sensor.py
+++ b/tests/custom_sensors/test_solar_confidence_sensor.py
@@ -1,0 +1,176 @@
+"""Restart/restore-correctness tests for HSEMSolarConfidenceSensor (issue #832).
+
+Covers:
+- Restored sensor state is only trusted when it parses as a finite float.
+- ``corrector.load_from_dict`` is called with ``restored_at=hsem_now()``.
+- Restore failures are caught and do not crash entity setup.
+- ``processed_through`` is surfaced via extra_state_attributes.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.hsem.custom_sensors.solar_confidence_sensor import (
+    HSEMSolarConfidenceSensor,
+)
+from custom_components.hsem.entity import HSEMCoordinatorEntity
+from custom_components.hsem.utils.solar_corrector import SolarForecastCorrector
+
+
+def _sensor(
+    *, corrector: SolarForecastCorrector | None, data: Any = None
+) -> HSEMSolarConfidenceSensor:
+    sensor = object.__new__(HSEMSolarConfidenceSensor)
+    sensor.coordinator = SimpleNamespace(  # type: ignore[assignment]
+        _solar_corrector=corrector,
+        data=data if data is not None else SimpleNamespace(solar_hour_factors={}),
+        last_update_success=True,
+    )
+    sensor._restored_state = None
+    return sensor
+
+
+async def _add_to_hass(sensor: HSEMSolarConfidenceSensor, restored: Any) -> None:
+    sensor.async_get_last_state = AsyncMock(return_value=restored)  # type: ignore[method-assign]
+    with patch.object(HSEMCoordinatorEntity, "async_added_to_hass", new=AsyncMock()):
+        await sensor.async_added_to_hass()
+
+
+class TestRestoredStateValidation:
+    """Only finite-float restored states should be trusted."""
+
+    @pytest.mark.asyncio
+    async def test_unavailable_state_is_rejected(self) -> None:
+        sensor = _sensor(corrector=SolarForecastCorrector())
+        restored = SimpleNamespace(state="unavailable", attributes={})
+
+        await _add_to_hass(sensor, restored)
+
+        assert sensor._restored_state is None
+
+    @pytest.mark.asyncio
+    async def test_non_numeric_garbage_state_is_rejected(self) -> None:
+        sensor = _sensor(corrector=SolarForecastCorrector())
+        restored = SimpleNamespace(state="garbage", attributes={})
+
+        await _add_to_hass(sensor, restored)
+
+        assert sensor._restored_state is None
+
+    @pytest.mark.asyncio
+    async def test_valid_numeric_state_is_trusted(self) -> None:
+        sensor = _sensor(corrector=SolarForecastCorrector())
+        restored = SimpleNamespace(state="0.987", attributes={})
+
+        await _add_to_hass(sensor, restored)
+
+        assert sensor._restored_state == "0.987"
+
+
+class TestRestoredAtWiring:
+    """load_from_dict must receive the app's own clock, not system UTC now."""
+
+    @pytest.mark.asyncio
+    async def test_load_from_dict_called_with_hsem_now(self) -> None:
+        fixed_now = datetime(2026, 8, 20, 12, 0, tzinfo=UTC)
+        corrector = SolarForecastCorrector()
+        corrector.load_from_dict = MagicMock()  # type: ignore[method-assign]
+        sensor = _sensor(corrector=corrector)
+        corrector_data = {"schema_version": 3}
+        restored = SimpleNamespace(
+            state="unknown",
+            attributes={"_solar_corrector_data": corrector_data},
+        )
+
+        with patch(
+            "custom_components.hsem.custom_sensors.solar_confidence_sensor.hsem_now",
+            return_value=fixed_now,
+        ):
+            await _add_to_hass(sensor, restored)
+
+        corrector.load_from_dict.assert_called_once_with(
+            corrector_data, restored_at=fixed_now
+        )
+
+    @pytest.mark.asyncio
+    async def test_missing_corrector_data_is_a_noop(self) -> None:
+        corrector = SolarForecastCorrector()
+        corrector.load_from_dict = MagicMock()  # type: ignore[method-assign]
+        sensor = _sensor(corrector=corrector)
+        restored = SimpleNamespace(state="unknown", attributes={})
+
+        await _add_to_hass(sensor, restored)
+
+        corrector.load_from_dict.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_corrector_on_coordinator_is_a_noop(self) -> None:
+        sensor = _sensor(corrector=None)
+        restored = SimpleNamespace(
+            state="unknown",
+            attributes={"_solar_corrector_data": {"schema_version": 3}},
+        )
+
+        # Must not raise even though the coordinator has no corrector yet.
+        await _add_to_hass(sensor, restored)
+
+
+class TestRestoreFailureHandling:
+    """Restore failures must be caught and never propagate."""
+
+    @pytest.mark.asyncio
+    async def test_load_from_dict_exception_does_not_crash_setup(self) -> None:
+        corrector = SolarForecastCorrector()
+
+        def _raise(data: object, *, restored_at: object | None = None) -> None:
+            raise RuntimeError("boom")
+
+        corrector.load_from_dict = _raise  # type: ignore[method-assign]
+        sensor = _sensor(corrector=corrector)
+        restored = SimpleNamespace(
+            state="unknown",
+            attributes={"_solar_corrector_data": {"schema_version": 3}},
+        )
+
+        with patch(
+            "custom_components.hsem.custom_sensors.solar_confidence_sensor._LOGGER"
+        ) as mock_logger:
+            await _add_to_hass(sensor, restored)
+            mock_logger.exception.assert_called_once()
+
+
+class TestProcessedThroughSurfacing:
+    """corrector.processed_through must reach extra_state_attributes."""
+
+    def test_processed_through_is_none_before_any_processing(self) -> None:
+        sensor = _sensor(corrector=SolarForecastCorrector())
+
+        attrs = sensor.extra_state_attributes
+
+        assert attrs is not None
+        assert attrs["processed_through"] is None
+
+    def test_processed_through_is_exposed_after_marking(self) -> None:
+        slot = datetime(2026, 8, 20, 10, 0, tzinfo=UTC)
+        corrector = SolarForecastCorrector()
+        corrector.mark_processed(slot)
+        sensor = _sensor(corrector=corrector)
+
+        attrs = sensor.extra_state_attributes
+
+        assert attrs is not None
+        assert attrs["processed_through"] == slot.isoformat()
+
+    def test_processed_through_is_none_without_a_corrector(self) -> None:
+        sensor = _sensor(corrector=None)
+
+        attrs = sensor.extra_state_attributes
+
+        assert attrs is not None
+        assert attrs["processed_through"] is None


### PR DESCRIPTION
## Summary

Fixes #832.

The ML/history restore-safety methods added to the tracker classes
(`ForecastTracker.to_persistence_dict()` / `restored_unfinalised_keys`,
`SolarForecastCorrector.processed_through`) were never wired into the two
sensors that actually consume them, so the restart-safety improvement
existed in the model layer but never reached the entities.

- **`forecast_accuracy_sensor.py`**
  - Persist via `tracker.to_persistence_dict(now=hsem_now(), max_records=24)`
    instead of the unbounded `to_dict()` + manual slice.
  - Validate the restored sensor state with `finite_float()` instead of the
    naive `STATE_UNAVAILABLE`/`STATE_UNKNOWN` gating (a corrupted restored
    state can no longer crash `native_value`'s unconditional `float()` call).
  - Wrap `tracker.load_from_dict()` in `try/except` so a malformed restore
    can't crash entity setup; logs via `HSEM_LOGGER.exception`.
  - Surface `restored_unfinalised_count` (derived from
    `tracker.restored_unfinalised_keys`) via `extra_state_attributes`.

- **`solar_confidence_sensor.py`**
  - Pass `restored_at=hsem_now()` to `corrector.load_from_dict()`.
  - Same `finite_float()` validation for the restored sensor state.
  - Wrap the restore call in `try/except`.
  - Expose `corrector.processed_through` via `extra_state_attributes`.

## Test plan

- [x] Added `tests/custom_sensors/test_forecast_accuracy_sensor.py` and
      `tests/custom_sensors/test_solar_confidence_sensor.py` covering:
      restored-state validation, restore-failure handling (no crash),
      `restored_unfinalised_count` / `processed_through` surfacing, and
      `to_persistence_dict` usage.
- [x] `./scripts/quality.sh lint`
- [x] `./scripts/quality.sh typing`
- [x] `./scripts/quality.sh quality`
- [x] `./scripts/quality.sh test` (2874 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)