### PR TITLE
fix(sensor): gate runtime-resolver force_export on excess-export setting and profitable export price

### DIFF
--- a/custom_components/hsem/custom_sensors/recommendation_resolver.py
+++ b/custom_components/hsem/custom_sensors/recommendation_resolver.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from custom_components.hsem.models.hourly_recommendation import HourlyRecommendation
 from custom_components.hsem.models.live_state import LiveState
+from custom_components.hsem.models.sensor_config import SensorConfig
 from custom_components.hsem.utils.conversion import convert_to_float
 from custom_components.hsem.utils.logger import HSEM_LOGGER
 from custom_components.hsem.utils.recommendations import Recommendations
@@ -28,6 +29,7 @@ def resolve_current_recommendation(
     rec: HourlyRecommendation,
     live: LiveState,
     batteries_schedules_remaining_capacity_needed: float,
+    cfg: SensorConfig,
 ) -> None:
     """Adjust the current-interval recommendation based on live runtime state.
 
@@ -35,7 +37,8 @@ def resolve_current_recommendation(
     cannot know, for example, whether a car just plugged in.  This function
     applies the final layer of real-time overrides in priority order:
 
-    1. **Negative import price** → force export everything to earn money.
+    1. **Negative import price** → force export, but only when exporting is
+       itself economically viable and permitted by the user's configuration.
     2. **Grid charge active** → grid charging takes priority over EV smart charge.
     3. **EV actively charging** → switch to EV smart charging mode.
     4. **Battery above remaining schedule need** → switch to discharge mode.
@@ -47,22 +50,54 @@ def resolve_current_recommendation(
         live: Live state snapshot at call time.
         batteries_schedules_remaining_capacity_needed: Total kWh still needed
             by all upcoming discharge-window schedules.
+        cfg: Current sensor configuration (excess-export toggle and export
+            price floors).
     """
     if rec is None:
         return
 
     original_recommendation = rec.recommendation
 
-    # 1. Negative import price → force export
+    # 1. Negative import price → force export.
+    #
+    # A negative import price alone does not make exporting profitable — the
+    # export price can be negative too (issue #732).  Only override when the
+    # user has opted into excess battery export AND the live export price is
+    # authoritative AND non-negative AND at/above the configured floor
+    # (the higher of the general and battery-specific export minimums).
     import_price = convert_to_float(live.import_electricity_price)
+    export_price = convert_to_float(live.export_electricity_price)
+    export_floor = max(
+        cfg.export_electricity_min_price, cfg.batteries_export_min_price, 0.0
+    )
+    export_is_profitable = (
+        live.export_electricity_price_available
+        and export_price is not None
+        and export_price >= export_floor
+    )
+
     if import_price is not None and import_price < 0:
-        rec.recommendation = Recommendations.ForceExport.value
+        if cfg.batteries_enable_excess_export and export_is_profitable:
+            rec.recommendation = Recommendations.ForceExport.value
+            HSEM_LOGGER.debug(
+                "[resolver] negative import price (%.4f) with profitable export "
+                "(%.4f >= floor %.4f) → overriding %s to force_export",
+                import_price,
+                export_price,
+                export_floor,
+                original_recommendation,
+            )
+            return
         HSEM_LOGGER.debug(
-            "[resolver] negative import price (%.4f) → overriding %s to force_export",
+            "[resolver] negative import price (%.4f) but export not viable "
+            "(excess_export_enabled=%s export_price=%s export_available=%s "
+            "floor=%.4f) → not forcing export",
             import_price,
-            original_recommendation,
+            cfg.batteries_enable_excess_export,
+            export_price,
+            live.export_electricity_price_available,
+            export_floor,
         )
-        return
 
     # 2. Grid charging in progress → preserve, do not override
     if rec.recommendation == Recommendations.BatteriesChargeGrid.value:

--- a/custom_components/hsem/custom_sensors/working_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/working_mode_sensor.py
@@ -520,6 +520,7 @@ class HSEMWorkingModeSensor(
                 hourly_rec,
                 live,
                 data.batteries_schedules_remaining_capacity_needed,
+                cfg,
             )
             # Sync data.state so the sensor's state property reflects the
             # resolved recommendation (e.g. ev_smart_charging) rather than

