### PR TITLE
chore(labels): consolidate label taxonomy into a single canonical manifest

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,5 @@
+# Label names used below must exist in .github/sync-labels.yml, the
+# canonical label manifest.
 name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
 change-template: "- #$NUMBER $TITLE @$AUTHOR"
@@ -37,6 +39,18 @@ categories:
   - title: "📦 Dependencies"
     labels:
       - "dependencies"
+
+  - title: "⚡ Performance"
+    labels:
+      - "performance"
+
+  - title: "♻️ Refactoring"
+    labels:
+      - "area:refactor"
+
+  - title: "🧪 Tests"
+    labels:
+      - "area:tests"
 
 version-resolver:
   major:
@@ -78,3 +92,12 @@ autolabeler:
   - label: "dependencies"
     branch:
       - '/deps\/.+/'
+  - label: "performance"
+    branch:
+      - '/perf\/.+/'
+  - label: "area:refactor"
+    branch:
+      - '/refactor\/.+/'
+  - label: "area:tests"
+    branch:
+      - '/test\/.+/'

--- a/.github/sync-labels.yml
+++ b/.github/sync-labels.yml
@@ -1,3 +1,12 @@
+# Canonical manifest of every label used in this repository.
+#
+# This file is the single source of truth for label existence (name, color,
+# description). Synced to GitHub by workflows/sync-labels.yaml on every push
+# to main that touches this file.
+#
+# workflows/auto-label.yml (PR labeling from conventional-commit type) and
+# release-drafter.yml (changelog categorization / version resolution) must
+# only reference label names that are defined here.
 ---
 - name: "breaking-change"
   color: b60205
@@ -38,6 +47,9 @@
 - name: "LOCKED"
   color: ff0000
   description: "This thread is locked"
+- name: "performance"
+  color: fbca04
+  description: "Performance and efficiency improvements"
 
 - name: "major"
   color: 2fff00
@@ -80,3 +92,50 @@
 - name: "size/XXL"
   color: b8bab8
   description: "Denotes a PR that changes 1000+ lines"
+
+# Issue triage taxonomy: which subsystem an issue touches.
+- name: "area:config"
+  color: bfd4f2
+  description: "Configuration, migration, validation, and defaults"
+- name: "area:diagnostics"
+  color: d4c5f9
+  description: "Debug output, status, diagnostics, and explainability"
+- name: "area:docs"
+  color: 0075ca
+  description: "Documentation and troubleshooting"
+- name: "area:ev-charging"
+  color: 5319e7
+  description: "EV charging, OCPP server, and charger coordination"
+- name: "area:forecast"
+  color: 5319e7
+  description: "PV, load, price, and prediction logic"
+- name: "area:home-assistant"
+  color: 006b75
+  description: "Home Assistant entities, services, coordinators, and config flow"
+- name: "area:inverter"
+  color: 7057ff
+  description: "Inverter control, write verification, and hardware capabilities"
+- name: "area:planner"
+  color: 1d76db
+  description: "Planner logic, scoring, schedules, and energy decisions"
+- name: "area:refactor"
+  color: c2e0c6
+  description: "Structure changes without intended behavior change"
+- name: "area:safety"
+  color: b60205
+  description: "Safety, degraded mode, validation, and hardware risk"
+- name: "area:tests"
+  color: c5def5
+  description: "Unit tests, HA mocks, regression tests, and benchmarks"
+
+# Issue triage taxonomy: how urgent an issue is.
+- name: "priority:p0"
+  color: b60205
+  description: "Must fix before real hardware control"
+- name: "priority:p1"
+  color: d93f0b
+  description: "Core architecture and planner improvements"
+
+- name: "feedback"
+  color: ededed
+  description: "Community feedback and bug-report megathreads"

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2025 Andreas Krüger
+#
+# Label names used below must exist in .github/sync-labels.yml, the
+# canonical label manifest.
 
 name: Auto Label PRs from Conventional Commits
 
