### PR TITLE
fix(config): declare scipy/numpy as manifest requirements

### DIFF
--- a/custom_components/hsem/manifest.json
+++ b/custom_components/hsem/manifest.json
@@ -18,5 +18,6 @@
     "documentation": "https://github.com/woopstar/hsem/blob/main/README.md",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/woopstar/hsem/issues",
+    "requirements": ["scipy==1.18.1", "numpy==2.5.2"],
     "version": "6.2.5-beta2"
 }

--- a/docs/candidate-generation.md
+++ b/docs/candidate-generation.md
@@ -39,7 +39,7 @@ alongside the MILP:
 | --- | ----------- | ------------------------------------------------------------------------------- |
 | 1   | `no_action` | Battery completely idle — no forced charge or discharge                         |
 | 2   | `passive`   | Solar charging only where PV surplus exists; no grid charge or forced discharge |
-| 3   | `milp`      | Globally-optimal LP solution (when scipy is available)                          |
+| 3   | `milp`      | Globally-optimal LP solution (scipy is a declared manifest requirement)         |
 
 ### Historical candidates (disabled)
 
@@ -112,7 +112,10 @@ variable vector and the energy balance equation includes EV charger load.
 
 If `scipy` is unavailable or the solver fails (infeasible / numerical issue),
 the MILP candidate is silently dropped and the remaining candidates
-(`no_action`, `passive`) compete as normal.
+(`no_action`, `passive`) compete as normal. `scipy`/`numpy` are declared in
+`manifest.json`'s `requirements`, so Home Assistant installs them for every
+user on integration setup — this fallback is a defensive path for solver
+failures, not the expected steady state for a missing dependency.
 
 ---
 

--- a/docs/milp-optimization.md
+++ b/docs/milp-optimization.md
@@ -1,6 +1,6 @@
 # HSEM MILP Optimization
 
-The MILP solver (`planner/milp_optimizer.py`) finds the globally optimal battery charge/discharge schedule using scipy's HiGHS linear programming solver. It is the **primary planner** — heuristic candidates are generated alongside it for benchmarking and fallback, but when scipy is available the MILP solution is preferred.
+The MILP solver (`planner/milp_optimizer.py`) finds the globally optimal battery charge/discharge schedule using scipy's HiGHS linear programming solver. It is the **primary planner** — heuristic candidates are generated alongside it for benchmarking and fallback, but the MILP solution is preferred whenever scipy is available. `scipy`/`numpy` are declared in `manifest.json`'s `requirements`, so Home Assistant installs them automatically on setup; the "unavailable" fallback below is a defensive path, not the expected steady state.
 
 ---
 
@@ -506,7 +506,7 @@ After the MILP (or baseline) winner is selected, the engine runs a final pass ov
 
 ## Fallback
 
-If `scipy` is unavailable, `usable_kwh ≤ 0`, or the solver fails (crash, timeout, or non-success status), `solve_milp()` returns `None`. The engine silently drops the MILP candidate and the heuristic candidates compete as normal. Pickup is be measured via the `hsem_plan_origin` metric: `milp` when the LP succeeds, `rule_based` otherwise.
+If `scipy` is unavailable, `usable_kwh ≤ 0`, or the solver fails (crash, timeout, or non-success status), `solve_milp()` returns `None`. The engine silently drops the MILP candidate and the heuristic candidates compete as normal. Since `scipy`/`numpy` are declared `manifest.json` requirements, Home Assistant installs them for every user on setup — `scipy unavailable` should now only occur if the environment's package installation itself failed, not as routine behavior. Pickup is be measured via the `hsem_plan_origin` metric: `milp` when the LP succeeds, `rule_based` otherwise.
 
 ---
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,59 @@
+"""Tests for manifest.json's declared requirements.
+
+Home Assistant only pip-installs packages listed in a component's
+``manifest.json`` ``requirements`` array (see ``Integration.requirements`` in
+HA core). The repo-root ``requirements.txt`` / ``pyproject.toml`` only pin
+dependencies for this repo's own dev/CI tooling and are never consulted by a
+real HA instance. The MILP optimiser (``planner/milp_optimizer.py``) needs
+scipy/numpy at runtime, so they must be declared here or MILP silently never
+activates for HACS users (issue #876).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+MANIFEST_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "custom_components"
+    / "hsem"
+    / "manifest.json"
+)
+
+
+def _load_manifest() -> dict[str, Any]:
+    manifest: dict[str, Any] = json.loads(MANIFEST_PATH.read_text())
+    return manifest
+
+
+def test_manifest_declares_scipy_and_numpy_requirements():
+    """MILP needs scipy/numpy; HA only installs what's in `requirements`."""
+    manifest = _load_manifest()
+    requirements = manifest.get("requirements", [])
+
+    assert any(req.startswith("scipy") for req in requirements), (
+        "manifest.json must declare scipy in 'requirements' so Home Assistant "
+        "installs it for HACS users — MILP silently falls back otherwise"
+    )
+    assert any(req.startswith("numpy") for req in requirements), (
+        "manifest.json must declare numpy in 'requirements' so Home Assistant "
+        "installs it for HACS users"
+    )
+
+
+def test_manifest_requirement_pins_match_repo_dev_pins():
+    """The manifest pins must stay in sync with requirements.txt's dev pins."""
+    manifest = _load_manifest()
+    requirements = {req.split("==")[0]: req for req in manifest["requirements"]}
+
+    repo_requirements_path = Path(__file__).resolve().parent.parent / "requirements.txt"
+    repo_pins = {
+        line.split("==")[0]: line
+        for line in repo_requirements_path.read_text().splitlines()
+        if "==" in line
+    }
+
+    assert requirements["scipy"] == repo_pins["scipy"]
+    assert requirements["numpy"] == repo_pins["numpy"]


