### PR TITLE
fix(config): use version ranges for scipy/numpy manifest requirements

### DIFF
--- a/custom_components/hsem/manifest.json
+++ b/custom_components/hsem/manifest.json
@@ -18,6 +18,6 @@
     "documentation": "https://github.com/woopstar/hsem/blob/main/README.md",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/woopstar/hsem/issues",
-    "requirements": ["scipy==1.18.1", "numpy==2.5.2"],
+    "requirements": ["scipy>=1.14,<2", "numpy>=2.0,<3"],
     "version": "6.2.5-beta2"
 }

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -7,6 +7,15 @@ dependencies for this repo's own dev/CI tooling and are never consulted by a
 real HA instance. The MILP optimiser (``planner/milp_optimizer.py``) needs
 scipy/numpy at runtime, so they must be declared here or MILP silently never
 activates for HACS users (issue #876).
+
+The requirements MUST be version ranges, not exact pins. Home Assistant core
+hard-pins numpy in its own ``homeassistant/package_constraints.txt`` (applied
+as a pip ``--constraint`` to every custom component install) and bumps that
+pin every few HA releases. An exact ``numpy==X`` pin here collides with
+whatever HA core currently pins and breaks setup for every user the moment
+the two diverge — this happened in production right after #876 shipped with
+an exact pin. A range that comfortably contains HA's current pin lets the
+resolver satisfy both without needing to track HA's release cadence.
 """
 
 from __future__ import annotations
@@ -15,6 +24,9 @@ import json
 from pathlib import Path
 from typing import Any
 
+from packaging.requirements import Requirement
+from packaging.version import Version
+
 MANIFEST_PATH = (
     Path(__file__).resolve().parent.parent
     / "custom_components"
@@ -22,38 +34,74 @@ MANIFEST_PATH = (
     / "manifest.json"
 )
 
+# Home Assistant core's package_constraints.txt has pinned numpy to 2.2.x/2.3.x
+# since 2025.6; verified directly against the constraints file for several
+# recent HA releases (2025.1 -> 2026.8). Our range must contain this pin.
+HA_CONSTRAINED_NUMPY_VERSION = Version("2.3.2")
+
 
 def _load_manifest() -> dict[str, Any]:
     manifest: dict[str, Any] = json.loads(MANIFEST_PATH.read_text())
     return manifest
 
 
+def _requirement_specs() -> dict[str, Requirement]:
+    manifest = _load_manifest()
+    requirements = [Requirement(req) for req in manifest["requirements"]]
+    return {req.name: req for req in requirements}
+
+
 def test_manifest_declares_scipy_and_numpy_requirements():
     """MILP needs scipy/numpy; HA only installs what's in `requirements`."""
-    manifest = _load_manifest()
-    requirements = manifest.get("requirements", [])
+    requirements = _requirement_specs()
 
-    assert any(req.startswith("scipy") for req in requirements), (
+    assert "scipy" in requirements, (
         "manifest.json must declare scipy in 'requirements' so Home Assistant "
         "installs it for HACS users — MILP silently falls back otherwise"
     )
-    assert any(req.startswith("numpy") for req in requirements), (
+    assert "numpy" in requirements, (
         "manifest.json must declare numpy in 'requirements' so Home Assistant "
         "installs it for HACS users"
     )
 
 
-def test_manifest_requirement_pins_match_repo_dev_pins():
-    """The manifest pins must stay in sync with requirements.txt's dev pins."""
-    manifest = _load_manifest()
-    requirements = {req.split("==")[0]: req for req in manifest["requirements"]}
+def test_manifest_requirements_are_ranges_not_exact_pins():
+    """Exact pins collide with HA core's own numpy pin; ranges must be used."""
+    requirements = _requirement_specs()
+
+    for name, req in requirements.items():
+        specifier_strs = {str(spec) for spec in req.specifier}
+        assert not any(s.startswith("==") for s in specifier_strs), (
+            f"manifest.json pins '{name}' to an exact version ({req}). "
+            "Home Assistant core hard-pins numpy in its own "
+            "package_constraints.txt and bumps it every few releases — an "
+            "exact pin here will conflict with HA's pin and break setup for "
+            "every user. Use a range instead (see module docstring)."
+        )
+
+
+def test_manifest_numpy_range_contains_ha_core_constrained_version():
+    """The declared numpy range must accept the version HA core currently pins."""
+    requirements = _requirement_specs()
+
+    assert requirements["numpy"].specifier.contains(HA_CONSTRAINED_NUMPY_VERSION), (
+        f"manifest.json's numpy requirement ({requirements['numpy']}) does not "
+        f"accept numpy=={HA_CONSTRAINED_NUMPY_VERSION}, which is what Home "
+        "Assistant core currently pins in package_constraints.txt — installs "
+        "will fail for every user."
+    )
+
+
+def test_manifest_requirement_ranges_contain_repo_dev_pins():
+    """The manifest ranges must accept the exact versions used for dev/CI."""
+    requirements = _requirement_specs()
 
     repo_requirements_path = Path(__file__).resolve().parent.parent / "requirements.txt"
     repo_pins = {
-        line.split("==")[0]: line
+        line.split("==")[0]: Version(line.split("==")[1])
         for line in repo_requirements_path.read_text().splitlines()
         if "==" in line
     }
 
-    assert requirements["scipy"] == repo_pins["scipy"]
-    assert requirements["numpy"] == repo_pins["numpy"]
+    assert requirements["scipy"].specifier.contains(repo_pins["scipy"])
+    assert requirements["numpy"].specifier.contains(repo_pins["numpy"])


### PR DESCRIPTION
## Summary

Regression fix for #877 (which fixed #876). The exact pins shipped in #877
(`scipy==1.18.1`, `numpy==2.5.2`) broke integration setup for every real HA
user immediately after merge:

```
Unable to install package numpy==2.5.2: × No solution found when resolving
dependencies:
  ╰─▶ Because you require numpy==2.5.2 and numpy==2.3.2, we can conclude
      that your requirements are unsatisfiable.
Setup failed for custom integration 'hsem': Requirements for hsem not
found: ['numpy==2.5.2'].
```

## Root cause

Home Assistant core hard-pins `numpy` in its own
[`homeassistant/package_constraints.txt`](https://github.com/home-assistant/core/blob/2026.8.3/homeassistant/package_constraints.txt),
applied as a pip `--constraint` to **every** custom component install — not
just core integrations. Currently pinned to `numpy==2.3.2`. Our exact
`numpy==2.5.2` pin directly collides with that constraint and is
unsatisfiable — confirmed by fetching the constraints file for the exact HA
version from the error log (`2026.8.3`) and reproducing the conflict with
`pip install --dry-run --constraint`.

Checked the constraint across several recent HA releases — it moves every
few months:

| HA release | numpy pin |
| ---------- | --------- |
| 2025.1.0   | 2.2.0     |
| 2025.6.0   | 2.2.2     |
| 2025.10.0 → 2026.8.3 | 2.3.2 |

Matching the pin exactly (e.g. `numpy==2.3.2`) would only defer the same
break to the next HA release that bumps it. `scipy` isn't currently
constrained by HA core at all (the only core integration that needs numpy,
`trend`, doesn't need scipy), but an exact pin there carries the same
latent fragility if that ever changes.

## Fix

Switched both requirements from exact pins to ranges wide enough to always
contain HA's current constraint, so the resolver can satisfy
manifest + scipy's own declared numpy bound (`numpy>=2.0.0,<2.8` per scipy
1.18.1's metadata) + HA's constraint simultaneously, without us needing to
track HA's release cadence:

```json
"requirements": ["scipy>=1.14,<2", "numpy>=2.0,<3"]
```

Verified with:

```bash
curl -s https://raw.githubusercontent.com/home-assistant/core/2026.8.3/homeassistant/package_constraints.txt -o /tmp/ha_constraints.txt
pip install --dry-run --constraint /tmp/ha_constraints.txt "scipy>=1.14,<2" "numpy>=2.0,<3"
# -> Would install numpy-2.3.2 (scipy already satisfied) — no conflict
```

## Files changed

- `custom_components/hsem/manifest.json` — exact pins → ranges
- `tests/test_manifest.py` — rewritten to assert requirements are ranges
  (not exact pins) and that the numpy range accepts HA core's currently
  constrained version (`2.3.2`), plus that both ranges still contain the
  repo's own dev/CI pins from `requirements.txt`. This should catch this
  class of regression before merge next time.

## Test plan

- [x] `./scripts/quality.sh lint` — pass
- [x] `./scripts/quality.sh typing` — 0 errors
- [x] `./scripts/quality.sh quality` — 0 errors, 0 warnings
- [x] `./scripts/quality.sh test` — 2991 passed
- [x] Reproduced HA's exact resolver conflict locally against the real
      `package_constraints.txt` for the failing HA version, then verified
      the new ranges resolve cleanly against it

Fixes the regression introduced by #877. Related: #876
