### PR TITLE
fix(sensor): resolve pyright reportOptionalMemberAccess on _update_task callback

### DIFF
--- a/custom_components/hsem/custom_sensors/working_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/working_mode_sensor.py
@@ -453,11 +453,12 @@ class HSEMWorkingModeSensor(
         """
         # Cancel any still-running task from the previous coordinator cycle.
         self._cancel_update_task()
-        self._update_task = self.hass.async_create_task(
+        task = self.hass.async_create_task(
             self._async_on_coordinator_update(),
             name="hsem_working_mode_update",
         )
-        self._update_task.add_done_callback(self._on_update_task_done)
+        self._update_task = task
+        task.add_done_callback(self._on_update_task_done)
 
     async def _async_on_coordinator_update(self) -> None:
         """Apply hardware writes then write state to HA.


### PR DESCRIPTION
## Summary

- Pyright's `quality` gate reported `reportOptionalMemberAccess` at `working_mode_sensor.py:460:27` — `"add_done_callback" is not a known attribute of "None"` — on `self._update_task.add_done_callback(...)`.
- `self._update_task` is declared as `asyncio.Task | None`. Pyright could not narrow the attribute to non-`None` across the `self._update_task = self.hass.async_create_task(...)` assignment in `_handle_coordinator_update()`, since attribute narrowing across statements is unreliable for mutable instance members.
- Fixed by binding the created task to a local variable (`task`), assigning it to `self._update_task`, and calling `add_done_callback()` on the local variable — which pyright narrows correctly as a plain local. No behavior change.

## Branch

`fix/pyright-working-mode-update-task-callback`

## Files changed

- `custom_components/hsem/custom_sensors/working_mode_sensor.py` — `_handle_coordinator_update()` now stores the created task in a local variable before assigning it to `self._update_task` and registering the done-callback.

## What changed and why

Pure type-safety fix flagged by `./scripts/quality.sh quality` (pyright). No functional change — the task is still created, stored on `self._update_task` for cancellation on unload, and the done-callback is still registered on the same task object.

## Tests

- No new tests needed (no behavior change).
- `tests/` filtered to `working_mode` — 22 passed.
- Full suite — 2980 passed.

## Test and lint results

- `./scripts/quality.sh lint` — pass
- `./scripts/quality.sh typing` — pass (0 errors)
- `./scripts/quality.sh quality` — pass (0 errors, 0 warnings — previously 1 warning, now resolved)
- `./scripts/quality.sh test` — 2980 passed

## Known limitations / open questions

None.