### PR DESCRIPTION
## Summary

`custom_components/hsem/manifest.json` never declared `scipy`/`numpy` in
`requirements`. Home Assistant's requirements installer only pip-installs
packages listed there (`Integration.requirements` in HA core) — it never
reads the repo-root `requirements.txt`/`pyproject.toml`, which only pin
these packages for this repo's dev/CI tooling. As a result, real HACS
users never got scipy installed, `is_scipy_available()` cached `False` for
the lifetime of the install, and `candidate_generator.py` gated the MILP
candidate out entirely — the planner silently ran on `passive`/`no_action`
fallback candidates every cycle instead of the documented primary MILP
optimisation path.

- Added `"requirements": ["scipy==1.18.1", "numpy==2.5.2"]` to
  `manifest.json`, pinned to the exact versions already used in
  `requirements.txt`/`pyproject.toml`.
- Verified wheel availability before picking the pin: `pip download
  --only-binary=:all:` confirms prebuilt wheels exist for both glibc
  (`manylinux_2_28`) and musl (`musllinux_1_2`) targets, on both
  `x86_64`/`aarch64`, for `cp313`/`cp314` — so setup won't fall back to an
  sdist build requiring a C/Fortran toolchain, even on constrained HAOS
  installs (Raspberry Pi, etc.). No looser pin was needed.
- **`version` field intentionally left unchanged.** Manifest version bumps
  in this repo are fully automated by `.github/workflows/release.yml` on
  GitHub release publish (bot "Updated manifest.json" commits) — every
  prior manual commit to `manifest.json` in git history confirms feature
  PRs never touch `version` themselves.
- Updated `docs/milp-optimization.md` and `docs/candidate-generation.md`:
  the "scipy unavailable" fallback wording now reads as a defensive path
  (solver crash/timeout/environment failure) rather than the expected
  steady state, since scipy/numpy are now a declared manifest requirement
  installed automatically by Home Assistant on setup.
- Added `tests/test_manifest.py`: asserts `manifest.json` declares scipy
  and numpy in `requirements`, and that the pins stay in sync with
  `requirements.txt`'s dev pins.

## Behavior change for existing users

This is a **behavior-affecting fix**, not a routine dependency bump.
After updating, Home Assistant will install scipy/numpy for users who
never had them, and the planner will switch from rule-based fallback
candidates (`passive`/`no_action`) to actual MILP optimisation
(price/PV/EV co-optimised). Users can confirm the switch via the
`hsem_plan_origin` metric flipping from `rule_based` to `milp` (see
`docs/milp-optimization.md`).

## Files changed

- `custom_components/hsem/manifest.json` — add `requirements`
- `docs/milp-optimization.md` — fallback framing update
- `docs/candidate-generation.md` — fallback framing update
- `tests/test_manifest.py` — new test

## Test plan

- [x] `./scripts/quality.sh lint` — pass
- [x] `./scripts/quality.sh typing` — 0 errors
- [x] `./scripts/quality.sh quality` — 0 errors (1 pre-existing unrelated warning)
- [x] `./scripts/quality.sh test` — 2982 passed
- [x] Manual wheel-availability check via `pip download --only-binary=:all:`
      across musllinux_1_2/manylinux_2_28 × x86_64/aarch64 × cp313/cp314

Fixes #876
