### PR TITLE
fix(planner): let battery discharge cover non-EV house load during EV charging

### DIFF
--- a/custom_components/hsem/planner/soc_simulation.py
+++ b/custom_components/hsem/planner/soc_simulation.py
@@ -167,11 +167,15 @@ def simulate_soc(
         #                        (base_load_includes_ev=True case)
         #
         # The EV charger and the house loads share the same AC bus with the
-        # battery inverter.  When the battery discharges, the AC power feeds
-        # EVERYTHING on the bus — you cannot selectively skip the EV charger.
-        # Therefore, when ev_load > 0, battery discharge is suppressed and
-        # ALL demand is covered from the grid to avoid DC→AC→DC conversion
-        # losses through the EV charger.
+        # battery inverter, but that does not require suppressing all
+        # discharge — the battery's net demand is computed from
+        # ``house_load - pv`` only, independent of EV load (issue #862).
+        # EV demand is served from grid/PV via ``ev_load`` below, exactly as
+        # in the PV-surplus branch. The physical safeguard against the
+        # battery draining into the EV is enforced at the hardware layer
+        # (``applier.py`` writes ``maximum_discharge_power`` from this
+        # slot's own solved ``batteries_discharged_kwh``, see issue #592),
+        # not by zeroing the plan's discharge here.
         #
         # For base_load_includes_ev=False:
         #   house_load = avg_house_consumption (pure house, no EV)
@@ -233,33 +237,28 @@ def simulate_soc(
             grid_import = slot.grid_import_kwh
             grid_export = slot.grid_export_kwh
         elif net_demand > 0:
-            # House demand exceeds PV on the shared AC bus.
+            # House demand exceeds PV.
             #
-            # When the EV is charging, the battery MUST NOT discharge.
-            # The battery, house loads, and EV charger all share one AC bus —
-            # you cannot selectively route discharge power to the house while
-            # excluding the EV.  Any DC→AC discharge would feed both, creating
-            # needless DC→AC→DC conversion losses through the EV charger.
-            # Instead, cover everything (house + EV + scheduled charge) from
-            # the grid when EV is active.
+            # EV load is served from grid/PV independently of the battery
+            # (see ``ev_load`` above) — an EV charging in this slot does not
+            # by itself block the battery from covering `house_load - pv`
+            # (issue #862; the earlier full-suppression-on-any-EV-load
+            # behaviour was a conservative simplification that silently
+            # diverged from this spec and defeated the hardware-level
+            # discharge cap in ``applier.py``, see issue #592).
             #
-            # Additionally, only discharge when the slot's recommendation
-            # explicitly calls for it — BatteriesDischargeMode or
-            # ForceBatteriesDischarge.  Slots with other recommendations
-            # (e.g. BatteriesWaitMode, None) should NOT drain the battery
-            # even if capacity is available, preserving stored energy for
-            # more expensive future slots.
+            # Only discharge when the slot's recommendation explicitly calls
+            # for it — BatteriesDischargeMode or ForceBatteriesDischarge.
+            # Slots with other recommendations (e.g. BatteriesWaitMode, None)
+            # should NOT drain the battery even if capacity is available,
+            # preserving stored energy for more expensive future slots.
             #
             # Discharge efficiency: to deliver `net_demand` kWh to the house
             # the battery must release `net_demand / discharge_eff` kWh.
             # We cap to available capacity and per-slot limit then compute
             # what the house actually receives from that draw.
-            if (
-                ev_load > 1e-9
-                or slot.recommendation == Recommendations.BatteriesWaitMode.value
-            ):
-                # EV is charging or slot is in wait mode — no battery discharge.
-                # Everything from grid.
+            if slot.recommendation == Recommendations.BatteriesWaitMode.value:
+                # Wait mode — no battery discharge. Everything from grid.
                 discharge = 0.0
                 house_grid_import = net_demand
                 grid_import = (

--- a/custom_components/hsem/utils/recommendations.py
+++ b/custom_components/hsem/utils/recommendations.py
@@ -52,11 +52,18 @@ class Recommendations(Enum):
     """
 
     EVSmartCharging = "ev_smart_charging"
-    """EV is charging — battery must NOT discharge to avoid DC→AC→DC losses.
+    """EV is charging — a display relabel applied after SoC simulation.
 
-    Battery:   hold (may charge from PV surplus)
-    House:     covered by grid
-    Grid:      import for house + EV; export PV surplus
+    The underlying energy flows (charge/discharge/import/export) are
+    computed by the SoC simulation *before* this label is applied and are
+    unaffected by it: the battery remains free to discharge for non-EV
+    house load (issue #862). Only the EV's own load is guaranteed to be
+    served from grid/PV, never the battery.
+
+    Battery:   whatever the simulation already solved (may discharge for
+               house load, charge from PV surplus, or hold)
+    House:     covered by battery first (if solved), grid for remainder
+    Grid:      import for EV + any uncovered house load; export PV surplus
     """
 
     # ------------------------------------------------------------------

--- a/tests/planner/test_ev_planned_load.py
+++ b/tests/planner/test_ev_planned_load.py
@@ -1470,12 +1470,17 @@ class TestEvAcLoadAndSoCPath:
     # ------------------------------------------------------------------
 
     def test_soc_simulation_accounts_for_ev_load(self):
-        """EV load goes to grid_import only; the battery does NOT discharge.
+        """EV load is always reflected in the slot's energy balance.
 
-        The EV charger and house loads share the same AC bus.  When the EV is
-        charging, battery discharge is suppressed to avoid DC→AC→DC conversion
-        losses.  Therefore `batteries_discharged_kwh` is 0 during EV slots, and
-        `grid_import_kwh` absorbs BOTH house and EV demand.
+        `ev_planned_load_kwh` is added to demand alongside house load; the
+        battery is independently free to cover the non-EV portion (house
+        load) even while the EV is charging (issue #862) — the winning
+        candidate here happens to be MILP, which chooses not to discharge
+        for this flat-price, no-PV scenario since cycling would incur cost
+        with no arbitrage benefit. See
+        `TestSimulateSocUnit.test_discharge_covers_non_ev_load_even_when_ev_charging`
+        in `tests/planner/test_soc_simulation.py` for a direct unit test of
+        the greedy (non-MILP) SoC-simulation discharge behaviour.
 
         Setup (battery has charge, no schedule forcing discharge):
           battery_soc_pct  = 80 %  (7.5 kWh above floor: (80-5)/100 × 10)
@@ -1485,12 +1490,8 @@ class TestEvAcLoadAndSoCPath:
           import_price     = flat 0.5
 
         Expected energy balance per EV slot:
-          batteries_discharged_kwh ≈ 0.0 kWh  (suppressed — EV is charging)
-          grid_import ≈ house + ev = 5.5 kWh  (everything from grid)
-          total supply = batteries_discharged_kwh + grid_import ≈ 5.5 kWh
-
-        The energy balance must still hold: supply ≈ demand — but the battery
-        does not discharge when the EV is active on the shared AC bus.
+          total supply (batteries_discharged_kwh + grid_import_kwh) covers
+          total demand (house load + EV load).
         """
         inp = PlannerInput(
             now_iso="2024-06-15T08:00:00+00:00",

--- a/tests/planner/test_soc_simulation.py
+++ b/tests/planner/test_soc_simulation.py
@@ -335,6 +335,52 @@ class TestSimulateSocUnit:
         assert s.batteries_discharged_kwh == pytest.approx(0.0)
         assert s.grid_import_kwh == pytest.approx(1.0)
 
+    def test_discharge_covers_non_ev_load_even_when_ev_charging(self):
+        """Battery discharges for house load even while an EV is charging (#862).
+
+        EV load is served from grid/PV independently of the battery; it must
+        not suppress discharge for the non-EV portion of demand.
+        """
+        from datetime import datetime
+
+        tz = ZoneInfo("Europe/Copenhagen")
+        t0 = datetime.fromisoformat("2024-06-15T00:00:00+02:00").replace(tzinfo=tz)
+        s = PlannedSlot(start=t0, end=t0 + timedelta(hours=1))
+        s.avg_house_consumption_kwh = 0.5  # pure house load
+        s.solcast_pv_estimate_kwh = 0.0
+        s.batteries_charged_kwh = 0.0
+        s.ev_planned_load_kwh = 5.0  # EV charging this slot
+        s.recommendation = Recommendations.BatteriesDischargeMode.value
+
+        simulate_soc(
+            [s], t0, 9.0, 9.0, 9.0, max_charge_per_slot=5.0, max_discharge_per_slot=None
+        )
+
+        # House load is covered from the battery, not suppressed by EV load.
+        assert s.batteries_discharged_kwh == pytest.approx(0.5)
+        # EV load is served entirely from the grid, independent of the battery.
+        assert s.grid_import_kwh == pytest.approx(5.0)
+
+    def test_battery_wait_mode_still_suppresses_discharge_with_ev_load(self):
+        """BatteriesWaitMode still blocks discharge even with EV load present."""
+        from datetime import datetime
+
+        tz = ZoneInfo("Europe/Copenhagen")
+        t0 = datetime.fromisoformat("2024-06-15T00:00:00+02:00").replace(tzinfo=tz)
+        s = PlannedSlot(start=t0, end=t0 + timedelta(hours=1))
+        s.avg_house_consumption_kwh = 0.5
+        s.solcast_pv_estimate_kwh = 0.0
+        s.batteries_charged_kwh = 0.0
+        s.ev_planned_load_kwh = 5.0
+        s.recommendation = Recommendations.BatteriesWaitMode.value
+
+        simulate_soc(
+            [s], t0, 9.0, 9.0, 9.0, max_charge_per_slot=5.0, max_discharge_per_slot=None
+        )
+
+        assert s.batteries_discharged_kwh == pytest.approx(0.0)
+        assert s.grid_import_kwh == pytest.approx(5.5)
+
     def test_past_slots_get_zero_fields(self):
         """Slots entirely before ``now`` should have all SoC fields zeroed."""
         from datetime import datetime


### PR DESCRIPTION
## Summary

Fixes #862 — the SoC simulation's `elif net_demand > 0:` branch in
`soc_simulation.py` was suppressing **all** battery discharge for a slot
whenever any EV load was present (`ev_load > 1e-9`), even though
`net_demand = house_load - pv` already excludes EV load by construction.
Only `Recommendations.BatteriesWaitMode` now suppresses discharge in this
branch; an EV charging in the slot no longer blocks the battery from
covering non-EV house load.

## Why this matters (not just a spec nit)

This is not only a docs/code divergence (`docs/planner-spec.md`'s "EV
charger energy source" section has always said `batteries_discharged` is
independent of `ev_planned_load_kwh` — that text needed no change).

Digging into issue #592's history showed the current, deliberate
architecture actively depends on the planner solving the correct non-EV
discharge amount:

- #592 established that the Huawei inverter's self-consumption mode reads
  total site draw off the CT clamp, so the real fix (#683/#684) was a
  **hardware-level** dynamic `maximum_discharge_power` cap set to the
  non-EV baseline — not suppressing the plan's discharge outright.
- Issue #797 refactored that into a permission-based ceiling
  (`applier.py` / `_planned_ev_discharge_cap_w`) that explicitly trusts
  `rec.batteries_discharged_kwh` — the planner's own solved value — as the
  safe non-EV discharge amount to write to hardware (see the comment at
  `applier.py:190-192`: *"the cap is now the planner's own solved discharge
  rate for this slot, not a derived historical/live-net guess"*).

Because `soc_simulation.py` forced `batteries_discharged_kwh = 0` any time
`ev_load > 1e-9`, that trusted input was **always zero** during EV
charging — silently defeating the #797 mechanism and reverting behaviour
to the blanket suppression that #592's multi-PR effort moved away from.

## Changes

### `custom_components/hsem/planner/soc_simulation.py`
- Removed the `ev_load > 1e-9` condition from the discharge-suppression
  guard in the `net_demand > 0` branch; only `BatteriesWaitMode` suppresses
  discharge there now.
- Updated the surrounding comments to describe the corrected semantics and
  reference issues #862 / #592.

### `custom_components/hsem/utils/recommendations.py`
- Corrected the `EVSmartCharging` docstring, which claimed the battery
  must hold — it's a post-simulation display relabel and does not affect
  the energy flows already solved.

### Tests
- `tests/planner/test_soc_simulation.py` — added two direct unit tests on
  `simulate_soc`:
  - `test_discharge_covers_non_ev_load_even_when_ev_charging` — battery
    discharges to cover house load while EV load goes entirely to grid.
  - `test_battery_wait_mode_still_suppresses_discharge_with_ev_load` —
    confirms `BatteriesWaitMode` suppression is untouched.
- `tests/planner/test_ev_planned_load.py::test_soc_simulation_accounts_for_ev_load`
  — docstring corrected (the scenario it covers resolves via the MILP
  path, which was already unaffected by this bug; the new direct unit
  tests above cover the greedy/non-MILP path this issue is about).

## Docs

`docs/planner-spec.md` already documented the correct behavior
("`batteries_discharged` is therefore independent of `ev_planned_load_kwh`")
— no spec changes needed; the implementation was the thing that had
drifted.

## Test plan

- [x] `./scripts/quality.sh lint` — pass
- [x] `./scripts/quality.sh typing` — pass, 0 errors
- [x] `./scripts/quality.sh quality` — pass, 0 errors (1 pre-existing
      unrelated warning in `working_mode_sensor.py`)
- [x] `./scripts/quality.sh test` — 2982 passed, `soc_simulation.py` at
      100% coverage

Fixes #862