--- a/docs/planner-guide.md
+++ b/docs/planner-guide.md
@@ -413,7 +413,7 @@ Each `PlannedSlot` in the output list covers one time interval and carries:
 | `batteries_charge_solar`    | Battery is charging from PV surplus                                                                                                                                                             |
 | `batteries_discharge_mode`  | Battery discharges to cover house load during high-price window                                                                                                                                 |
 | `force_batteries_discharge` | Forced discharge (excess export to grid)                                                                                                                                                        |
-| `force_export`              | Negative import price — all available energy exported to earn money                                                                                                                             |
+| `force_export`              | Export price above import/threshold (planner), or — at runtime only — a negative import price combined with a profitable live export price and excess battery export enabled                    |
 | `ev_smart_charging`         | EV charging load is allocated to this slot (planner or runtime resolver)                                                                                                                        |
 | `batteries_wait_mode`       | Battery idle by default; when **Wait mode behaviour** is set to _Self-consumption with reserve_, normal household self-consumption is allowed using energy above the planner's required reserve |
 | `time_passed`               | Slot is in the past — no recommendation applied                                                                                                                                                 |
@@ -534,24 +534,28 @@ permission.
 Applied to the **current slot only** at hardware-write time. Overrides the planner
 output with live sensor readings that were unknown at planning time.
 
-| Priority    | Condition                                                 | Result                                |
-| ----------- | --------------------------------------------------------- | ------------------------------------- |
-| 1 (highest) | Live import price < 0                                     | → `force_export`                      |
-| 2           | Current recommendation = `batteries_charge_grid`          | Kept — grid charge never overridden   |
-| 3           | Any EV (primary or second) is actively charging right now | → `ev_smart_charging`                 |
-| 4           | Battery energy > remaining discharge-schedule need        | → `batteries_discharge_mode`          |
-| —           | None of the above                                         | Planner recommendation kept unchanged |
+| Priority    | Condition                                                                                                                                                                                    | Result                                |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| 1 (highest) | Live import price < 0 AND **Enable Excess Battery Export** is on AND the live export price is available, non-negative, and ≥ `max(export_electricity_min_price, batteries_export_min_price)` | → `force_export`                      |
+| 2           | Current recommendation = `batteries_charge_grid`                                                                                                                                             | Kept — grid charge never overridden   |
+| 3           | Any EV (primary or second) is actively charging right now                                                                                                                                    | → `ev_smart_charging`                 |
+| 4           | Battery energy > remaining discharge-schedule need                                                                                                                                           | → `batteries_discharge_mode`          |
+| —           | None of the above                                                                                                                                                                            | Planner recommendation kept unchanged |
 
