### PR TITLE
fix(ci): call quality.sh for the prettier check instead of duplicating it

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -35,10 +35,9 @@ jobs:
           scandir: "./scripts"
 
       - name: Check Prettier formatting
-        # Pinned to the same version as the pre-commit hook
-        # (.pre-commit-config.yaml, mirrors-prettier v3.1.0) so a locally
-        # clean file can never fail here on a version difference.
-        run: npx --yes prettier@3.1.0 --check .
+        # Goes through quality.sh so the version and invocation live in one
+        # place; see PRETTIER_VERSION there.
+        run: ./scripts/quality.sh format-check
 
   quality:
     name: Quality gates (devcontainer)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
   - repo: local
     hooks:
       - id: lint
-        name: Format and lint (ruff)
+        name: Format and lint (ruff + prettier)
         language: system
         entry: ./scripts/quality.sh
         args: [lint]
@@ -36,11 +36,3 @@ repos:
         args: [quality]
         pass_filenames: false
         always_run: true
-
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
-    hooks:
-      - id: prettier
-        name: Format with Prettier
-        types_or: [markdown, yaml, json]
-        exclude: "^custom_components/.*\\.json$|^translations/.*"

--- a/docs/quality-checks.md
+++ b/docs/quality-checks.md
@@ -26,6 +26,17 @@ This document describes the static quality tools available in HSEM and how to ru
 This runs ruff format, ruff check, and prettier (markdown/YAML/JSON). Must pass before a PR
 can be opened.
 
+### Verify formatting without writing (CI mode)
+
+```bash
+./scripts/quality.sh format-check
+```
+
+Same prettier invocation and pinned version as `lint`, but `--check` instead of
+`--write`, so it never mutates the tree. This is what the GitHub Actions
+workflow calls — the version and the command live only in `scripts/quality.sh`,
+so CI, the pre-commit hook and a local run can never drift apart.
+
 ### Run mypy type checking
 
 ```bash

--- a/scripts/quality.sh
+++ b/scripts/quality.sh
@@ -36,17 +36,26 @@ run() {
     fi
 }
 
-# Format markdown/YAML/JSON with prettier, pinned to the same version as the
-# pre-commit hook and the CI check so all three agree. Skipped with a warning
-# when node isn't present rather than failing the whole gate — CI still
-# enforces it, so a missing local toolchain can't let drift through.
+# Prettier formats markdown/YAML/JSON.  This is the single source of truth for
+# the version and the invocation: the pre-commit hook and the CI workflow both
+# reach prettier through this script, so there is nothing to keep in sync.
+# Scope is owned by .prettierignore, not by per-caller include/exclude lists.
 PRETTIER_VERSION="3.1.0"
-prettier_format() {
+
+# Usage: prettier_run --write | --check
+# --write is used by the fixing targets (lint/all), matching ruff's behaviour.
+# --check is used by CI, which must never mutate the tree.
+prettier_run() {
+    local mode="$1"
     if ! command -v npx >/dev/null 2>&1; then
+        if [[ "${mode}" == "--check" ]]; then
+            echo "[error] npx not found — cannot verify prettier formatting" >&2
+            return 1
+        fi
         echo "[warn] npx not found — skipping prettier (CI will still check it)" >&2
         return 0
     fi
-    run npx --yes "prettier@${PRETTIER_VERSION}" --write .
+    run npx --yes "prettier@${PRETTIER_VERSION}" "${mode}" .
 }
 
 usage() {
@@ -54,9 +63,10 @@ usage() {
 Usage: quality <command>
 
 Commands:
-  lint      Format and lint code (ruff format + ruff check + prettier)
+  lint      Format and lint code (ruff format + ruff check + prettier --write)
   typing    Type check with mypy
   quality   Static quality checks (pyright + vulture)
+  format-check  Verify prettier formatting without writing (used by CI)
   skylos    Run Skylos static analysis (experimental, not in 'all')
   test      Run tests with pytest and coverage
   all       Run lint, typing, quality, and test in sequence
@@ -68,7 +78,7 @@ case "${1:-}" in
     lint)
         run ruff format .
         run ruff check . --fix
-        prettier_format
+        prettier_run --write
         ;;
     typing)
         run mypy custom_components tests
@@ -76,6 +86,9 @@ case "${1:-}" in
     quality)
         run python -m pyright
         run python -m vulture custom_components/hsem tests vulture_whitelist.py --min-confidence 80
+        ;;
+    format-check)
+        prettier_run --check
         ;;
     skylos)
         SKYLOS_GREP_BUDGET=120 run skylos custom_components -a
@@ -92,7 +105,7 @@ case "${1:-}" in
     all)
         echo "=== Lint ==="
         run ruff format .
-        prettier_format
+        prettier_run --write
         echo ""
         echo "=== Type Check ==="
         run mypy custom_components tests


### PR DESCRIPTION
## Problem

The CI step added in #855 inlined the prettier invocation:

```yaml
run: npx --yes prettier@3.1.0 --check .
```

That made **three** independent pins of the same version, which had to be bumped together with nothing enforcing that they were:

| Where | Pin |
|---|---|
| `scripts/quality.sh` | `PRETTIER_VERSION="3.1.0"` |
| `.github/workflows/lint-and-test.yml` | `prettier@3.1.0` inline |
| `.pre-commit-config.yaml` | `mirrors-prettier rev: v3.1.0` |

Ironic for a change whose whole point was making the config and its enforcement agree.

## Fix — one source of truth

**`scripts/quality.sh`** — `prettier_format()` becomes `prettier_run <mode>`, plus a new `format-check` target:

```bash
./scripts/quality.sh lint          # --write  (fixing, alongside ruff format)
./scripts/quality.sh format-check  # --check  (CI, never mutates)
```

**`.github/workflows/lint-and-test.yml`** — now `run: ./scripts/quality.sh format-check`.

**`.pre-commit-config.yaml`** — the `mirrors-prettier` hook is **removed**. It became redundant the moment `quality.sh lint` started running prettier, and its `types_or`/`exclude` duplicated what `.prettierignore` now owns. The existing local `lint` hook already calls the script, so coverage is unchanged — actually *wider*, since `prettier --write .` covers everything prettier supports rather than just markdown/YAML/JSON.

`PRETTIER_VERSION` is now the only place the version appears.

## One behaviour change worth calling out

A missing `npx` now **fails** in `--check` mode instead of warning:

```bash
if ! command -v npx >/dev/null 2>&1; then
    if [[ "${mode}" == "--check" ]]; then
        echo "[error] npx not found — cannot verify prettier formatting" >&2
        return 1
    fi
    echo "[warn] npx not found — skipping prettier (CI will still check it)" >&2
    return 0
fi
```

The warn-and-continue path existed so a contributor without node isn't blocked locally — but that reasoning depends on *CI* catching it. Now that CI runs the same function, silently skipping there would let drift through while reporting success. `--write` keeps the lenient behaviour; `--check` fails closed.

## Verification

| | |
|---|---|
| `format-check` on clean tree | exit 0 |
| `format-check` on a deliberately malformed file | **exit non-zero** ← the one that matters |
| `format-check` mutates the tree? | no |
| `lint` still formats | yes |
| `quality.sh all` | green, 2958 tests |
| `scripts/validate-yaml.py` on the changed workflow | OK |
| `bash -n scripts/quality.sh` | OK |

Testing that the check *fails when it should* matters more than testing that it passes — a check that can only ever succeed is worse than no check, and that is exactly the failure mode this PR is correcting.

`docs/quality-checks.md` documents the new target.

Refs #854.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
