### PR TITLE
fix(coordinator): fail closed on live-power replan revalidation

### DIFF
--- a/custom_components/hsem/coordinator_planner_phase.py
+++ b/custom_components/hsem/coordinator_planner_phase.py
@@ -53,7 +53,6 @@ from custom_components.hsem.utils.datetime_utils import (
     as_tz,
     utc_key,
 )
-from custom_components.hsem.utils.live_power import LivePowerEstimate
 from custom_components.hsem.utils.logger import (
     async_log,
     set_hsem_verbose,
@@ -152,7 +151,7 @@ class CoordinatorPlannerPhaseMixin(CoordinatorSharedState):
             live,
             now,
             load_forecast_signature=self._current_load_forecast_signature,
-            live_power_estimate=live_power_estimate,
+            live_power_replan_request_slot=live_power_replan_request_slot,
         )
 
         if should_replan:
@@ -507,7 +506,7 @@ class CoordinatorPlannerPhaseMixin(CoordinatorSharedState):
         now: datetime,
         *,
         load_forecast_signature: LoadForecastSignature | None = None,
-        live_power_estimate: LivePowerEstimate | None = None,
+        live_power_replan_request_slot: datetime | None = None,
     ) -> bool:
         """Determine whether the planner should be re-run.
 
@@ -538,12 +537,7 @@ class CoordinatorPlannerPhaseMixin(CoordinatorSharedState):
             )
             return True
 
-        pending_live_power_slot = getattr(self, "_live_power_replan_pending_slot", None)
-        if pending_live_power_slot is not None and (
-            live_power_estimate is None
-            or self._actionable_live_power_replan_slot(now, live_power_estimate)
-            is not None
-        ):
+        if live_power_replan_request_slot is not None:
             async_log(
                 "debug",
                 "[replan] Sustained live power changed — re-planning.",

--- a/tests/test_live_power_coordinator.py
+++ b/tests/test_live_power_coordinator.py
@@ -21,6 +21,7 @@ from custom_components.hsem.coordinator_live_power import (
     LIVE_POWER_REPLAN_MAX_CORRECTIONS_PER_SLOT,
 )
 from custom_components.hsem.models.live_state import EVLiveState, LiveState
+from custom_components.hsem.models.planner_output import PlannerOutput
 from custom_components.hsem.models.sensor_config import SensorConfig
 from custom_components.hsem.utils.live_power import LivePowerEstimate, LivePowerWindow
 
@@ -333,3 +334,48 @@ class TestLivePowerMismatchToAcceptanceFlow:
 
         assert coord._live_power_replanned_slot_start is None
         assert coord._live_power_replan_count == 0
+
+
+# ---------------------------------------------------------------------------
+# _should_replan must never fire blind on a pending live-power request
+# (issue #866) — it only fires when this cycle's already-revalidated
+# ``live_power_replan_request_slot`` is a concrete slot, never merely
+# because a request is pending.
+# ---------------------------------------------------------------------------
+
+
+class TestShouldReplanLivePowerFailsClosed:
+    def _prime(self, coord: HSEMDataUpdateCoordinator, live: LiveState) -> None:
+        """Put the coordinator in a settled post-plan state at ``_NOW``."""
+        coord._last_planner_output = PlannerOutput()
+        coord._last_plan_slot_start = _NOW
+        coord._persist_plan_state(live)
+
+    def test_no_request_slot_this_cycle_does_not_force_replan(self) -> None:
+        """A pending request alone must not bypass revalidation.
+
+        Even though a live-power replan request is pending, if this cycle's
+        already-revalidated ``live_power_replan_request_slot`` is ``None``
+        (no fresh estimate proved it actionable), no blind replan may fire.
+        """
+        coord = _make_coordinator()
+        live = LiveState()
+        self._prime(coord, live)
+        coord._live_power_replan_pending_slot = _NOW
+
+        assert (
+            coord._should_replan(live, _NOW, live_power_replan_request_slot=None)
+            is False
+        )
+
+    def test_actionable_request_slot_forces_replan(self) -> None:
+        """A concrete, already-revalidated request slot does trigger a replan."""
+        coord = _make_coordinator()
+        live = LiveState()
+        self._prime(coord, live)
+        coord._live_power_replan_pending_slot = _NOW
+
+        assert (
+            coord._should_replan(live, _NOW, live_power_replan_request_slot=_NOW)
+            is True
+        )


### PR DESCRIPTION
## Summary

- `_should_replan()` had a fail-open branch: when a live-power replan request was pending *and* `live_power_estimate` was `None`, it treated the request as unconditionally actionable, skipping `_actionable_live_power_replan_slot()`'s freshness/materiality/budget revalidation entirely — contradicting `docs/planner-spec.md`'s guarantee that a pending request is always revalidated against fresh evidence before firing.
- Not a live bug today: the sole caller, `_run_planner_phase`, always passes a concrete `LivePowerEstimate` from `_seed_live_power_window`, which never returns `None`. But the fail-open branch was reachable by the type signature and diverged from this codebase's usual fail-closed pattern (e.g. `_live_power_site_balance_direction`).
- Fix: `_should_replan()` now takes `live_power_replan_request_slot: datetime | None` — the already-computed, already-revalidated result of `_actionable_live_power_replan_slot()` from `_run_planner_phase` — instead of a raw `LivePowerEstimate | None`. A replan only fires when that slot is a concrete value, making the fail-open path structurally unreachable and eliminating the redundant second per-cycle evaluation of `_actionable_live_power_replan_slot()`.

## Test plan

- [x] Added `TestShouldReplanLivePowerFailsClosed` in `tests/test_live_power_coordinator.py`: a pending request with `live_power_replan_request_slot=None` does not force a replan; a concrete request slot does.
- [x] Existing live-power replan budget/debounce/materiality tests pass unchanged.
- [x] `./scripts/quality.sh all` passes (lint, typing, quality, tests — 2982 passed).

Fixes #866

🤖 Generated with [Claude Code](https://claude.com/claude-code)
