### PR TITLE
fix(sensor): distinguish unconfigured OCPP status from disconnected, add listen diagnostics

### DIFF
--- a/custom_components/hsem/coordinator_cycle.py
+++ b/custom_components/hsem/coordinator_cycle.py
@@ -544,18 +544,22 @@ class CoordinatorCycleMixin(CoordinatorSharedState):
         # Package OCPP charger state for sensor entities.
         ocpp_chargers: dict | None = None
         ocpp_sessions: list | None = None
+        ocpp_listening = False
         ocpp = getattr(self, "_ocpp_server", None)
         if ocpp is not None:
             ocpp_chargers = ocpp.charger_sessions
             ocpp_sessions = list(self._ocpp_sessions)
+            ocpp_listening = ocpp.is_listening
 
         # Second EV's OCPP server state.
         ocpp_second_chargers: dict | None = None
         ocpp_second_sessions: list | None = None
+        ocpp_second_listening = False
         ocpp_second = getattr(self, "_ocpp_second_server", None)
         if ocpp_second is not None:
             ocpp_second_chargers = ocpp_second.charger_sessions
             ocpp_second_sessions = []
+            ocpp_second_listening = ocpp_second.is_listening
 
         data = CoordinatorData(
             cfg=self._cfg,
@@ -583,6 +587,8 @@ class CoordinatorCycleMixin(CoordinatorSharedState):
             ocpp_sessions=ocpp_sessions,
             ocpp_second_chargers=ocpp_second_chargers,
             ocpp_second_sessions=ocpp_second_sessions,
+            ocpp_listening=ocpp_listening,
+            ocpp_second_listening=ocpp_second_listening,
             capacity_learner=getattr(self, "_capacity_learner", CapacityLearner()),
             solar_hour_factors=dict(
                 getattr(self, "_solar_corrector", SolarForecastCorrector()).hour_factors

--- a/custom_components/hsem/coordinator_data.py
+++ b/custom_components/hsem/coordinator_data.py
@@ -94,3 +94,9 @@ class CoordinatorData:
     ocpp_second_chargers: dict | None = None
     #: Second EV OCPP completed session log.
     ocpp_second_sessions: list | None = None
+    #: True while the primary OCPP server's WebSocket site is bound and
+    #: active (issue #858). False when disabled or not yet started.
+    ocpp_listening: bool = False
+    #: True while the second EV's OCPP server WebSocket site is bound and
+    #: active (issue #858).
+    ocpp_second_listening: bool = False

--- a/custom_components/hsem/custom_sensors/ocpp_sensors.py
+++ b/custom_components/hsem/custom_sensors/ocpp_sensors.py
@@ -19,6 +19,7 @@ They read charger state from :attr:`CoordinatorData.ocpp_chargers` and
 from __future__ import annotations
 
 from typing import Any, override
+from urllib.parse import urlparse
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.sensor.const import SensorStateClass
@@ -27,6 +28,7 @@ from homeassistant.const import (
     EntityCategory,
     UnitOfPower,
 )
+from homeassistant.helpers.network import NoURLAvailableError, get_url
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from custom_components.hsem.coordinator import (
@@ -34,6 +36,7 @@ from custom_components.hsem.coordinator import (
     HSEMDataUpdateCoordinator,
 )
 from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
+from custom_components.hsem.models.sensor_config import SensorConfig
 from custom_components.hsem.utils.sensornames.ocpp import (
     get_ocpp_charger_info_sensor_entity_id,
     get_ocpp_charger_info_sensor_name,
@@ -64,6 +67,46 @@ def _chargers_for(data: CoordinatorData | None, charger_index: int) -> dict | No
     return data.ocpp_chargers
 
 
+def _ocpp_enabled_for(cfg: SensorConfig, charger_index: int) -> bool:
+    """Return whether OCPP is configured/enabled for the given EV's server."""
+    if charger_index == 2:
+        return cfg.ocpp_second_enabled
+    return cfg.ocpp_enabled
+
+
+def _is_listening(data: CoordinatorData | None, charger_index: int) -> bool:
+    """Return whether the given EV's OCPP server is currently listening."""
+    if data is None:
+        return False
+    if charger_index == 2:
+        return data.ocpp_second_listening
+    return data.ocpp_listening
+
+
+def _configured_port(cfg: SensorConfig, charger_index: int) -> int:
+    """Return the configured TCP port for the given EV's OCPP server."""
+    return cfg.ocpp_second_port if charger_index == 2 else cfg.ocpp_port
+
+
+def _connection_url(hass: Any, port: int) -> str | None:
+    """Build a best-effort ``ws://<host>:<port>/`` connection URL.
+
+    The embedded server binds ``0.0.0.0`` (all interfaces), which isn't a
+    usable address for an EVSE to dial. Resolve HA's own LAN-reachable host
+    via :func:`homeassistant.helpers.network.get_url` instead. Returns
+    ``None`` when no usable URL can be resolved — the caller falls back to
+    showing host/port separately.
+    """
+    try:
+        base = get_url(hass, allow_internal=True, allow_ip=True, prefer_external=False)
+    except NoURLAvailableError:
+        return None
+    host = urlparse(base).hostname
+    if not host:
+        return None
+    return f"ws://{host}:{port}/"
+
+
 # ---------------------------------------------------------------------------
 # OCPP Charger Status Sensor
 # ---------------------------------------------------------------------------
@@ -78,7 +121,8 @@ class HSEMOCPPChargerStatusSensor(
     """Diagnostic sensor exposing OCPP charger connection and charging status.
 
     State is one of:
-    - ``"disconnected"`` — No charger connected.
+    - ``"not_configured"`` — This EV's OCPP server isn't enabled in config.
+    - ``"disconnected"`` — Server enabled but no charger connected.
     - ``"Available"`` — Charger connected but idle.
     - ``"Preparing"`` — Preparing to charge.
     - ``"Charging"`` — Actively charging.
@@ -137,6 +181,11 @@ class HSEMOCPPChargerStatusSensor(
         if data is None:
             return self._restored_state or "disconnected"
 
+        if data.cfg is not None and not _ocpp_enabled_for(
+            data.cfg, self._charger_index
+        ):
+            return "not_configured"
+
         chargers = _chargers_for(data, self._charger_index) or {}
         if not chargers:
             return "disconnected"
@@ -148,22 +197,37 @@ class HSEMOCPPChargerStatusSensor(
     @property
     @override
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Return per-charger status details."""
+        """Return server diagnostics and per-charger status details."""
         data: CoordinatorData | None = self.coordinator.data
-        chargers = _chargers_for(data, self._charger_index)
-        if not chargers:
+        if (
+            data is None
+            or data.cfg is None
+            or not _ocpp_enabled_for(data.cfg, self._charger_index)
+        ):
             return {}
 
-        attrs: dict[str, Any] = {}
-        for cpid, session in chargers.items():
-            attrs[cpid] = {
-                "status": session.status,
-                "power_w": round(session.current_power_w, 1),
-                "transaction_id": session.transaction_id,
-                "connected_at": (
-                    session.connected_at.isoformat() if session.connected_at else None
-                ),
-            }
+        port = _configured_port(data.cfg, self._charger_index)
+        attrs: dict[str, Any] = {
+            "listening": _is_listening(data, self._charger_index),
+            "port": port,
+        }
+        url = _connection_url(self.hass, port)
+        if url is not None:
+            attrs["url"] = url
+
+        chargers = _chargers_for(data, self._charger_index)
+        if chargers:
+            for cpid, session in chargers.items():
+                attrs[cpid] = {
+                    "status": session.status,
+                    "power_w": round(session.current_power_w, 1),
+                    "transaction_id": session.transaction_id,
+                    "connected_at": (
+                        session.connected_at.isoformat()
+                        if session.connected_at
+                        else None
+                    ),
+                }
         return attrs
 
     @property

--- a/custom_components/hsem/custom_sensors/ocpp_server.py
+++ b/custom_components/hsem/custom_sensors/ocpp_server.py
@@ -156,6 +156,21 @@ class OCPPServer:
         _LOGGER.info("OCPP server stopped")
 
     @property
+    def host(self) -> str:
+        """Return the configured bind address."""
+        return self._host
+
+    @property
+    def port(self) -> int:
+        """Return the configured TCP port."""
+        return self._port
+
+    @property
+    def is_listening(self) -> bool:
+        """Return True while the aiohttp WebSocket site is bound and active."""
+        return self._site is not None
+
+    @property
     def charger_sessions(self) -> dict[str, ChargerSession]:
         """Return a copy of the current charger sessions dict."""
         return dict(self._chargers)

--- a/docs/sensors-reference.md
+++ b/docs/sensors-reference.md
@@ -511,10 +511,11 @@ Sensors providing live status and diagnostics for an OCPP-compliant EV charger c
 
 ### `sensor.hsem_ocpp_charger_status`
 
-| Property  | Value                                                                    |
-| --------- | ------------------------------------------------------------------------ |
-| **Type**  | `sensor`                                                                 |
-| **State** | Connection/charging state: `connected`, `charging`, `disconnected`, etc. |
+| Property       | Value                                                                                                                                                                                                                                                                                                                   |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Type**       | `sensor`                                                                                                                                                                                                                                                                                                                |
+| **State**      | `not_configured` (this EV's OCPP server isn't enabled), `disconnected` (enabled, no charger connected), or the live connection/charging state (`Available`, `Preparing`, `Charging`, `Finishing`)                                                                                                                       |
+| **Attributes** | `listening` (bool — server socket bound), `port`, `url` (best-effort `ws://<host>:<port>/` for the EVSE's OCPP config, when HA can resolve a reachable host) — present only when this EV's OCPP server is enabled; plus one entry per connected charger CPID with `status`, `power_w`, `transaction_id`, `connected_at` |
 
 ### `sensor.hsem_ocpp_charger_power`
 

--- a/tests/custom_sensors/test_ocpp_sensors.py
+++ b/tests/custom_sensors/test_ocpp_sensors.py
@@ -1,0 +1,130 @@
+"""Tests for the OCPP charger status sensor's config-awareness (issue #858).
+
+Covers:
+- ``state`` reports ``not_configured`` (not the misleading ``disconnected``)
+  when this EV's OCPP server isn't enabled in config.
+- ``state`` still reports ``disconnected`` when enabled but idle, and the
+  live charger status when a charger is connected.
+- ``extra_state_attributes`` exposes ``listening``/``port``/``url`` only
+  when this EV's OCPP server is enabled.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.hsem.coordinator_data import CoordinatorData
+from custom_components.hsem.custom_sensors.ocpp_sensors import (
+    HSEMOCPPChargerStatusSensor,
+)
+from custom_components.hsem.models.ocpp_session import ChargerSession
+from custom_components.hsem.models.sensor_config import SensorConfig
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config_entry() -> MagicMock:
+    entry = MagicMock()
+    entry.entry_id = "test_entry_id"
+    return entry
+
+
+def _make_coordinator(data: CoordinatorData | None) -> MagicMock:
+    coordinator = MagicMock()
+    coordinator.data = data
+    coordinator.last_update_success = data is not None
+    return coordinator
+
+
+def _make_hass_without_url() -> MagicMock:
+    """A hass mock where ``get_url`` cleanly raises ``NoURLAvailableError``."""
+    hass = MagicMock()
+    hass.config.api = None
+    hass.config.internal_url = None
+    hass.config.external_url = None
+    return hass
+
+
+# ---------------------------------------------------------------------------
+# state
+# ---------------------------------------------------------------------------
+
+
+def test_state_not_configured_when_ocpp_disabled() -> None:
+    """Primary sensor reports not_configured, not disconnected, when off."""
+    data = CoordinatorData(cfg=SensorConfig(ocpp_enabled=False))
+    sensor = HSEMOCPPChargerStatusSensor(_make_config_entry(), _make_coordinator(data))
+    assert sensor.state == "not_configured"
+
+
+def test_state_disconnected_when_enabled_but_idle() -> None:
+    """Enabled server with no connected charger still reports disconnected."""
+    data = CoordinatorData(cfg=SensorConfig(ocpp_enabled=True), ocpp_chargers={})
+    sensor = HSEMOCPPChargerStatusSensor(_make_config_entry(), _make_coordinator(data))
+    assert sensor.state == "disconnected"
+
+
+def test_state_reflects_connected_charger() -> None:
+    """Enabled server with a connected charger reports its live status."""
+    data = CoordinatorData(
+        cfg=SensorConfig(ocpp_enabled=True),
+        ocpp_chargers={"CP1": ChargerSession(cpid="CP1", status="Charging")},
+    )
+    sensor = HSEMOCPPChargerStatusSensor(_make_config_entry(), _make_coordinator(data))
+    assert sensor.state == "Charging"
+
+
+def test_second_charger_state_uses_second_flag() -> None:
+    """charger_index=2 checks ocpp_second_enabled, not the primary flag."""
+    data = CoordinatorData(
+        cfg=SensorConfig(ocpp_enabled=True, ocpp_second_enabled=False)
+    )
+    sensor = HSEMOCPPChargerStatusSensor(
+        _make_config_entry(), _make_coordinator(data), charger_index=2
+    )
+    assert sensor.state == "not_configured"
+
+
+# ---------------------------------------------------------------------------
+# extra_state_attributes
+# ---------------------------------------------------------------------------
+
+
+def test_attributes_empty_when_not_configured() -> None:
+    """No diagnostic attributes are exposed when OCPP isn't enabled."""
+    data = CoordinatorData(cfg=SensorConfig(ocpp_enabled=False))
+    sensor = HSEMOCPPChargerStatusSensor(_make_config_entry(), _make_coordinator(data))
+    sensor.hass = _make_hass_without_url()
+    assert sensor.extra_state_attributes == {}
+
+
+def test_attributes_include_listening_and_port_when_enabled() -> None:
+    """listening/port are always present when this EV's server is enabled."""
+    data = CoordinatorData(
+        cfg=SensorConfig(ocpp_enabled=True, ocpp_port=9000),
+        ocpp_listening=True,
+    )
+    sensor = HSEMOCPPChargerStatusSensor(_make_config_entry(), _make_coordinator(data))
+    sensor.hass = _make_hass_without_url()
+    attrs = sensor.extra_state_attributes
+    assert attrs["listening"] is True
+    assert attrs["port"] == 9000
+    assert "url" not in attrs  # no resolvable HA URL in this mock hass
+
+
+def test_attributes_include_per_charger_session_details() -> None:
+    """Connected charger details are merged alongside server diagnostics."""
+    data = CoordinatorData(
+        cfg=SensorConfig(ocpp_enabled=True, ocpp_port=9000),
+        ocpp_listening=True,
+        ocpp_chargers={
+            "CP1": ChargerSession(cpid="CP1", status="Charging", current_power_w=7400.0)
+        },
+    )
+    sensor = HSEMOCPPChargerStatusSensor(_make_config_entry(), _make_coordinator(data))
+    sensor.hass = _make_hass_without_url()
+    attrs = sensor.extra_state_attributes
+    assert attrs["CP1"]["status"] == "Charging"
+    assert attrs["CP1"]["power_w"] == 7400.0


### PR DESCRIPTION
## Summary

- The primary OCPP charger status sensor (`sensor.hsem_ocpp_charger_status`) was created unconditionally and reported `"disconnected"` forever on every install that never enabled OCPP, because the embedded server is never started and `ocpp_chargers` stays empty. It now reports `"not_configured"` per EV when the relevant `hsem_ocpp_enabled` / `hsem_ocpp_second_enabled` flag is off.
- Added `listening` / `port` / `url` diagnostic attributes to the status sensor (per OCPP server), so users can confirm the embedded server is actually up and get a ready-to-use `ws://<host>:<port>/` URL for their EVSE's OCPP configuration.
- `OCPPServer` gains `host`, `port`, and `is_listening` accessors; `CoordinatorData` carries the live listening state through each cycle for both the primary and second server.

## Branch

`fix/858-ocpp-status-diagnostics`

## Files changed

- `custom_components/hsem/custom_sensors/ocpp_server.py` — `host`/`port`/`is_listening` properties
- `custom_components/hsem/coordinator_data.py` — new `ocpp_listening` / `ocpp_second_listening` fields
- `custom_components/hsem/coordinator_cycle.py` — populate the new fields from the live server state each cycle
- `custom_components/hsem/custom_sensors/ocpp_sensors.py` — `not_configured` state + `listening`/`port`/`url` attributes on `HSEMOCPPChargerStatusSensor`
- `docs/sensors-reference.md` — documents the new state and attributes
- `tests/custom_sensors/test_ocpp_sensors.py` — new tests

## What changed and why

Previously "disconnected" was ambiguous — it looked identical whether OCPP was fully configured with no charger plugged in, or never turned on at all. The fix distinguishes the two, following the same config-gating pattern already used for the second OCPP server's entity creation (`sensor.py:197-206`). The new attributes give users a way to verify from Home Assistant that the embedded server is actually listening and what URL to point their EVSE at, without needing to check `hsem.log`.

Entity *creation* gating (skipping OCPP/EV1/EV2 entities entirely when unconfigured) is tracked separately in #859 and intentionally out of scope here.

## Tests added or updated

- `tests/custom_sensors/test_ocpp_sensors.py` (new): `not_configured` vs `disconnected` vs live status, second-EV flag independence, and `extra_state_attributes` gating/content.
- Existing `tests/custom_sensors/test_ocpp_per_ev.py` and `test_ocpp_server.py` still pass unchanged.

## Test and lint results

All four quality gates pass:

```
./scripts/quality.sh lint     ✅ ruff format + ruff check + prettier — clean
./scripts/quality.sh typing   ✅ mypy — 0 errors
./scripts/quality.sh quality  ✅ pyright + vulture — 0 errors (1 pre-existing unrelated warning)
./scripts/quality.sh test     ✅ 2971 passed
```

## Known limitations

- `url` is a best-effort attribute resolved via `homeassistant.helpers.network.get_url()`; it's omitted when HA can't resolve a usable internal/external URL (e.g. no `internal_url` configured), and the caller should fall back to the `port` attribute plus their HA host's own LAN IP.

Fixes #858
