### PR TITLE
feat(sensor): gate OCPP/EV1/EV2 entity creation on config instead of always creating them

### DIFF
--- a/.claude/skills/hsem-issue-creation/SKILL.md
+++ b/.claude/skills/hsem-issue-creation/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: hsem-issue-creation
+description: Activate when creating a new GitHub issue for the HSEM repository. Ensures every issue has a Conventional Commits title, a detailed description, a proposed solution, acceptance criteria, a tailored fix prompt, and labels.
+---
+
+# HSEM Issue Creation
+
+Activate this skill whenever a new GitHub issue is being created for this repository —
+whether reporting a bug, filing an enhancement, or capturing a chore/tech-debt item.
+
+## Step 1: Investigate Before Drafting
+
+Read the relevant code (and `docs/planner-spec.md` / `AGENTS.md` if the area applies)
+before writing the issue. An issue drafted without reading the code produces a vague
+description and an unusable "solution" — grep for the symptom, find the responsible
+file(s), and cite concrete `file:line` references in the body.
+
+## Step 2: Title — Conventional Commits
+
+Format: `<type>(<scope>): <description>`
+
+Types: `feat`, `fix`, `chore`, `docs`, `refactor`, `perf`, `test`, `ci`
+
+Scope should name the specific domain (e.g. `sensor`, `ocpp`, `planner`, `config`,
+`milp`). Keep the description short and imperative — it becomes the branch slug and,
+eventually, the commit/PR title.
+
+Examples:
+
+```
+fix(ocpp): status sensor misleadingly shows 'disconnected' when unconfigured
+feat(planner): add temperature-adaptive charge rate
+chore(quality): enforce prettier for markdown in CI
+```
+
+## Step 3: Body — Required Sections
+
+Every issue body MUST contain these four sections, in this order:
+
+```markdown
+## Description
+
+<Detailed explanation of the problem or request: what happens, why it's wrong or
+missing, where it lives in the code (file:line references), and root cause if known.
+For enhancements, explain the user-visible gap being filled.>
+
+## Possible Solution
+
+<A concrete, plausible approach to fix/implement this — specific enough to guide
+implementation, but not a full diff. Name the functions/files likely to change.
+If there are multiple viable approaches, note the trade-off briefly and recommend one.>
+
+## Acceptance Criteria
+
+- [ ] <Specific, testable condition that must hold once this is fixed>
+- [ ] <Another condition — cover edge cases, not just the happy path>
+- [ ] Tests added/updated covering the above
+- [ ] `./scripts/quality.sh all` passes
+
+## Suggested Prompt
+
+\`\`\`
+<A ready-to-run prompt tailored to this specific issue — enough context that a fresh
+Claude Code session with no prior conversation could act on it directly: the file(s)
+involved, the expected behavior change, and a pointer to run the pre-flight skill and
+quality gates before opening a PR. Do not write a generic "fix issue #N" placeholder.>
+\`\`\`
+```
+
+Do not omit or reorder these sections. Do not pad the description with sections the
+repo doesn't use elsewhere (no "Environment", "Steps to Reproduce", etc. unless the
+issue genuinely needs them as sub-content within Description).
+
+## Step 4: Labels
+
+Always attach at least one label. Check current labels first — they do change:
+
+```bash
+rtk gh label list
+```
+
+Pick from the repo's existing taxonomy (see below); do not invent new labels without
+asking the user first. At minimum, apply:
+
+1. **One type label** — `bug` or `enhancement` (or `chore` for maintenance-only work).
+2. **One `area:*` label** matching the affected subsystem, if one fits:
+   `area:planner`, `area:inverter`, `area:forecast`, `area:config`,
+   `area:home-assistant`, `area:diagnostics`, `area:safety`, `area:tests`,
+   `area:docs`, `area:refactor`.
+3. Optional topical labels when relevant: `ocpp`, `ev-charging`, `sensors`,
+   `services`, `logging`, `dashboard`, `config`, `dependencies`, `breaking-change`.
+4. Optional priority label if urgency is known: `priority:p0` (must fix before real
+   hardware control) or `priority:p1` (core architecture/planner improvements).
+
+Skip `type:bug` / `type:feature` unless the user's convention has shifted to those —
+`bug` / `enhancement` are the labels actually in use on current open issues.
+
+## Step 5: Create the Issue
+
+Draft the body in a temp markdown file and pass it via `--body-file` — never inline a
+multiline body as a shell argument.
+
+```bash
+gh issue create \
+  --title "fix(ocpp): status sensor misleadingly shows 'disconnected' when unconfigured" \
+  --body-file /tmp/issue-body.md \
+  --label bug --label area:diagnostics --label ocpp
+```
+
+Prefer `rtk gh issue create` for the token-savings passthrough.
+
+## Step 6: Verify
+
+```bash
+rtk gh issue view <number>
+```
+
+Confirm the title parses as Conventional Commits, all four body sections are present,
+and the labels applied match the taxonomy.

