### PR TITLE
fix(planner): clamp EVConfig.deadline_escalated to solve horizon

### DIFF
--- a/custom_components/hsem/models/ev_config.py
+++ b/custom_components/hsem/models/ev_config.py
@@ -137,8 +137,7 @@ class EVConfig:
         """
         return min(self.target_kwh + self.deadline_margin_kwh, self.capacity_kwh)
 
-    @property
-    def deadline_escalated(self) -> bool:
+    def deadline_escalated(self, m: int) -> bool:
         """Return whether even max-power charging can't reach the margined target.
 
         A stateless reachability check, re-evaluated on every MILP solve
@@ -148,10 +147,20 @@ class EVConfig:
         is steepened (issue #845), so the solver is free to charge past the
         normal margined ceiling when that's the only way to still meet the
         deadline.
+
+        Args:
+            m: Number of LP slots in the current solve horizon. ``deadline_slot``
+                is clamped to ``[0, m - 1]`` before use, mirroring every
+                constraint-building site that consumes it (see
+                ``planner/milp/_ev_constraints.py``'s ``d = max(0, min(d, m - 1))``).
+                Requiring the caller's actual horizon here — rather than caching
+                a horizon length on the config at construction time — makes it
+                impossible for this check to diverge from the horizon the MILP
+                constraints were built against, even if a future caller builds
+                ``EVConfig`` against a mismatched slot list.
         """
         if self.deadline_slot is None:
             return False
-        max_reachable = self.initial_soc_kwh + self.max_charge_per_slot * (
-            self.deadline_slot + 1
-        )
+        d = max(0, min(self.deadline_slot, m - 1))
+        max_reachable = self.initial_soc_kwh + self.max_charge_per_slot * (d + 1)
         return max_reachable < self.effective_deadline_target_kwh - 1e-9

--- a/custom_components/hsem/planner/milp/_ev_constraints.py
+++ b/custom_components/hsem/planner/milp/_ev_constraints.py
@@ -190,7 +190,7 @@ def add_ev_and_session_constraint_rows(
             ):
                 cap_target = (
                     ev.capacity_kwh
-                    if ev.deadline_escalated
+                    if ev.deadline_escalated(m)
                     else ev.effective_deadline_target_kwh
                 )
                 shortfall = cap_target - ev.initial_soc_kwh

--- a/custom_components/hsem/planner/milp/_objective.py
+++ b/custom_components/hsem/planner/milp/_objective.py
@@ -230,7 +230,7 @@ def _build_objective(
             # cost-equivalent solutions above the target.
             energy_needed = ev.effective_deadline_target_kwh - ev.initial_soc_kwh
             ev_penalty_cost = max(p_imp_max, 0.1) * max(energy_needed, 1.0) * 10.0
-            if ev.deadline_escalated:
+            if ev.deadline_escalated(m):
                 ev_penalty_cost *= _EV_DEADLINE_ESCALATION_PENALTY_MULTIPLIER
             c_obj[ev_pen_offsets[ev_idx]] = ev_penalty_cost
 

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -714,9 +714,18 @@ persistent trajectory state):
   for; `target_kwh` itself is untouched everywhere else, so `deadline_met`
   in diagnostics (`ev_pen < 1e-6`) now certifies the strictly stronger
   "target + margin was met" outcome.
-- `deadline_escalated` — `True` when even max-power charging for every
+- `deadline_escalated(m)` — `True` when even max-power charging for every
   remaining pre-deadline slot can't reach `effective_deadline_target_kwh`
-  (`initial_soc_kwh + max_charge_per_slot × (deadline_slot + 1) < effective_deadline_target_kwh`).
+  (`initial_soc_kwh + max_charge_per_slot × (d + 1) < effective_deadline_target_kwh`,
+  where `d = max(0, min(deadline_slot, m - 1))`). It takes the current
+  solve's LP slot count `m` as an explicit argument — the same value every
+  constraint-building site in `planner/milp/_ev_constraints.py` already has
+  in scope — and clamps `deadline_slot` to `[0, m - 1]` before use, exactly
+  like every other consumer of `deadline_slot` (`_ev_constraints.py` lines
+  ~158-160, 197-198, 225-226). This makes it impossible for the escalation
+  check to diverge from what the constraints actually do with
+  `deadline_slot`, even if a future caller builds `EVConfig` against a
+  mismatched horizon (issue #864).
   When escalated, the target-cap's `cap_target` lifts all the way to
   `capacity_kwh` (the margin itself is no longer achievable, so the solver
   is freed to charge as much as physically possible instead of staying
@@ -734,7 +743,7 @@ boundary, EV state change, live-power drift) to force the next solve.
 
 ```text
 ev_penalty_cost = max(p_imp) * max(energy_needed, 1.0) * 10
-if ev.deadline_escalated:
+if ev.deadline_escalated(m):
     ev_penalty_cost *= 5.0
 ```
 

--- a/tests/models/test_ev_config.py
+++ b/tests/models/test_ev_config.py
@@ -43,7 +43,7 @@ def test_deadline_escalated_false_without_deadline() -> None:
         deadline_slot=None,
         max_charge_per_slot=1.0,
     )
-    assert ev.deadline_escalated is False
+    assert ev.deadline_escalated(48) is False
 
 
 def test_deadline_escalated_false_when_reachable() -> None:
@@ -56,7 +56,7 @@ def test_deadline_escalated_false_when_reachable() -> None:
         deadline_slot=9,  # 10 slots
         max_charge_per_slot=10.0,  # 100 kWh reachable, far above 55.5
     )
-    assert ev.deadline_escalated is False
+    assert ev.deadline_escalated(48) is False
 
 
 def test_deadline_escalated_true_when_unreachable_at_max_power() -> None:
@@ -69,4 +69,29 @@ def test_deadline_escalated_true_when_unreachable_at_max_power() -> None:
         deadline_slot=3,  # 4 slots
         max_charge_per_slot=10.0,  # reachable = 10 + 10*4 = 50 < 54
     )
-    assert ev.deadline_escalated is True
+    assert ev.deadline_escalated(48) is True
+
+
+def test_deadline_escalated_clamps_deadline_slot_to_horizon() -> None:
+    """A deadline_slot built against a longer horizon than the current solve
+    must be clamped to ``m - 1``, exactly like
+    ``planner/milp/_ev_constraints.py``'s ``d = max(0, min(d, m - 1))``,
+    instead of using the raw out-of-range index directly (issue #864).
+    """
+    # deadline_slot=95 would come from e.g. a 96-slot horizon, but this
+    # solve only covers m=4 slots (indices 0..3).
+    ev = EVConfig(
+        initial_soc_kwh=10.0,
+        target_kwh=50.0,  # shortfall 40
+        capacity_kwh=80.0,
+        deadline_margin_kwh=4.0,  # effective target 54
+        deadline_slot=95,
+        max_charge_per_slot=10.0,
+    )
+    # Clamped to d = min(95, 4 - 1) = 3 -> reachable = 10 + 10*4 = 50 < 54.
+    assert ev.deadline_escalated(4) is True
+    # Matches what the same clamp applied to the constraint math would give.
+    assert ev.deadline_slot is not None
+    d = max(0, min(ev.deadline_slot, 4 - 1))
+    max_reachable = ev.initial_soc_kwh + ev.max_charge_per_slot * (d + 1)
+    assert max_reachable < ev.effective_deadline_target_kwh - 1e-9

--- a/tests/planner/test_milp_ev.py
+++ b/tests/planner/test_milp_ev.py
@@ -1095,7 +1095,7 @@ def test_ev_deadline_escalated_charges_to_physical_max():
         deadline_slot=3,  # 4 slots => 40 kWh physically reachable
         deadline_margin_kwh=4.0,
     )
-    assert ev.deadline_escalated is True
+    assert ev.deadline_escalated(len(slots)) is True
 
     result = solve_milp(
         slots,


### PR DESCRIPTION
## Summary

`EVConfig.deadline_escalated` computed `max_reachable` from the raw `deadline_slot`
without clamping it to the current solve's horizon, unlike every constraint-building
site in `planner/milp/_ev_constraints.py` (lines ~158-160, 197-198, 225-226), which all
clamp `d = max(0, min(d, m - 1))` before use. This was benign today only because
`engine_ev_milp.py` always derives `deadline_slot` from the same `future_slots`
enumeration the MILP horizon is built from — nothing in `EVConfig` itself enforced that
invariant.

- Turned `deadline_escalated` from a property into a method,
  `deadline_escalated(self, m: int) -> bool`, that clamps `deadline_slot` to
  `[0, m - 1]` before computing `max_reachable` — the exact same clamp
  `_ev_constraints.py` applies.
- `m` (the current solve's LP slot count) is passed in explicitly by both call
  sites (`_ev_constraints.py`, `_objective.py`), which already had `m` in scope.
  This ties the escalation check directly to the horizon each MILP solve is
  actually built against, rather than caching a separate horizon length on the
  config (which could itself drift out of sync with a mismatched caller).
- Updated `docs/planner-spec.md` to reflect the new signature and the clamp.

## Why this approach

The issue's proposed option 1 (threading a horizon length into `EVConfig` at
construction) would add a new field that a future caller must also remember to
set correctly — reproducing the same class of bug this fix is meant to close.
Converting the property to a method parameterized by `m` instead makes the
correctness invariant self-enforcing: every call site is forced to supply the
actual horizon it is solving against, so the check cannot silently diverge from
the constraints built in that same solve.

## Files changed

- `custom_components/hsem/models/ev_config.py` — `deadline_escalated` property → method, clamps `deadline_slot` to `[0, m-1]`
- `custom_components/hsem/planner/milp/_ev_constraints.py` — call site updated to `ev.deadline_escalated(m)`
- `custom_components/hsem/planner/milp/_objective.py` — call site updated to `ev.deadline_escalated(m)`
- `docs/planner-spec.md` — updated signature/description
- `tests/models/test_ev_config.py` — updated existing tests for new signature; added `test_deadline_escalated_clamps_deadline_slot_to_horizon` regression test with a deliberately out-of-range `deadline_slot` (95) against a 4-slot horizon
- `tests/planner/test_milp_ev.py` — updated call site for new signature

## Tests

- Added `test_deadline_escalated_clamps_deadline_slot_to_horizon`: constructs an
  `EVConfig` with `deadline_slot=95` against a solve with `m=4`, and confirms
  `deadline_escalated(4)` matches the same `d = max(0, min(d, m - 1))` clamp
  applied manually — i.e. it reproduces exactly what the constraint math would do.
- All existing EV deadline/escalation tests pass unchanged (signature-only update).

## Quality gates

```
./scripts/quality.sh lint     ✅
./scripts/quality.sh typing   ✅ (0 errors)
./scripts/quality.sh quality  ✅ (0 errors, 1 pre-existing unrelated warning in working_mode_sensor.py)
./scripts/quality.sh test     ✅ 2981 passed
```

Fixes #864