@@ -53,5 +56,17 @@ jobs:
               - type: 'dependencies'
                 nouns: ['deps', 'dep', 'dependencies', 'dependency']
                 labels: ['dependencies']
+              - type: 'refactor'
+                nouns: ['refactor', 'Refactor', 'REFACTOR']
+                labels: ['area:refactor']
+              - type: 'perf'
+                nouns: ['perf', 'Perf', 'PERF', 'performance']
+                labels: ['performance']
+              - type: 'test'
+                nouns: ['test', 'Test', 'TEST', 'tests']
+                labels: ['area:tests']
+              - type: 'ci'
+                nouns: ['ci', 'CI']
+                labels: ['build']
           maintain-labels-not-matched: false
           apply-changes: true


### PR DESCRIPTION
## Summary

Consolidates the GitHub label taxonomy so `.github/sync-labels.yml` is the single
source of truth for every label that exists, and both `auto-label.yml` (PR
auto-labeling from conventional-commit type) and `release-drafter.yml` (changelog
categorization + version resolution) now only reference label names defined there.

## Background

The label list had drifted into two parallel systems: the automation-linked flat
labels (`bug`, `enhancement`, `chore`, ...) tracked in `sync-labels.yml`, and a
newer `type:*`/`area:*`/`priority:*` issue-triage taxonomy that was applied to
issues manually and never added to the manifest. On top of that, several flat
topic tags (`planner`, `ev`, `ev-charging`, `ocpp`, `sensors`, `dashboard`,
`services`, `refactor`, `async`, `logging`, `python:uv`) duplicated what the
`area:*` labels already covered.

## Changes

- **`.github/sync-labels.yml`**: now the canonical manifest of all 41 labels.
  Added the previously-untracked `area:*`, `priority:*`, and `feedback` labels,
  plus two new labels: `area:ev-charging` and `performance`.
- **GitHub labels** (already applied directly via `gh`, not part of this diff):
  - Relabeled every issue/PR that carried a deprecated label with its canonical
    replacement, then deleted 14 redundant labels: `type:bug` → `bug`,
    `type:feature` → `enhancement`, `type:tech-debt` → `chore`, `refactor` →
    `area:refactor`, `planner` → `area:planner`, `ev`/`ev-charging`/`ocpp` →
    `area:ev-charging`, `sensors`/`dashboard`/`services` → `area:home-assistant`,
    `async` → `area:safety`, `logging` → `area:diagnostics`, `python:uv` →
    `dependencies`.
  - Labeled the 3 open issues that had no labels at all (#858, #859, #860).
- **`.github/workflows/auto-label.yml`**: added missing conventional-commit
  mappings — `refactor` → `area:refactor`, `perf` → `performance`, `test` →
  `area:tests`, `ci` → `build` — so all 8 commit types from `AGENTS.md`/
  `CLAUDE.md` (`feat`, `fix`, `chore`, `docs`, `refactor`, `perf`, `test`, `ci`)
  now map to a label.
- **`.github/release-drafter.yml`**: added matching categories (Performance,
  Refactoring, Tests) and `autolabeler` branch-pattern entries for the same
  three new mappings.
- Both workflow files now carry a header comment pointing back to
  `sync-labels.yml` as the canonical source.

## Note on "single source of truth"

`sync-labels.yml`, `auto-label.yml`, and `release-drafter.yml` are each consumed
by a different third-party GitHub Action with its own config schema, so they
can't be merged into one physical file. This PR gets as close as the tooling
allows: one manifest owns label existence/color/description, and the other two
are verified to only reference names that live in it.

## Test plan

- [x] `python3 -c "yaml.safe_load(...)"` on all three files — valid YAML
- [x] Verified every label name referenced in `auto-label.yml` and
      `release-drafter.yml` exists in `sync-labels.yml` (scripted check, no
      missing names)
- [ ] On merge, confirm the `Sync labels` workflow run is green and does not
      attempt to touch labels outside this manifest
