### PR TITLE
fix(planner): bound dynamic-floor bridge scan, remove Skylos-flagged dead params

### DIFF
--- a/custom_components/hsem/coordinator_planner_phase.py
+++ b/custom_components/hsem/coordinator_planner_phase.py
@@ -91,7 +91,6 @@ class CoordinatorPlannerPhaseMixin(CoordinatorSharedState):
             min_soc_pct = live.huawei_batteries_end_of_discharge_soc_pct or 0.0
             max_soc_pct = live.huawei_batteries_charging_cutoff_capacity_pct or 100.0
             _usable_kwh = usable_kwh_from_rated(rated_kwh, min_soc_pct, max_soc_pct)
-            _current_kwh = (live.huawei_batteries_soc_pct or 0.0) / 100.0 * _usable_kwh
             _bridge_slots: list = []
             for rec in self._hourly_recommendations:
                 _bridge_slots.append(
@@ -108,7 +107,6 @@ class CoordinatorPlannerPhaseMixin(CoordinatorSharedState):
             floor_pct, floor_diag = self._dynamic_floor.compute_floor(
                 now=now,
                 slots=_bridge_slots,
-                current_kwh=_current_kwh,
                 usable_kwh=_usable_kwh,
                 configured_min_soc_pct=min_soc_pct,
             )

--- a/custom_components/hsem/planner/milp/_constraints.py
+++ b/custom_components/hsem/planner/milp/_constraints.py
@@ -55,8 +55,6 @@ def _build_constraints(
     session_ev_indices: list[int],
     slot_hours: float,
     _has_session_demand: bool,
-    max_grid_export_per_slot_kwh: float = 0.0,
-    export_limit_active: bool = False,
     battery_export_blocked: np.ndarray | None = None,  # type: ignore[name-defined]
     battery_export_off: int = 0,
     export_mode_off: int = 0,
@@ -387,7 +385,6 @@ def _build_constraints(
             export_mode_off=export_mode_off,
             usable_kwh=usable_kwh,
             current_kwh=current_kwh,
-            discharge_eff=discharge_eff,
             checkpoints=checkpoints,
             reserve_kwh=usable_kwh * reserve_pct / 100.0 if reserve_active else 0.0,
             immediate_reserve_kwh=forecast_reserve_kwh

--- a/custom_components/hsem/planner/milp/_diagnostics.py
+++ b/custom_components/hsem/planner/milp/_diagnostics.py
@@ -55,8 +55,6 @@ def _compute_milp_diagnostics(
     s_max_off: int,
     s_min_off: int,
     curt_off: int,
-    gi_off: int,
-    gi_pen_off: int,
     replacement_price_per_kwh: float | None,
     fuse_active: bool,
     max_grid_import_per_slot_kwh: float,
@@ -76,7 +74,7 @@ def _compute_milp_diagnostics(
         slots: Original (unmodified) slot list.
         future_idx: Indices of future (LP-variable) slots.
         m: Number of active LP slots.
-        s_max_off, s_min_off, curt_off, gi_off, gi_pen_off:
+        s_max_off, s_min_off, curt_off:
             Variable offsets into ``result.x``.
         current_kwh: Battery energy at horizon start (above floor, kWh).
         usable_kwh: Maximum usable energy (kWh).

--- a/custom_components/hsem/planner/milp/_ev_amp_lattice.py
+++ b/custom_components/hsem/planner/milp/_ev_amp_lattice.py
@@ -191,7 +191,6 @@ def add_ev_amp_lattice_constraints(
     ed_off: int,
     max_dis: float,
     available_slot_hours: np.ndarray,  # type: ignore[type-arg]
-    session_dc_by_ev: dict[int, dict[int, float]],
 ) -> dict[str, Any]:
     """Link managed EV energy to executable whole-amp commands.
 

--- a/custom_components/hsem/planner/milp/_export_reserve.py
+++ b/custom_components/hsem/planner/milp/_export_reserve.py
@@ -48,7 +48,6 @@ def _add_battery_export_reserve_constraints(
     export_mode_off: int,
     usable_kwh: float,
     current_kwh: float,
-    discharge_eff: float,
     checkpoints: np.ndarray | None,
     reserve_kwh: float,
     immediate_reserve_kwh: float = 0.0,

--- a/custom_components/hsem/planner/milp/_session_window.py
+++ b/custom_components/hsem/planner/milp/_session_window.py
@@ -43,7 +43,6 @@ def resolve_session_windows(
     future_idx: list[int],
     now: datetime,
     active_evs: list[EVConfig],
-    m: int,
 ) -> SessionWindows:
     """Return each active EV's live-session certainty window.
 

--- a/custom_components/hsem/planner/milp_optimizer.py
+++ b/custom_components/hsem/planner/milp_optimizer.py
@@ -346,7 +346,6 @@ def solve_milp(
         future_idx=future_idx,
         now=now,
         active_evs=active_evs,
-        m=m,
     )
     slot_hours = _session_windows.slot_hours
     available_slot_hours = _session_windows.available_slot_hours
@@ -432,8 +431,8 @@ def solve_milp(
     (
         grid_import_ub_per_slot,
         grid_export_ub_per_slot,
-        export_limit_active,
-        max_grid_export_per_slot_kwh,
+        _export_limit_active,
+        _max_grid_export_per_slot_kwh,
     ) = resolve_grid_bounds(
         active_evs=active_evs,
         base_load=base_load,
@@ -533,8 +532,6 @@ def solve_milp(
         session_dc_by_ev=session_dc_by_ev,
         available_slot_hours=available_slot_hours,
         column_layout=column_layout,
-        max_grid_export_per_slot_kwh=max_grid_export_per_slot_kwh,
-        export_limit_active=export_limit_active,
         battery_export_blocked=battery_export_blocked,
         battery_export_off=battery_export_off,
         export_mode_off=export_mode_off,
@@ -569,7 +566,6 @@ def solve_milp(
         ed_off=ed_off,
         max_dis=max_dis,
         available_slot_hours=available_slot_hours,
-        session_dc_by_ev=session_dc_by_ev,
     )
 
     A_eq = constraints["A_eq"]
@@ -729,8 +725,6 @@ def solve_milp(
         s_max_off,
         s_min_off,
         curt_off,
-        gi_off,
-        gi_pen_off,
         replacement_price_per_kwh,
         fuse_active,
         max_grid_import_per_slot_kwh,

--- a/custom_components/hsem/utils/dynamic_floor.py
+++ b/custom_components/hsem/utils/dynamic_floor.py
@@ -13,7 +13,7 @@ the actual SoC to let the safety margin self-correct over time.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from custom_components.hsem.utils.logger import log_planner
 from custom_components.hsem.utils.units import slot_duration_hours
@@ -79,7 +79,6 @@ class DynamicDischargeFloor:
         self,
         now: datetime,
         slots: list,  # list[PlannedSlot] — kept typing-free for pure-Python testability
-        current_kwh: float,
         usable_kwh: float,
         configured_min_soc_pct: float,
         hours_ahead: int = 48,
@@ -105,8 +104,6 @@ class DynamicDischargeFloor:
                 Future planner output slots (list of objects with
                 ``start``, ``end``, ``estimated_net_consumption_kwh``,
                 ``batteries_charged_kwh``, and ``recommendation`` attributes).
-            current_kwh:
-                Current usable battery energy above the absolute floor (kWh).
             usable_kwh:
                 Maximum usable battery capacity (kWh).
             configured_min_soc_pct:
@@ -139,8 +136,11 @@ class DynamicDischargeFloor:
             )
             return configured_min_soc_pct, diag
 
-        # Filter to future slots only, ordered chronologically.
-        future = [s for s in slots if s.end > now]
+        # Filter to future slots only, ordered chronologically, bounded to
+        # the look-ahead window — low-confidence day+2/day+3 forecasts
+        # beyond hours_ahead must not extend the bridge scan.
+        horizon_end = now + timedelta(hours=hours_ahead)
+        future = [s for s in slots if s.end > now and s.start < horizon_end]
         if not future:
             log_planner(
                 "debug",

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -2446,9 +2446,21 @@ bridge_reserve_pct  = (next_refill_need_kwh / usable_capacity_kwh) × 100
                     × safety_margin
 ```
 
-Where `safety_margin` is a self-learning multiplier that starts at **1.50**
-and decays toward **1.05** as successful solar refills are observed.  The
-floor is never lower than the hardware-configured minimum SoC.
+Where `safety_margin` is a self-learning multiplier that starts at **1.15**
+(a 15 % buffer) and self-corrects within **[1.05, 1.50]**: it steps up by
+0.05 after 2 consecutive days where actual SoC fell below the floor, and
+steps down by 0.02 after 7 consecutive days where actual SoC stayed
+comfortably above the floor (`DynamicDischargeFloor.correct_margin()`,
+`utils/dynamic_floor.py`). The floor is never lower than the
+hardware-configured minimum SoC.
+
+The bridge scan (`DynamicDischargeFloor.compute_floor()`,
+`utils/dynamic_floor.py`) is bounded to a `hours_ahead` look-ahead window
+(default 48 h): slots starting at or after `now + hours_ahead` are excluded
+before the refill scan and consumption accumulation run, so a low-confidence
+day+2/day+3 forecast refill cannot extend the bridge past the window. If no
+refill is found within the window, consumption accumulates only over the
+in-window slots.
 
 #### Dynamic floor invariant
 

--- a/tests/utils/test_dynamic_floor.py
+++ b/tests/utils/test_dynamic_floor.py
@@ -82,7 +82,6 @@ class TestBridgeComputation:
         floor_pct, diag = df.compute_floor(
             now=now,
             slots=slots,
-            current_kwh=5.0,
             usable_kwh=10.0,
             configured_min_soc_pct=10.0,
         )
@@ -108,7 +107,6 @@ class TestBridgeComputation:
         floor_pct, diag = df.compute_floor(
             now=now,
             slots=slots,
-            current_kwh=5.0,
             usable_kwh=10.0,
             configured_min_soc_pct=10.0,
         )
@@ -126,7 +124,6 @@ class TestBridgeComputation:
         floor_pct, diag = df.compute_floor(
             now=now,
             slots=slots,
-            current_kwh=5.0,
             usable_kwh=10.0,
             configured_min_soc_pct=15.0,
         )
@@ -141,7 +138,6 @@ class TestBridgeComputation:
         floor_pct, diag = df.compute_floor(
             now=now,
             slots=slots,
-            current_kwh=5.0,
             usable_kwh=10.0,
             configured_min_soc_pct=5.0,
         )
@@ -156,7 +152,6 @@ class TestBridgeComputation:
         floor_pct, diag = df.compute_floor(
             now=now,
             slots=[],
-            current_kwh=5.0,
             usable_kwh=10.0,
             configured_min_soc_pct=10.0,
         )
@@ -188,7 +183,6 @@ class TestBridgeComputation:
         floor_pct, diag = df.compute_floor(
             now=now,
             slots=slots,
-            current_kwh=5.0,
             usable_kwh=10.0,
             configured_min_soc_pct=5.0,
         )
@@ -204,7 +198,6 @@ class TestBridgeComputation:
         floor_pct, diag = df.compute_floor(
             now=now,
             slots=slots,
-            current_kwh=5.0,
             usable_kwh=10.0,
             configured_min_soc_pct=5.0,
         )
@@ -222,13 +215,49 @@ class TestBridgeComputation:
         floor_pct, diag = df.compute_floor(
             now=now,
             slots=slots,
-            current_kwh=5.0,
             usable_kwh=10.0,
             configured_min_soc_pct=5.0,
         )
         assert diag["refill_type"] == "solar_surplus"
         assert diag["reserve_kwh"] == pytest.approx(0.5, rel=1e-4)
         assert diag["bridge_duration_hours"] == pytest.approx(1.0, rel=1e-4)
+
+    def test_hours_ahead_bounds_the_scan(self) -> None:
+        """A refill beyond hours_ahead must not extend the bridge scan."""
+        now = datetime(2025, 6, 15, 12, 0)
+        df = DynamicDischargeFloor()
+        # 50 hourly slots of steady consumption; solar surplus only shows up
+        # at hour 49 — outside the default 48h look-ahead window.
+        net_values = [0.5] * 49 + [-5.0]
+        slots = _make_slots(now, net_values)
+        floor_pct, diag = df.compute_floor(
+            now=now,
+            slots=slots,
+            usable_kwh=100.0,
+            configured_min_soc_pct=5.0,
+        )
+        # The surplus slot at hour 49 must be excluded from the scan, so no
+        # refill is found within the window and consumption accumulates
+        # only over the 48 in-window slots (0.5 * 48 = 24.0 kWh).
+        assert diag["refill_type"] == "none"
+        assert diag["reserve_kwh"] == pytest.approx(24.0, rel=1e-4)
+
+    def test_hours_ahead_custom_window(self) -> None:
+        """A custom hours_ahead further restricts the scan window."""
+        now = datetime(2025, 6, 15, 12, 0)
+        df = DynamicDischargeFloor()
+        # Solar surplus at hour 5, but hours_ahead=3 excludes it.
+        net_values = [0.5, 0.5, 0.5, 0.5, 0.5, -5.0]
+        slots = _make_slots(now, net_values)
+        floor_pct, diag = df.compute_floor(
+            now=now,
+            slots=slots,
+            usable_kwh=100.0,
+            configured_min_soc_pct=5.0,
+            hours_ahead=3,
+        )
+        assert diag["refill_type"] == "none"
+        assert diag["reserve_kwh"] == pytest.approx(1.5, rel=1e-4)
 
     def test_solar_surplus_between_consumption_reduces_reserve(self) -> None:
         """Solar surplus stops the scan at first surplus, even if followed by more consumption."""
@@ -238,7 +267,6 @@ class TestBridgeComputation:
         floor_pct, diag = df.compute_floor(
             now=now,
             slots=slots,
-            current_kwh=5.0,
             usable_kwh=10.0,
             configured_min_soc_pct=5.0,
         )


### PR DESCRIPTION
## Summary

PR #847 added the experimental Skylos scanner, which flagged 17 dead-code
candidates (16 unused params, 1 unused var). Each was traced through its
callers and, where relevant, git history before deciding what to do with it.

- **Bug fix**: `DynamicDischargeFloor.compute_floor()` documented an
  `hours_ahead` look-ahead cap ("Look-ahead window in hours. Defaults to
  48") that was never actually applied — the bridge scan ran over every
  future slot unconditionally, including low-confidence day+2/day+3
  forecast slots. Now bounded to `now + hours_ahead` as documented.
- **Dead-param cleanup** (8 params/vars removed, verified via call-site
  tracing and git archaeology, not missing implementations):
  - `max_grid_export_per_slot_kwh` / `export_limit_active` (`_constraints.py`)
    — already folded into `grid_export_ub_per_slot` upstream by
    `_export_cap.py`'s `resolve_grid_bounds()`.
  - `gi_off` / `gi_pen_off` (`_diagnostics.py`) — superseded by PR #783's
    switch to recomputing fuse diagnostics from the final executable
    (rounded) output slots instead of raw LP variables.
  - `m` (`_session_window.py`) — duplicate of `len(future_idx)`.
  - `discharge_eff` (`_export_reserve.py`) — the export-reserve constraint
    operates entirely in battery-DC-kWh terms; no efficiency conversion
    needed.
  - `session_dc_by_ev` (`_ev_amp_lattice.py`) — mutually exclusive with the
    managed-EV amp lattice by issue #797's design (session pinning only
    ever applies to *unmanaged* EVs; this function only processes *managed*
    EVs).
  - `current_kwh` (`dynamic_floor.py`) — the floor is a threshold
    percentage, independent of current SoC by design; the comparison
    against actual SoC happens separately in `correct_margin()`.
- **Doc fix**: `docs/planner-spec.md`'s dynamic-floor section claimed
  `safety_margin` "starts at 1.50 and decays toward 1.05" — the actual
  code default is 1.15, self-correcting within `[1.05, 1.50]` (+0.05 after
  2 bad days, −0.02 after 7 good days). Updated to match the code, and
  documented the `hours_ahead` bound.

Remaining Skylos findings were investigated and left as-is: 5 `hass`
params mandated by Home Assistant callback signatures (`add_update_listener`,
platform-setup callbacks), one deliberately-documented unused param
(`slots_per_day` in `ml/history_reader.py`), and one likely-intentional
unused var (`_live_solar_available` in `coordinator_builder.py`, probably
avoiding zeroing a dawn/dusk PV forecast on a momentary 0 W reading).

## Test plan

- [x] `./scripts/quality.sh lint` — clean, no reformatting
- [x] `./scripts/quality.sh typing` — clean
- [x] `./scripts/quality.sh quality` (pyright + vulture) — clean (1 pre-existing unrelated warning)
- [x] `./scripts/quality.sh test` — 2940 passed
- [x] Added regression tests for the `hours_ahead` bound
      (`test_hours_ahead_bounds_the_scan`, `test_hours_ahead_custom_window`)
- [x] Re-ran Skylos: dead-code count dropped from 17 to 8, matching exactly
      the items intentionally left as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)