### PR TITLE
docs(ocpp): record deliberate no-op decision on manual-override API (#843)

### DIFF
--- a/custom_components/hsem/custom_sensors/ocpp_server.py
+++ b/custom_components/hsem/custom_sensors/ocpp_server.py
@@ -162,7 +162,12 @@ class OCPPServer:
 
     @property
     def active_chargers(self) -> list[str]:
-        """Return list of CPIDs for currently connected chargers."""
+        """Return list of CPIDs for currently connected chargers.
+
+        Manual/diagnostic accessor — no HA service currently exposes this
+        (see issue #843). Kept as public API for direct/test use alongside
+        :meth:`send_set_charging_profile` and :meth:`send_remote_stop`.
+        """
         return list(self._chargers.keys())
 
     async def update_charge_target(
@@ -256,6 +261,11 @@ class OCPPServer:
         Bypasses the anti-flap state machine.  Use
         :meth:`update_charge_target` for normal planner-driven operation.
 
+        No HA service registers this as a manual override (see issue #843
+        — deliberately left unwired: registering it would let a user bypass
+        the anti-flap safety window with no corresponding product need).
+        Kept as public API for direct/test use.
+
         Args:
             cpid: Charge-point identifier.
             max_power_w: Maximum charging power in watts.
@@ -272,6 +282,10 @@ class OCPPServer:
 
     async def send_remote_stop(self, cpid: str) -> None:
         """Directly send a ``RemoteStopTransaction`` to a charger.
+
+        Bypasses the anti-flap state machine — see
+        :meth:`send_set_charging_profile` for why this is intentionally not
+        wired to an HA service (issue #843).
 
         Args:
             cpid: Charge-point identifier.


### PR DESCRIPTION
## Summary

Resolves the ambiguity filed in #843 (a side-finding from the dead-code audit
in #844): `OCPPServer.active_chargers`, `send_set_charging_profile`, and
`send_remote_stop` have no caller anywhere except the test suite.

Investigated whether a manual-override HA service was planned but never
wired up:

- The original feature PR (#606, item #603) description for the OCPP server
  lists only the anti-flap `update_charge_target` flow — no manual-override
  service was ever in scope.
- No `services.yaml` entry, `translations/en.json` string, or doc mentions
  such a service anywhere in the repo (contrast with `set_temporary_override`
  / `clear_override`, which have all three).
- The current `vulture` gate (`--min-confidence 80`, includes `tests/`)
  doesn't flag these methods — they're legitimately exercised by
  `tests/custom_sensors/test_ocpp_server.py`.

Conclusion: this is intentionally-exposed API for direct/manual and test use,
not a forgotten wire-up. Registering a service for it would let an operator
bypass the anti-flap safety window with no corresponding product need, which
is out of scope without a specific request.

## Changes

- Added docstring notes on the three methods recording this decision and
  cross-referencing #843, so a future dead-code audit doesn't re-flag them
  as accidental leftovers.
- No behavior change.

## Test plan

- [x] `./scripts/quality.sh lint`
- [x] `./scripts/quality.sh typing`
- [x] `./scripts/quality.sh quality` (pyright + vulture)
- [x] `./scripts/quality.sh test` (2923 passed)

Fixes #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)