### PR TITLE
feat(planner): EV deadline safety margin, escalation, and redistribution

### DIFF
--- a/custom_components/hsem/const.py
+++ b/custom_components/hsem/const.py
@@ -68,6 +68,7 @@ DEFAULT_CONFIG_VALUES = {
     "hsem_ev_planned_load_charger_efficiency": 100,
     "hsem_ev_planned_load_charger_min_power_w": 1380,
     "hsem_ev_planned_load_charger_phase_topology": "single_phase",
+    "hsem_ev_planned_load_deadline_safety_margin_pct": 0,
     # EV planned load integration — second EV (optional, disabled by default)
     "hsem_ev_second_planned_load_enabled": False,
     "hsem_ev_second_planned_load_battery_capacity_kwh": 0.0,
@@ -75,6 +76,7 @@ DEFAULT_CONFIG_VALUES = {
     "hsem_ev_second_planned_load_charger_efficiency": 100,
     "hsem_ev_second_planned_load_charger_min_power_w": 1380,
     "hsem_ev_second_planned_load_charger_phase_topology": "single_phase",
+    "hsem_ev_second_planned_load_deadline_safety_margin_pct": 0,
     "hsem_ev_second_allow_charge_past_target_soc": False,
     "hsem_ev_second_past_target_confidence_factor": 0.9,
     "hsem_ev_second_charger_force_max_discharge_power": False,

--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -40,6 +40,9 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from custom_components.hsem.coordinator_cycle import CoordinatorCycleMixin
 from custom_components.hsem.coordinator_data import CoordinatorData
+from custom_components.hsem.coordinator_ev_deadline_pacing import (
+    CoordinatorEvDeadlinePacingMixin,
+)
 from custom_components.hsem.coordinator_helpers import (
     LoadForecastSignature,
     apply_force_charge_now,
@@ -121,6 +124,7 @@ class HSEMDataUpdateCoordinator(
     CoordinatorCycleMixin,
     CoordinatorPlannerPhaseMixin,
     CoordinatorLivePowerMixin,
+    CoordinatorEvDeadlinePacingMixin,
     DataUpdateCoordinator[CoordinatorData],
 ):
     """DataUpdateCoordinator for HSEM.

--- a/custom_components/hsem/coordinator_builder.py
+++ b/custom_components/hsem/coordinator_builder.py
@@ -395,6 +395,10 @@ def build_planner_input(
             cfg.ev.max_discharge_power
         )
         or 0.0,
+        ev_planned_load_deadline_safety_margin_pct=convert_to_float(
+            cfg.ev_planned_load_deadline_safety_margin_pct
+        )
+        or 0.0,
         # Second EV planned load
         ev_second_planned_load_enabled=bool(cfg.ev_second_planned_load_enabled),
         ev_second_planned_load_connected=bool(live.ev_second_planned_load_connected),
@@ -441,6 +445,10 @@ def build_planner_input(
         ),
         ev_second_planned_load_max_discharge_power_w=convert_to_float(
             cfg.ev_second.max_discharge_power
+        )
+        or 0.0,
+        ev_second_planned_load_deadline_safety_margin_pct=convert_to_float(
+            cfg.ev_second_planned_load_deadline_safety_margin_pct
         )
         or 0.0,
         time_discount_rate=0.995,

--- a/custom_components/hsem/coordinator_cycle.py
+++ b/custom_components/hsem/coordinator_cycle.py
@@ -72,6 +72,11 @@ EV_DELIVERED_ENERGY_REPLAN_DELTA_KWH = 0.25
 EV_DELIVERED_ENERGY_REPLAN_MIN_SECONDS = 60.0
 EV_DELIVERED_ENERGY_MAX_GAP_SECONDS = 3600.0
 
+# An EV that can no longer reach its margined deadline target at max
+# charger power should trigger a prompt replan (issue #845) rather than
+# waiting for an unrelated event — but not on every single cadence tick.
+EV_DEADLINE_PACING_REPLAN_MIN_SECONDS = 120.0
+
 
 class CoordinatorCycleMixin(CoordinatorSharedState):
     """Live-state collection and the guarded update cycle for the coordinator."""

--- a/custom_components/hsem/coordinator_ev_deadline_pacing.py
+++ b/custom_components/hsem/coordinator_ev_deadline_pacing.py
@@ -1,0 +1,127 @@
+"""EV deadline-pacing replan trigger (issue #845).
+
+Extracted from ``coordinator_planner_phase.py`` to satisfy the repository's
+30 KB / 1000-line file limit.
+
+Full replans already run every ``hsem_update_interval`` and each re-derives
+EV SoC from live state, re-applying the deadline safety margin and
+escalation logic (``EVConfig.deadline_escalated`` in
+``planner/milp/_ev_constraints.py`` / ``_objective.py``). This module adds
+one lightweight trigger so escalation doesn't have to wait for some
+unrelated event to force the next replan: as soon as max-power charging for
+the remaining time can no longer reach ``target + margin``, a fresh plan is
+requested promptly.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from custom_components.hsem.coordinator_cycle import (
+    EV_DEADLINE_PACING_REPLAN_MIN_SECONDS,
+)
+from custom_components.hsem.coordinator_state import CoordinatorSharedState
+from custom_components.hsem.models.live_state import LiveState
+from custom_components.hsem.utils.datetime_utils import utc_key
+from custom_components.hsem.utils.logger import async_log
+
+
+class CoordinatorEvDeadlinePacingMixin(CoordinatorSharedState):
+    """EV deadline-pacing replan trigger (issue #845)."""
+
+    def _ev_deadline_pacing_requires_replan(
+        self,
+        live: LiveState,
+        now: datetime,
+    ) -> bool:
+        """Return whether an EV can no longer reach its margined target at max power.
+
+        Gated by a minimum cadence so it doesn't fire on every tick.
+        """
+        last_plan_at = self._last_plan_slot_start
+        elapsed_seconds: float | None = None
+        if last_plan_at is not None:
+            try:
+                elapsed_seconds = (utc_key(now) - utc_key(last_plan_at)).total_seconds()
+            except TypeError, ValueError:
+                elapsed_seconds = None
+
+        if last_plan_at is not None and (
+            elapsed_seconds is None
+            or elapsed_seconds < EV_DEADLINE_PACING_REPLAN_MIN_SECONDS
+        ):
+            return False
+
+        for (
+            label,
+            ev_live,
+            connected,
+            smart_charging,
+            target_soc_pct,
+            deadline,
+            capacity_kwh,
+            charger_power_kw,
+            charger_efficiency_pct,
+            margin_pct,
+        ) in (
+            (
+                "EV",
+                live.ev,
+                live.ev_planned_load_connected,
+                live.ev_planned_load_smart_charging_enabled,
+                live.ev_planned_load_target_soc_pct,
+                live.ev_planned_load_deadline,
+                float(self._cfg.ev_planned_load_battery_capacity_kwh),
+                float(self._cfg.ev_planned_load_charger_power_kw),
+                float(self._cfg.ev_planned_load_charger_efficiency_pct),
+                float(self._cfg.ev_planned_load_deadline_safety_margin_pct),
+            ),
+            (
+                "EV2",
+                live.ev_second,
+                live.ev_second_planned_load_connected,
+                live.ev_second_planned_load_smart_charging_enabled,
+                live.ev_second_planned_load_target_soc_pct,
+                live.ev_second_planned_load_deadline,
+                float(self._cfg.ev_second_planned_load_battery_capacity_kwh),
+                float(self._cfg.ev_second_planned_load_charger_power_kw),
+                float(self._cfg.ev_second_planned_load_charger_efficiency_pct),
+                float(self._cfg.ev_second_planned_load_deadline_safety_margin_pct),
+            ),
+        ):
+            if not connected or not smart_charging or deadline is None:
+                continue
+            if capacity_kwh <= 1e-9 or charger_power_kw <= 1e-9:
+                continue
+            current_kwh = self._ev_effective_energy_kwh(ev_live, capacity_kwh)
+            if current_kwh is None:
+                continue
+            target_pct = max(min(float(target_soc_pct), 100.0), 0.0)
+            target_kwh = target_pct / 100.0 * capacity_kwh
+            if current_kwh + 1e-9 >= target_kwh:
+                continue
+            try:
+                remaining_hours = (deadline - now).total_seconds() / 3600.0
+            except TypeError:
+                continue
+            if remaining_hours <= 0:
+                continue
+            margin_kwh = (target_kwh - current_kwh) * margin_pct / 100.0
+            effective_target_kwh = min(target_kwh + margin_kwh, capacity_kwh)
+            efficiency = max(charger_efficiency_pct, 1.0) / 100.0
+            max_reachable_kwh = (
+                current_kwh + charger_power_kw * efficiency * remaining_hours
+            )
+            if max_reachable_kwh < effective_target_kwh - 1e-9:
+                async_log(
+                    "debug",
+                    "[replan] %s can no longer reach its margined deadline "
+                    "target at max power (%.3f reachable vs %.3f needed by "
+                    "%s) — re-planning.",
+                    label,
+                    max_reachable_kwh,
+                    effective_target_kwh,
+                    deadline.isoformat(),
+                )
+                return True
+        return False

--- a/custom_components/hsem/coordinator_planner_phase.py
+++ b/custom_components/hsem/coordinator_planner_phase.py
@@ -518,6 +518,8 @@ class CoordinatorPlannerPhaseMixin(CoordinatorSharedState):
         - Import price changed significantly (new price period)
         - Sustained material rolling house/PV change in the current slot,
           within its bounded correction budget (issue #797)
+        - An EV can no longer reach its margined deadline target at max
+          charger power for the remaining time (issue #845)
 
         Returns ``False`` when nothing material changed — the previous
         plan can be reused.
@@ -580,6 +582,9 @@ class CoordinatorPlannerPhaseMixin(CoordinatorSharedState):
                 return True
 
         if self._ev_delivered_energy_requires_replan(live, now):
+            return True
+
+        if self._ev_deadline_pacing_requires_replan(live, now):
             return True
 
         # EV connection state changed.

--- a/custom_components/hsem/coordinator_state.py
+++ b/custom_components/hsem/coordinator_state.py
@@ -204,3 +204,9 @@ class CoordinatorSharedState(_Base):
     def _ev_effective_energy_kwh(
         ev_live: Any, battery_capacity_kwh: float
     ) -> float | None: ...
+
+    # Method provided by CoordinatorEvDeadlinePacingMixin.
+    def _ev_deadline_pacing_requires_replan(
+        self, live: LiveState, now: datetime
+    ) -> bool:
+        raise NotImplementedError

--- a/custom_components/hsem/custom_sensors/config_reader.py
+++ b/custom_components/hsem/custom_sensors/config_reader.py
@@ -473,6 +473,14 @@ def build_sensor_config(
     cfg.ev_planned_load_charger_phase_topology = normalize_ev_phase_topology(
         get_config_value(config_entry, "hsem_ev_planned_load_charger_phase_topology")
     )
+    _margin_pct = convert_to_float(
+        get_config_value(
+            config_entry, "hsem_ev_planned_load_deadline_safety_margin_pct"
+        )
+    )
+    cfg.ev_planned_load_deadline_safety_margin_pct = (
+        _margin_pct if _margin_pct is not None else 0.0
+    )
 
     # Second EV planned load integration
     cfg.ev_second_planned_load_enabled = convert_to_boolean(
@@ -510,6 +518,14 @@ def build_sensor_config(
         get_config_value(
             config_entry, "hsem_ev_second_planned_load_charger_phase_topology"
         )
+    )
+    _s2_margin_pct = convert_to_float(
+        get_config_value(
+            config_entry, "hsem_ev_second_planned_load_deadline_safety_margin_pct"
+        )
+    )
+    cfg.ev_second_planned_load_deadline_safety_margin_pct = (
+        _s2_margin_pct if _s2_margin_pct is not None else 0.0
     )
 
     # EV auto-Full on negative price (issue #609)

--- a/custom_components/hsem/flows/ev_planned_load_helpers.py
+++ b/custom_components/hsem/flows/ev_planned_load_helpers.py
@@ -78,6 +78,20 @@ _MIN_POWER_W_SELECTOR = selector(
     }
 )
 
+# Extra energy budgeted above the deadline target so normal execution-layer
+# friction doesn't turn an exact plan into a missed deadline (issue #845).
+_DEADLINE_SAFETY_MARGIN_SELECTOR = selector(
+    {
+        "number": {
+            "min": 0,
+            "max": 50,
+            "step": 1,
+            "unit_of_measurement": PERCENTAGE,
+            "mode": "slider",
+        }
+    }
+)
+
 # Charger phase topology decides how much of an EV command any single phase
 # may be assumed to carry in the hard per-phase fuse rows.  ``single_phase``
 # is the safe default: it keeps the pre-feature worst-case envelope.
@@ -139,6 +153,10 @@ async def build_ev_planned_load_schema(  # NOSONAR
                 _k("charger_phase_topology"),
                 default=_v("charger_phase_topology"),
             ): _PHASE_TOPOLOGY_SELECTOR,
+            vol.Required(
+                _k("deadline_safety_margin_pct"),
+                default=_v("deadline_safety_margin_pct"),
+            ): _DEADLINE_SAFETY_MARGIN_SELECTOR,
         }
     )
 

--- a/custom_components/hsem/flows/migrations.py
+++ b/custom_components/hsem/flows/migrations.py
@@ -87,11 +87,13 @@ _V2_NEW_KEY_DEFAULTS: dict[str, Any] = {
     "hsem_ev_planned_load_charger_power_kw": 0.0,
     "hsem_ev_planned_load_charger_efficiency": 100,
     "hsem_ev_planned_load_charger_min_power_w": 1380,
+    "hsem_ev_planned_load_deadline_safety_margin_pct": 0,
     "hsem_ev_second_planned_load_enabled": False,
     "hsem_ev_second_planned_load_battery_capacity_kwh": 0.0,
     "hsem_ev_second_planned_load_charger_power_kw": 0.0,
     "hsem_ev_second_planned_load_charger_efficiency": 100,
     "hsem_ev_second_planned_load_charger_min_power_w": 1380,
+    "hsem_ev_second_planned_load_deadline_safety_margin_pct": 0,
     # Planner hysteresis
     "hsem_planner_hysteresis_enabled": True,
     "hsem_planner_hysteresis_absolute": 0.0,

--- a/custom_components/hsem/models/ev_config.py
+++ b/custom_components/hsem/models/ev_config.py
@@ -42,6 +42,14 @@ class EVConfig:
             captured in the house consumption sensor.  The MILP will mark
             the EV load as accounted rather than planned (affects how the
             results are written to ``PlannedSlot`` fields).
+        deadline_margin_kwh: Extra energy budgeted above ``target_kwh`` for
+            the deadline soft-goal and target-cap constraints, so normal
+            execution-layer friction (anti-flap windows, min-power floors,
+            phase-headroom throttling) doesn't turn an on-paper-exact plan
+            into a missed deadline (issue #845).  Derived by the caller as
+            a configured percentage of the shortfall
+            (``target_kwh - initial_soc_kwh``).  ``0.0`` reproduces the
+            pre-#845 exact-target behaviour.
     """
 
     enabled: bool = False
@@ -53,6 +61,7 @@ class EVConfig:
     charger_min_power_w: float = 1380.0
     deadline_slot: int | None = None
     base_load_includes_ev: bool = False
+    deadline_margin_kwh: float = 0.0
     #: When True, the EV is already at its user-configured target SoC and
     #: is only included so the MILP can allocate surplus PV that would
     #: otherwise be exported at low/negative prices.  In this mode the
@@ -115,3 +124,34 @@ class EVConfig:
         published-plan validation cannot diverge.
         """
         return ev_phase_share(self.charger_phase_topology)
+
+    @property
+    def effective_deadline_target_kwh(self) -> float:
+        """Return ``target_kwh`` inflated by the safety margin, capped at capacity.
+
+        This is the value the deadline soft-constraint and target-cap
+        constraint actually aim for (issue #845) — ``target_kwh`` itself
+        stays the literal user-configured target for diagnostics (e.g.
+        ``deadline_met``), which now certifies the strictly stronger
+        "target + margin was met" outcome.
+        """
+        return min(self.target_kwh + self.deadline_margin_kwh, self.capacity_kwh)
+
+    @property
+    def deadline_escalated(self) -> bool:
+        """Return whether even max-power charging can't reach the margined target.
+
+        A stateless reachability check, re-evaluated on every MILP solve
+        from the current (live) ``initial_soc_kwh`` — no persistent
+        trajectory tracking is needed.  When ``True``, the target-cap
+        constraint is lifted to ``capacity_kwh`` and the deadline penalty
+        is steepened (issue #845), so the solver is free to charge past the
+        normal margined ceiling when that's the only way to still meet the
+        deadline.
+        """
+        if self.deadline_slot is None:
+            return False
+        max_reachable = self.initial_soc_kwh + self.max_charge_per_slot * (
+            self.deadline_slot + 1
+        )
+        return max_reachable < self.effective_deadline_target_kwh - 1e-9

--- a/custom_components/hsem/models/planner_input.py
+++ b/custom_components/hsem/models/planner_input.py
@@ -265,6 +265,10 @@ class PlannerInput:
     #: Huawei discharge ceiling (W) while the primary EV charges.  Only
     #: meaningful when ``ev_planned_load_force_max_discharge_power`` is True.
     ev_planned_load_max_discharge_power_w: float = 0.0
+    #: Percentage of the deadline shortfall budgeted as extra safety margin
+    #: above the target SoC, so execution-layer friction doesn't turn an
+    #: exact plan into a missed deadline (issue #845).
+    ev_planned_load_deadline_safety_margin_pct: float = 0.0
 
     # --- EV planned load integration — second EV (optional, disabled by default) ---
     #: When True, the second EV planned load feature is active.
@@ -289,6 +293,8 @@ class PlannerInput:
     ev_second_planned_load_force_max_discharge_power: bool = False
     #: Same as ev_planned_load_max_discharge_power_w, for the second EV.
     ev_second_planned_load_max_discharge_power_w: float = 0.0
+    #: Same as ev_planned_load_deadline_safety_margin_pct, for the second EV.
+    ev_second_planned_load_deadline_safety_margin_pct: float = 0.0
 
     # --- planner hysteresis — keep the active plan unless the new plan
     # is materially better (anti-flapping, issue #372). ---

--- a/custom_components/hsem/models/sensor_config.py
+++ b/custom_components/hsem/models/sensor_config.py
@@ -292,6 +292,10 @@ class SensorConfig:
     ev_planned_load_charger_min_power_w: float = 1380.0
     #: Electrical topology of the primary charger (see ``utils/phase_power``).
     ev_planned_load_charger_phase_topology: str = "single_phase"
+    #: Percentage of the deadline shortfall budgeted as extra safety margin
+    #: above the target SoC, so execution-layer friction doesn't turn an
+    #: exact plan into a missed deadline (issue #845).
+    ev_planned_load_deadline_safety_margin_pct: float = 0.0
     # EV planned load integration — second EV (optional, disabled by default)
     ev_second_planned_load_enabled: bool = False
     ev_second_planned_load_battery_capacity_kwh: float = 0.0
@@ -300,6 +304,8 @@ class SensorConfig:
     ev_second_planned_load_charger_min_power_w: float = 1380.0
     #: Electrical topology of the second charger (see ``utils/phase_power``).
     ev_second_planned_load_charger_phase_topology: str = "single_phase"
+    #: Same as ev_planned_load_deadline_safety_margin_pct, for the second EV.
+    ev_second_planned_load_deadline_safety_margin_pct: float = 0.0
 
     # Seasonal configuration
     months_winter: list[int] = field(default_factory=list)

--- a/custom_components/hsem/planner/engine_ev_milp.py
+++ b/custom_components/hsem/planner/engine_ev_milp.py
@@ -80,6 +80,7 @@ def _build_ev_configs_for_milp(
             float,
             bool,
             float,
+            float,
             bool,
         ]
     ] = [
@@ -100,6 +101,7 @@ def _build_ev_configs_for_milp(
             inp.ev_past_target_confidence_factor,
             inp.ev_planned_load_force_max_discharge_power,
             inp.ev_planned_load_max_discharge_power_w,
+            inp.ev_planned_load_deadline_safety_margin_pct,
             False,  # is_second = False (primary EV)
         ),
         (
@@ -121,6 +123,7 @@ def _build_ev_configs_for_milp(
             inp.ev_second_past_target_confidence_factor,
             inp.ev_second_planned_load_force_max_discharge_power,
             inp.ev_second_planned_load_max_discharge_power_w,
+            inp.ev_second_planned_load_deadline_safety_margin_pct,
             True,  # is_second = True (second EV)
         ),
     ]
@@ -141,6 +144,7 @@ def _build_ev_configs_for_milp(
         past_target_confidence_factor,
         force_max_discharge_power,
         max_discharge_power_w,
+        deadline_margin_pct,
         is_second,
     ) in ev_sources:
         label = "second" if is_second else "primary"
@@ -209,6 +213,7 @@ def _build_ev_configs_for_milp(
         deadline_slot: int | None = None
         charge_past_target = False
         managed_session_cap_only = False
+        deadline_margin_kwh = 0.0
         if fixed_session_only:
             initial_kwh = 0.0
             target_kwh = 0.0
@@ -255,6 +260,14 @@ def _build_ev_configs_for_milp(
                 )
                 continue
             charge_past_target = False
+            # Safety margin (issue #845): budget extra energy above the
+            # bare target, proportional to the shortfall, so normal
+            # execution-layer friction (anti-flap windows, min-power
+            # floors, phase-headroom throttling) doesn't turn an
+            # on-paper-exact plan into a missed deadline.
+            deadline_margin_kwh = (
+                max(target_kwh - initial_kwh, 0.0) * deadline_margin_pct / 100.0
+            )
 
         # Configured power is the hard actuator nameplate for every managed
         # session. Only an unmanaged session may expand its *accounting*
@@ -306,6 +319,7 @@ def _build_ev_configs_for_milp(
                 charger_min_power_w=round(effective_min_power_w, 1),
                 charger_phase_topology=phase_topology,
                 deadline_slot=deadline_slot,
+                deadline_margin_kwh=round(deadline_margin_kwh, 3),
                 base_load_includes_ev=base_includes,
                 charge_past_target=charge_past_target,
                 future_value_per_kwh=future_value_per_kwh,

--- a/custom_components/hsem/planner/milp/_ev_constraints.py
+++ b/custom_components/hsem/planner/milp/_ev_constraints.py
@@ -144,8 +144,13 @@ def add_ev_and_session_constraint_rows(
             ev_row += m
 
             # EV deadline soft constraint:
-            # initial_soc + Σ_{k≤D} ev_c[k] + penalty ≥ target
-            # → -Σ_{k≤D} ev_c[k] - penalty ≤ initial_soc - target
+            # initial_soc + Σ_{k≤D} ev_c[k] + penalty ≥ effective_target
+            # → -Σ_{k≤D} ev_c[k] - penalty ≤ initial_soc - effective_target
+            # ``effective_deadline_target_kwh`` is target_kwh plus a
+            # configured safety margin (issue #845), so the plan aims past
+            # the bare target and has slack to absorb execution-layer
+            # friction (anti-flap windows, min-power floors, phase-headroom
+            # throttling) without silently missing the deadline.
             if (
                 ev.deadline_slot is not None
                 and ev.target_kwh > ev.initial_soc_kwh + 1e-9
@@ -156,14 +161,14 @@ def add_ev_and_session_constraint_rows(
                 for k in range(d + 1):
                     A_ub[ev_row, ev_off + k] = -1.0
                 A_ub[ev_row, ev_pen_offsets[ev_idx]] = -1.0
-                b_ub[ev_row] = ev.initial_soc_kwh - ev.target_kwh
+                b_ub[ev_row] = ev.initial_soc_kwh - ev.effective_deadline_target_kwh
                 ev_row += 1
 
             # EV target-cap constraint:
-            # Σ_{k≤D} ev_c[k] ≤ target_kwh - initial_soc_kwh + activation_quantum
-            # Caps EV charging near the economic target for pre-deadline
-            # slots.  Without this, the benefit coefficient on ev_c[t]
-            # would drive charging all the way to capacity_kwh
+            # Σ_{k≤D} ev_c[k] ≤ cap_target - initial_soc_kwh + activation_quantum
+            # Caps EV charging near the economic target (plus safety margin)
+            # for pre-deadline slots.  Without this, the benefit coefficient
+            # on ev_c[t] would drive charging all the way to capacity_kwh
             # regardless of the actual shortfall.  One activation quantum
             # (the smallest executable whole-amp energy) is permitted above
             # the exact target: whole-amp hardware may have no executable
@@ -172,12 +177,23 @@ def add_ev_and_session_constraint_rows(
             # Does NOT apply when charge_past_target is enabled — that
             # mode intentionally allows charging beyond target_kwh via
             # a separate surplus-only mechanism.
+            # When ``deadline_escalated`` is True — even max-power charging
+            # for every remaining pre-deadline slot can't reach the margined
+            # target — the cap is lifted all the way to capacity_kwh
+            # (issue #845), so the solver isn't artificially blocked from
+            # charging as much as physically possible once the safety
+            # margin itself is no longer achievable.
             if (
                 ev.deadline_slot is not None
                 and ev.target_kwh > ev.initial_soc_kwh + 1e-9
                 and not ev.charge_past_target
             ):
-                shortfall = ev.target_kwh - ev.initial_soc_kwh
+                cap_target = (
+                    ev.capacity_kwh
+                    if ev.deadline_escalated
+                    else ev.effective_deadline_target_kwh
+                )
+                shortfall = cap_target - ev.initial_soc_kwh
                 d = ev.deadline_slot
                 d = max(0, min(d, m - 1))
                 activation_quantum_dc = target_cap_activation_quantum_dc(

--- a/custom_components/hsem/planner/milp/_ev_power_writeout.py
+++ b/custom_components/hsem/planner/milp/_ev_power_writeout.py
@@ -44,6 +44,15 @@ def _write_ev_power_fields_to_slots(
     for ev_idx, ev in enumerate(active_evs):
         ev_off = ev_var_offsets[ev_idx]
         ev_c_sol = executable_x[ev_off : ev_off + m]
+        # Redistribution target window (issue #845): a deadline-driven EV
+        # may move a below-minimum-power slot's energy forward instead of
+        # discarding it.  Charge-past-target EVs have no deadline to
+        # protect, so they're excluded.
+        deadline_lp_limit = (
+            max(0, min(ev.deadline_slot, m - 1))
+            if ev.deadline_slot is not None and not ev.charge_past_target
+            else None
+        )
         for lp_t, slot_i in enumerate(future_idx):
             ev_dc_kwh = float(ev_c_sol[lp_t])
             if ev_dc_kwh < _min_action_kwh:
@@ -108,9 +117,47 @@ def _write_ev_power_fields_to_slots(
             # field so the applier does not attempt to throttle below
             # the minimum.
             if ev.charger_min_power_w > 1e-9 and ac_power_w < ev.charger_min_power_w:
+                # Before discarding, try to move this slot's energy forward
+                # onto a later pre-deadline slot with headroom (issue #845)
+                # instead of silently losing it.  ``ev_c_sol`` is mutated in
+                # place, so the loop's own later iteration over the target
+                # slot picks up the boosted value, re-derives its charger
+                # command from it, and re-subjects it to this same floor
+                # check.  The grid-balance correction below mirrors the
+                # discard formula (net_grid = import - export ± ac_load),
+                # since the extra draw at the target slot wasn't accounted
+                # for by the original MILP-level grid-balance write-out.
+                remaining_dc = ev_dc_kwh
+                if deadline_lp_limit is not None:
+                    for lp_t2 in range(lp_t + 1, deadline_lp_limit + 1):
+                        if remaining_dc <= 1e-9:
+                            break
+                        headroom_dc = max(
+                            ev.max_charge_per_slot - float(ev_c_sol[lp_t2]), 0.0
+                        )
+                        if headroom_dc <= 1e-9:
+                            continue
+                        take_dc = min(headroom_dc, remaining_dc)
+                        ev_c_sol[lp_t2] += take_dc
+                        take_ac = ev_dc_to_ac_kwh(take_dc, ev.charger_efficiency)
+                        target_slot_i = future_idx[lp_t2]
+                        target_net_grid = (
+                            out_slots[target_slot_i].grid_import_kwh
+                            - out_slots[target_slot_i].grid_export_kwh
+                            + take_ac
+                        )
+                        out_slots[target_slot_i].grid_import_kwh = round(
+                            max(target_net_grid, 0.0), 3
+                        )
+                        out_slots[target_slot_i].grid_export_kwh = round(
+                            max(-target_net_grid, 0.0), 3
+                        )
+                        remaining_dc -= take_dc
                 # The charger cannot execute this fragment. Remove its
                 # energy and grid flow instead of publishing energy with a
-                # zero command.
+                # zero command.  (Whatever was placed forward above is now
+                # counted at its new slot instead, so this slot's own
+                # contribution must still go to zero either way.)
                 if ev.base_load_includes_ev:
                     out_slots[slot_i].ev_accounted_load_kwh = round(
                         max(out_slots[slot_i].ev_accounted_load_kwh - ac_load, 0.0),

--- a/custom_components/hsem/planner/milp/_objective.py
+++ b/custom_components/hsem/planner/milp/_objective.py
@@ -27,6 +27,12 @@ _BATTERY_EXPORT_SOURCE_TIEBREAK = 1e-7
 # smallest executable whole-amp energy above the target (issue #797).
 _EV_TARGET_ENERGY_TIEBREAK_COST = 1e-7
 
+# When even max-power charging can't reach the margined deadline target
+# (EVConfig.deadline_escalated), steepen the deadline penalty so the LP
+# treats closing the gap as more urgent than its already-high baseline
+# priority (issue #845).
+_EV_DEADLINE_ESCALATION_PENALTY_MULTIPLIER = 5.0
+
 
 def _build_objective(
     slots: list[PlannedSlot],
@@ -222,8 +228,10 @@ def _build_objective(
             # executable (whole-amp) energy that clears the target-cap
             # constraint, rather than leaving it indifferent among
             # cost-equivalent solutions above the target.
-            energy_needed = ev.target_kwh - ev.initial_soc_kwh
+            energy_needed = ev.effective_deadline_target_kwh - ev.initial_soc_kwh
             ev_penalty_cost = max(p_imp_max, 0.1) * max(energy_needed, 1.0) * 10.0
+            if ev.deadline_escalated:
+                ev_penalty_cost *= _EV_DEADLINE_ESCALATION_PENALTY_MULTIPLIER
             c_obj[ev_pen_offsets[ev_idx]] = ev_penalty_cost
 
             ev_off = ev_var_offsets[ev_idx]

--- a/custom_components/hsem/planner/milp/_write_results.py
+++ b/custom_components/hsem/planner/milp/_write_results.py
@@ -113,7 +113,9 @@ def _write_milp_results_to_slots(
                     np.sum(values[: max(0, min(ev.deadline_slot, m - 1)) + 1])
                 )
             deadline_penalty = max(
-                ev.target_kwh - ev.initial_soc_kwh - delivered_by_deadline,
+                ev.effective_deadline_target_kwh
+                - ev.initial_soc_kwh
+                - delivered_by_deadline,
                 0.0,
             )
             ev_writeback_diagnostics[f"ev{ev_idx}"] = {
@@ -137,7 +139,9 @@ def _write_milp_results_to_slots(
                     np.sum(values[: max(0, min(ev.deadline_slot, m - 1)) + 1])
                 )
             deadline_penalty = max(
-                ev.target_kwh - ev.initial_soc_kwh - delivered_by_deadline,
+                ev.effective_deadline_target_kwh
+                - ev.initial_soc_kwh
+                - delivered_by_deadline,
                 0.0,
             )
             ev_writeback_diagnostics[key] = {

--- a/custom_components/hsem/translations/da.json
+++ b/custom_components/hsem/translations/da.json
@@ -46,14 +46,16 @@
           "hsem_ev_planned_load_battery_capacity_kwh": "EV batterikapacitet (kWh)",
           "hsem_ev_planned_load_charger_power_kw": "EV lader-effekt (kW)",
           "hsem_ev_planned_load_charger_efficiency": "EV lader-efficiens",
-          "hsem_ev_planned_load_charger_min_power_w": "EV lader minimumseffekt (W)"
+          "hsem_ev_planned_load_charger_min_power_w": "EV lader minimumseffekt (W)",
+          "hsem_ev_planned_load_deadline_safety_margin_pct": "Sikkerhedsmargin til deadline (%)"
         },
         "data_description": {
           "hsem_ev_planned_load_enabled": "Aktiver eller deaktiver planlagt EV-opladningsbelastningsintegration.",
           "hsem_ev_planned_load_battery_capacity_kwh": "EV-batteriets nominelle kapacitet i kWh.",
           "hsem_ev_planned_load_charger_power_kw": "AC-udgangseffekt for EV-laderen i kW.",
           "hsem_ev_planned_load_charger_efficiency": "Laderefficiens i procent (1-100). Standard: 100.",
-          "hsem_ev_planned_load_charger_min_power_w": "Minimum AC-effekt (W) som EV-laderen skal bruge for at starte opladning. Under dette niveau vil laderen ikke fungere. Standard: 1380 W (230 V × 6 A)."
+          "hsem_ev_planned_load_charger_min_power_w": "Minimum AC-effekt (W) som EV-laderen skal bruge for at starte opladning. Under dette niveau vil laderen ikke fungere. Standard: 1380 W (230 V × 6 A).",
+          "hsem_ev_planned_load_deadline_safety_margin_pct": "Ekstra energi budgetteret ud over mål-SoC, som en procentdel af manglen, så normal opladningsfriktion (startforsinkelser, minimumseffektgrænser, gennemtvinget reduktion) ikke får deadline til at blive overskredet. Standard: 0% (deaktiveret)."
         },
         "description": "Konfigurer valgfri planlagt EV-opladningsbelastningsintegration. Når aktiveret, tager HSEM højde for kommende EV-opladningsbehov pr. planslot.",
         "title": "EV-planlagt belastningsintegration"
@@ -64,14 +66,16 @@
           "hsem_ev_second_planned_load_battery_capacity_kwh": "EV 2 batterikapacitet (kWh)",
           "hsem_ev_second_planned_load_charger_power_kw": "EV 2 lader-effekt (kW)",
           "hsem_ev_second_planned_load_charger_efficiency": "EV 2 lader-efficiens",
-          "hsem_ev_second_planned_load_charger_min_power_w": "EV 2 lader minimumseffekt (W)"
+          "hsem_ev_second_planned_load_charger_min_power_w": "EV 2 lader minimumseffekt (W)",
+          "hsem_ev_second_planned_load_deadline_safety_margin_pct": "EV 2 sikkerhedsmargin til deadline (%)"
         },
         "data_description": {
           "hsem_ev_second_planned_load_enabled": "Aktiver eller deaktiver planlagt opladningsbelastningsintegration for den anden EV.",
           "hsem_ev_second_planned_load_battery_capacity_kwh": "Nominel batterikapacitet for den anden EV i kWh.",
           "hsem_ev_second_planned_load_charger_power_kw": "AC-udgangseffekt for den anden EV-lader i kW.",
           "hsem_ev_second_planned_load_charger_efficiency": "Anden EV-lader-efficiens i procent (1-100). Standard: 100.",
-          "hsem_ev_second_planned_load_charger_min_power_w": "Minimum AC-effekt (W) som den anden EV-lader skal bruge for at starte opladning. Standard: 1380 W (230 V × 6 A)."
+          "hsem_ev_second_planned_load_charger_min_power_w": "Minimum AC-effekt (W) som den anden EV-lader skal bruge for at starte opladning. Standard: 1380 W (230 V × 6 A).",
+          "hsem_ev_second_planned_load_deadline_safety_margin_pct": "Samme som den primære EVs sikkerhedsmargin til deadline, for den anden EV. Standard: 0% (deaktiveret)."
         },
         "description": "Konfigurer valgfri planlagt opladningsbelastningsintegration for den anden EV. Vises kun, når en anden EV-lader er aktiveret.",
         "title": "EV 2-planlagt belastningsintegration"
@@ -571,14 +575,16 @@
           "hsem_ev_second_planned_load_battery_capacity_kwh": "EV 2 batterikapacitet (kWh)",
           "hsem_ev_second_planned_load_charger_power_kw": "EV 2 lader-effekt (kW)",
           "hsem_ev_second_planned_load_charger_efficiency": "EV 2 lader-efficiens",
-          "hsem_ev_second_planned_load_charger_min_power_w": "EV 2 lader minimumseffekt (W)"
+          "hsem_ev_second_planned_load_charger_min_power_w": "EV 2 lader minimumseffekt (W)",
+          "hsem_ev_second_planned_load_deadline_safety_margin_pct": "EV 2 sikkerhedsmargin til deadline (%)"
         },
         "data_description": {
           "hsem_ev_second_planned_load_enabled": "Aktiver eller deaktiver planlagt opladningsbelastningsintegration for den anden EV.",
           "hsem_ev_second_planned_load_battery_capacity_kwh": "Nominel batterikapacitet for den anden EV i kWh.",
           "hsem_ev_second_planned_load_charger_power_kw": "AC-udgangseffekt for den anden EV-lader i kW.",
           "hsem_ev_second_planned_load_charger_efficiency": "Anden EV-lader-efficiens i procent (1-100). Standard: 100.",
-          "hsem_ev_second_planned_load_charger_min_power_w": "Minimum AC-effekt (W) som den anden EV-lader skal bruge for at starte opladning. Standard: 1380 W (230 V × 6 A)."
+          "hsem_ev_second_planned_load_charger_min_power_w": "Minimum AC-effekt (W) som den anden EV-lader skal bruge for at starte opladning. Standard: 1380 W (230 V × 6 A).",
+          "hsem_ev_second_planned_load_deadline_safety_margin_pct": "Samme som den primære EVs sikkerhedsmargin til deadline, for den anden EV. Standard: 0% (deaktiveret)."
         },
         "description": "Konfigurer valgfri planlagt opladningsbelastningsintegration for den anden EV. Vises kun, når en anden EV-lader er aktiveret.",
         "title": "EV 2-planlagt belastningsintegration"

--- a/custom_components/hsem/translations/en.json
+++ b/custom_components/hsem/translations/en.json
@@ -51,7 +51,8 @@
           "hsem_ev_planned_load_charger_power_kw": "EV Charger Power (kW)",
           "hsem_ev_planned_load_charger_efficiency": "EV Charger Efficiency",
           "hsem_ev_planned_load_charger_min_power_w": "EV Charger Minimum Power (W)",
-          "hsem_ev_planned_load_charger_phase_topology": "Charger phase topology"
+          "hsem_ev_planned_load_charger_phase_topology": "Charger phase topology",
+          "hsem_ev_planned_load_deadline_safety_margin_pct": "Deadline Safety Margin (%)"
         },
         "data_description": {
           "hsem_ev_planned_load_enabled": "Enable or disable planned EV charging load integration.",
@@ -59,7 +60,8 @@
           "hsem_ev_planned_load_charger_power_kw": "AC output power of the EV charger in kW.",
           "hsem_ev_planned_load_charger_efficiency": "Charger efficiency as a percentage (1-100). Default: 100.",
           "hsem_ev_planned_load_charger_min_power_w": "Minimum AC power (W) the EV charger needs to start charging. Below this the charger will not operate. Default: 1380 W (230 V × 6 A).",
-          "hsem_ev_planned_load_charger_phase_topology": "How the charger distributes its load across the mains phases. Choose 'Single-phase or unknown' unless you have confirmed the charger draws balanced current on all three phases. With per-phase fuse protection enabled, the safe default assumes the entire charger command can land on one phase, which limits planned charging to the single-phase fuse headroom."
+          "hsem_ev_planned_load_charger_phase_topology": "How the charger distributes its load across the mains phases. Choose 'Single-phase or unknown' unless you have confirmed the charger draws balanced current on all three phases. With per-phase fuse protection enabled, the safe default assumes the entire charger command can land on one phase, which limits planned charging to the single-phase fuse headroom.",
+          "hsem_ev_planned_load_deadline_safety_margin_pct": "Extra energy budgeted above the target SoC, as a percentage of the shortfall, so normal charging friction (start delays, minimum-power floors, throttling) doesn't cause the deadline to be missed. Default: 0% (disabled)."
         },
         "description": "Configure optional planned EV charging load integration. When enabled, HSEM accounts for upcoming EV charging demand per planner slot.",
         "title": "EV Planned Load Integration"
@@ -71,7 +73,8 @@
           "hsem_ev_second_planned_load_charger_power_kw": "EV 2 Charger Power (kW)",
           "hsem_ev_second_planned_load_charger_efficiency": "EV 2 Charger Efficiency",
           "hsem_ev_second_planned_load_charger_min_power_w": "EV 2 Charger Minimum Power (W)",
-          "hsem_ev_second_planned_load_charger_phase_topology": "Charger phase topology"
+          "hsem_ev_second_planned_load_charger_phase_topology": "Charger phase topology",
+          "hsem_ev_second_planned_load_deadline_safety_margin_pct": "EV 2 Deadline Safety Margin (%)"
         },
         "data_description": {
           "hsem_ev_second_planned_load_enabled": "Enable or disable planned charging load integration for the second EV.",
@@ -79,7 +82,8 @@
           "hsem_ev_second_planned_load_charger_power_kw": "AC output power of the second EV charger in kW.",
           "hsem_ev_second_planned_load_charger_efficiency": "Second EV charger efficiency as a percentage (1-100). Default: 100.",
           "hsem_ev_second_planned_load_charger_min_power_w": "Minimum AC power (W) the second EV charger needs to start charging. Default: 1380 W (230 V × 6 A).",
-          "hsem_ev_second_planned_load_charger_phase_topology": "How the charger distributes its load across the mains phases. Choose 'Single-phase or unknown' unless you have confirmed the charger draws balanced current on all three phases. With per-phase fuse protection enabled, the safe default assumes the entire charger command can land on one phase, which limits planned charging to the single-phase fuse headroom."
+          "hsem_ev_second_planned_load_charger_phase_topology": "How the charger distributes its load across the mains phases. Choose 'Single-phase or unknown' unless you have confirmed the charger draws balanced current on all three phases. With per-phase fuse protection enabled, the safe default assumes the entire charger command can land on one phase, which limits planned charging to the single-phase fuse headroom.",
+          "hsem_ev_second_planned_load_deadline_safety_margin_pct": "Same as the primary EV's deadline safety margin, for the second EV. Default: 0% (disabled)."
         },
         "description": "Configure optional planned charging load integration for the second EV. Only shown when a second EV charger is enabled.",
         "title": "EV 2 Planned Load Integration"
@@ -566,7 +570,8 @@
           "hsem_ev_planned_load_charger_power_kw": "EV Charger Power (kW)",
           "hsem_ev_planned_load_charger_efficiency": "EV Charger Efficiency",
           "hsem_ev_planned_load_charger_min_power_w": "EV Charger Minimum Power (W)",
-          "hsem_ev_planned_load_charger_phase_topology": "Charger phase topology"
+          "hsem_ev_planned_load_charger_phase_topology": "Charger phase topology",
+          "hsem_ev_planned_load_deadline_safety_margin_pct": "Deadline Safety Margin (%)"
         },
         "data_description": {
           "hsem_ev_planned_load_enabled": "Enable or disable planned EV charging load integration.",
@@ -574,7 +579,8 @@
           "hsem_ev_planned_load_charger_power_kw": "AC output power of the EV charger in kW.",
           "hsem_ev_planned_load_charger_efficiency": "Charger efficiency as a percentage (1-100). Default: 100.",
           "hsem_ev_planned_load_charger_min_power_w": "Minimum AC power (W) the EV charger needs to start charging. Below this the charger will not operate. Default: 1380 W (230 V × 6 A).",
-          "hsem_ev_planned_load_charger_phase_topology": "How the charger distributes its load across the mains phases. Choose 'Single-phase or unknown' unless you have confirmed the charger draws balanced current on all three phases. With per-phase fuse protection enabled, the safe default assumes the entire charger command can land on one phase, which limits planned charging to the single-phase fuse headroom."
+          "hsem_ev_planned_load_charger_phase_topology": "How the charger distributes its load across the mains phases. Choose 'Single-phase or unknown' unless you have confirmed the charger draws balanced current on all three phases. With per-phase fuse protection enabled, the safe default assumes the entire charger command can land on one phase, which limits planned charging to the single-phase fuse headroom.",
+          "hsem_ev_planned_load_deadline_safety_margin_pct": "Extra energy budgeted above the target SoC, as a percentage of the shortfall, so normal charging friction (start delays, minimum-power floors, throttling) doesn't cause the deadline to be missed. Default: 0% (disabled)."
         },
         "description": "Configure optional planned EV charging load integration. When enabled, HSEM accounts for upcoming EV charging demand per planner slot.",
         "title": "EV Planned Load Integration"
@@ -586,7 +592,8 @@
           "hsem_ev_second_planned_load_charger_power_kw": "EV 2 Charger Power (kW)",
           "hsem_ev_second_planned_load_charger_efficiency": "EV 2 Charger Efficiency",
           "hsem_ev_second_planned_load_charger_min_power_w": "EV 2 Charger Minimum Power (W)",
-          "hsem_ev_second_planned_load_charger_phase_topology": "Charger phase topology"
+          "hsem_ev_second_planned_load_charger_phase_topology": "Charger phase topology",
+          "hsem_ev_second_planned_load_deadline_safety_margin_pct": "EV 2 Deadline Safety Margin (%)"
         },
         "data_description": {
           "hsem_ev_second_planned_load_enabled": "Enable or disable planned charging load integration for the second EV.",
@@ -594,7 +601,8 @@
           "hsem_ev_second_planned_load_charger_power_kw": "AC output power of the second EV charger in kW.",
           "hsem_ev_second_planned_load_charger_efficiency": "Second EV charger efficiency as a percentage (1-100). Default: 100.",
           "hsem_ev_second_planned_load_charger_min_power_w": "Minimum AC power (W) the second EV charger needs to start charging. Default: 1380 W (230 V × 6 A).",
-          "hsem_ev_second_planned_load_charger_phase_topology": "How the charger distributes its load across the mains phases. Choose 'Single-phase or unknown' unless you have confirmed the charger draws balanced current on all three phases. With per-phase fuse protection enabled, the safe default assumes the entire charger command can land on one phase, which limits planned charging to the single-phase fuse headroom."
+          "hsem_ev_second_planned_load_charger_phase_topology": "How the charger distributes its load across the mains phases. Choose 'Single-phase or unknown' unless you have confirmed the charger draws balanced current on all three phases. With per-phase fuse protection enabled, the safe default assumes the entire charger command can land on one phase, which limits planned charging to the single-phase fuse headroom.",
+          "hsem_ev_second_planned_load_deadline_safety_margin_pct": "Same as the primary EV's deadline safety margin, for the second EV. Default: 0% (disabled)."
         },
         "description": "Configure optional planned charging load integration for the second EV. Only shown when a second EV charger is enabled.",
         "title": "EV 2 Planned Load Integration"

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -624,7 +624,9 @@ the MILP decides **when and how much each EV charges**.
 **EV variables** (per active EV):
 - `ev_c[t]` — DC-side energy delivered to the EV battery in slot `t` (kWh).
   Bounded by `[0, ev.max_charge_per_slot]`.
-- `ev_pen` — single slack variable absorbing unmet deadline target (kWh).
+- `ev_pen` — single slack variable absorbing unmet deadline target (kWh),
+  measured against the margined target (see *Deadline safety margin and
+  escalation* below).
 - `ev_amps[t]` — solver-native whole-amp charger command for a **managed**
   EV (not `fixed_session_only`), semi-integer (HiGHS type 3): either `0` or
   an integer in `[min_amp, rated_amp]` (issue #797).  Linked to `ev_c[t]` by
@@ -639,22 +641,25 @@ the MILP decides **when and how much each EV charges**.
 - SOC dynamics (cumulative, no discharge):
   `ev_soc[t] = ev_initial + Σ_{k≤t} ev_c[k]`
 - SOC upper bound per slot: `ev_soc[t] ≤ ev_capacity`
-- Deadline soft goal: `ev_soc[D] + ev_pen ≥ ev_target` where `D` is the
-  LP-slot index of the effective deadline.
+- Deadline soft goal: `ev_soc[D] + ev_pen ≥ effective_target` where `D` is
+  the LP-slot index of the effective deadline and `effective_target` is
+  `ev_target` plus the configured safety margin (see below).
 - **Post-deadline zero-charge**: For EVs with a deadline and `charge_past_target=False`,
   `ev_c[t] = 0` for all `t > D`. This prevents charging after the deadline.
-- **Target-cap constraint** (issue #636, relaxed by issue #797): For EVs
-  with a deadline and `charge_past_target=False`, a hard upper bound caps
-  cumulative pre-deadline charge near the economic shortfall:
-  `Σ_{k≤D} ev_c[k] ≤ target_kwh − initial_soc_kwh + activation_quantum`.
-  `activation_quantum` is the largest single-slot energy the EV's charger
-  startup minimum could deliver across the pre-deadline slots — the
-  smallest amount whole-amp hardware might have to overshoot by when no
-  executable point lands exactly on the target.  Without this relaxation, a
-  target with no exact whole-amp solution reports an avoidable deadline
-  miss even though the nearest reachable whole-amp point is one activation
-  quantum away.  `charge_past_target=True` still uses its own surplus-only
-  mechanism instead.
+- **Target-cap constraint** (issue #636, relaxed by issue #797, margin/escalation
+  added by issue #845): For EVs with a deadline and `charge_past_target=False`,
+  a hard upper bound caps cumulative pre-deadline charge near the economic
+  shortfall:
+  `Σ_{k≤D} ev_c[k] ≤ cap_target − initial_soc_kwh + activation_quantum`, where
+  `cap_target` is `effective_target` normally, or `capacity_kwh` when the EV
+  is *deadline-escalated* (see below). `activation_quantum` is the largest
+  single-slot energy the EV's charger startup minimum could deliver across
+  the pre-deadline slots — the smallest amount whole-amp hardware might have
+  to overshoot by when no executable point lands exactly on the target.
+  Without this relaxation, a target with no exact whole-amp solution reports
+  an avoidable deadline miss even though the nearest reachable whole-amp
+  point is one activation quantum away.  `charge_past_target=True` still uses
+  its own surplus-only mechanism instead.
 - **Surplus-only for charge-past-target**: When `charge_past_target=True`,
   `ev_c[t]/η_charger ≤ max(0, pv[t] − base_load[t])` — charging only from PV surplus.
 - **Battery-first for charge-past-target (issue #775)**: When `charge_past_target=True`,
@@ -673,11 +678,48 @@ gi + pv + ed·η_dis = base_load + ec/η_chg + ge + Σ ev_c/eff
 where `base_load` is recomputed **without** pre-computed EV planned loads
 (only house consumption minus PV).
 
+**Deadline safety margin and escalation** (issue #845): the exact-target
+design above (target-cap capped precisely at the computed shortfall) leaves
+zero slack for execution-layer friction — OCPP anti-flap start/stop windows,
+the charger minimum-power floor, and Huawei phase-headroom/discharge-permission
+throttling can all silently shave delivered energy off an already-tight plan,
+turning an on-paper-exact plan into a missed deadline. Two mechanisms address
+this, both computed on `EVConfig` and re-evaluated fresh on every solve (no
+persistent trajectory state):
+- `effective_deadline_target_kwh = min(target_kwh + deadline_margin_kwh, capacity_kwh)`.
+  `deadline_margin_kwh` is supplied by the caller as a configured percentage
+  of the shortfall (`hsem_ev_planned_load_deadline_safety_margin_pct`,
+  default 0%, disabled — opt in via config; 0% reproduces the pre-#845
+  exact-target behaviour exactly). This is
+  the target the deadline soft-goal and target-cap constraint actually aim
+  for; `target_kwh` itself is untouched everywhere else, so `deadline_met`
+  in diagnostics (`ev_pen < 1e-6`) now certifies the strictly stronger
+  "target + margin was met" outcome.
+- `deadline_escalated` — `True` when even max-power charging for every
+  remaining pre-deadline slot can't reach `effective_deadline_target_kwh`
+  (`initial_soc_kwh + max_charge_per_slot × (deadline_slot + 1) < effective_deadline_target_kwh`).
+  When escalated, the target-cap's `cap_target` lifts all the way to
+  `capacity_kwh` (the margin itself is no longer achievable, so the solver
+  is freed to charge as much as physically possible instead of staying
+  artificially capped below full capacity), and the deadline penalty
+  (below) is multiplied by `_EV_DEADLINE_ESCALATION_PENALTY_MULTIPLIER = 5.0`.
+
+A dedicated coordinator trigger, `_ev_deadline_pacing_requires_replan`
+(`coordinator_ev_deadline_pacing.py`), forces a prompt out-of-cycle replan as
+soon as an EV's live SoC makes the margined target unreachable at max
+charger power, gated by a minimum cadence (`EV_DEADLINE_PACING_REPLAN_MIN_SECONDS`,
+120s) so escalation doesn't have to wait for an unrelated trigger (slot
+boundary, EV state change, live-power drift) to force the next solve.
+
 **Objective** includes a high-cost deadline penalty:
 ```text
 ev_penalty_cost = max(p_imp) * max(energy_needed, 1.0) * 10
+if ev.deadline_escalated:
+    ev_penalty_cost *= 5.0
 ```
-ensuring the MILP always prefers meeting the target when physically possible.
+where `energy_needed = effective_deadline_target_kwh − initial_soc_kwh`,
+ensuring the MILP always prefers meeting the (margined, possibly escalated)
+target when physically possible.
 
 **Pre-deadline slots** (`t ≤ D`, issue #797): `ev_c[t]` receives **no** direct
 per-kWh benefit coefficient.  The slack penalty alone already prices meeting
@@ -801,14 +843,26 @@ revenue the optimiser forbade.
 - EV charge per slot never exceeds `ev.max_charge_per_slot`.
 - Cumulative EV SoC never exceeds `ev.capacity_kwh`.
 - For EVs with a deadline and `charge_past_target=False`, cumulative
-  pre-deadline charge `Σ_{k≤D} ev_c[k]` never exceeds `target_kwh − initial_soc_kwh`.
-- When `ev.deadline_slot` is provided and the target is reachable, the
-  deadline penalty `ev_pen` is zero.
+  pre-deadline charge `Σ_{k≤D} ev_c[k]` never exceeds
+  `effective_deadline_target_kwh − initial_soc_kwh` (issue #845), or
+  `capacity_kwh − initial_soc_kwh` when `deadline_escalated` is `True`.
+- `deadline_margin_kwh = 0.0` reproduces the pre-#845 exact-target
+  behaviour exactly (`effective_deadline_target_kwh == target_kwh`).
+- When `ev.deadline_slot` is provided and the margined target is reachable,
+  the deadline penalty `ev_pen` is zero.
 - When the target is unreachable within the available slots, `ev_pen > 0`
   absorbs the shortfall — the MILP never becomes infeasible due to EV
-  constraints.
+  constraints. When `deadline_escalated` is `True`, `ev_penalty_cost` is
+  multiplied by `_EV_DEADLINE_ESCALATION_PENALTY_MULTIPLIER` (5.0).
 - EV diagnostics (total DC kWh delivered, deadline penalty, deadline met)
-  are included in the diagnostics dict under the `"ev"` key.
+  are included in the diagnostics dict under the `"ev"` key; `deadline_met`
+  now certifies meeting `target_kwh + deadline_margin_kwh` (or
+  `capacity_kwh` under escalation), a strictly stronger guarantee than the
+  bare `target_kwh` it certified before issue #845.
+- A write-out slot dropped for falling below `charger_min_power_w` is
+  first redistributed forward onto a later pre-deadline slot with
+  headroom (`planner/milp/_ev_power_writeout.py`, issue #845); only the
+  portion that cannot be placed anywhere is discarded.
 
 ### MILP decision priority
 
@@ -852,7 +906,9 @@ has zero cost.  The LP always uses available PV to cover house load first.
 When the EV is **below target SoC** with a deadline approaching:
 
 - Penalty: `max(p_imp) × max(energy_needed, 1.0) × 10` per kWh shortfall
-- Constraint: `initial_soc + Σ ev_c + penalty ≥ target`
+  against the margined target (`energy_needed = effective_deadline_target_kwh
+  − initial_soc_kwh`), multiplied by 5 when `deadline_escalated` (issue #845).
+- Constraint: `initial_soc + Σ ev_c + penalty ≥ effective_deadline_target_kwh`
 - **Pre-deadline benefit**: Each slot `t ≤ D` gets coefficient `-ev_penalty_cost`
   on `ev_c[t]`, so the LP always prefers charging over paying the penalty.
 - This penalty dominates everything — the LP will import at high prices

--- a/tests/models/test_ev_config.py
+++ b/tests/models/test_ev_config.py
@@ -1,0 +1,72 @@
+"""Tests for EVConfig deadline safety margin / escalation properties (issue #845)."""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.hsem.models.ev_config import EVConfig
+
+
+def test_effective_deadline_target_kwh_adds_margin() -> None:
+    """The effective target adds the configured margin on top of target_kwh."""
+    ev = EVConfig(
+        initial_soc_kwh=50.0,
+        target_kwh=55.0,
+        capacity_kwh=80.0,
+        deadline_margin_kwh=0.5,
+        deadline_slot=9,
+        max_charge_per_slot=10.0,
+    )
+    assert ev.effective_deadline_target_kwh == pytest.approx(55.5)
+
+
+def test_effective_deadline_target_kwh_capped_at_capacity() -> None:
+    """The margined target never exceeds the EV's nameplate capacity."""
+    ev = EVConfig(
+        initial_soc_kwh=50.0,
+        target_kwh=55.0,
+        capacity_kwh=57.0,
+        deadline_margin_kwh=10.0,  # would overshoot capacity without the cap
+        deadline_slot=9,
+        max_charge_per_slot=10.0,
+    )
+    assert ev.effective_deadline_target_kwh == pytest.approx(57.0)
+
+
+def test_deadline_escalated_false_without_deadline() -> None:
+    """No deadline means no escalation, regardless of margin/reachability."""
+    ev = EVConfig(
+        initial_soc_kwh=0.0,
+        target_kwh=50.0,
+        capacity_kwh=60.0,
+        deadline_margin_kwh=5.0,
+        deadline_slot=None,
+        max_charge_per_slot=1.0,
+    )
+    assert ev.deadline_escalated is False
+
+
+def test_deadline_escalated_false_when_reachable() -> None:
+    """Max-power charging over the remaining slots comfortably reaches the margined target."""
+    ev = EVConfig(
+        initial_soc_kwh=50.0,
+        target_kwh=55.0,
+        capacity_kwh=80.0,
+        deadline_margin_kwh=0.5,
+        deadline_slot=9,  # 10 slots
+        max_charge_per_slot=10.0,  # 100 kWh reachable, far above 55.5
+    )
+    assert ev.deadline_escalated is False
+
+
+def test_deadline_escalated_true_when_unreachable_at_max_power() -> None:
+    """Even max-power charging can't reach the margined target before the deadline."""
+    ev = EVConfig(
+        initial_soc_kwh=10.0,
+        target_kwh=50.0,  # shortfall 40
+        capacity_kwh=80.0,
+        deadline_margin_kwh=4.0,  # effective target 54
+        deadline_slot=3,  # 4 slots
+        max_charge_per_slot=10.0,  # reachable = 10 + 10*4 = 50 < 54
+    )
+    assert ev.deadline_escalated is True

--- a/tests/planner/test_ev_power_writeout.py
+++ b/tests/planner/test_ev_power_writeout.py
@@ -1,0 +1,127 @@
+"""Tests for EV write-out below-minimum-power forward redistribution (issue #845).
+
+Before this fix, a slot whose derived AC power fell below
+``charger_min_power_w`` had its energy silently discarded. Now that energy
+is first offered to later pre-deadline slots with headroom.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import numpy as np
+import pytest
+
+from custom_components.hsem.models.ev_config import EVConfig
+from custom_components.hsem.models.planned_slot import PlannedSlot
+from custom_components.hsem.planner.milp._ev_power_writeout import (
+    _write_ev_power_fields_to_slots,
+)
+
+_TZ = ZoneInfo("Europe/Copenhagen")
+
+
+def _make_out_slots(n: int, start: datetime) -> list[PlannedSlot]:
+    slots = []
+    for i in range(n):
+        s = PlannedSlot(
+            start=start + timedelta(hours=i), end=start + timedelta(hours=i + 1)
+        )
+        slots.append(s)
+    return slots
+
+
+def test_below_minimum_power_slot_redistributed_forward() -> None:
+    """A below-minimum-power slot moves its energy to the next slot with headroom.
+
+    Slot 0 has a tiny 0.1 kWh fragment (100 W over a 1h slot, below the
+    1380 W default minimum). Slot 1 already has 4.9 kWh solved (out of a
+    5.0 kWh/slot cap), leaving exactly 0.1 kWh of headroom — enough to
+    absorb slot 0's fragment in full instead of discarding it.
+    """
+    now = datetime(2024, 6, 15, 12, 0, tzinfo=_TZ)
+    start = datetime(2024, 6, 15, 14, 0, tzinfo=_TZ)  # all slots are future
+    out_slots = _make_out_slots(3, start)
+    future_idx = [0, 1, 2]
+    m = 3
+
+    ev = EVConfig(
+        enabled=True,
+        initial_soc_kwh=10.0,
+        target_kwh=20.0,
+        capacity_kwh=50.0,
+        max_charge_per_slot=5.0,
+        charger_efficiency=1.0,
+        charger_min_power_w=1380.0,
+        deadline_slot=2,
+    )
+
+    executable_x = np.array([0.1, 4.9, 0.0])
+
+    _write_ev_power_fields_to_slots(
+        out_slots,
+        future_idx,
+        now,
+        executable_x,
+        m,
+        1.0,  # full_slot_hours
+        [ev],
+        [0],  # ev_var_offsets
+        1e-4,
+    )
+
+    # Slot 0's fragment was moved forward, not delivered locally.
+    assert out_slots[0].ev_total_planned_load_kwh == pytest.approx(0.0)
+    assert out_slots[0].ev_charger_calculated_power == pytest.approx(0.0)
+
+    # Slot 1 absorbed the full 5.0 kWh (4.9 solved + 0.1 redistributed).
+    assert out_slots[1].ev_total_planned_load_kwh == pytest.approx(5.0)
+    assert out_slots[1].ev_charger_calculated_power == pytest.approx(5000.0)
+
+    # Total EV energy delivered across the plan is conserved (5.0 kWh),
+    # not silently reduced by the dropped fragment.
+    total = sum(s.ev_total_planned_load_kwh for s in out_slots)
+    assert total == pytest.approx(5.0)
+
+
+def test_below_minimum_power_slot_discarded_when_no_headroom_anywhere() -> None:
+    """Falls back to today's discard behavior when nothing has headroom."""
+    now = datetime(2024, 6, 15, 12, 0, tzinfo=_TZ)
+    start = datetime(2024, 6, 15, 14, 0, tzinfo=_TZ)
+    out_slots = _make_out_slots(2, start)
+    future_idx = [0, 1]
+    m = 2
+
+    ev = EVConfig(
+        enabled=True,
+        initial_soc_kwh=10.0,
+        target_kwh=20.0,
+        capacity_kwh=50.0,
+        max_charge_per_slot=5.0,
+        charger_efficiency=1.0,
+        charger_min_power_w=1380.0,
+        deadline_slot=1,
+    )
+
+    # Slot 1 is already at its per-slot cap — no headroom to absorb slot 0.
+    executable_x = np.array([0.1, 5.0])
+    initial_import = 3.0
+    out_slots[0].grid_import_kwh = initial_import
+
+    _write_ev_power_fields_to_slots(
+        out_slots,
+        future_idx,
+        now,
+        executable_x,
+        m,
+        1.0,
+        [ev],
+        [0],
+        1e-4,
+    )
+
+    assert out_slots[0].ev_total_planned_load_kwh == pytest.approx(0.0)
+    assert out_slots[1].ev_total_planned_load_kwh == pytest.approx(5.0)
+    # Discarded energy reduces the donor slot's grid import, as before.
+    assert out_slots[0].grid_import_kwh == pytest.approx(initial_import - 0.1)

--- a/tests/planner/test_milp_ev.py
+++ b/tests/planner/test_milp_ev.py
@@ -921,6 +921,7 @@ def test_ev_target_capped_not_to_capacity():
         max_charge_per_slot=10.0,
         charger_efficiency=0.90,
         deadline_slot=9,
+        deadline_margin_kwh=0.0,  # exact-target behavior, no safety margin (issue #845)
     )
 
     result = solve_milp(
@@ -963,6 +964,7 @@ def test_ev_target_capped_large_reachable_shortfall():
         max_charge_per_slot=10.0,
         charger_efficiency=0.90,
         deadline_slot=5,  # slots 0-5 = 6 slots, 6*10 = 60 kWh max
+        deadline_margin_kwh=0.0,  # exact-target behavior, no safety margin (issue #845)
     )
 
     result = solve_milp(
@@ -985,6 +987,136 @@ def test_ev_target_capped_large_reachable_shortfall():
     assert ev_total_dc == pytest.approx(40.0, rel=0.05), (
         f"Expected ~40 kWh DC (target shortfall), got {ev_total_dc}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Deadline safety margin and escalation (issue #845)
+# ---------------------------------------------------------------------------
+
+
+@_pytestmark_scipy
+def test_ev_charges_to_margined_target_not_bare_target():
+    """A configured safety margin is charged on top of the bare target.
+
+    EV at 50/80 kWh needs +5 kWh to reach the 55 kWh target, plus a 0.5 kWh
+    safety margin (10% of the 5 kWh shortfall). Total DC charge should land
+    at ~5.5 kWh, not the bare 5 kWh shortfall.
+    """
+    slots = _build_slots(10, start_hour=14, import_price=3.00)
+    ev = EVConfig(
+        enabled=True,
+        initial_soc_kwh=50.0,
+        target_kwh=55.0,
+        capacity_kwh=80.0,
+        max_charge_per_slot=10.0,
+        charger_efficiency=0.90,
+        deadline_slot=9,
+        deadline_margin_kwh=0.5,
+    )
+
+    result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=0.0,
+        usable_kwh=0.001,
+        max_charge_per_slot=0.001,
+        max_discharge_per_slot=None,
+        ev_configs=[ev],
+    )
+
+    assert result is not None
+    out_slots, _diag = result
+
+    ev_total_dc = sum(s.ev_total_planned_load_kwh * 0.9 for s in out_slots)
+    assert ev_total_dc == pytest.approx(5.5, rel=0.05), (
+        f"Expected ~5.5 kWh DC (shortfall + margin), got {ev_total_dc} kWh"
+    )
+
+
+@_pytestmark_scipy
+def test_ev_margin_capped_at_capacity():
+    """The margined target-cap never allows charging past capacity_kwh.
+
+    EV at 50/57 kWh needs +5 kWh to reach the 55 kWh target; a huge margin
+    would overshoot the 57 kWh capacity, so the cap must stay at capacity.
+    """
+    slots = _build_slots(10, start_hour=14, import_price=3.00)
+    ev = EVConfig(
+        enabled=True,
+        initial_soc_kwh=50.0,
+        target_kwh=55.0,
+        capacity_kwh=57.0,
+        max_charge_per_slot=10.0,
+        charger_efficiency=0.90,
+        deadline_slot=9,
+        deadline_margin_kwh=10.0,  # would push target+margin to 65 > capacity
+    )
+
+    result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=0.0,
+        usable_kwh=0.001,
+        max_charge_per_slot=0.001,
+        max_discharge_per_slot=None,
+        ev_configs=[ev],
+    )
+
+    assert result is not None
+    out_slots, _diag = result
+
+    ev_total_dc = sum(s.ev_total_planned_load_kwh * 0.9 for s in out_slots)
+    # Capacity headroom above initial_soc_kwh is 7 kWh (57 - 50).
+    assert ev_total_dc == pytest.approx(7.0, rel=0.05), (
+        f"Expected ~7 kWh DC (capped at capacity), got {ev_total_dc} kWh"
+    )
+
+
+@_pytestmark_scipy
+def test_ev_deadline_escalated_charges_to_physical_max():
+    """When even max-power charging can't reach the margined target, escalate.
+
+    EV at 10/80 kWh needs 40 kWh to reach the 50 kWh target, plus a 4 kWh
+    margin (effective target 54 kWh). With only 4 slots at 10 kWh/slot, the
+    physical maximum reachable is 40 kWh — below the margined target, so
+    the EV is deadline_escalated. The MILP should still charge to the full
+    physical maximum (40 kWh) despite an extreme import price, and the
+    deadline penalty should reflect the true shortfall against the
+    margined target (54 - 50 = 4 kWh), not report a met deadline.
+    """
+    slots = _build_slots(10, start_hour=14, import_price=3.00)
+    ev = EVConfig(
+        enabled=True,
+        initial_soc_kwh=10.0,
+        target_kwh=50.0,
+        capacity_kwh=80.0,
+        max_charge_per_slot=10.0,
+        charger_efficiency=0.90,
+        deadline_slot=3,  # 4 slots => 40 kWh physically reachable
+        deadline_margin_kwh=4.0,
+    )
+    assert ev.deadline_escalated is True
+
+    result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=0.0,
+        usable_kwh=0.001,
+        max_charge_per_slot=0.001,
+        max_discharge_per_slot=None,
+        ev_configs=[ev],
+    )
+
+    assert result is not None
+    out_slots, diag = result
+
+    ev_total_dc = sum(s.ev_total_planned_load_kwh * 0.9 for s in out_slots)
+    assert ev_total_dc == pytest.approx(40.0, rel=0.05), (
+        f"Expected ~40 kWh DC (full physical max under escalation), got {ev_total_dc} kWh"
+    )
+    ev_diag = diag["ev"]["ev0"]
+    assert ev_diag["deadline_met"] is False
+    assert ev_diag["deadline_penalty_kwh"] == pytest.approx(4.0, abs=0.5)
 
 
 @_pytestmark_scipy

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -575,3 +575,92 @@ class TestEVDeliveredEnergyReplan:
             next_material_change,
         )
         assert coordinator._should_replan(live, next_material_change) is True
+
+
+class TestEVDeadlinePacingReplan:
+    """An EV that can no longer reach its margined target at max power forces a replan."""
+
+    @staticmethod
+    def _coordinator_and_cfg(
+        now: datetime,
+    ) -> tuple[HSEMDataUpdateCoordinator, SensorConfig]:
+        coordinator = _make_bare_coordinator()
+        cfg = SensorConfig()
+        cfg.ev_planned_load_battery_capacity_kwh = 100.0
+        cfg.ev_planned_load_charger_power_kw = 7.0
+        cfg.ev_planned_load_charger_efficiency_pct = 100.0
+        cfg.ev_planned_load_deadline_safety_margin_pct = 10.0
+        coordinator._cfg = cfg
+        # A previous plan exists, old enough to clear the cadence gate.
+        coordinator._last_plan_slot_start = now - timedelta(seconds=200)
+        return coordinator, cfg
+
+    def test_replan_when_max_power_cannot_reach_margined_target(self) -> None:
+        now = datetime(2026, 8, 23, 8, 0, tzinfo=UTC)
+        coordinator, _cfg = self._coordinator_and_cfg(now)
+
+        live = LiveState()
+        live.ev_planned_load_connected = True
+        live.ev_planned_load_smart_charging_enabled = True
+        live.ev_planned_load_target_soc_pct = 80.0
+        live.ev.effective_soc_pct = 20.0  # 20 kWh of 100 kWh capacity
+        live.ev_planned_load_deadline = now + timedelta(hours=1)
+
+        # Shortfall 60 kWh + 10% margin (6 kWh) = 86 kWh needed; at 7 kW for
+        # 1h only 27 kWh is physically reachable.
+        assert coordinator._ev_deadline_pacing_requires_replan(live, now) is True
+
+    def test_no_replan_with_comfortable_margin_and_time(self) -> None:
+        now = datetime(2026, 8, 23, 8, 0, tzinfo=UTC)
+        coordinator, _cfg = self._coordinator_and_cfg(now)
+
+        live = LiveState()
+        live.ev_planned_load_connected = True
+        live.ev_planned_load_smart_charging_enabled = True
+        live.ev_planned_load_target_soc_pct = 80.0
+        live.ev.effective_soc_pct = 20.0
+        live.ev_planned_load_deadline = now + timedelta(hours=20)
+
+        # 7 kW for 20h reaches 160 kWh, far more than the 86 kWh needed.
+        assert coordinator._ev_deadline_pacing_requires_replan(live, now) is False
+
+    def test_no_replan_when_ev_not_connected(self) -> None:
+        now = datetime(2026, 8, 23, 8, 0, tzinfo=UTC)
+        coordinator, _cfg = self._coordinator_and_cfg(now)
+
+        live = LiveState()
+        live.ev_planned_load_connected = False
+        live.ev_planned_load_smart_charging_enabled = True
+        live.ev_planned_load_target_soc_pct = 80.0
+        live.ev.effective_soc_pct = 20.0
+        live.ev_planned_load_deadline = now + timedelta(hours=1)
+
+        assert coordinator._ev_deadline_pacing_requires_replan(live, now) is False
+
+    def test_no_replan_without_deadline(self) -> None:
+        now = datetime(2026, 8, 23, 8, 0, tzinfo=UTC)
+        coordinator, _cfg = self._coordinator_and_cfg(now)
+
+        live = LiveState()
+        live.ev_planned_load_connected = True
+        live.ev_planned_load_smart_charging_enabled = True
+        live.ev_planned_load_target_soc_pct = 80.0
+        live.ev.effective_soc_pct = 20.0
+        live.ev_planned_load_deadline = None
+
+        assert coordinator._ev_deadline_pacing_requires_replan(live, now) is False
+
+    def test_cadence_gate_blocks_immediate_retrigger(self) -> None:
+        now = datetime(2026, 8, 23, 8, 0, tzinfo=UTC)
+        coordinator, _cfg = self._coordinator_and_cfg(now)
+        # Last plan was only 10s ago — inside the cadence window.
+        coordinator._last_plan_slot_start = now - timedelta(seconds=10)
+
+        live = LiveState()
+        live.ev_planned_load_connected = True
+        live.ev_planned_load_smart_charging_enabled = True
+        live.ev_planned_load_target_soc_pct = 80.0
+        live.ev.effective_soc_pct = 20.0
+        live.ev_planned_load_deadline = now + timedelta(hours=1)
+
+        assert coordinator._ev_deadline_pacing_requires_replan(live, now) is False


### PR DESCRIPTION
## Summary

Fixes #845 — EV deadline charging was a soft, zero-margin constraint: the MILP capped pre-deadline charging at exactly the computed shortfall, so normal execution-layer friction (OCPP anti-flap windows, charger minimum-power floors, Huawei phase-headroom throttling) could silently miss the deadline with no correction.

- **Safety margin**: `EVConfig` gains `deadline_margin_kwh` / `effective_deadline_target_kwh`. The MILP's deadline soft-goal and target-cap constraints now aim for `target + margin` instead of the bare target. New config option `hsem_ev_planned_load_deadline_safety_margin_pct` (default **0%**, so existing installs and tests are unaffected until a user opts in).
- **Escalation**: `EVConfig.deadline_escalated` is a stateless reachability check (re-evaluated on every solve) — when even max-power charging for the remaining slots can't reach the margined target, the target-cap constraint lifts to `capacity_kwh` and the deadline penalty is multiplied 5x.
- **Write-out redistribution**: `_ev_power_writeout.py` now tries to move a below-`charger_min_power_w` slot's energy forward onto a later pre-deadline slot with headroom, instead of silently discarding it.
- **Coordinator trigger**: new `coordinator_ev_deadline_pacing.py` mixin forces a prompt out-of-cycle replan as soon as an EV can no longer reach its margined target at max power, rather than waiting for an unrelated trigger (slot boundary, EV state change, live-power drift).
- `docs/planner-spec.md` updated (EV co-optimisation section + invariants) per the mandatory planner-spec-compliance workflow.

## Test plan

- [x] `./scripts/quality.sh lint` — clean
- [x] `./scripts/quality.sh typing` — clean
- [x] `./scripts/quality.sh quality` (pyright + vulture) — clean
- [x] `./scripts/quality.sh test` — 2938 passed
- [x] New tests: `tests/models/test_ev_config.py` (margin/escalation properties), `tests/planner/test_ev_power_writeout.py` (redistribution), `tests/planner/test_milp_ev.py` (margin/escalation end-to-end MILP behavior), `tests/test_coordinator.py::TestEVDeadlinePacingReplan` (new replan trigger)
- [x] Existing capped-shortfall tests (issue #636/#797) still pass unchanged (margin defaults to 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)