--- a/custom_components/hsem/number.py
+++ b/custom_components/hsem/number.py
@@ -15,6 +15,7 @@ from custom_components.hsem.custom_numbers.battery_efficiency import (
     HSEMBatteryEfficiencyNumber,
 )
 from custom_components.hsem.custom_numbers.ev_target_soc import HSEMEVTargetSocNumber
+from custom_components.hsem.utils.misc import get_config_value
 from custom_components.hsem.utils.sensornames.controls import (
     get_charge_efficiency_number_entity_id,
     get_charge_efficiency_number_key,
@@ -97,8 +98,20 @@ async def async_setup_entry(  # NOSONAR -- HA platform callback, must be async
         get_ev_second_target_soc_number_key(),
     }
 
+    # EV target-SoC numbers only apply when that EV's planned load (managed
+    # charging) is enabled (issue #859).
+    _gated_keys = {
+        get_ev_target_soc_number_key(): "hsem_ev_planned_load_enabled",
+        get_ev_second_target_soc_number_key(): "hsem_ev_second_planned_load_enabled",
+    }
+
     entities: list[NumberEntity] = []
     for description in NUMBER_DESCRIPTIONS:
+        config_flag = _gated_keys.get(description.key)
+        if config_flag is not None and not bool(
+            get_config_value(config_entry, config_flag)
+        ):
+            continue
         if description.key in _ev_target_soc_keys:
             entities.append(
                 HSEMEVTargetSocNumber(

--- a/custom_components/hsem/sensor.py
+++ b/custom_components/hsem/sensor.py
@@ -128,25 +128,26 @@ async def async_setup_entry(  # NOSONAR -- HA platform callback, must be async
     net_consumption_sensor = HSEMNetConsumptionSensor(config_entry, coordinator)
     battery_soc_sensor = HSEMBatterySoCSensor(config_entry, coordinator)
     force_mode_sensor = HSEMForceModeSensor(config_entry, coordinator)
-    ev_charging_sensor = HSEMEVChargingSensor(config_entry, coordinator)
-    ev_optimal_charging_plan_sensor = HSEMEVOptimalChargingPlanSensor(
-        config_entry, coordinator
-    )
-    ev_second_optimal_charging_plan_sensor = HSEMEVSecondOptimalChargingPlanSensor(
-        config_entry, coordinator
-    )
-    ev_charger_calculated_power_sensor = HSEMEVChargerCalculatedPowerSensor(
-        config_entry, coordinator
-    )
-    ev_second_charger_calculated_power_sensor = (
-        HSEMEVSecondChargerCalculatedPowerSensor(config_entry, coordinator)
-    )
-    ev_charger_current_limit_sensor = HSEMEVChargerCurrentLimitSensor(
-        config_entry, coordinator
-    )
-    ev_second_charger_current_limit_sensor = HSEMEVSecondChargerCurrentLimitSensor(
-        config_entry, coordinator
-    )
+
+    # EV1 sensors — only meaningful when the primary EV's planned load
+    # (managed charging) is configured (issue #859).
+    ev_entities = []
+    if bool(get_config_value(config_entry, "hsem_ev_planned_load_enabled")):
+        ev_entities = [
+            HSEMEVChargingSensor(config_entry, coordinator),
+            HSEMEVOptimalChargingPlanSensor(config_entry, coordinator),
+            HSEMEVChargerCalculatedPowerSensor(config_entry, coordinator),
+            HSEMEVChargerCurrentLimitSensor(config_entry, coordinator),
+        ]
+
+    # EV2 sensors — only when the second EV's planned load is configured.
+    ev_second_entities = []
+    if bool(get_config_value(config_entry, "hsem_ev_second_planned_load_enabled")):
+        ev_second_entities = [
+            HSEMEVSecondOptimalChargingPlanSensor(config_entry, coordinator),
+            HSEMEVSecondChargerCalculatedPowerSensor(config_entry, coordinator),
+            HSEMEVSecondChargerCurrentLimitSensor(config_entry, coordinator),
+        ]
 
     # Forecast accuracy sensor — exposes predicted-vs-actual metrics.
     forecast_accuracy_sensor = HSEMForecastAccuracySensor(config_entry, coordinator)
@@ -186,13 +187,16 @@ async def async_setup_entry(  # NOSONAR -- HA platform callback, must be async
     savings_sensor = HSEMSavingsSensor(config_entry, coordinator)
 
     # OCPP charger sensors — expose charger state when OCPP server is enabled.
-    # One set per EV: the second set only when the second EV is configured.
-    ocpp_charger_status_sensor = HSEMOCPPChargerStatusSensor(config_entry, coordinator)
-    ocpp_charger_power_sensor = HSEMOCPPChargerPowerSensor(config_entry, coordinator)
-    ocpp_charger_info_sensor = HSEMOCPPChargerInfoSensor(config_entry, coordinator)
-    ocpp_charger_sessions_sensor = HSEMOCPPChargerSessionsSensor(
-        config_entry, coordinator
-    )
+    # One set per EV: each set only when that EV's OCPP server is configured
+    # (issue #859 — previously the primary set was always created).
+    ocpp_entities = []
+    if bool(get_config_value(config_entry, "hsem_ocpp_enabled")):
+        ocpp_entities = [
+            HSEMOCPPChargerStatusSensor(config_entry, coordinator),
+            HSEMOCPPChargerPowerSensor(config_entry, coordinator),
+            HSEMOCPPChargerInfoSensor(config_entry, coordinator),
+            HSEMOCPPChargerSessionsSensor(config_entry, coordinator),
+        ]
 
     ocpp_second_entities = []
     if bool(
@@ -218,13 +222,8 @@ async def async_setup_entry(  # NOSONAR -- HA platform callback, must be async
             net_consumption_sensor,
             battery_soc_sensor,
             force_mode_sensor,
-            ev_charging_sensor,
-            ev_optimal_charging_plan_sensor,
-            ev_second_optimal_charging_plan_sensor,
-            ev_charger_calculated_power_sensor,
-            ev_second_charger_calculated_power_sensor,
-            ev_charger_current_limit_sensor,
-            ev_second_charger_current_limit_sensor,
+            *ev_entities,
+            *ev_second_entities,
             applier_status_sensor,
             plan_explanation_sensor,
             forecast_accuracy_sensor,
@@ -238,10 +237,7 @@ async def async_setup_entry(  # NOSONAR -- HA platform callback, must be async
             import_cost_sensor,
             net_grid_balance_sensor,
             working_mode_sensor,
-            ocpp_charger_status_sensor,
-            ocpp_charger_power_sensor,
-            ocpp_charger_info_sensor,
-            ocpp_charger_sessions_sensor,
+            *ocpp_entities,
             *ocpp_second_entities,
         ]
     )

--- a/custom_components/hsem/switch.py
+++ b/custom_components/hsem/switch.py
@@ -13,6 +13,7 @@ from custom_components.hsem.custom_switches.description import (
     HSEMSwitchEntityDescription,
 )
 from custom_components.hsem.custom_switches.switch import HSEMSwitch
+from custom_components.hsem.utils.misc import get_config_value
 from custom_components.hsem.utils.sensornames.controls import (
     get_batteries_schedule_1_switch_key,
     get_batteries_schedule_2_switch_key,
@@ -120,15 +121,38 @@ SWITCH_DESCRIPTIONS: tuple[HSEMSwitchEntityDescription, ...] = (
 )
 
 
+# Switch keys that only apply to a configured EV — created only when that
+# EV's planned load (managed charging) is enabled (issue #859).
+_EV_SWITCH_KEYS = {
+    get_ev_force_discharge_switch_key(),
+    get_ev_smart_charging_switch_key(),
+    get_ev_force_charge_now_switch_key(),
+    get_ev_auto_full_negative_price_switch_key(),
+}
+_EV_SECOND_SWITCH_KEYS = {
+    get_ev_second_smart_charging_switch_key(),
+    get_ev_second_force_charge_now_switch_key(),
+}
+
+
 async def async_setup_entry(  # NOSONAR -- HA platform callback, must be async
     hass: HomeAssistant,
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up HSEM switch entities from a config entry."""
+    ev_enabled = bool(get_config_value(config_entry, "hsem_ev_planned_load_enabled"))
+    ev_second_enabled = bool(
+        get_config_value(config_entry, "hsem_ev_second_planned_load_enabled")
+    )
+
+    descriptions = [
+        description
+        for description in SWITCH_DESCRIPTIONS
+        if (description.key not in _EV_SWITCH_KEYS or ev_enabled)
+        and (description.key not in _EV_SECOND_SWITCH_KEYS or ev_second_enabled)
+    ]
+
     async_add_entities(
-        [
-            HSEMSwitch(hass, config_entry, description)
-            for description in SWITCH_DESCRIPTIONS
-        ]
+        [HSEMSwitch(hass, config_entry, description) for description in descriptions]
     )

--- a/custom_components/hsem/time.py
+++ b/custom_components/hsem/time.py
@@ -73,12 +73,27 @@ TIME_DESCRIPTIONS: tuple[HSEMTimeEntityDescription, ...] = (
 )
 
 
+# Time entity keys that only apply to a configured EV — created only when
+# that EV's planned load (managed charging) is enabled (issue #859).
+_EV_TIME_GATES: dict[str, str] = {
+    get_ev_deadline_time_key(): "hsem_ev_planned_load_enabled",
+    get_ev_second_deadline_time_key(): "hsem_ev_second_planned_load_enabled",
+}
+
+
 async def async_setup_entry(  # NOSONAR -- HA platform callback, must be async
     hass: HomeAssistant,
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up HSEM time entities from a config entry."""
+    descriptions = [
+        description
+        for description in TIME_DESCRIPTIONS
+        if (config_flag := _EV_TIME_GATES.get(description.key)) is None
+        or bool(get_config_value(config_entry, config_flag))
+    ]
+
     async_add_entities(
         [
             HSEMTimeEntity(
@@ -93,6 +108,6 @@ async def async_setup_entry(  # NOSONAR -- HA platform callback, must be async
                     default_value=str(get_config_value(config_entry, description.key)),
                 ),
             )
-            for description in TIME_DESCRIPTIONS
+            for description in descriptions
         ]
     )

--- a/docs/sensors-reference.md
+++ b/docs/sensors-reference.md
@@ -309,8 +309,8 @@ Diagnostic sensors displaying the EV charging plan details.
 
 **Entities:**
 
-- `sensor.hsem_ev_optimal_charging_plan` — Primary EV
-- `sensor.hsem_ev_second_optimal_charging_plan` — Second EV
+- `sensor.hsem_ev_optimal_charging_plan` — Primary EV, created only when `hsem_ev_planned_load_enabled` is set
+- `sensor.hsem_ev_second_optimal_charging_plan` — Second EV, created only when `hsem_ev_second_planned_load_enabled` is set (issue #859)
 
 | State                     | Meaning                                  |
 | ------------------------- | ---------------------------------------- |
@@ -345,8 +345,8 @@ without parsing the working-mode sensor attributes.
 
 **Entities:**
 
-- `sensor.hsem_ev_charger_calculated_power` — Primary EV
-- `sensor.hsem_ev_second_charger_calculated_power` — Second EV
+- `sensor.hsem_ev_charger_calculated_power` — Primary EV, created only when `hsem_ev_planned_load_enabled` is set
+- `sensor.hsem_ev_second_charger_calculated_power` — Second EV, created only when `hsem_ev_second_planned_load_enabled` is set (issue #859)
 
 | State | Unit | Description                                                                          |
 | ----- | ---- | ------------------------------------------------------------------------------------ |
@@ -377,8 +377,8 @@ stranded-residue re-portioning_).
 
 **Entities:**
 
-- `sensor.hsem_ev_charger_current_limit` — Primary EV
-- `sensor.hsem_ev_second_charger_current_limit` — Second EV
+- `sensor.hsem_ev_charger_current_limit` — Primary EV, created only when `hsem_ev_planned_load_enabled` is set
+- `sensor.hsem_ev_second_charger_current_limit` — Second EV, created only when `hsem_ev_second_planned_load_enabled` is set (issue #859)
 
 | State | Unit | Description                                                                          |
 | ----- | ---- | ------------------------------------------------------------------------------------ |
@@ -413,7 +413,7 @@ throughput on a per-calendar-day basis using cumulative energy meter readings.
 
 Boolean sensor indicating whether any EV is actively drawing power.
 
-**Entity:** `sensor.hsem_ev_charging_sensor`
+**Entity:** `sensor.hsem_ev_charging_sensor` — created only when `hsem_ev_planned_load_enabled` is set (issue #859)
 
 | State | Meaning                     |
 | ----- | --------------------------- |
@@ -494,7 +494,7 @@ Controls and reports the effective discharge floor SoC, which the planner uses a
 
 ## OCPP charger sensors
 
-Sensors providing live status and diagnostics for an OCPP-compliant EV charger connected via the integrated OCPP server. HSEM runs **one OCPP server per EV** (primary EV on port 9000 by default, second EV on port 9001) — the `_second` variants below exist only when the second EV is configured and the second OCPP server is enabled.
+Sensors providing live status and diagnostics for an OCPP-compliant EV charger connected via the integrated OCPP server. HSEM runs **one OCPP server per EV** (primary EV on port 9000 by default, second EV on port 9001). The primary sensors below are only created when `hsem_ocpp_enabled` is set; the `_second` variants exist only when the second EV is configured and the second OCPP server is enabled (issue #859).
 
 **Configuration keys** (set in config flow):
 
@@ -676,6 +676,11 @@ This setting is also configurable in the options flow.
 
 ## Switch entities
 
+EV switches are only created when the corresponding EV's planned load
+(managed charging) is enabled — `hsem_ev_planned_load_enabled` for the
+primary EV, `hsem_ev_second_planned_load_enabled` for the second EV
+(issue #859). All other switches are always created.
+
 | Entity                                              | Purpose                                        |
 | --------------------------------------------------- | ---------------------------------------------- |
 | `switch.hsem_read_only`                             | Block all hardware writes                      |
@@ -698,6 +703,11 @@ This setting is also configurable in the options flow.
 
 ## Number entities
 
+`number.hsem_ev_target_soc` is only created when `hsem_ev_planned_load_enabled`
+is set; `number.hsem_ev_second_target_soc` only when
+`hsem_ev_second_planned_load_enabled` is set (issue #859). The battery
+efficiency numbers are always created.
+
 | Entity                                     | Purpose                      | Range   |
 | ------------------------------------------ | ---------------------------- | ------- |
 | `number.hsem_battery_charge_efficiency`    | Battery charge efficiency    | 1–100 % |
@@ -708,6 +718,11 @@ This setting is also configurable in the options flow.
 ---
 
 ## Time entities
+
+`time.hsem_ev_deadline` is only created when `hsem_ev_planned_load_enabled`
+is set; `time.hsem_ev_second_deadline` only when
+`hsem_ev_second_planned_load_enabled` is set (issue #859). The battery
+schedule time entities are always created (tracked separately in #860).
 
 | Entity                                 | Purpose                    |
 | -------------------------------------- | -------------------------- |

--- a/tests/test_entity_gating_config.py
+++ b/tests/test_entity_gating_config.py
@@ -1,0 +1,267 @@
+"""Tests for config-gated entity creation (issue #859).
+
+Verifies that OCPP, EV1, and EV2 entities across the sensor, switch,
+number, and time platforms are only created when the corresponding
+feature is actually configured, instead of always being registered.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.hsem.custom_sensors.ev_charger_calculated_power_sensor import (
+    HSEMEVChargerCalculatedPowerSensor,
+    HSEMEVSecondChargerCalculatedPowerSensor,
+)
+from custom_components.hsem.custom_sensors.ev_charging_sensor import (
+    HSEMEVChargingSensor,
+)
+from custom_components.hsem.custom_sensors.ev_optimal_charging_plan_sensor import (
+    HSEMEVOptimalChargingPlanSensor,
+)
+from custom_components.hsem.custom_sensors.ev_second_optimal_charging_plan_sensor import (
+    HSEMEVSecondOptimalChargingPlanSensor,
+)
+from custom_components.hsem.custom_sensors.ocpp_sensors import (
+    HSEMOCPPChargerStatusSensor,
+)
+from custom_components.hsem.number import async_setup_entry as number_setup_entry
+from custom_components.hsem.sensor import async_setup_entry as sensor_setup_entry
+from custom_components.hsem.switch import async_setup_entry as switch_setup_entry
+from custom_components.hsem.time import async_setup_entry as time_setup_entry
+from custom_components.hsem.utils.sensornames.ev import (
+    get_ev_deadline_time_key,
+    get_ev_second_deadline_time_key,
+    get_ev_second_target_soc_number_key,
+    get_ev_target_soc_number_key,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config_entry(**options: Any) -> MagicMock:
+    entry = MagicMock()
+    entry.entry_id = "test_entry_id"
+    entry.options = options
+    entry.data = {}
+    return entry
+
+
+def _collector() -> tuple[list[Any], Any]:
+    added: list[Any] = []
+
+    def add_entities(entities: Any, _update_before_add: bool = False) -> None:
+        added.extend(entities)
+
+    return added, add_entities
+
+
+# ---------------------------------------------------------------------------
+# switch.py
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_switch_setup_excludes_ev_switches_when_disabled() -> None:
+    """No EV switches are created when neither EV's planned load is enabled."""
+    from custom_components.hsem.utils.sensornames.controls import (
+        get_read_only_switch_key,
+    )
+    from custom_components.hsem.utils.sensornames.ev import (
+        get_ev_auto_full_negative_price_switch_key,
+        get_ev_force_charge_now_switch_key,
+        get_ev_force_discharge_switch_key,
+        get_ev_second_force_charge_now_switch_key,
+        get_ev_second_smart_charging_switch_key,
+        get_ev_smart_charging_switch_key,
+    )
+
+    config_entry = _make_config_entry(
+        hsem_ev_planned_load_enabled=False,
+        hsem_ev_second_planned_load_enabled=False,
+    )
+    added, add_entities = _collector()
+    await switch_setup_entry(MagicMock(), config_entry, add_entities)
+    keys = {e.entity_description.key for e in added}
+    for ev_key in (
+        get_ev_force_discharge_switch_key(),
+        get_ev_smart_charging_switch_key(),
+        get_ev_force_charge_now_switch_key(),
+        get_ev_auto_full_negative_price_switch_key(),
+        get_ev_second_smart_charging_switch_key(),
+        get_ev_second_force_charge_now_switch_key(),
+    ):
+        assert ev_key not in keys
+    # Non-EV switches (e.g. read-only) are still present.
+    assert get_read_only_switch_key() in keys
+
+
+@pytest.mark.asyncio
+async def test_switch_setup_includes_ev1_switches_when_enabled() -> None:
+    """EV1 switches appear when only the primary EV's planned load is enabled."""
+    from custom_components.hsem.utils.sensornames.ev import (
+        get_ev_second_smart_charging_switch_key,
+        get_ev_smart_charging_switch_key,
+    )
+
+    config_entry = _make_config_entry(
+        hsem_ev_planned_load_enabled=True,
+        hsem_ev_second_planned_load_enabled=False,
+    )
+    added, add_entities = _collector()
+    await switch_setup_entry(MagicMock(), config_entry, add_entities)
+    keys = {e.entity_description.key for e in added}
+    assert get_ev_smart_charging_switch_key() in keys
+    assert get_ev_second_smart_charging_switch_key() not in keys
+
+
+@pytest.mark.asyncio
+async def test_switch_setup_includes_all_ev_switches_when_both_enabled() -> None:
+    """Both EVs' switches appear when both planned loads are enabled."""
+    from custom_components.hsem.switch import SWITCH_DESCRIPTIONS
+
+    config_entry = _make_config_entry(
+        hsem_ev_planned_load_enabled=True,
+        hsem_ev_second_planned_load_enabled=True,
+    )
+    added, add_entities = _collector()
+    await switch_setup_entry(MagicMock(), config_entry, add_entities)
+    assert len(added) == len(SWITCH_DESCRIPTIONS)
+
+
+# ---------------------------------------------------------------------------
+# number.py
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_number_setup_excludes_ev_target_soc_when_disabled() -> None:
+    """EV target-SoC numbers are absent when planned load is disabled."""
+    config_entry = _make_config_entry(
+        hsem_ev_planned_load_enabled=False,
+        hsem_ev_second_planned_load_enabled=False,
+    )
+    added, add_entities = _collector()
+    await number_setup_entry(MagicMock(), config_entry, add_entities)
+    keys = {e.entity_description.key for e in added}
+    assert get_ev_target_soc_number_key() not in keys
+    assert get_ev_second_target_soc_number_key() not in keys
+    # Battery efficiency numbers are never gated.
+    from custom_components.hsem.utils.sensornames.controls import (
+        get_charge_efficiency_number_key,
+    )
+
+    assert get_charge_efficiency_number_key() in keys
+
+
+@pytest.mark.asyncio
+async def test_number_setup_includes_ev_target_soc_when_enabled() -> None:
+    """EV target-SoC numbers appear once planned load is enabled."""
+    config_entry = _make_config_entry(
+        hsem_ev_planned_load_enabled=True,
+        hsem_ev_second_planned_load_enabled=True,
+    )
+    added, add_entities = _collector()
+    await number_setup_entry(MagicMock(), config_entry, add_entities)
+    keys = {e.entity_description.key for e in added}
+    assert get_ev_target_soc_number_key() in keys
+    assert get_ev_second_target_soc_number_key() in keys
+
+
+# ---------------------------------------------------------------------------
+# time.py
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_time_setup_excludes_ev_deadline_when_disabled() -> None:
+    """EV deadline time entities are absent when planned load is disabled."""
+    config_entry = _make_config_entry(
+        hsem_ev_planned_load_enabled=False,
+        hsem_ev_second_planned_load_enabled=False,
+    )
+    added, add_entities = _collector()
+    await time_setup_entry(MagicMock(), config_entry, add_entities)
+    keys = {e.entity_description.key for e in added}
+    assert get_ev_deadline_time_key() not in keys
+    assert get_ev_second_deadline_time_key() not in keys
+    # Battery schedule time entities are never gated (tracked separately, #860).
+    from custom_components.hsem.utils.sensornames.controls import (
+        get_schedule_1_start_time_key,
+    )
+
+    assert get_schedule_1_start_time_key() in keys
+
+
+@pytest.mark.asyncio
+async def test_time_setup_includes_ev_deadline_when_enabled() -> None:
+    """EV deadline time entities appear once planned load is enabled."""
+    config_entry = _make_config_entry(
+        hsem_ev_planned_load_enabled=True,
+        hsem_ev_second_planned_load_enabled=True,
+    )
+    added, add_entities = _collector()
+    await time_setup_entry(MagicMock(), config_entry, add_entities)
+    keys = {e.entity_description.key for e in added}
+    assert get_ev_deadline_time_key() in keys
+    assert get_ev_second_deadline_time_key() in keys
+
+
+# ---------------------------------------------------------------------------
+# sensor.py
+# ---------------------------------------------------------------------------
+
+
+def _make_sensor_config_entry(**options: Any) -> MagicMock:
+    entry = _make_config_entry(**options)
+    entry.runtime_data.coordinator = MagicMock()
+    return entry
+
+
+@pytest.mark.asyncio
+async def test_sensor_setup_excludes_ocpp_and_ev_when_all_disabled() -> None:
+    """No OCPP or EV sensors are created when none of the features are enabled."""
+    config_entry = _make_sensor_config_entry(
+        hsem_ocpp_enabled=False,
+        hsem_ocpp_second_enabled=False,
+        hsem_ev_planned_load_enabled=False,
+        hsem_ev_second_planned_load_enabled=False,
+    )
+    added, add_entities = _collector()
+    await sensor_setup_entry(MagicMock(), config_entry, add_entities)
+
+    assert not any(isinstance(e, HSEMOCPPChargerStatusSensor) for e in added)
+    assert not any(isinstance(e, HSEMEVChargingSensor) for e in added)
+    assert not any(isinstance(e, HSEMEVOptimalChargingPlanSensor) for e in added)
+    assert not any(isinstance(e, HSEMEVChargerCalculatedPowerSensor) for e in added)
+    assert not any(isinstance(e, HSEMEVSecondOptimalChargingPlanSensor) for e in added)
+    assert not any(
+        isinstance(e, HSEMEVSecondChargerCalculatedPowerSensor) for e in added
+    )
+
+
+@pytest.mark.asyncio
+async def test_sensor_setup_includes_ocpp_and_ev1_when_enabled() -> None:
+    """Primary OCPP and EV1 sensors appear when those flags are enabled."""
+    config_entry = _make_sensor_config_entry(
+        hsem_ocpp_enabled=True,
+        hsem_ocpp_second_enabled=False,
+        hsem_ev_planned_load_enabled=True,
+        hsem_ev_second_planned_load_enabled=False,
+    )
+    added, add_entities = _collector()
+    await sensor_setup_entry(MagicMock(), config_entry, add_entities)
+
+    ocpp_status_sensors = [
+        e for e in added if isinstance(e, HSEMOCPPChargerStatusSensor)
+    ]
+    assert len(ocpp_status_sensors) == 1
+    assert ocpp_status_sensors[0]._charger_index == 1
+    assert any(isinstance(e, HSEMEVChargingSensor) for e in added)
+    assert any(isinstance(e, HSEMEVOptimalChargingPlanSensor) for e in added)
+    assert not any(isinstance(e, HSEMEVSecondOptimalChargingPlanSensor) for e in added)

--- a/tests/test_platform_entity_refactor.py
+++ b/tests/test_platform_entity_refactor.py
@@ -55,6 +55,11 @@ def _mock_config_entry(entry_id: str = "test_entry_id", **opts: Any) -> MagicMoc
         "hsem_batteries_enable_batteries_schedule_2": False,
         "hsem_batteries_enable_batteries_schedule_3": False,
         "hsem_ev_charger_force_max_discharge_power": False,
+        # Both EVs' planned load enabled by default so exhaustive
+        # "all descriptions created" setup tests keep covering every switch
+        # (issue #859 gates EV switches on these flags).
+        "hsem_ev_planned_load_enabled": True,
+        "hsem_ev_second_planned_load_enabled": True,
         "hsem_batteries_enable_batteries_schedule_1_start": "07:00:00",
         "hsem_batteries_enable_batteries_schedule_1_end": "09:00:00",
         "hsem_batteries_enable_batteries_schedule_2_start": "17:00:00",


### PR DESCRIPTION
## Summary

- OCPP, EV1, and EV2 entities across the sensor, switch, number, and time platforms were created unconditionally, even when those features were never configured — cluttering the entity list with permanently unavailable/meaningless entities.
- Extends the existing conditional-list gating pattern (already used for the second OCPP server's sensors, `sensor.py:197-206`) to cover the remaining OCPP/EV1/EV2 entities.

## Branch

`feat/859-gate-entity-creation`

## Files changed

- `custom_components/hsem/sensor.py` — primary OCPP sensors gated on `hsem_ocpp_enabled`; EV1 sensors gated on `hsem_ev_planned_load_enabled`; EV2 sensors gated on `hsem_ev_second_planned_load_enabled`
- `custom_components/hsem/switch.py` — EV1/EV2 switches filtered out of `SWITCH_DESCRIPTIONS` at setup time when the corresponding planned-load flag is off
- `custom_components/hsem/number.py` — EV1/EV2 target-SoC numbers gated the same way
- `custom_components/hsem/time.py` — EV1/EV2 deadline time entities gated the same way
- `docs/sensors-reference.md` — documents which entities are now conditional
- `tests/test_entity_gating_config.py` (new) — regression coverage for all four platforms
- `tests/test_platform_entity_refactor.py` — updated the "creates all switches" fixture to enable both EVs, since that test's intent is exhaustive coverage of `SWITCH_DESCRIPTIONS`

## What changed and why

Following the pattern the second OCPP server's sensors already used, entities that only make sense for a configured EV or OCPP server are now built into a conditional list at `async_setup_entry` time instead of always being instantiated. Battery-schedule switches/time entities are intentionally **not** gated here — that's tracked separately in #860, since it's a distinct question (whether the schedule feature itself is still used at all under MILP).

## Tests added or updated

- `tests/test_entity_gating_config.py` (new): switch/number/time/sensor platform setup with OCPP/EV1/EV2 enabled and disabled in various combinations.
- `tests/test_platform_entity_refactor.py`: updated the shared mock config entry to enable both EVs by default so the existing "all switches created" exhaustive test keeps its original meaning.

## Test and lint results

All four quality gates pass:

```
./scripts/quality.sh lint     ✅ ruff format + ruff check + prettier — clean
./scripts/quality.sh typing   ✅ mypy — 0 errors
./scripts/quality.sh quality  ✅ pyright + vulture — 0 errors (1 pre-existing unrelated warning)
./scripts/quality.sh test     ✅ 2973 passed
```

## Known limitations

None.

Fixes #859
