### PR TITLE
fix(planner): compute MILP SoC/fuse/EV penalty magnitudes from sanitized import prices

### DIFF
--- a/custom_components/hsem/planner/milp/_objective.py
+++ b/custom_components/hsem/planner/milp/_objective.py
@@ -52,7 +52,6 @@ def _build_objective(
     ev_var_offsets: list[int],
     ev_pen_offsets: list[int],
     active_evs: list[EVConfig],
-    p_imp: np.ndarray,  # type: ignore[name-defined]
     p_imp_obj: np.ndarray,  # type: ignore[name-defined]
     p_exp: np.ndarray,  # type: ignore[name-defined]
     p_soc: float,
@@ -95,7 +94,7 @@ def _build_objective(
         )
         _deferred_by_lp_idx = [_by_slot_idx[i] for i in future_idx]
 
-    p_imp_max = float(np.max(p_imp)) if m > 0 else 0.1
+    p_imp_max = float(np.max(p_imp_obj)) if m > 0 else 0.1
     use_discount = time_discount_rate < 1.0 - 1e-9
 
     for t in range(m):

--- a/custom_components/hsem/planner/milp_optimizer.py
+++ b/custom_components/hsem/planner/milp_optimizer.py
@@ -449,7 +449,7 @@ def solve_milp(
     # ------------------------------------------------------------------
     # Build objective vector and constraint matrices
     # ------------------------------------------------------------------
-    p_imp_max = float(np.max(p_imp)) if m > 0 else 0.1
+    p_imp_max = float(np.max(p_imp_obj)) if m > 0 else 0.1
     p_soc = max(p_imp_max, 0.1) * 100.0
 
     from custom_components.hsem.planner.milp._constraints import _build_constraints
@@ -473,7 +473,6 @@ def solve_milp(
         ev_var_offsets,
         ev_pen_offsets,
         active_evs,
-        p_imp,
         p_imp_obj,
         p_exp,
         p_soc,

--- a/tests/planner/test_milp_optimizer.py
+++ b/tests/planner/test_milp_optimizer.py
@@ -294,6 +294,50 @@ def test_milp_fallback_on_empty_slot_list():
 
 
 @_scipy_skip()
+def test_milp_handles_nan_import_price_on_future_slot():
+    """A NaN import_price on a future slot must not poison the objective.
+
+    Regression for issue #863: ``p_soc``, ``p_fuse``, and ``ev_penalty_cost``
+    were derived from ``np.max()`` of the raw pre-sanitize import price array
+    instead of the NaN-cleaned ``p_imp_obj`` returned by ``sanitize_prices()``.
+    A single NaN future-slot price (a real scenario — see ``SlotPrice``'s
+    ``MISSING_SENTINEL`` docstring) would poison every SoC/fuse/EV-deadline
+    penalty coefficient with NaN, risking a solver error or a degenerate
+    solution.
+    """
+    cheap = [0, 1, 2, 3]
+    expensive = [20, 21, 22, 23]
+    slots = _make_arbitrage_slots(
+        cheap, expensive, cheap_price=0.05, expensive_price=3.0
+    )
+
+    # Poison a neutral (non-cheap/expensive) future slot's raw import price.
+    slots[10].price = SlotPrice(
+        import_price=float("nan"), export_price=slots[10].price.export_price
+    )
+
+    milp_result = solve_milp(
+        slots,
+        _NOW,
+        current_kwh=0.0,
+        usable_kwh=9.0,
+        max_charge_per_slot=5.0,
+        max_discharge_per_slot=5.0,
+    )
+
+    assert milp_result is not None, (
+        "MILP must still return a valid solution when a future slot has a "
+        "NaN import price"
+    )
+    result, _diag = milp_result
+    for slot in result:
+        assert math.isfinite(slot.batteries_charged_kwh), (
+            f"Non-finite batteries_charged_kwh at {slot.start}: NaN leaked "
+            "into the LP solution"
+        )
+
+
+@_scipy_skip()
 def test_milp_candidate_present_in_planner_output():
     """A full planner run must include the 'milp' candidate in output.candidates."""
     inp = make_winter_day_input(battery_soc_pct=20.0)


### PR DESCRIPTION
## Summary

- `p_imp_max` (feeding `p_soc`, `p_fuse`, and `ev_penalty_cost`) was computed from the **raw** pre-sanitize import price array (`p_imp`) instead of the NaN-cleaned `p_imp_obj` returned by `sanitize_prices()`.
- A NaN `import_price` on any future slot (a real, anticipated scenario — see `SlotPrice`'s `MISSING_SENTINEL` docstring) would poison every SoC-violation, fuse-violation, and EV-deadline penalty coefficient in the MILP objective with NaN, risking a HiGHS solver error or a degenerate/garbage solution.
- Fixed by removing the now-redundant raw `p_imp` parameter from `_build_objective()` (`custom_components/hsem/planner/milp/_objective.py`) and computing `p_imp_max` from `p_imp_obj` in both `milp_optimizer.py:453` and `_objective.py:98` — the only two places `p_imp_max` is derived.

## Branch

`fix/863-milp-nan-import-price`

## Files changed

- `custom_components/hsem/planner/milp_optimizer.py` — `p_imp_max` now derived from `p_imp_obj`; dropped the redundant raw `p_imp` argument passed into `_build_objective()`.
- `custom_components/hsem/planner/milp/_objective.py` — removed the unused raw `p_imp` parameter; `p_imp_max` now derived from `p_imp_obj`.
- `tests/planner/test_milp_optimizer.py` — new regression test `test_milp_handles_nan_import_price_on_future_slot`.

## What changed and why

`sanitize_prices()` returns a *new* NaN-cleaned array (`p_imp_obj`) rather than mutating its input in place. The caller in `milp_optimizer.py` never rebound its own `p_imp` variable to the sanitized result, so `np.max(p_imp)` at `milp_optimizer.py:452` (and the duplicated pattern at `_objective.py:98`) operated on the raw, possibly-NaN array. Every other use of import prices in `_objective.py` already correctly used `p_imp_obj`; this was the one place that didn't.

This is a pure bug fix restoring the invariant already documented in `docs/planner-spec.md` (`p_soc = max(p_imp) * 100`, `ev_penalty_cost = max(p_imp) * ...`) — the spec's `p_imp` notation refers to the sanitized array, matching every other usage. No spec or semantics change was needed.

## Tests added

- `test_milp_handles_nan_import_price_on_future_slot` — builds an arbitrage slot list, poisons one future slot's `import_price` with `float("nan")`, and asserts `solve_milp()` still returns a valid solution with finite `batteries_charged_kwh` on every output slot.
- Verified the test fails without the fix (confirmed by stashing the fix and rerunning — assertion failed with `milp_result is None`) and passes with the fix.

## Test and lint results

- `./scripts/quality.sh lint` — pass
- `./scripts/quality.sh typing` — pass (0 errors)
- `./scripts/quality.sh quality` — pass (0 errors, 1 pre-existing unrelated warning in `working_mode_sensor.py`)
- `./scripts/quality.sh test` — 2981 passed

## Known limitations / open questions

None.

Fixes #863
