### PR TITLE
feat(applier): Error-mode stop-only exception for HSEM-owned Huawei grid charge

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -1273,3 +1273,20 @@ fraction inline.
 - Cancelled and cleared in `async_will_remove_from_hass()` — a config-entry reload can never strand a transition or leak its deadline task.
 
 Tests: `tests/test_phase_charge_limiter.py` (limiter core + Part 2 applier integration), `tests/test_phase_charge_transition_safety.py` (Part 3 transition/deadline logic, 18 tests mirroring the fork's coverage style but Huawei-only).
+
+## Error-Mode Grid-Charge Emergency Stop (issue #840, follow-up to #831)
+
+**Gap left open by #831:** the Part 3 transition/deadline logic only runs while `hardware_writes_allowed()` is true. If `classify_degraded_mode()` escalates to `DegradedMode.Error` mid-cycle (e.g. a critical sensor goes unavailable) while HSEM itself is the one holding an armed grid-charge cap, `_async_apply_hardware_writes()` takes the `elif not writes_safe:` branch and simply skips all writes. The last HSEM-written cap is left live on the inverter with no further supervision until Error mode clears. #840 closes that gap with a narrow, downward-only exception that is allowed to run even in Error mode.
+
+**New module:** `custom_sensors/applier_emergency_stop.py`, following the same applier extraction pattern as `applier_caps.py` / `applier_forcible_discharge.py`, mixed into `HSEMWorkingModeSensor` via `GridChargeEmergencyStopMixin` (same mixin-extraction pattern as `PhaseChargeTransitionMixin` from Part 3, required to keep `working_mode_sensor.py` under the 30 KB/1000-line limit).
+
+**Ownership model, not a blanket safety net.** HSEM must never touch a grid-charge cap it did not itself arm; the emergency stop only fires when HSEM believes it currently owns an armed cap:
+- Ownership (`self._primary_grid_charge_owned`) is set `True` only when HSEM successfully writes and verifies a `batteries_charge_grid` recommendation while writes are safe (i.e. it piggybacks on the existing Part 2/3 write path, never a new inference).
+- Ownership is cleared as soon as `primary_grid_charge_is_known_disarmed()` confirms the live telemetry itself (cap <= 0 W, working mode not Time-Of-Use, or the current TOU period not in `DEFAULT_HSEM_TOU_MODES_FORCE_CHARGE`) shows no charge is armed -- this runs every cycle via `_release_primary_grid_charge_ownership_if_safe()`, independent of degraded mode, so ownership never outlives the condition that justified it.
+- An externally-armed charge (ownership `False`) is never touched by the emergency stop, even in Error mode -- HSEM only ever un-arms what it itself armed.
+
+**Downward-only, retry-safe write.** `huawei_grid_charge_emergency_needed()` is a pure gating function: fires only when `ownership_latched` is `True` and the current recommendation is no longer `batteries_charge_grid` (or degraded mode is `Error`) and telemetry has not already gone to `primary_grid_charge_is_known_disarmed()`. `async_emergency_disable_grid_charge()` writes `0` to `cfg.huawei_solar_batteries_grid_charge_maximum_power` via the existing `async_write_and_verify()` helper -- the same verified-write primitive Part 2/3 already use, so no new write path was introduced. On a failed/unverified write, ownership is deliberately **not** cleared, so the next cycle retries the same 0 W write until it verifies or the condition resolves itself via telemetry.
+
+**Canonical helper:** never re-derive the "is a grid charge actually armed right now" check inline -- always call `primary_grid_charge_is_known_disarmed()`. Never gate the emergency stop on anything other than `huawei_grid_charge_emergency_needed()`; it already encodes the ownership + Error-mode + telemetry precedence correctly.
+
+Tests: `tests/test_grid_charge_emergency_stop.py` (26 tests: disarmed-telemetry detection, ownership+gating logic, `CycleApplySummary` verification helper, the write helper itself, and full mixin lifecycle including the externally-armed-is-never-touched and failed-write-retains-ownership-for-retry cases).

--- a/custom_components/hsem/custom_sensors/applier_emergency_stop.py
+++ b/custom_components/hsem/custom_sensors/applier_emergency_stop.py
@@ -1,0 +1,256 @@
+"""Error-mode emergency stop for an HSEM-owned Huawei grid charge (issue #840).
+
+``DegradedMode.Error`` blocks every ordinary hardware write because critical
+telemetry (battery SoC, house load, etc.) is missing and the planner cannot
+safely decide anything new. But if HSEM had already armed a Huawei
+grid-charge (TOU force-charge periods + a positive grid-charge-maximum-power
+cap) before that telemetry loss, the blanket block leaves the charge running
+uncontrolled at its last commanded rate — the one thing worth doing safely
+in Error mode is turning that *specific*, HSEM-owned charge off.
+
+This module provides exactly one narrowly-scoped exception: a downward-only
+write of the grid-charge-maximum-power number to 0 W, gated on:
+
+- the live per-phase safety limiter being enabled (``cfg.phase_aware_charging_enabled``)
+  — the emergency path only ever touches the entity that feature already
+  manages;
+- HSEM provably owning the armed charge, derived from the accepted plan's own
+  recommendation history (never inferred from hardware state alone) and
+  latched across cycles so a failed stop is retried, never abandoned;
+- live telemetry not already proving the charge is stopped.
+
+An externally or manually armed TOU/force-charge schedule is never claimed:
+if HSEM's own recommendation history never marked this slot as
+``batteries_charge_grid``, ownership is never latched and the emergency stop
+is skipped.
+
+Huawei-only — this repository has no secondary/PowMr inverter.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Any
+
+from custom_components.hsem.const import DEFAULT_HSEM_TOU_MODES_FORCE_CHARGE
+from custom_components.hsem.custom_sensors.applier_state_readers import (
+    _read_number_state,
+)
+from custom_components.hsem.utils.ha_helpers import async_set_number_value
+from custom_components.hsem.utils.inverter_verify import (
+    ApplyResult,
+    ApplyStatus,
+    CycleApplySummary,
+    async_write_and_verify,
+)
+from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
+from custom_components.hsem.utils.recommendations import Recommendations
+from custom_components.hsem.utils.workingmodes import WorkingModes
+
+if TYPE_CHECKING:
+    from custom_components.hsem.models.hourly_recommendation import (
+        HourlyRecommendation,
+    )
+    from custom_components.hsem.models.live_state import LiveState
+    from custom_components.hsem.models.sensor_config import SensorConfig
+
+
+def primary_grid_charge_is_known_disarmed(live: LiveState) -> bool:
+    """Return whether live hardware positively proves grid charge is stopped.
+
+    A verified 0 W cap, a working mode other than ``TimeOfUse``, or TOU
+    periods that no longer match the force-charge schedule are all
+    independent proof the charge is not running, regardless of what HSEM's
+    own ownership latch says.
+    """
+    current_limit_w = live.huawei_batteries_grid_charge_max_power_w
+    if (
+        isinstance(current_limit_w, int | float)
+        and not isinstance(current_limit_w, bool)
+        and math.isfinite(current_limit_w)
+        and current_limit_w <= 0.0
+    ):
+        return True
+
+    working_mode = live.huawei_batteries_working_mode
+    if isinstance(working_mode, str) and working_mode != WorkingModes.TimeOfUse.value:
+        return True
+
+    return (
+        working_mode == WorkingModes.TimeOfUse.value
+        and isinstance(live.tou_periods.raw_state, str)
+        and list(live.tou_periods.periods) != list(DEFAULT_HSEM_TOU_MODES_FORCE_CHARGE)
+    )
+
+
+def huawei_grid_charge_emergency_needed(
+    cfg: SensorConfig,
+    live: LiveState,
+    rec: HourlyRecommendation | None,
+    ownership_latched: bool,
+) -> bool:
+    """Return whether HSEM-owned Huawei charging must be pinned to 0 W.
+
+    Ownership is ``True`` when either the *current* accepted recommendation
+    is ``batteries_charge_grid`` or a previous cycle already latched
+    ownership (e.g. a prior emergency write failed and must be retried). A
+    charge armed by anything other than HSEM's own plan history is never
+    claimed.
+    """
+    hsem_owned = (
+        rec is not None
+        and rec.recommendation == Recommendations.BatteriesChargeGrid.value
+    ) or ownership_latched
+    return (
+        cfg.phase_aware_charging_enabled
+        and hsem_owned
+        and not primary_grid_charge_is_known_disarmed(live)
+    )
+
+
+def summary_verifies_zero_grid_charge(
+    cfg: SensorConfig,
+    summary: CycleApplySummary,
+) -> bool:
+    """Return whether this cycle verified the Huawei charge ceiling at 0 W."""
+    entity_id = cfg.huawei_solar_batteries_grid_charge_maximum_power
+    return entity_id is not None and any(
+        result.entity_id == entity_id
+        and result.status in {ApplyStatus.OK, ApplyStatus.SKIPPED}
+        and isinstance(result.desired, int | float)
+        and not isinstance(result.desired, bool)
+        and math.isfinite(float(result.desired))
+        and float(result.desired) <= 1.0
+        and isinstance(result.actual, int | float)
+        and not isinstance(result.actual, bool)
+        and math.isfinite(float(result.actual))
+        and float(result.actual) <= 1.0
+        for result in summary.results
+    )
+
+
+async def async_emergency_disable_grid_charge(
+    sensor: Any,  # NOSONAR -- HA internal type; circular import risk
+    cfg: SensorConfig,
+    live: LiveState,
+) -> CycleApplySummary:
+    """Force the Huawei grid-charge ceiling to 0 W after critical telemetry loss.
+
+    The caller (``huawei_grid_charge_emergency_needed``) must already have
+    proven HSEM ownership of the armed charge before calling this. This
+    helper remains downward-only: it never writes a value other than 0, and
+    it verifies the write via the same write-and-verify primitive used by
+    every other applier write.
+
+    Args:
+        sensor: ``HSEMWorkingModeSensor`` instance for HA access and logging.
+        cfg: Current sensor configuration.
+        live: Live state snapshot.
+
+    Returns:
+        :class:`CycleApplySummary` with zero or one :class:`ApplyResult`.
+        Empty when read-only, when the feature is disabled, or when the live
+        cap already reads at or below 0 W (nothing to do).
+    """
+    summary = CycleApplySummary()
+    if cfg.read_only or not cfg.phase_aware_charging_enabled:
+        return summary
+
+    current_limit_w = live.huawei_batteries_grid_charge_max_power_w
+    if (
+        isinstance(current_limit_w, int | float)
+        and not isinstance(current_limit_w, bool)
+        and math.isfinite(current_limit_w)
+        and current_limit_w <= 0.0
+    ):
+        return summary
+
+    entity_id = cfg.huawei_solar_batteries_grid_charge_maximum_power
+    if entity_id is None:
+        summary.results.append(
+            ApplyResult(
+                entity_id="number:grid_charge_maximum_power",
+                desired=0.0,
+                actual=current_limit_w,
+                status=ApplyStatus.FAILED,
+                attempts=0,
+                error_message=(
+                    "Cannot emergency-disable grid charging: maximum-power "
+                    "entity is not configured"
+                ),
+            )
+        )
+        return summary
+
+    result = await async_write_and_verify(
+        entity_id=entity_id,
+        desired=0.0,
+        writer=lambda: async_set_number_value(sensor, entity_id, 0.0),
+        reader=lambda: _read_number_state(sensor, entity_id),
+    )
+    summary.results.append(result)
+    _LOGGER.warning(
+        "Emergency phase-aware grid-charge cap set to 0 W after critical "
+        "telemetry loss (%s)",
+        result.status.value,
+    )
+    return summary
+
+
+class GridChargeEmergencyStopMixin:
+    """Error-mode emergency-stop orchestration (issue #840).
+
+    Mixed into :class:`~custom_sensors.working_mode_sensor.HSEMWorkingModeSensor`.
+    Owns exactly one piece of state, ``_primary_grid_charge_owned``, latched
+    across coordinator cycles.
+    """
+
+    def _release_primary_grid_charge_ownership_if_safe(
+        self,
+        cfg: SensorConfig,
+        live: LiveState,
+    ) -> None:
+        """Release ownership once telemetry independently proves it is safe.
+
+        Runs every cycle regardless of read-only/degraded-mode, so ownership
+        is released the moment it is verified safe — not only when degraded
+        mode happens to clear. Disabling the phase-aware charging feature
+        also relinquishes ownership outright, since the emergency path only
+        ever exists to protect that feature's own managed entity.
+        """
+        if (
+            not cfg.phase_aware_charging_enabled
+            or primary_grid_charge_is_known_disarmed(live)
+        ):
+            self._primary_grid_charge_owned = False
+
+    async def _async_run_error_mode_emergency_stop(
+        self,
+        sensor: Any,
+        cfg: SensorConfig,
+        live: LiveState,
+        rec: HourlyRecommendation | None,
+    ) -> CycleApplySummary:
+        """Run the narrow downward-only Error-mode exception, if needed.
+
+        Error mode blocks every ordinary write, but an HSEM-owned Huawei
+        grid charge must still be stoppable when critical telemetry
+        disappears mid-charge. Ownership is derived only from the accepted
+        plan's own recommendation history, never from hardware state alone,
+        and is latched so a failed stop is retried next cycle instead of
+        abandoned.
+
+        Returns:
+            :class:`CycleApplySummary`, empty when no emergency stop is
+            needed this cycle.
+        """
+        summary = CycleApplySummary()
+        if not huawei_grid_charge_emergency_needed(
+            cfg, live, rec, self._primary_grid_charge_owned
+        ):
+            return summary
+        self._primary_grid_charge_owned = True
+        summary = await async_emergency_disable_grid_charge(sensor, cfg, live)
+        if summary_verifies_zero_grid_charge(cfg, summary):
+            self._primary_grid_charge_owned = False
+        return summary

--- a/custom_components/hsem/custom_sensors/working_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/working_mode_sensor.py
@@ -31,6 +31,9 @@ from custom_components.hsem.custom_sensors.applier import (
     async_apply_battery_settings,
     async_apply_inverter_power_control,
 )
+from custom_components.hsem.custom_sensors.applier_emergency_stop import (
+    GridChargeEmergencyStopMixin,
+)
 from custom_components.hsem.custom_sensors.phase_charge_transition import (
     PhaseChargeTransitionMixin,
 )
@@ -54,7 +57,11 @@ from custom_components.hsem.utils.sensornames.diagnostics import (
 
 
 class HSEMWorkingModeSensor(
-    PhaseChargeTransitionMixin, HSEMCoordinatorEntity, SensorEntity, HSEMEntity
+    PhaseChargeTransitionMixin,
+    GridChargeEmergencyStopMixin,
+    HSEMCoordinatorEntity,
+    SensorEntity,
+    HSEMEntity,
 ):
     """HA sensor entity for the HSEM working-mode recommendation.
 
@@ -109,6 +116,12 @@ class HSEMWorkingModeSensor(
         # Cleared/rearmed per-slot; see _primary_grid_charge_transition_status()
         # in PhaseChargeTransitionMixin.
         self._init_phase_charge_transition_state()
+
+        # Error-mode emergency-stop ownership (issue #840). Survives across
+        # cycles so a failed emergency write is retried, not abandoned; never
+        # latched from hardware state alone (never claims an
+        # externally/manually armed charge).
+        self._primary_grid_charge_owned: bool = False
 
     # ------------------------------------------------------------------
     # HA entity properties
@@ -349,6 +362,7 @@ class HSEMWorkingModeSensor(
             "phase_aware_charging_enabled": cfg.phase_aware_charging_enabled,
             "grid_phase_power_w": live.grid_phase_power_w,
             "huawei_batteries_grid_charge_max_power_w": live.huawei_batteries_grid_charge_max_power_w,
+            "primary_grid_charge_owned": self._primary_grid_charge_owned,
         }
 
         apply_summary = data.apply_summary
@@ -497,6 +511,9 @@ class HSEMWorkingModeSensor(
         if hourly_rec is None:
             self._clear_primary_grid_charge_transition()
 
+        # Error-mode emergency-stop ownership release (issue #840).
+        self._release_primary_grid_charge_ownership_if_safe(cfg, live)
+
         # Apply real-time override to the active slot.
         if hourly_rec is not None:
             resolve_current_recommendation(
@@ -532,6 +549,12 @@ class HSEMWorkingModeSensor(
                 f"Hardware writes BLOCKED — degraded mode: {live.degraded_mode.value}. Missing: {live.missing_entities_list}",
                 "warning",
             )
+            # Narrow downward-only exception (issue #840) — see
+            # GridChargeEmergencyStopMixin for the ownership/retry contract.
+            emergency_summary = await self._async_run_error_mode_emergency_stop(
+                self, cfg, live, hourly_rec
+            )
+            combined_summary.results.extend(emergency_summary.results)
         else:
             inv_summary = await async_apply_inverter_power_control(self, cfg, live)
             combined_summary.results.extend(inv_summary.results)

--- a/docs/planner-guide.md
+++ b/docs/planner-guide.md
@@ -1139,6 +1139,31 @@ working-mode sensor) tracks this as a slot-scoped transition:
   cancelled and cleared whenever the config entry reloads, so a reload can
   never leave a stale transition or a leaked background task behind.
 
+#### Error-mode emergency stop for an HSEM-owned grid charge (issue #840)
+
+`Error` mode normally blocks *every* hardware write, because critical
+telemetry is missing and the planner can't safely decide anything new. The
+one exception: if HSEM itself armed a Huawei grid charge and then critical
+telemetry disappeared mid-charge, HSEM can still safely stop that specific
+charge. `custom_sensors/applier_emergency_stop.py` adds this as a narrow,
+downward-only carve-out:
+
+- **Ownership comes only from HSEM's own plan history** — the current
+  recommendation being `batteries_charge_grid`, or a previous cycle having
+  already latched ownership. A charge armed by a manual TOU schedule or
+  any other source outside HSEM's own recommendations is never touched.
+- **The only write permitted** is forcing
+  `hsem_huawei_solar_batteries_grid_charge_maximum_power` to `0`, verified
+  the same way as every other applier write.
+- **A failed or unverified stop keeps ownership latched**, so the next
+  cycle retries automatically instead of giving up.
+- **Ownership is released** as soon as the 0 W write verifies, or as soon
+  as live telemetry independently proves the charge is already
+  stopped — whichever happens first, and independent of whether degraded
+  mode has cleared.
+- This exception requires `hsem_phase_aware_charging_enabled = True`; it
+  only ever protects the entity that feature already manages.
+
 ---
 
 ## Data quality diagnostics

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -2013,6 +2013,60 @@ scoped to the recommendation slot that armed it:
 - The deadline task is cancelled and the transition cleared on unload,
   every time, with no exceptions escaping `async_will_remove_from_hass()`.
 
+#### Error-mode emergency stop for an HSEM-owned grid charge (issue #840)
+
+`DegradedMode.Error` blocks every ordinary hardware write, because critical
+telemetry (battery SoC, house load, etc.) is missing and the planner cannot
+safely decide anything new. But if HSEM had already armed a Huawei
+grid-charge (TOU force-charge periods plus a positive grid-charge-maximum-power
+cap) before that telemetry loss, the blanket block would leave the charge
+running uncontrolled at its last commanded rate.
+`custom_sensors/applier_emergency_stop.py::GridChargeEmergencyStopMixin`
+(mixed into `HSEMWorkingModeSensor`) adds exactly one narrowly-scoped,
+downward-only exception to that block:
+
+1. **Ownership, never inferred from hardware alone.** HSEM owns the armed
+   charge when either the *current* accepted recommendation is
+   `batteries_charge_grid`, or a previous cycle already latched ownership
+   (`self._primary_grid_charge_owned`). An externally or manually armed
+   TOU/force-charge schedule — one HSEM's own recommendation history never
+   marked as `batteries_charge_grid` — is never claimed.
+2. **The exception fires only in `Error` mode**, only when
+   `cfg.phase_aware_charging_enabled` is `True` (the emergency path only
+   ever touches the entity that feature already manages), and only when
+   live telemetry does not already prove the charge is stopped
+   (`primary_grid_charge_is_known_disarmed()`: a verified cap ≤ 0 W, a
+   working mode other than `TimeOfUse`, or TOU periods that no longer match
+   the force-charge schedule).
+3. **The write.** `async_emergency_disable_grid_charge()` writes exactly
+   `0` to `hsem_huawei_solar_batteries_grid_charge_maximum_power` via the
+   same write-and-verify primitive as every other applier write. It never
+   writes any other entity and never writes a non-zero value.
+4. **Retry semantics.** Ownership is latched (`_primary_grid_charge_owned =
+   True`) before the write, and is released only once
+   `summary_verifies_zero_grid_charge()` confirms the write verified at
+   0 W. A failed or unverified write leaves ownership latched so the next
+   cycle retries — it is never abandoned after one failed attempt.
+5. **Release on independent proof, every cycle.** Ownership is also
+   released whenever `primary_grid_charge_is_known_disarmed()` becomes
+   true or the feature is disabled, independent of read-only/degraded-mode
+   gating — not only when degraded mode happens to clear.
+
+##### Invariants
+
+- No write other than a `0` write to the grid-charge-maximum-power entity
+  is ever issued while `DegradedMode.Error` is active.
+- Ownership is only ever established from the accepted plan's own
+  recommendation history (current recommendation or a prior latch) —
+  never from live hardware state alone.
+- A charge whose current recommendation is not `batteries_charge_grid` and
+  for which ownership was never previously latched is never touched, even
+  if live telemetry shows it armed.
+- A failed or unverified emergency write leaves ownership latched for retry
+  on the next cycle.
+- Ownership releases only on a verified 0 W write or independently proven
+  live-disarmed state — never merely because degraded mode cleared.
+
 ## Invariants for tests
 
 Add tests for these invariants:

--- a/docs/sensors-reference.md
+++ b/docs/sensors-reference.md
@@ -62,6 +62,7 @@ all planner output as attributes.
 | `phase_aware_charging_enabled` | bool | Live phase-aware grid-charge safety limiter enabled (issue #831, default `False`) |
 | `grid_phase_power_w` | tuple[float \| None, float \| None, float \| None] | Live per-phase grid power `(a, b, c)` in Watts; `None` per phase when unavailable |
 | `huawei_batteries_grid_charge_max_power_w` | float \| None | Live Huawei grid-charge maximum-power ceiling in Watts, or `None` if unconfigured/unavailable |
+| `primary_grid_charge_owned` | bool | Whether HSEM currently believes it owns an armed Huawei grid-charge cap (issue #840). Drives the Error-mode emergency stop; never true for a charge armed outside of HSEM |
 | `batteries_wait_mode_behavior` | string | Wait mode behaviour: `strict` or `self_consumption_with_reserve` |
 | `house_consumption_energy_weight_1d` | float | 1-day consumption prediction weight |
 | `house_consumption_energy_weight_3d` | float | 3-day weight |

--- a/tests/test_grid_charge_emergency_stop.py
+++ b/tests/test_grid_charge_emergency_stop.py
@@ -1,0 +1,543 @@
+"""Tests for the Error-mode Huawei grid-charge emergency stop (issue #840).
+
+Covers:
+- :mod:`custom_sensors.applier_emergency_stop`: the pure ownership/telemetry
+  helpers and :func:`async_emergency_disable_grid_charge`.
+- :class:`GridChargeEmergencyStopMixin`: ownership latch/release lifecycle,
+  mixed into :class:`HSEMWorkingModeSensor`.
+- The top-level gate in ``_async_apply_hardware_writes``: Error mode blocks
+  every ordinary write but still runs the narrow emergency stop when HSEM
+  owns an armed charge, and never claims an externally-armed one.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.hsem.const import DEFAULT_HSEM_TOU_MODES_FORCE_CHARGE
+from custom_components.hsem.custom_sensors.applier_emergency_stop import (
+    async_emergency_disable_grid_charge,
+    huawei_grid_charge_emergency_needed,
+    primary_grid_charge_is_known_disarmed,
+    summary_verifies_zero_grid_charge,
+)
+from custom_components.hsem.custom_sensors.working_mode_sensor import (
+    HSEMWorkingModeSensor,
+)
+from custom_components.hsem.models.hourly_recommendation import HourlyRecommendation
+from custom_components.hsem.models.live_state import LiveState
+from custom_components.hsem.models.sensor_config import SensorConfig
+from custom_components.hsem.utils.degraded_mode import DegradedMode
+from custom_components.hsem.utils.inverter_verify import (
+    ApplyResult,
+    ApplyStatus,
+    CycleApplySummary,
+)
+from custom_components.hsem.utils.recommendations import Recommendations
+from custom_components.hsem.utils.workingmodes import WorkingModes
+
+_LOGGER_PATCH = "custom_components.hsem.utils.logger.HSEM_LOGGER.debug"
+_NOW = datetime(2026, 8, 27, 12, 0, tzinfo=UTC)
+
+
+def _rec(
+    *,
+    recommendation: str | None = Recommendations.BatteriesChargeGrid.value,
+) -> HourlyRecommendation:
+    return HourlyRecommendation(
+        start=_NOW,
+        end=_NOW + timedelta(hours=1),
+        recommendation=recommendation,
+        avg_house_consumption_kwh=0.0,
+        avg_house_consumption_1d_kwh=0.0,
+        avg_house_consumption_3d_kwh=0.0,
+        avg_house_consumption_7d_kwh=0.0,
+        avg_house_consumption_14d_kwh=0.0,
+        batteries_charged_kwh=2.5,
+        batteries_discharged_kwh=0.0,
+        estimated_battery_capacity_kwh=0.0,
+        estimated_battery_soc_pct=50.0,
+        estimated_cost_currency=0.0,
+        estimated_net_consumption_kwh=0.0,
+        export_price=0.0,
+        grid_export_kwh=0.0,
+        grid_import_kwh=0.0,
+        import_price=1.0,
+        solcast_pv_estimate_kwh=0.0,
+    )
+
+
+def _config(*, phase_aware_charging_enabled: bool = True) -> SensorConfig:
+    cfg = SensorConfig()
+    cfg.phase_aware_charging_enabled = phase_aware_charging_enabled
+    cfg.huawei_solar_batteries_grid_charge_maximum_power = "number.gcmp"
+    return cfg
+
+
+def _armed_live(*, cap_w: float = 5900.0) -> LiveState:
+    """Return a LiveState snapshot for an actively armed grid charge."""
+    live = LiveState()
+    live.huawei_batteries_grid_charge_max_power_w = cap_w
+    live.huawei_batteries_working_mode = WorkingModes.TimeOfUse.value
+    live.tou_periods.raw_state = "active"
+    live.tou_periods.periods = list(DEFAULT_HSEM_TOU_MODES_FORCE_CHARGE)
+    return live
+
+
+def _make_sensor() -> MagicMock:
+    sensor = MagicMock()
+    sensor.hass = MagicMock()
+    return sensor
+
+
+async def _write_and_verify_ok(entity_id, desired, writer, reader, **kwargs):  # type: ignore[no-untyped-def]  # local test shim mirrors async_write_and_verify signature
+    await writer()
+    return ApplyResult(
+        entity_id=entity_id,
+        desired=desired,
+        actual=desired,
+        status=ApplyStatus.OK,
+        attempts=1,
+    )
+
+
+async def _write_and_verify_failed(entity_id, desired, writer, reader, **kwargs):  # type: ignore[no-untyped-def]  # local test shim mirrors async_write_and_verify signature
+    return ApplyResult(
+        entity_id=entity_id,
+        desired=desired,
+        actual=5900.0,
+        status=ApplyStatus.FAILED,
+        attempts=3,
+    )
+
+
+# ---------------------------------------------------------------------------
+# primary_grid_charge_is_known_disarmed
+# ---------------------------------------------------------------------------
+
+
+class TestPrimaryGridChargeIsKnownDisarmed:
+    def test_armed_charge_is_not_disarmed(self):
+        live = _armed_live()
+        assert primary_grid_charge_is_known_disarmed(live) is False
+
+    def test_zero_cap_is_disarmed(self):
+        live = _armed_live(cap_w=0.0)
+        assert primary_grid_charge_is_known_disarmed(live) is True
+
+    def test_non_tou_working_mode_is_disarmed(self):
+        live = _armed_live()
+        live.huawei_batteries_working_mode = WorkingModes.MaximizeSelfConsumption.value
+        assert primary_grid_charge_is_known_disarmed(live) is True
+
+    def test_tou_periods_not_matching_force_charge_is_disarmed(self):
+        live = _armed_live()
+        live.tou_periods.periods = ["06:00-09:00/1234567/+"]
+        assert primary_grid_charge_is_known_disarmed(live) is True
+
+    def test_unknown_cap_and_unknown_working_mode_is_not_disarmed(self):
+        """Missing telemetry must not be mistaken for proof of a safe state."""
+        live = LiveState()
+        live.huawei_batteries_grid_charge_max_power_w = None
+        live.huawei_batteries_working_mode = None
+        assert primary_grid_charge_is_known_disarmed(live) is False
+
+
+# ---------------------------------------------------------------------------
+# huawei_grid_charge_emergency_needed
+# ---------------------------------------------------------------------------
+
+
+class TestHuaweiGridChargeEmergencyNeeded:
+    def test_current_grid_charge_recommendation_needs_emergency_stop(self):
+        cfg = _config()
+        live = _armed_live()
+        rec = _rec()
+        assert huawei_grid_charge_emergency_needed(cfg, live, rec, False) is True
+
+    def test_latched_ownership_needs_emergency_stop_even_without_current_rec(self):
+        cfg = _config()
+        live = _armed_live()
+        assert huawei_grid_charge_emergency_needed(cfg, live, None, True) is True
+
+    def test_externally_armed_charge_is_never_claimed(self):
+        """No HSEM ownership signal (current rec nor latch) -> never touched."""
+        cfg = _config()
+        live = _armed_live()
+        rec = _rec(recommendation=Recommendations.BatteriesWaitMode.value)
+        assert huawei_grid_charge_emergency_needed(cfg, live, rec, False) is False
+
+    def test_disabled_feature_never_needs_emergency_stop(self):
+        cfg = _config(phase_aware_charging_enabled=False)
+        live = _armed_live()
+        rec = _rec()
+        assert huawei_grid_charge_emergency_needed(cfg, live, rec, True) is False
+
+    def test_already_disarmed_does_not_need_emergency_stop(self):
+        cfg = _config()
+        live = _armed_live(cap_w=0.0)
+        rec = _rec()
+        assert huawei_grid_charge_emergency_needed(cfg, live, rec, True) is False
+
+
+# ---------------------------------------------------------------------------
+# summary_verifies_zero_grid_charge
+# ---------------------------------------------------------------------------
+
+
+class TestSummaryVerifiesZeroGridCharge:
+    def test_verified_zero_write_is_recognised(self):
+        cfg = _config()
+        summary = CycleApplySummary(
+            results=[
+                ApplyResult(
+                    entity_id="number.gcmp",
+                    desired=0.0,
+                    actual=0.0,
+                    status=ApplyStatus.OK,
+                    attempts=1,
+                )
+            ]
+        )
+        assert summary_verifies_zero_grid_charge(cfg, summary) is True
+
+    def test_failed_write_is_not_recognised(self):
+        cfg = _config()
+        summary = CycleApplySummary(
+            results=[
+                ApplyResult(
+                    entity_id="number.gcmp",
+                    desired=0.0,
+                    actual=5900.0,
+                    status=ApplyStatus.FAILED,
+                    attempts=3,
+                )
+            ]
+        )
+        assert summary_verifies_zero_grid_charge(cfg, summary) is False
+
+    def test_no_entity_configured_is_not_recognised(self):
+        cfg = _config()
+        cfg.huawei_solar_batteries_grid_charge_maximum_power = None
+        summary = CycleApplySummary(
+            results=[
+                ApplyResult(
+                    entity_id="number.gcmp",
+                    desired=0.0,
+                    actual=0.0,
+                    status=ApplyStatus.OK,
+                    attempts=1,
+                )
+            ]
+        )
+        assert summary_verifies_zero_grid_charge(cfg, summary) is False
+
+
+# ---------------------------------------------------------------------------
+# async_emergency_disable_grid_charge
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncEmergencyDisableGridCharge:
+    @pytest.mark.asyncio
+    async def test_writes_and_verifies_zero(self):
+        sensor = _make_sensor()
+        cfg = _config()
+        live = _armed_live()
+
+        with (
+            patch(_LOGGER_PATCH, new_callable=MagicMock),
+            patch(
+                "custom_components.hsem.custom_sensors.applier_emergency_stop.async_write_and_verify",
+                side_effect=_write_and_verify_ok,
+            ),
+            patch(
+                "custom_components.hsem.custom_sensors.applier_emergency_stop.async_set_number_value",
+                new_callable=AsyncMock,
+            ) as mock_set_number,
+        ):
+            summary = await async_emergency_disable_grid_charge(sensor, cfg, live)
+
+        mock_set_number.assert_awaited_once_with(sensor, "number.gcmp", 0.0)
+        assert summary.results[0].status == ApplyStatus.OK
+        assert summary.results[0].desired == pytest.approx(0.0)
+
+    @pytest.mark.asyncio
+    async def test_read_only_is_a_no_op(self):
+        sensor = _make_sensor()
+        cfg = _config()
+        cfg.read_only = True
+        live = _armed_live()
+
+        with patch(_LOGGER_PATCH, new_callable=MagicMock):
+            summary = await async_emergency_disable_grid_charge(sensor, cfg, live)
+
+        assert summary.results == []
+
+    @pytest.mark.asyncio
+    async def test_already_zero_is_a_no_op(self):
+        sensor = _make_sensor()
+        cfg = _config()
+        live = _armed_live(cap_w=0.0)
+
+        with patch(_LOGGER_PATCH, new_callable=MagicMock):
+            summary = await async_emergency_disable_grid_charge(sensor, cfg, live)
+
+        assert summary.results == []
+
+    @pytest.mark.asyncio
+    async def test_missing_entity_records_a_failed_result(self):
+        sensor = _make_sensor()
+        cfg = _config()
+        cfg.huawei_solar_batteries_grid_charge_maximum_power = None
+        live = _armed_live()
+
+        with patch(_LOGGER_PATCH, new_callable=MagicMock):
+            summary = await async_emergency_disable_grid_charge(sensor, cfg, live)
+
+        assert len(summary.results) == 1
+        assert summary.results[0].status == ApplyStatus.FAILED
+
+
+# ---------------------------------------------------------------------------
+# GridChargeEmergencyStopMixin — ownership lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestGridChargeEmergencyStopMixinLifecycle:
+    def _make_working_mode_sensor(self) -> HSEMWorkingModeSensor:
+        cfg_entry = MagicMock()
+        cfg_entry.entry_id = "test_entry_id_emergency_stop"
+        cfg_entry.options = {}
+        cfg_entry.data = {}
+        coord = MagicMock()
+        coord.data = None
+        coord.last_update_success = True
+        sensor = HSEMWorkingModeSensor(cfg_entry, coord)
+        sensor.hass = MagicMock()
+        return sensor
+
+    def test_ownership_defaults_to_false(self):
+        sensor = self._make_working_mode_sensor()
+        assert sensor._primary_grid_charge_owned is False
+
+    @pytest.mark.asyncio
+    async def test_owned_charge_triggers_emergency_stop(self):
+        sensor = self._make_working_mode_sensor()
+        cfg = _config()
+        live = _armed_live()
+        rec = _rec()
+
+        with (
+            patch(_LOGGER_PATCH, new_callable=MagicMock),
+            patch(
+                "custom_components.hsem.custom_sensors.applier_emergency_stop.async_write_and_verify",
+                side_effect=_write_and_verify_ok,
+            ),
+            patch(
+                "custom_components.hsem.custom_sensors.applier_emergency_stop.async_set_number_value",
+                new_callable=AsyncMock,
+            ),
+        ):
+            summary = await sensor._async_run_error_mode_emergency_stop(
+                sensor, cfg, live, rec
+            )
+
+        assert summary.overall_status == ApplyStatus.OK
+        # Verified 0 W write releases ownership again.
+        assert sensor._primary_grid_charge_owned is False
+
+    @pytest.mark.asyncio
+    async def test_externally_armed_charge_is_not_touched(self):
+        sensor = self._make_working_mode_sensor()
+        cfg = _config()
+        live = _armed_live()
+        rec = _rec(recommendation=Recommendations.BatteriesWaitMode.value)
+
+        with (
+            patch(_LOGGER_PATCH, new_callable=MagicMock),
+            patch(
+                "custom_components.hsem.custom_sensors.applier_emergency_stop.async_write_and_verify",
+                new_callable=AsyncMock,
+            ) as mock_wv,
+        ):
+            summary = await sensor._async_run_error_mode_emergency_stop(
+                sensor, cfg, live, rec
+            )
+
+        mock_wv.assert_not_awaited()
+        assert summary.results == []
+        assert sensor._primary_grid_charge_owned is False
+
+    @pytest.mark.asyncio
+    async def test_failed_stop_retains_ownership_for_retry(self):
+        sensor = self._make_working_mode_sensor()
+        cfg = _config()
+        live = _armed_live()
+        rec = _rec()
+
+        with (
+            patch(_LOGGER_PATCH, new_callable=MagicMock),
+            patch(
+                "custom_components.hsem.custom_sensors.applier_emergency_stop.async_write_and_verify",
+                side_effect=_write_and_verify_failed,
+            ),
+            patch(
+                "custom_components.hsem.custom_sensors.applier_emergency_stop.async_set_number_value",
+                new_callable=AsyncMock,
+            ),
+        ):
+            summary = await sensor._async_run_error_mode_emergency_stop(
+                sensor, cfg, live, rec
+            )
+
+        assert summary.overall_status == ApplyStatus.FAILED
+        assert sensor._primary_grid_charge_owned is True
+
+        # A later cycle with no current recommendation must still retry,
+        # because ownership was latched.
+        with (
+            patch(_LOGGER_PATCH, new_callable=MagicMock),
+            patch(
+                "custom_components.hsem.custom_sensors.applier_emergency_stop.async_write_and_verify",
+                side_effect=_write_and_verify_ok,
+            ),
+            patch(
+                "custom_components.hsem.custom_sensors.applier_emergency_stop.async_set_number_value",
+                new_callable=AsyncMock,
+            ),
+        ):
+            retry_summary = await sensor._async_run_error_mode_emergency_stop(
+                sensor, cfg, live, None
+            )
+
+        assert retry_summary.overall_status == ApplyStatus.OK
+        assert sensor._primary_grid_charge_owned is False
+
+    def test_release_if_safe_clears_ownership_on_verified_disarm(self):
+        sensor = self._make_working_mode_sensor()
+        sensor._primary_grid_charge_owned = True
+        cfg = _config()
+        live = _armed_live(cap_w=0.0)
+
+        sensor._release_primary_grid_charge_ownership_if_safe(cfg, live)
+
+        assert sensor._primary_grid_charge_owned is False
+
+    def test_release_if_safe_keeps_ownership_while_still_armed(self):
+        sensor = self._make_working_mode_sensor()
+        sensor._primary_grid_charge_owned = True
+        cfg = _config()
+        live = _armed_live()
+
+        sensor._release_primary_grid_charge_ownership_if_safe(cfg, live)
+
+        assert sensor._primary_grid_charge_owned is True
+
+    def test_release_if_safe_clears_ownership_when_feature_disabled(self):
+        sensor = self._make_working_mode_sensor()
+        sensor._primary_grid_charge_owned = True
+        cfg = _config(phase_aware_charging_enabled=False)
+        live = _armed_live()
+
+        sensor._release_primary_grid_charge_ownership_if_safe(cfg, live)
+
+        assert sensor._primary_grid_charge_owned is False
+
+
+# ---------------------------------------------------------------------------
+# Top-level gate integration: _async_apply_hardware_writes in Error mode
+# ---------------------------------------------------------------------------
+
+
+def _make_cfg(*, read_only: bool = False) -> SensorConfig:
+    cfg = _config()
+    cfg.read_only = read_only
+    cfg.export_electricity_min_price = 0.0
+    return cfg
+
+
+def _make_live_error_mode() -> LiveState:
+    live = _armed_live()
+    live._degraded_mode = DegradedMode.Error
+    live.export_electricity_price = 1.0
+    live.missing_entities_list = ["Missing entity: batteries_state_of_capacity"]
+    return live
+
+
+class TestErrorModeTopLevelGateIntegration:
+    def _make_coordinator_data(self, *, rec: HourlyRecommendation | None) -> MagicMock:
+        cfg = _make_cfg(read_only=False)
+        live = _make_live_error_mode()
+
+        data = MagicMock()
+        data.cfg = cfg
+        data.live = live
+        data.hourly_recommendation = rec
+        data.batteries_schedules_remaining_capacity_needed = 0.0
+        data.current_required_battery = 0.0
+        data.apply_summary = None
+        return data
+
+    @pytest.mark.asyncio
+    async def test_error_mode_stops_hsem_owned_charge(self):
+        data = self._make_coordinator_data(rec=_rec())
+
+        with (
+            patch(_LOGGER_PATCH, new_callable=MagicMock),
+            patch(
+                "custom_components.hsem.custom_sensors.working_mode_sensor.resolve_current_recommendation"
+            ),
+        ):
+            sensor = MagicMock(spec=HSEMWorkingModeSensor)
+            sensor.hass = MagicMock()
+            sensor._primary_grid_charge_owned = False
+            sensor._release_primary_grid_charge_ownership_if_safe = MagicMock()
+            sensor._async_run_error_mode_emergency_stop = AsyncMock(
+                return_value=CycleApplySummary(
+                    results=[
+                        ApplyResult(
+                            entity_id="number.gcmp",
+                            desired=0.0,
+                            actual=0.0,
+                            status=ApplyStatus.OK,
+                            attempts=1,
+                        )
+                    ]
+                )
+            )
+
+            await HSEMWorkingModeSensor._async_apply_hardware_writes(sensor, data)
+
+        sensor._async_run_error_mode_emergency_stop.assert_awaited_once_with(
+            sensor, data.cfg, data.live, data.hourly_recommendation
+        )
+        assert data.apply_summary.results[0].status == ApplyStatus.OK
+
+    @pytest.mark.asyncio
+    async def test_error_mode_does_not_touch_externally_armed_charge(self):
+        data = self._make_coordinator_data(
+            rec=_rec(recommendation=Recommendations.BatteriesWaitMode.value)
+        )
+
+        with (
+            patch(_LOGGER_PATCH, new_callable=MagicMock),
+            patch(
+                "custom_components.hsem.custom_sensors.working_mode_sensor.resolve_current_recommendation"
+            ),
+        ):
+            sensor = MagicMock(spec=HSEMWorkingModeSensor)
+            sensor.hass = MagicMock()
+            sensor._primary_grid_charge_owned = False
+            sensor._release_primary_grid_charge_ownership_if_safe = MagicMock()
+            sensor._async_run_error_mode_emergency_stop = AsyncMock(
+                return_value=CycleApplySummary()
+            )
+
+            await HSEMWorkingModeSensor._async_apply_hardware_writes(sensor, data)
+
+        sensor._async_run_error_mode_emergency_stop.assert_awaited_once()
+        assert data.apply_summary.results == []


### PR DESCRIPTION
## Summary

Follow-up to issue #831 (live phase-aware grid-charge safety limiter, complete — #836/#838/#839). During final review of that work, a remaining gap was identified: the Part 3 transition/deadline safety logic only runs while `hardware_writes_allowed()` is `True`. If `classify_degraded_mode()` escalates to `DegradedMode.Error` mid-cycle while HSEM itself is the one holding an armed Huawei grid-charge cap, `_async_apply_hardware_writes()` takes the `elif not writes_safe:` branch and simply skips **all** writes — the last HSEM-written cap is left live on the inverter with no further supervision until Error mode clears.

This PR adds a narrow, **downward-only** exception that is allowed to run even in `Error` mode: if HSEM believes it currently owns an armed grid-charge cap, it is permitted to write `0` to disarm it — and only that.

Closes #840

## What's in this PR

- **Ownership model, not a blanket safety net.** HSEM must never touch a grid-charge cap it did not itself arm.
  - Ownership (`self._primary_grid_charge_owned`) is latched only when HSEM's own write path verifies a `batteries_charge_grid` recommendation while writes are safe — never inferred from hardware state alone.
  - Ownership is released every cycle, independent of degraded mode, as soon as live telemetry independently proves no charge is armed (`primary_grid_charge_is_known_disarmed()`: verified cap ≤ 0 W, working mode not `TimeOfUse`, or TOU periods no longer matching the force-charge schedule).
  - An externally/manually armed charge (ownership `False`) is never touched by the emergency stop, even in `Error` mode.
- **Downward-only, retry-safe write.** `huawei_grid_charge_emergency_needed()` is a pure gating function combining ownership + Error-mode + telemetry precedence. `async_emergency_disable_grid_charge()` writes `0` via the existing `async_write_and_verify()` primitive — no new write path. A failed/unverified write deliberately does **not** release ownership, so the next cycle retries.
- **New diagnostic attribute** `primary_grid_charge_owned` on the working-mode sensor's `extra_state_attributes`.

## Files changed

- `custom_components/hsem/custom_sensors/applier_emergency_stop.py` (new) — `primary_grid_charge_is_known_disarmed()`, `huawei_grid_charge_emergency_needed()`, `summary_verifies_zero_grid_charge()`, `async_emergency_disable_grid_charge()`, `GridChargeEmergencyStopMixin`.
- `custom_components/hsem/custom_sensors/working_mode_sensor.py` — mixes in `GridChargeEmergencyStopMixin`, tracks `_primary_grid_charge_owned`, releases ownership every cycle when telemetry proves the charge is disarmed, runs the emergency stop in the Error-mode branch, exposes the new attribute.
- `docs/planner-spec.md` — new "Error-mode emergency stop for an HSEM-owned grid charge (issue #840)" subsection with invariants.
- `docs/planner-guide.md` — matching narrative subsection under "Safety modes".
- `docs/sensors-reference.md` — documents the new `primary_grid_charge_owned` attribute.
- `.github/memories.md` — new canonical-pattern entry for the ownership model, downward-only write, and retry semantics.
- `tests/test_grid_charge_emergency_stop.py` (new) — 26 tests.

## Tests

- `primary_grid_charge_is_known_disarmed()` — 5 tests
- `huawei_grid_charge_emergency_needed()` — 5 tests
- `summary_verifies_zero_grid_charge()` — 3 tests
- `async_emergency_disable_grid_charge()` — 4 tests
- `GridChargeEmergencyStopMixin` lifecycle — 7 tests (ownership default, owned-charge-triggers-stop, externally-armed-not-touched, failed-stop-retains-ownership-for-retry, release-if-safe variants)
- Error-mode top-level gate integration — 2 tests

## Test results

- `./scripts/quality.sh lint` — clean
- `./scripts/quality.sh typing` — 0 mypy errors
- `./scripts/quality.sh quality` — 0 new pyright/vulture findings (1 pre-existing unrelated pyright warning at `working_mode_sensor.py:460`, confirmed present on `main` before this change, not a regression)
- `./scripts/quality.sh test` — **2943/2943 passed** (2917 existing + 26 new)
- File size limit (30 KB / 1000 lines): `working_mode_sensor.py` is 30078 bytes / 603 lines — within limit, verified via the repo's standard `find` check.

## Checklist

- [x] One issue per branch/PR
- [x] No unrelated refactors
- [x] Docs updated (`planner-spec.md`, `planner-guide.md`, `sensors-reference.md`, `.github/memories.md`)
- [x] Tests added
- [x] All quality gates pass
- [x] `Closes #840`
