### PR TITLE
chore(planner): dead total_excess_kwh computation and redundant loop in phase envelope validation

### DIFF
--- a/custom_components/hsem/planner/milp/_phase_fuse.py
+++ b/custom_components/hsem/planner/milp/_phase_fuse.py
@@ -166,7 +166,7 @@ def validate_published_phase_envelope(
     """
     if not phase_fuse_active:
         return {"valid": True, "reason": "ok"}
-    max_phase_kwh, _excess = phase_envelope_from_published_slots(
+    max_phase_kwh = phase_envelope_from_published_slots(
         out_slots=out_slots,
         future_idx=future_idx,
         active_evs=active_evs,
@@ -188,16 +188,20 @@ def phase_envelope_from_published_slots(
     active_evs: list[EVConfig],
     session_slots_by_ev: dict[int, set[int]],
     slot_hours: float,
-) -> tuple[float, float]:
-    """Return ``(max_phase_import_kwh, total_excess_kwh)`` for a solved plan.
+) -> float:
+    """Return ``max_phase_import_kwh`` for a solved plan.
 
     Reconstructs the worst-case per-phase envelope from the **published**
     slot fields (rounded grid flows and charger power commands) using exactly
     the same topology shares as the constraint rows.  This is the post-solve
     validation half of the shared-helper contract.
+
+    The balanced/executable/session terms are already phase-independent
+    (the balanced third is split evenly and the EV terms use a single
+    topology share for the whole slot), so one evaluation per slot gives
+    the same worst-case value a per-phase loop would.
     """
     max_phase_kwh = 0.0
-    total_excess = 0.0
     for lp_t, slot_i in enumerate(future_idx):
         slot = out_slots[slot_i]
         balanced_kwh = (
@@ -216,7 +220,6 @@ def phase_envelope_from_published_slots(
             lp_t=lp_t,
             hours=slot_hours,
         )
-        for _phase_index in range(PHASE_COUNT):
-            value = balanced_kwh + executable_kwh + session_kwh
-            max_phase_kwh = max(max_phase_kwh, value)
-    return (max_phase_kwh, total_excess)
+        value = balanced_kwh + executable_kwh + session_kwh
+        max_phase_kwh = max(max_phase_kwh, value)
+    return max_phase_kwh

--- a/tests/planner/test_ev_charger_phase_topology.py
+++ b/tests/planner/test_ev_charger_phase_topology.py
@@ -16,6 +16,9 @@ import pytest
 
 from custom_components.hsem.models.ev_config import EVConfig
 from custom_components.hsem.models.planned_slot import PlannedSlot
+from custom_components.hsem.planner.milp._phase_fuse import (
+    phase_envelope_from_published_slots,
+)
 from custom_components.hsem.planner.milp_optimizer import (
     is_scipy_available,
     solve_milp,
@@ -173,3 +176,25 @@ def test_published_plan_survives_its_own_phase_validation() -> None:
     # No phase envelope exceeds the rated fuse for the solved plan.
     phase_limit_kwh = _FUSE_AMPS * 230.0 / 1000.0
     assert diagnostics["max_phase_import_kwh"] <= phase_limit_kwh + 1e-6
+
+
+def test_phase_envelope_from_published_slots_returns_a_plain_float() -> None:
+    """Regression: the function returns just the envelope, not a diagnostic pair.
+
+    ``total_excess_kwh`` was declared and returned but never updated, and its
+    sole caller discarded it — the dead second tuple element was removed.
+    """
+    slot = _slots(1)[0]
+    slot.grid_import_kwh = 3.0
+    slot.grid_export_kwh = 0.0
+
+    max_phase_kwh = phase_envelope_from_published_slots(
+        out_slots=[slot],
+        future_idx=[0],
+        active_evs=[],
+        session_slots_by_ev={},
+        slot_hours=1.0,
+    )
+
+    assert isinstance(max_phase_kwh, float)
+    assert max_phase_kwh == pytest.approx(3.0 / PHASE_COUNT)


### PR DESCRIPTION
## Summary

- Removed the dead `total_excess_kwh` second element from `phase_envelope_from_published_slots()`'s return tuple in `custom_components/hsem/planner/milp/_phase_fuse.py` — it was initialized to `0.0` and never updated, and its sole caller (`validate_published_phase_envelope`) already discarded it as `_excess`. Nothing in the returned diagnostics dict or `docs/planner-spec.md` consumes it (the spec only documents `max_phase_import_kwh`), so removing it was the right call over implementing it as a real diagnostic.
- Collapsed the inner `for _phase_index in range(PHASE_COUNT)` loop, which computed and maxed over the identical `value` `PHASE_COUNT` times per slot with no per-phase variation — the balanced/executable/session terms are already phase-independent (balanced third split evenly, EV terms use a single topology share for the whole slot), so one evaluation per slot gives the same worst-case value.
- No behavioural change: `max_phase_import_kwh` is computed identically; `validate_published_phase_envelope`'s returned dict is unaffected.
- `docs/planner-spec.md` unchanged — it never documented `total_excess_kwh`, only `max_phase_import_kwh`, so no semantics diverged.

## Test plan

- [x] Added `test_phase_envelope_from_published_slots_returns_a_plain_float` in `tests/planner/test_ev_charger_phase_topology.py`, locking in the new `float` return type and verifying the computed envelope value.
- [x] Existing `test_published_plan_survives_its_own_phase_validation` (integration path through `solve_milp` → `validate_published_phase_envelope`) still passes unchanged.
- [x] `./scripts/quality.sh all` passes (lint, typing, quality, tests — 2981 passed).

Fixes #865

🤖 Generated with [Claude Code](https://claude.com/claude-code)