-> **Note:** Priorities 1 and 3 interact. A negative import price always wins — even
-> when an EV is charging. However, a grid-charge slot (priority 2) is never overridden
-> by an actively charging EV (priority 3).
+> **Note (issue #732):** a negative import price alone does not make exporting
+> profitable — the export price can be negative too, or the user may have
+> disabled excess battery export. Priority 1 only fires when exporting is
+> both permitted and economically viable; otherwise evaluation falls through
+> to priority 2 and beyond. When priority 1 does fire it always wins — even
+> over an actively charging EV (priority 3). A grid-charge slot (priority 2)
+> is never overridden by an actively charging EV (priority 3).
 
 ---
 
 ##### Summary: full priority stack (highest → lowest)
 
 ```
-1. import_price < 0               → force_export           [runtime resolver]
+1. import_price < 0 + profitable export + excess export enabled → force_export [runtime resolver]
 2. batteries_charge_grid active   → batteries_charge_grid  [runtime resolver guard]
 3. EV actively charging (live)    → ev_smart_charging      [runtime resolver]
 4. Battery above schedule need    → batteries_discharge_mode [runtime resolver]

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -124,7 +124,13 @@ session.
 
 Applied to the current slot immediately before hardware writes, using live sensor data:
 
-1. `import_price < 0` → `force_export` (overrides everything)
+1. `import_price < 0` AND `batteries_enable_excess_export` is enabled AND the
+   live export price is authoritative, non-negative, and at/above
+   `max(export_electricity_min_price, batteries_export_min_price)` →
+   `force_export` (overrides everything else). Otherwise this rule does not
+   fire and evaluation continues at rule 2 (issue #732 — a negative import
+   price does not by itself make exporting profitable, and must not silently
+   override a disabled excess-export setting).
 2. `batteries_charge_grid` → kept (must never be overridden by EV or discharge rule)
 3. Any EV actively charging → `ev_smart_charging`
 4. Battery energy > remaining discharge-schedule need → `batteries_discharge_mode`
@@ -139,13 +145,21 @@ Applied to the current slot immediately before hardware writes, using live senso
   must be relabelled `ev_smart_charging` after layer 2.
 - A slot with `ev_planned_load_kwh > 0` and recommendation `batteries_wait_mode`
   must be relabelled `ev_smart_charging` after layer 2.
-- The runtime resolver must set `force_export` when `import_price < 0`, regardless
-  of the planner recommendation.
+- The runtime resolver must set `force_export` when `import_price < 0` AND
+  excess battery export is enabled AND the live export price is available,
+  non-negative, and at/above the configured export floor — regardless of the
+  planner recommendation.
+- The runtime resolver must NOT set `force_export` when `import_price < 0` but
+  `batteries_enable_excess_export` is disabled.
+- The runtime resolver must NOT set `force_export` when `import_price < 0` but
+  the live export price is negative, below the configured floor, or
+  unavailable.
 - The runtime resolver must NOT override `batteries_charge_grid` even when an EV
   is actively charging.
 - The runtime resolver must NOT override `batteries_charge_grid` even when
   `import_price < 0` is False and EV is charging.
-- Priority 1 (negative price → `force_export`) always beats priority 3 (EV charging).
+- Priority 1 (negative price + profitable export → `force_export`) always
+  beats priority 3 (EV charging) when it fires.
 
 ## Energy balance per slot
 

--- a/tests/planner/test_slot_ownership.py
+++ b/tests/planner/test_slot_ownership.py
@@ -48,6 +48,7 @@ from custom_components.hsem.models.live_state import EVLiveState, LiveState
 from custom_components.hsem.models.planned_slot import PlannedSlot
 from custom_components.hsem.models.planner_input import PlannerInput
 from custom_components.hsem.models.price_point import PricePoint
+from custom_components.hsem.models.sensor_config import SensorConfig
 from custom_components.hsem.models.solcast_slot import SolcastSlot
 from custom_components.hsem.planner import run_planner
 from custom_components.hsem.planner.candidate_generator import (
@@ -204,14 +205,24 @@ def _make_live(
     ev2_charging: bool = False,
     import_price: float = 0.20,
     battery_kwh: float = 5.0,
+    export_price: float = 0.20,
 ) -> LiveState:
     """Build a minimal :class:`LiveState` for resolver tests."""
     live = LiveState()
     live.import_electricity_price = import_price
+    live.export_electricity_price = export_price
+    live.export_electricity_price_available = True
     live.ev = EVLiveState(is_charging=ev_charging)
     live.ev_second = EVLiveState(is_charging=ev2_charging)
     live.battery_current_capacity_kwh = battery_kwh
     return live
+
+
+def _make_resolver_cfg() -> SensorConfig:
+    """Build a :class:`SensorConfig` with excess battery export enabled."""
+    cfg = SensorConfig()
+    cfg.batteries_enable_excess_export = True
+    return cfg
 
 
 # ===========================================================================
@@ -599,7 +610,9 @@ class TestResolverPreservesEnergyFields:
             ev_kwh=2.5, estimated_net_consumption_kwh=0.5, batteries_charged_kwh=1.0
         )
         before = self._snapshot_energy(rec)
-        resolve_current_recommendation(rec, _make_live(import_price=-0.05), 0.0)
+        resolve_current_recommendation(
+            rec, _make_live(import_price=-0.05), 0.0, _make_resolver_cfg()
+        )
         assert rec.recommendation == Recommendations.ForceExport.value
         assert self._snapshot_energy(rec) == before
 
@@ -610,7 +623,9 @@ class TestResolverPreservesEnergyFields:
         )
         rec.ev_charger_calculated_power = 7500.0
         before = self._snapshot_energy(rec)
-        resolve_current_recommendation(rec, _make_live(ev_charging=True), 0.0)
+        resolve_current_recommendation(
+            rec, _make_live(ev_charging=True), 0.0, _make_resolver_cfg()
+        )
         assert rec.recommendation == Recommendations.EVSmartCharging.value
         assert self._snapshot_energy(rec) == before
 
@@ -624,6 +639,7 @@ class TestResolverPreservesEnergyFields:
             rec,
             _make_live(battery_kwh=10.0),
             batteries_schedules_remaining_capacity_needed=5.0,
+            cfg=_make_resolver_cfg(),
         )
         assert rec.recommendation == Recommendations.BatteriesDischargeMode.value
         assert self._snapshot_energy(rec) == before
@@ -637,7 +653,9 @@ class TestResolverPreservesEnergyFields:
         )
         before_rec = rec.recommendation
         before = self._snapshot_energy(rec)
-        resolve_current_recommendation(rec, _make_live(ev_charging=True), 0.0)
+        resolve_current_recommendation(
+            rec, _make_live(ev_charging=True), 0.0, _make_resolver_cfg()
+        )
         assert rec.recommendation == before_rec  # unchanged
         assert self._snapshot_energy(rec) == before
 
@@ -651,7 +669,10 @@ class TestResolverPreservesEnergyFields:
         before_rec = rec.recommendation
         before = self._snapshot_energy(rec)
         resolve_current_recommendation(
-            rec, _make_live(ev_charging=False, import_price=0.20), 0.0
+            rec,
+            _make_live(ev_charging=False, import_price=0.20),
+            0.0,
+            _make_resolver_cfg(),
         )
         assert rec.recommendation == before_rec
         assert self._snapshot_energy(rec) == before
@@ -671,6 +692,7 @@ class TestResolverPreservesEnergyFields:
                     ev_charging=ev_charging, import_price=import_price, battery_kwh=10.0
                 ),
                 batteries_schedules_remaining_capacity_needed=sched_needed,
+                cfg=_make_resolver_cfg(),
             )
             assert abs(rec.ev_planned_load_kwh - 4.2) < 1e-9, (
                 f"ev_planned_load_kwh was modified to {rec.ev_planned_load_kwh} "

--- a/tests/sensors/test_recommendation_resolver.py
+++ b/tests/sensors/test_recommendation_resolver.py
@@ -13,6 +13,7 @@ from custom_components.hsem.custom_sensors.recommendation_resolver import (
 )
 from custom_components.hsem.models.hourly_recommendation import HourlyRecommendation
 from custom_components.hsem.models.live_state import EVLiveState, LiveState
+from custom_components.hsem.models.sensor_config import SensorConfig
 from custom_components.hsem.utils.recommendations import Recommendations
 
 # ---------------------------------------------------------------------------
@@ -55,13 +56,29 @@ def _make_live(
     battery_kwh: float = 5.0,
     ev_power_w: float | None = None,
     ev2_power_w: float | None = None,
+    export_price: float = 0.5,
+    export_price_available: bool = True,
 ) -> LiveState:
     live = LiveState()
     live.import_electricity_price = import_price
+    live.export_electricity_price = export_price
+    live.export_electricity_price_available = export_price_available
     live.ev = EVLiveState(is_charging=ev_charging, power_w=ev_power_w)
     live.ev_second = EVLiveState(is_charging=ev2_charging, power_w=ev2_power_w)
     live.battery_current_capacity_kwh = battery_kwh
     return live
+
+
+def _make_cfg(
+    batteries_enable_excess_export: bool = True,
+    export_electricity_min_price: float = 0.0,
+    batteries_export_min_price: float = 0.0,
+) -> SensorConfig:
+    cfg = SensorConfig()
+    cfg.batteries_enable_excess_export = batteries_enable_excess_export
+    cfg.export_electricity_min_price = export_electricity_min_price
+    cfg.batteries_export_min_price = batteries_export_min_price
+    return cfg
 
 
 # ---------------------------------------------------------------------------
@@ -72,18 +89,61 @@ def _make_live(
 class TestNegativeImportPrice:
     def test_negative_price_overrides_any_recommendation(self):
         rec = _make_rec(recommendation=Recommendations.BatteriesDischargeMode.value)
-        resolve_current_recommendation(rec, _make_live(import_price=-0.01), 0.0)
+        resolve_current_recommendation(
+            rec, _make_live(import_price=-0.01), 0.0, _make_cfg()
+        )
         assert rec.recommendation == Recommendations.ForceExport.value
 
     def test_zero_price_does_not_force_export(self):
         rec = _make_rec(recommendation=Recommendations.BatteriesWaitMode.value)
-        resolve_current_recommendation(rec, _make_live(import_price=0.0), 0.0)
+        resolve_current_recommendation(
+            rec, _make_live(import_price=0.0), 0.0, _make_cfg()
+        )
         assert rec.recommendation == Recommendations.BatteriesWaitMode.value
 
     def test_positive_price_does_not_force_export(self):
         rec = _make_rec(recommendation=Recommendations.BatteriesWaitMode.value)
-        resolve_current_recommendation(rec, _make_live(import_price=0.5), 0.0)
+        resolve_current_recommendation(
+            rec, _make_live(import_price=0.5), 0.0, _make_cfg()
+        )
         assert rec.recommendation == Recommendations.BatteriesWaitMode.value
+
+    def test_negative_import_and_export_price_does_not_force_export(self):
+        """Issue #732: negative export price must not be forced to export."""
+        rec = _make_rec(recommendation=Recommendations.BatteriesWaitMode.value)
+        live = _make_live(import_price=-0.7254, export_price=-0.708)
+        resolve_current_recommendation(rec, live, 0.0, _make_cfg())
+        assert rec.recommendation == Recommendations.BatteriesWaitMode.value
+
+    def test_negative_import_price_with_excess_export_disabled_no_override(self):
+        """Issue #732: a disabled excess-export toggle must not be bypassed."""
+        rec = _make_rec(recommendation=Recommendations.BatteriesWaitMode.value)
+        live = _make_live(import_price=-0.05, export_price=0.5)
+        cfg = _make_cfg(batteries_enable_excess_export=False)
+        resolve_current_recommendation(rec, live, 0.0, cfg)
+        assert rec.recommendation == Recommendations.BatteriesWaitMode.value
+
+    def test_negative_import_price_export_below_floor_no_override(self):
+        rec = _make_rec(recommendation=Recommendations.BatteriesWaitMode.value)
+        live = _make_live(import_price=-0.05, export_price=0.1)
+        cfg = _make_cfg(export_electricity_min_price=0.2)
+        resolve_current_recommendation(rec, live, 0.0, cfg)
+        assert rec.recommendation == Recommendations.BatteriesWaitMode.value
+
+    def test_negative_import_price_export_unavailable_no_override(self):
+        rec = _make_rec(recommendation=Recommendations.BatteriesWaitMode.value)
+        live = _make_live(
+            import_price=-0.05, export_price=0.5, export_price_available=False
+        )
+        resolve_current_recommendation(rec, live, 0.0, _make_cfg())
+        assert rec.recommendation == Recommendations.BatteriesWaitMode.value
+
+    def test_negative_import_price_profitable_export_overrides(self):
+        rec = _make_rec(recommendation=Recommendations.BatteriesWaitMode.value)
+        live = _make_live(import_price=-0.05, export_price=0.3)
+        cfg = _make_cfg(export_electricity_min_price=0.2)
+        resolve_current_recommendation(rec, live, 0.0, cfg)
+        assert rec.recommendation == Recommendations.ForceExport.value
 
 
 # ---------------------------------------------------------------------------
@@ -95,15 +155,22 @@ class TestGridChargePreserved:
     def test_grid_charge_not_overridden_by_ev(self):
         rec = _make_rec(recommendation=Recommendations.BatteriesChargeGrid.value)
         live = _make_live(import_price=0.5, ev_charging=True)
-        resolve_current_recommendation(rec, live, 0.0)
+        resolve_current_recommendation(rec, live, 0.0, _make_cfg())
         assert rec.recommendation == Recommendations.BatteriesChargeGrid.value
 
     def test_grid_charge_not_overridden_by_negative_price(self):
         rec = _make_rec(recommendation=Recommendations.BatteriesChargeGrid.value)
-        live = _make_live(import_price=-0.05)
-        # Negative price is priority 1, so it DOES override grid charge
-        resolve_current_recommendation(rec, live, 0.0)
+        live = _make_live(import_price=-0.05, export_price=0.5)
+        # Negative price with profitable export is priority 1, so it DOES
+        # override grid charge.
+        resolve_current_recommendation(rec, live, 0.0, _make_cfg())
         assert rec.recommendation == Recommendations.ForceExport.value
+
+    def test_grid_charge_not_overridden_by_negative_price_unprofitable_export(self):
+        rec = _make_rec(recommendation=Recommendations.BatteriesChargeGrid.value)
+        live = _make_live(import_price=-0.05, export_price=-0.03)
+        resolve_current_recommendation(rec, live, 0.0, _make_cfg())
+        assert rec.recommendation == Recommendations.BatteriesChargeGrid.value
 
 
 # ---------------------------------------------------------------------------
@@ -116,20 +183,20 @@ class TestEVSmartCharging:
         rec = _make_rec(recommendation=Recommendations.BatteriesDischargeMode.value)
         rec.ev_charger_calculated_power = 7500.0  # Planner allocated power
         live = _make_live(import_price=0.5, ev_charging=True)
-        resolve_current_recommendation(rec, live, 0.0)
+        resolve_current_recommendation(rec, live, 0.0, _make_cfg())
         assert rec.recommendation == Recommendations.EVSmartCharging.value
 
     def test_ev2_charging_triggers_ev_mode(self):
         rec = _make_rec(recommendation=Recommendations.BatteriesWaitMode.value)
         rec.ev_second_charger_calculated_power = 11000.0  # Planner allocated power
         live = _make_live(import_price=0.5, ev2_charging=True)
-        resolve_current_recommendation(rec, live, 0.0)
+        resolve_current_recommendation(rec, live, 0.0, _make_cfg())
         assert rec.recommendation == Recommendations.EVSmartCharging.value
 
     def test_no_ev_charging_no_override(self):
         rec = _make_rec(recommendation=Recommendations.BatteriesWaitMode.value)
         live = _make_live(ev_charging=False, ev2_charging=False)
-        resolve_current_recommendation(rec, live, 0.0)
+        resolve_current_recommendation(rec, live, 0.0, _make_cfg())
         assert rec.recommendation == Recommendations.BatteriesWaitMode.value
 
     def test_ev1_charging_but_planner_zero_power_no_override(self):
@@ -139,7 +206,7 @@ class TestEVSmartCharging:
         rec.ev_charger_calculated_power = 0.0
         rec.ev_total_planned_load_kwh = 0.0
         live = _make_live(ev_charging=True)
-        resolve_current_recommendation(rec, live, 0.0)
+        resolve_current_recommendation(rec, live, 0.0, _make_cfg())
         # Should keep original WaitMode because planner said stop
         assert rec.recommendation == Recommendations.BatteriesWaitMode.value
 
@@ -148,7 +215,7 @@ class TestEVSmartCharging:
         rec = _make_rec(recommendation=Recommendations.BatteriesWaitMode.value)
         rec.ev_charger_calculated_power = 7500.0  # Planner allocated power
         live = _make_live(ev_charging=True)
-        resolve_current_recommendation(rec, live, 0.0)
+        resolve_current_recommendation(rec, live, 0.0, _make_cfg())
         assert rec.recommendation == Recommendations.EVSmartCharging.value
 
     def test_ev2_charging_with_positive_power_overrides(self):
@@ -156,7 +223,7 @@ class TestEVSmartCharging:
         rec = _make_rec(recommendation=Recommendations.BatteriesWaitMode.value)
         rec.ev_second_charger_calculated_power = 11000.0  # Planner allocated power
         live = _make_live(ev2_charging=True)
-        resolve_current_recommendation(rec, live, 0.0)
+        resolve_current_recommendation(rec, live, 0.0, _make_cfg())
         assert rec.recommendation == Recommendations.EVSmartCharging.value
 
 
@@ -171,7 +238,10 @@ class TestBatteryAboveScheduleNeed:
         live = _make_live(battery_kwh=8.0)
         # remaining need = 5 kWh, battery = 8 kWh → discharge mode
         resolve_current_recommendation(
-            rec, live, batteries_schedules_remaining_capacity_needed=5.0
+            rec,
+            live,
+            batteries_schedules_remaining_capacity_needed=5.0,
+            cfg=_make_cfg(),
         )
         assert rec.recommendation == Recommendations.BatteriesDischargeMode.value
 
@@ -179,7 +249,10 @@ class TestBatteryAboveScheduleNeed:
         rec = _make_rec(recommendation=Recommendations.BatteriesWaitMode.value)
         live = _make_live(battery_kwh=5.0)
         resolve_current_recommendation(
-            rec, live, batteries_schedules_remaining_capacity_needed=5.0
+            rec,
+            live,
+            batteries_schedules_remaining_capacity_needed=5.0,
+            cfg=_make_cfg(),
         )
         # Not strictly greater, so no override
         assert rec.recommendation == Recommendations.BatteriesWaitMode.value
@@ -188,7 +261,10 @@ class TestBatteryAboveScheduleNeed:
         rec = _make_rec(recommendation=Recommendations.BatteriesWaitMode.value)
         live = _make_live(battery_kwh=10.0)
         resolve_current_recommendation(
-            rec, live, batteries_schedules_remaining_capacity_needed=0.0
+            rec,
+            live,
+            batteries_schedules_remaining_capacity_needed=0.0,
+            cfg=_make_cfg(),
         )
         assert rec.recommendation == Recommendations.BatteriesWaitMode.value
 
@@ -201,5 +277,5 @@ class TestBatteryAboveScheduleNeed:
 class TestNoneRec:
     def test_none_rec_does_not_raise(self):
         live = _make_live()
-        resolve_current_recommendation(None, live, 0.0)  # type: ignore[arg-type]
+        resolve_current_recommendation(None, live, 0.0, _make_cfg())  # type: ignore[arg-type]
         # No exception = pass

--- a/tests/test_convert_to_float_none.py
+++ b/tests/test_convert_to_float_none.py
@@ -206,29 +206,37 @@ class TestRecommendationResolverNullSafety:
             resolve_current_recommendation,
         )
         from custom_components.hsem.models.live_state import LiveState
+        from custom_components.hsem.models.sensor_config import SensorConfig
         from custom_components.hsem.utils.recommendations import Recommendations
 
         rec = self._make_rec()
         live = LiveState()
         live.import_electricity_price = 0.0  # explicitly zero — not negative
+        cfg = SensorConfig()
+        cfg.batteries_enable_excess_export = True
 
-        resolve_current_recommendation(rec, live, 0.0)
+        resolve_current_recommendation(rec, live, 0.0, cfg)
         # Should NOT override to ForceExport with a zero (non-negative) price
         assert rec.recommendation != Recommendations.ForceExport.value
 
     def test_negative_import_price_triggers_force_export(self) -> None:
-        """A confirmed negative price still triggers ForceExport."""
+        """A confirmed negative price with profitable export still triggers ForceExport."""
         from custom_components.hsem.custom_sensors.recommendation_resolver import (
             resolve_current_recommendation,
         )
         from custom_components.hsem.models.live_state import LiveState
+        from custom_components.hsem.models.sensor_config import SensorConfig
         from custom_components.hsem.utils.recommendations import Recommendations
 
         rec = self._make_rec()
         live = LiveState()
         live.import_electricity_price = -0.05
+        live.export_electricity_price = 0.10
+        live.export_electricity_price_available = True
+        cfg = SensorConfig()
+        cfg.batteries_enable_excess_export = True
 
-        resolve_current_recommendation(rec, live, 0.0)
+        resolve_current_recommendation(rec, live, 0.0, cfg)
         assert rec.recommendation == Recommendations.ForceExport.value
 
 

--- a/tests/test_datetime_utils.py
+++ b/tests/test_datetime_utils.py
@@ -730,6 +730,8 @@ class TestResolverDoesNotEraseEVFields:
 
         defaults = {
             "import_electricity_price": "0.25",
+            "export_electricity_price": "0.25",
+            "export_electricity_price_available": True,
             "ev": MagicMock(is_charging=False),
             "ev_second": MagicMock(is_charging=False),
             "battery_current_capacity_kwh": 5.0,
@@ -740,6 +742,14 @@ class TestResolverDoesNotEraseEVFields:
         for k, v in defaults.items():
             setattr(live, k, v)
         return live
+
+    def _make_resolver_cfg(self):
+        """Build a SensorConfig with excess battery export enabled."""
+        from custom_components.hsem.models.sensor_config import SensorConfig
+
+        cfg = SensorConfig()
+        cfg.batteries_enable_excess_export = True
+        return cfg
 
     def test_resolver_preserves_ev_load_when_relabelling(self):
         """Resolver changing the label must not zero out ev_planned_load_kwh."""
@@ -764,7 +774,10 @@ class TestResolverDoesNotEraseEVFields:
         live = self._make_live_state(ev=MagicMock(is_charging=True))
 
         resolve_current_recommendation(
-            rec, live, batteries_schedules_remaining_capacity_needed=0.0
+            rec,
+            live,
+            batteries_schedules_remaining_capacity_needed=0.0,
+            cfg=self._make_resolver_cfg(),
         )
 
         # Label changes but energy fields must be preserved
@@ -794,14 +807,19 @@ class TestResolverDoesNotEraseEVFields:
             recommendation="batteries_charge_solar",
         )
 
-        # Negative import price → ForceExport
+        # Negative import price with profitable export → ForceExport
         live = self._make_live_state(
             import_electricity_price="-0.05",
+            export_electricity_price="0.10",
+            export_electricity_price_available=True,
             ev=MagicMock(is_charging=False),
         )
 
         resolve_current_recommendation(
-            rec, live, batteries_schedules_remaining_capacity_needed=0.0
+            rec,
+            live,
+            batteries_schedules_remaining_capacity_needed=0.0,
+            cfg=self._make_resolver_cfg(),
         )
 
         assert rec.recommendation == "force_export"
@@ -835,7 +853,10 @@ class TestResolverDoesNotEraseEVFields:
         )
 
         resolve_current_recommendation(
-            rec, live, batteries_schedules_remaining_capacity_needed=5.0
+            rec,
+            live,
+            batteries_schedules_remaining_capacity_needed=5.0,
+            cfg=self._make_resolver_cfg(),
         )
 
         assert rec.recommendation == "batteries_discharge_mode"


### PR DESCRIPTION
## Summary

The runtime resolver (`resolve_current_recommendation`) forced `force_export`
whenever the live import price was negative, without checking the live
export price, the configured export-price floors, or the **Enable Excess
Battery Export** setting. In tariffs where a negative import price coincides
with a negative export price (reported: Swedish SE4, import ≈ −0.7254
SEK/kWh, export ≈ −0.708 SEK/kWh), this pushed the inverter into
`FullyFedToGrid` even though exporting cost money, and silently overrode a
user-disabled excess-export toggle.

- `force_export` now only fires when:
  - `import_price < 0`, **and**
  - `cfg.batteries_enable_excess_export` is enabled, **and**
  - the live export price is authoritative (`export_electricity_price_available`),
    non-negative, and ≥ `max(export_electricity_min_price, batteries_export_min_price)`.
- When any of these conditions fail, the resolver no longer returns early —
  evaluation falls through to the remaining priority rules (grid-charge
  preservation, EV active-charging override, battery-above-schedule-need).
- `resolve_current_recommendation()` gained a `cfg: SensorConfig` parameter
  so it can read the excess-export toggle and price floors; the sole caller
  in `working_mode_sensor.py` was updated to pass it.

## Branch

`fix/732-runtime-resolver-force-export-negative-price`

## Files changed

- `custom_components/hsem/custom_sensors/recommendation_resolver.py` — gated `force_export` rule
- `custom_components/hsem/custom_sensors/working_mode_sensor.py` — pass `cfg` to the resolver
- `docs/planner-spec.md` — Layer 3 runtime resolver rule + invariants updated
- `docs/planner-guide.md` — recommendation table, Layer 3 table, and priority-stack summary updated
- `tests/sensors/test_recommendation_resolver.py` — new gating tests (disabled toggle, unprofitable/negative export, unavailable export, below-floor, profitable-export-still-overrides)
- `tests/planner/test_slot_ownership.py`, `tests/test_convert_to_float_none.py`, `tests/test_datetime_utils.py` — updated existing call sites for the new `cfg` parameter and made export-price fixtures explicit

## Why

Reported in #732 (comment
https://github.com/woopstar/hsem/issues/732#issuecomment-5470863065): a
safety review before disabling Read Only mode found the resolver would
command full grid export at a real monetary loss, and would do so even with
Excess Battery Export disabled.

## Tests

- Added regression tests covering: disabled excess-export toggle, negative
  export price, export price below the configured floor, unavailable export
  price sensor, and the case where export is genuinely profitable (still
  overrides correctly).
- `./scripts/quality.sh lint` — pass
- `./scripts/quality.sh typing` — pass, 0 errors
- `./scripts/quality.sh quality` — pass, 0 errors (1 pre-existing, unrelated pyright warning in `working_mode_sensor.py`)
- `./scripts/quality.sh test` — 2964 passed

## Known limitations

None. `docs/planner-spec.md` and `docs/planner-guide.md` are updated to keep
spec and implementation consistent per the repo's planner-change rules.

Addresses the resolver bug reported in
https://github.com/woopstar/hsem/issues/732#issuecomment-5470863065 (not
using "Fixes" since #732 is the general v6.x feedback mega-thread, not a
dedicated bug issue — merging this PR should not auto-close it).
