### PR TITLE
fix(services): unregister HSEM services on unload; clean up dead code

### DIFF
--- a/custom_components/hsem/__init__.py
+++ b/custom_components/hsem/__init__.py
@@ -21,7 +21,10 @@ from homeassistant.exceptions import (
 
 from custom_components.hsem.const import DOMAIN, MIN_HUAWEI_SOLAR_VERSION
 from custom_components.hsem.coordinator import HSEMDataUpdateCoordinator
-from custom_components.hsem.services import async_register_services
+from custom_components.hsem.services import (
+    async_register_services,
+    async_unregister_services,
+)
 from custom_components.hsem.utils.logger import (
     async_close_hsem_logger,
     async_init_hsem_logger,
@@ -213,6 +216,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: HSEMConfigEntry) -> boo
 
     if unload_ok:
         entry.runtime_data = None  # type: ignore[assignment]  # HA convention: clear on unload
+
+    # HSEM only supports a single config entry, so unloading it means the
+    # services registered in async_setup are no longer backed by a coordinator.
+    await async_unregister_services(hass)
 
     # Close the HSEM dedicated log file handler.
     await async_close_hsem_logger()

--- a/custom_components/hsem/flows/ev_planned_load_helpers.py
+++ b/custom_components/hsem/flows/ev_planned_load_helpers.py
@@ -32,6 +32,11 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.selector import selector
 
+from custom_components.hsem.utils.config_validator import (
+    merge_errors,
+    validate_energy_limits,
+    validate_power_limits,
+)
 from custom_components.hsem.utils.misc import get_config_value
 from custom_components.hsem.utils.phase_power import EV_PHASE_TOPOLOGIES
 
@@ -228,4 +233,17 @@ async def validate_ev_planned_load_schema_input(
     if not user_input.get(f"{prefix}_enabled", False):
         return {}
 
-    return {}
+    capacity_errors = validate_energy_limits(
+        user_input,
+        f"{prefix}_battery_capacity_kwh",
+        min_kwh=0.0,
+        max_kwh=200.0,
+    )
+    min_power_errors = validate_power_limits(
+        user_input,
+        f"{prefix}_charger_min_power_w",
+        min_watts=0.0,
+        max_watts=22_000.0,
+    )
+
+    return merge_errors(capacity_errors, min_power_errors)

--- a/custom_components/hsem/planner/milp/_incumbent.py
+++ b/custom_components/hsem/planner/milp/_incumbent.py
@@ -8,7 +8,7 @@ the complete model that was passed to the solver.
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from typing import Any
 
 from custom_components.hsem.utils.logger import log_planner
@@ -27,10 +27,6 @@ class IncumbentValidation:
     max_inequality_violation: float = 0.0
     max_bound_violation: float = 0.0
     max_integrality_violation: float = 0.0
-
-    def as_dict(self) -> dict[str, Any]:
-        """Return JSON-safe fields for planner diagnostics."""
-        return asdict(self)
 
 
 def _invalid(

--- a/custom_components/hsem/utils/forecast_tracker.py
+++ b/custom_components/hsem/utils/forecast_tracker.py
@@ -592,17 +592,6 @@ class ForecastTracker:
     # Serialization (reboot persistence)
     # ------------------------------------------------------------------
 
-    def to_dict(self) -> dict[str, Any]:
-        """Serialize all tracker records to a JSON-safe dictionary.
-
-        Returns:
-            A dictionary with the full record list suitable for storage
-            in a Home Assistant sensor's ``extra_state_attributes``.
-        """
-        return {
-            "records": [r.to_dict() for r in self._records],
-        }
-
     def to_persistence_dict(
         self,
         *,

--- a/custom_components/hsem/utils/time_windows.py
+++ b/custom_components/hsem/utils/time_windows.py
@@ -8,26 +8,6 @@ start, and determine if an interval ends before a window begins.
 from datetime import datetime, time, timedelta
 
 
-def is_time_in_window(current: time, start: time, end: time) -> bool:
-    """Check whether *current* falls within the [start, end) window.
-
-    Handles windows that cross midnight (e.g. 23:00–02:00) correctly.
-
-    Args:
-        current: The time to test.
-        start: Start of the window (inclusive).
-        end: End of the window (exclusive).
-
-    Returns:
-        True if *current* is within the window, False otherwise.
-    """
-    if start <= end:
-        # Same-day window (e.g. 07:00–09:00)
-        return start <= current < end
-    # Cross-midnight window (e.g. 23:00–02:00)
-    return current >= start or current < end
-
-
 def next_window_start_dt(now: datetime, window_start: time) -> datetime:
     """Return the next upcoming datetime when a discharge/charge window begins.
 

--- a/custom_components/hsem/utils/units.py
+++ b/custom_components/hsem/utils/units.py
@@ -10,7 +10,7 @@ All functions accept ``int`` or ``float`` and return ``float``.
 Usage
 -----
 >>> from custom_components.hsem.utils.units import (
-...     watt_to_kilowatt, kilowatt_to_watt,
+...     watt_to_kilowatt,
 ...     watthours_to_kilowatthours, kilowatthours_to_watthours,
 ...     energy_to_power_kw,
 ...     timedelta_to_hours, slot_duration_hours, hours_ahead,
@@ -46,18 +46,6 @@ def watt_to_kilowatt(power_w: float) -> float:
         Power in kiloWatts (kW).
     """
     return power_w / 1000.0
-
-
-def kilowatt_to_watt(power_kw: float) -> float:
-    """Convert kiloWatts to Watts.
-
-    Args:
-        power_kw: Power in kiloWatts (kW).
-
-    Returns:
-        Power in Watts (W).
-    """
-    return power_kw * 1000.0
 
 
 # ---------------------------------------------------------------------------
@@ -337,44 +325,6 @@ def ev_ac_to_dc_kwh(ac_kwh: float, charger_efficiency: float) -> float:
         Energy delivered to the EV battery (kWh, DC side).
     """
     return ac_kwh * charger_efficiency
-
-
-# ---------------------------------------------------------------------------
-# Price / cost helpers
-# ---------------------------------------------------------------------------
-
-
-def energy_cost(energy_kwh: float, price_per_kwh: float) -> float:
-    """Compute the monetary cost of a given amount of energy.
-
-    ``cost = energy_kwh × price_per_kwh``
-
-    Args:
-        energy_kwh: Energy in kiloWatt-hours (kWh).
-        price_per_kwh: Price per kiloWatt-hour (local currency/kWh).
-
-    Returns:
-        Monetary cost in local currency.
-    """
-    return energy_kwh * price_per_kwh
-
-
-def implied_price_per_kwh(total_cost: float, energy_kwh: float) -> float:
-    """Compute the implied average price from a total cost and energy.
-
-    ``price_per_kwh = total_cost ÷ energy_kwh``
-
-    Args:
-        total_cost: Total monetary cost (local currency).
-        energy_kwh: Energy in kiloWatt-hours (kWh).
-
-    Returns:
-        Implied average price per kWh.  Returns ``0.0`` if *energy_kwh* is
-        zero or negative (to avoid division-by-zero or nonsensical results).
-    """
-    if energy_kwh <= 0.0:
-        return 0.0
-    return total_cost / energy_kwh
 
 
 #: Planner flow fields are published to three decimal places, so exactly

--- a/docs/forecast-accuracy-tracking.md
+++ b/docs/forecast-accuracy-tracking.md
@@ -131,7 +131,8 @@ Key methods:
 | `finalise_record(start)`                 | Finalise a specific record                                           |
 | `finalise_past_records(now)`             | Finalise all records whose `end <= now`                              |
 | `set_forecasts(start, pv_kwh, load_kwh)` | Set forecast values (only if not finalised)                          |
-| `to_dict()` / `load_from_dict(data)`     | Serialize / deserialize the full record list                         |
+| `to_persistence_dict(now, max_records)`  | Serialize the bounded records that matter across a restart           |
+| `load_from_dict(data)`                   | Deserialize records produced by `to_persistence_dict()`              |
 
 The default maximum is 2880 records, which covers approximately 30 days
 of 15-minute slots. Older records are automatically pruned.
@@ -288,8 +289,8 @@ The forecast tracker data survives HA restarts using the standard
 `RestoreEntity` pattern already used by other HSEM diagnostic sensors:
 
 1. **Every cycle**, the sensor's `extra_state_attributes` includes a
-   `_forecast_tracker_data` key containing the full serialised record
-   list from `tracker.to_dict()`.
+   `_forecast_tracker_data` key containing the bounded record list from
+   `tracker.to_persistence_dict()`.
 
 2. **HA's recorder** automatically stores these attributes in its database.
 

--- a/tests/test_ev_planned_load_flow_validation.py
+++ b/tests/test_ev_planned_load_flow_validation.py
@@ -1,0 +1,87 @@
+"""Tests for EV planned load config/options flow validation (issue #891).
+
+``validate_ev_planned_load_schema_input`` used to be a no-op stub that
+always returned ``{}`` once the step was enabled, so out-of-range
+``battery_capacity_kwh``/``charger_min_power_w`` values submitted through
+the config or options flow were silently accepted even though
+``validate_power_limits``/``validate_energy_limits`` existed in
+``utils/config_validator.py`` for exactly this purpose. These tests cover
+the real validation now wired in for both the primary and second EV
+planned-load steps.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.hsem.flows.ev_planned_load_helpers import (
+    validate_ev_planned_load_schema_input,
+)
+
+_PREFIXES = ["hsem_ev_planned_load", "hsem_ev_second_planned_load"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prefix", _PREFIXES)
+async def test_disabled_step_skips_validation(prefix: str) -> None:
+    """Disabled steps are not validated, regardless of field contents."""
+    user_input = {
+        f"{prefix}_enabled": False,
+        f"{prefix}_battery_capacity_kwh": -50.0,
+        f"{prefix}_charger_min_power_w": -1.0,
+    }
+    errors = await validate_ev_planned_load_schema_input(user_input, prefix)
+    assert errors == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prefix", _PREFIXES)
+async def test_valid_values_pass(prefix: str) -> None:
+    """In-range capacity and charger minimum power produce no errors."""
+    user_input = {
+        f"{prefix}_enabled": True,
+        f"{prefix}_battery_capacity_kwh": 75.0,
+        f"{prefix}_charger_min_power_w": 1400.0,
+    }
+    errors = await validate_ev_planned_load_schema_input(user_input, prefix)
+    assert errors == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prefix", _PREFIXES)
+async def test_battery_capacity_out_of_range_is_rejected(prefix: str) -> None:
+    """battery_capacity_kwh must stay within the 0-200 kWh selector bounds."""
+    user_input = {
+        f"{prefix}_enabled": True,
+        f"{prefix}_battery_capacity_kwh": 250.0,
+        f"{prefix}_charger_min_power_w": 1400.0,
+    }
+    errors = await validate_ev_planned_load_schema_input(user_input, prefix)
+    assert errors[f"{prefix}_battery_capacity_kwh"] == "energy_out_of_range"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prefix", _PREFIXES)
+async def test_charger_min_power_out_of_range_is_rejected(prefix: str) -> None:
+    """charger_min_power_w must stay within the 0-22000 W selector bounds."""
+    user_input = {
+        f"{prefix}_enabled": True,
+        f"{prefix}_battery_capacity_kwh": 75.0,
+        f"{prefix}_charger_min_power_w": 25_000.0,
+    }
+    errors = await validate_ev_planned_load_schema_input(user_input, prefix)
+    assert errors[f"{prefix}_charger_min_power_w"] == "power_out_of_range"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prefix", _PREFIXES)
+async def test_both_fields_out_of_range_reports_both_errors(prefix: str) -> None:
+    """Both fields are validated independently in a single call."""
+    user_input = {
+        f"{prefix}_enabled": True,
+        f"{prefix}_battery_capacity_kwh": -1.0,
+        f"{prefix}_charger_min_power_w": -1.0,
+    }
+    errors = await validate_ev_planned_load_schema_input(user_input, prefix)
+    assert errors[f"{prefix}_battery_capacity_kwh"] == "energy_out_of_range"
+    assert errors[f"{prefix}_charger_min_power_w"] == "power_out_of_range"

--- a/tests/test_forecast_tracker.py
+++ b/tests/test_forecast_tracker.py
@@ -564,14 +564,14 @@ class TestForecastTrackerSerialization:
         assert restored.mae_pv == pytest.approx(1.0)
         assert restored.bias_pv == pytest.approx(1.0)
 
-    def test_tracker_to_dict_empty(self) -> None:
-        """An empty tracker serializes to an empty record list."""
-        tracker = ForecastTracker()
-        d = tracker.to_dict()
-        assert d == {"records": []}
+    def test_tracker_to_persistence_dict_round_trip(self) -> None:
+        """Full round-trip via the real reboot-persistence path.
 
-    def test_tracker_to_dict_round_trip(self) -> None:
-        """Full round-trip: populate, serialize, deserialize, verify summary."""
+        Populate, persist with ``to_persistence_dict`` (the method HSEM
+        actually uses to save tracker state — see
+        ``forecast_accuracy_sensor.py``), restore into a fresh tracker, and
+        verify the summary matches.
+        """
         original = ForecastTracker()
 
         # Add two finalised records
@@ -588,9 +588,10 @@ class TestForecastTrackerSerialization:
             original.finalise_record(_slot_start(hour))
 
         original_summary = original.summary
+        assert original_summary.finalised_count == 2
 
-        # Serialize
-        data = original.to_dict()
+        # Persist via the real reboot-persistence path
+        data = original.to_persistence_dict(now=_slot_start(12))
         assert len(data["records"]) == 2
 
         # Deserialize into a fresh tracker
@@ -607,34 +608,6 @@ class TestForecastTrackerSerialization:
         assert restored_summary.mape_pv_pct == pytest.approx(
             original_summary.mape_pv_pct
         )
-
-    def test_tracker_to_dict_unfinalised_records(self) -> None:
-        """Unfinalised serialized records restore correctly (with zero bias)."""
-        tracker = ForecastTracker()
-        tracker.get_or_create_record(_slot_start(10), _slot_start(11))
-        tracker.set_forecasts(
-            _slot_start(10),
-            4.0,
-            2.0,
-            forecast_soc_pct=78.0,
-            forecast_action="charge",
-        )
-        # Accumulate but do NOT finalise
-
-        data = tracker.to_dict()
-        assert len(data["records"]) == 1
-        assert data["records"][0]["finalised"] is False
-        assert data["records"][0]["actual_pv_kwh"] == pytest.approx(0.0)
-
-        restored = ForecastTracker()
-        restored.load_from_dict(data)
-        rec = restored.find_record(_slot_start(10))
-        assert rec is not None
-        assert rec.finalised is False
-        assert rec.forecast_pv_kwh == pytest.approx(4.0)
-        assert rec.forecast_soc_pct == pytest.approx(78.0)
-        assert rec.forecast_action == "charge"
-        assert rec.prediction_eligible is True
 
     def test_legacy_payload_is_restored_but_excluded_from_accuracy(self) -> None:
         """Pre-baseline-schema records must not train or skew metrics."""

--- a/tests/test_init_unload.py
+++ b/tests/test_init_unload.py
@@ -1,0 +1,110 @@
+"""Tests for HSEM's config-entry unload lifecycle.
+
+Covers the real bug from issue #891: ``async_unload_entry`` tore down the
+coordinator and platforms but never called ``async_unregister_services``,
+leaving HSEM's services registered in ``hass.services`` after the
+integration was unloaded or reloaded.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.hsem import HSEMRuntimeData, async_unload_entry
+from custom_components.hsem.const import DOMAIN
+from custom_components.hsem.services import SERVICE_HANDLER_MAP, async_register_services
+
+
+class _FakeServiceRegistry:
+    """Minimal stateful stand-in for HomeAssistant's real service registry.
+
+    Tracks registered (domain, service) pairs so the test can assert on the
+    actual post-unload state instead of just call-args on a mock.
+    """
+
+    def __init__(self) -> None:
+        self._services: dict[str, set[str]] = {}
+
+    def has_service(self, domain: str, service: str) -> bool:
+        return service in self._services.get(domain, set())
+
+    def async_register(
+        self,
+        domain: str,
+        service: str,
+        service_func: Any,
+        schema: Any = None,
+        supports_response: Any = None,
+    ) -> None:
+        assert callable(service_func)
+        self._services.setdefault(domain, set()).add(service)
+
+    def async_remove(self, domain: str, service: str) -> None:
+        self._services.get(domain, set()).discard(service)
+
+
+@pytest.fixture
+def mock_hass() -> MagicMock:
+    """Return a mocked HomeAssistant with a stateful fake service registry."""
+    hass = MagicMock()
+    hass.services = _FakeServiceRegistry()
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+    return hass
+
+
+@pytest.mark.asyncio
+async def test_async_unload_entry_removes_hsem_services(
+    mock_hass: MagicMock,
+) -> None:
+    """async_unload_entry must unregister every HSEM service (issue #891)."""
+    await async_register_services(mock_hass)
+    assert all(
+        mock_hass.services.has_service(DOMAIN, name) for name in SERVICE_HANDLER_MAP
+    )
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.async_teardown = AsyncMock()
+
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    entry.runtime_data = HSEMRuntimeData(coordinator=mock_coordinator)
+
+    result = await async_unload_entry(mock_hass, entry)
+
+    assert result is True
+    mock_coordinator.async_teardown.assert_awaited_once()
+    assert not any(
+        mock_hass.services.has_service(DOMAIN, name) for name in SERVICE_HANDLER_MAP
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_unload_entry_skips_service_removal_when_platforms_fail(
+    mock_hass: MagicMock,
+) -> None:
+    """Services are still unregistered even if platform unload fails.
+
+    ``async_unregister_services`` runs unconditionally after the platform
+    unload attempt, matching the real HA teardown ordering used elsewhere
+    in ``async_unload_entry``.
+    """
+    mock_hass.config_entries.async_unload_platforms = AsyncMock(return_value=False)
+    await async_register_services(mock_hass)
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.async_teardown = AsyncMock()
+
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    entry.runtime_data = HSEMRuntimeData(coordinator=mock_coordinator)
+
+    result = await async_unload_entry(mock_hass, entry)
+
+    assert result is False
+    assert not any(
+        mock_hass.services.has_service(DOMAIN, name) for name in SERVICE_HANDLER_MAP
+    )

--- a/tests/test_midnight_rollover.py
+++ b/tests/test_midnight_rollover.py
@@ -16,10 +16,7 @@ Windows.
 import asyncio
 from datetime import UTC, datetime, time, timedelta
 
-from custom_components.hsem.utils.time_windows import (
-    interval_ends_before_window_start,
-    is_time_in_window,
-)
+from custom_components.hsem.utils.time_windows import interval_ends_before_window_start
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -35,65 +32,13 @@ def _dt(hour: int, minute: int = 0, date_offset: int = 0) -> datetime:
 
 
 # ---------------------------------------------------------------------------
-# Tests for is_time_in_window
-# ---------------------------------------------------------------------------
-
-
-class TestIsTimeInWindow:
-    """Unit tests for the is_time_in_window helper."""
-
-    # --- Same-day windows ---------------------------------------------------
-
-    def test_same_day_inside(self):
-        """Current time falls inside a same-day window."""
-        assert is_time_in_window(time(8, 0), time(7, 0), time(9, 0)) is True
-
-    def test_same_day_at_start(self):
-        """Current time equals the window start (inclusive boundary)."""
-        assert is_time_in_window(time(7, 0), time(7, 0), time(9, 0)) is True
-
-    def test_same_day_at_end(self):
-        """Current time equals the window end (exclusive boundary)."""
-        assert is_time_in_window(time(9, 0), time(7, 0), time(9, 0)) is False
-
-    def test_same_day_before_window(self):
-        """Current time is before a same-day window."""
-        assert is_time_in_window(time(6, 59), time(7, 0), time(9, 0)) is False
-
-    def test_same_day_after_window(self):
-        """Current time is after a same-day window."""
-        assert is_time_in_window(time(9, 1), time(7, 0), time(9, 0)) is False
-
-    # --- Cross-midnight windows (P0-02 acceptance criteria) ----------------
-
-    def test_cross_midnight_23_to_02_at_2300(self):
-        """At 23:00 the 23:00-02:00 window has just started → inside."""
-        assert is_time_in_window(time(23, 0), time(23, 0), time(2, 0)) is True
-
-    def test_cross_midnight_23_to_02_at_0100(self):
-        """At 01:00 we are inside the 23:00-02:00 window."""
-        assert is_time_in_window(time(1, 0), time(23, 0), time(2, 0)) is True
-
-    def test_cross_midnight_23_to_02_at_0200(self):
-        """At 02:00 the 23:00-02:00 window has ended (exclusive)."""
-        assert is_time_in_window(time(2, 0), time(23, 0), time(2, 0)) is False
-
-    def test_cross_midnight_23_to_02_at_2100(self):
-        """At 21:00 the 23:00-02:00 window has not started yet."""
-        assert is_time_in_window(time(21, 0), time(23, 0), time(2, 0)) is False
-
-    def test_cross_midnight_0000_to_0600_at_0300(self):
-        """At 03:00 we are inside the 00:00-06:00 window (P0-02 AC)."""
-        # 00:00-06:00 is a same-day window (start < end)
-        assert is_time_in_window(time(3, 0), time(0, 0), time(6, 0)) is True
-
-    def test_cross_midnight_0000_to_0600_at_2300(self):
-        """At 23:00 we are outside the 00:00-06:00 window."""
-        assert is_time_in_window(time(23, 0), time(0, 0), time(6, 0)) is False
-
-
-# ---------------------------------------------------------------------------
 # Tests for interval_ends_before_window_start
+#
+# Note: the sibling ``is_time_in_window`` helper (formerly tested here) was
+# removed as dead code in issue #891 — it had no production caller.
+# Production cross-midnight window handling lives inline in
+# ``planner/discharge_scheduler.py``, exercised by the planner test suite
+# and ``tests/test_cross_day_charge_windows.py``.
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_p0_regression_suite.py
+++ b/tests/test_p0_regression_suite.py
@@ -147,44 +147,21 @@ class TestP001MonthMatching:
 
 
 class TestP002MidnightRollover:
-    """OLD BUG: ``is_time_in_window`` and ``interval_ends_before_window_start``
-    only handled same-day windows (start < end).  A cross-midnight window such
-    as 23:00–02:00 was silently treated as always-false, causing HSEM to skip
-    valid overnight charge/discharge windows entirely.
+    """OLD BUG: ``interval_ends_before_window_start`` only handled same-day
+    windows (start < end).  A cross-midnight window such as 23:00-02:00 was
+    silently treated as always-false, causing HSEM to skip valid overnight
+    charge/discharge windows entirely.
 
-    FIX: Both helpers now detect when ``start > end`` (cross-midnight) and
-    use the corresponding logic branch.
+    FIX: The helper now detects when ``start > end`` (cross-midnight) and
+    uses the corresponding logic branch.
+
+    Note: the sibling ``is_time_in_window`` helper covered by the original
+    fix was removed as dead code in issue #891 — it had no production
+    caller. Production cross-midnight window handling for discharge
+    schedules lives inline in ``planner/discharge_scheduler.py`` (the
+    ``sched.end > sched.start`` branch), exercised by
+    ``tests/test_cross_day_charge_windows.py`` and the planner test suite.
     """
-
-    def test_inside_cross_midnight_window(self) -> None:
-        """01:00 is inside the 23:00-02:00 window."""
-        from custom_components.hsem.utils.time_windows import is_time_in_window
-
-        assert is_time_in_window(time(1, 0), time(23, 0), time(2, 0)) is True
-
-    def test_at_start_of_cross_midnight_window(self) -> None:
-        """23:00 is the inclusive start of the 23:00-02:00 window."""
-        from custom_components.hsem.utils.time_windows import is_time_in_window
-
-        assert is_time_in_window(time(23, 0), time(23, 0), time(2, 0)) is True
-
-    def test_at_end_of_cross_midnight_window_is_exclusive(self) -> None:
-        """02:00 is the exclusive end — must be False."""
-        from custom_components.hsem.utils.time_windows import is_time_in_window
-
-        assert is_time_in_window(time(2, 0), time(23, 0), time(2, 0)) is False
-
-    def test_before_cross_midnight_window(self) -> None:
-        """21:00 is before the 23:00 start — must be False."""
-        from custom_components.hsem.utils.time_windows import is_time_in_window
-
-        assert is_time_in_window(time(21, 0), time(23, 0), time(2, 0)) is False
-
-    def test_after_cross_midnight_window(self) -> None:
-        """03:00 is after the 02:00 end of the cross-midnight window."""
-        from custom_components.hsem.utils.time_windows import is_time_in_window
-
-        assert is_time_in_window(time(3, 0), time(23, 0), time(2, 0)) is False
 
     def test_interval_ending_before_cross_midnight_window_start(self) -> None:
         """An interval ending at 22:00 is before a 23:00 cross-midnight window."""
@@ -207,13 +184,6 @@ class TestP002MidnightRollover:
         assert (
             interval_ends_before_window_start(interval_end, time(23, 0), now) is False
         )
-
-    def test_same_day_window_still_works(self) -> None:
-        """Ordinary same-day windows continue to work after the fix."""
-        from custom_components.hsem.utils.time_windows import is_time_in_window
-
-        assert is_time_in_window(time(8, 0), time(7, 0), time(9, 0)) is True
-        assert is_time_in_window(time(6, 59), time(7, 0), time(9, 0)) is False
 
 
 # ===========================================================================

--- a/tests/test_unit_conversions.py
+++ b/tests/test_unit_conversions.py
@@ -10,13 +10,10 @@ from __future__ import annotations
 import pytest
 
 from custom_components.hsem.utils.units import (
-    energy_cost,
     energy_to_power_kw,
     ev_ac_to_dc_kwh,
     ev_dc_to_ac_kwh,
     fuse_max_energy_per_slot_kwh,
-    implied_price_per_kwh,
-    kilowatt_to_watt,
     kilowatthours_to_watthours,
     watt_to_kilowatt,
     watthours_to_kilowatthours,
@@ -49,31 +46,6 @@ class TestWattToKilowatt:
     def test_negative(self) -> None:
         """-500 W → -0.5 kW (negative power is valid for reverse flow)."""
         assert watt_to_kilowatt(-500.0) == pytest.approx(-0.5)
-
-
-class TestKilowattToWatt:
-    """Tests for :func:`kilowatt_to_watt`."""
-
-    def test_typical_value(self) -> None:
-        """5.0 kW → 5000 W."""
-        assert kilowatt_to_watt(5.0) == pytest.approx(5000.0)
-
-    def test_zero(self) -> None:
-        """0.0 kW → 0 W."""
-        assert kilowatt_to_watt(0.0) == pytest.approx(0.0)
-
-    def test_small_value(self) -> None:
-        """0.001 kW → 1 W."""
-        assert kilowatt_to_watt(0.001) == pytest.approx(1.0)
-
-    def test_negative(self) -> None:
-        """-2.5 kW → -2500 W."""
-        assert kilowatt_to_watt(-2.5) == pytest.approx(-2500.0)
-
-    def test_roundtrip(self) -> None:
-        """Round-trip: W → kW → W preserves value."""
-        original = 7642.0
-        assert kilowatt_to_watt(watt_to_kilowatt(original)) == pytest.approx(original)
 
 
 # ---------------------------------------------------------------------------
@@ -151,86 +123,6 @@ class TestEnergyToPowerKw:
         assert energy_to_power_kw(energy_kwh=-3.0, duration_h=1.0) == pytest.approx(
             -3.0
         )
-
-
-# ---------------------------------------------------------------------------
-# Price / cost helpers
-# ---------------------------------------------------------------------------
-
-
-class TestEnergyCost:
-    """Tests for :func:`energy_cost`."""
-
-    def test_typical_value(self) -> None:
-        """10 kWh × 0.50 DKK/kWh → 5.0 DKK."""
-        assert energy_cost(energy_kwh=10.0, price_per_kwh=0.50) == pytest.approx(5.0)
-
-    def test_zero_energy(self) -> None:
-        """0 kWh × 0.50 → 0.0."""
-        assert energy_cost(energy_kwh=0.0, price_per_kwh=0.50) == pytest.approx(0.0)
-
-    def test_zero_price(self) -> None:
-        """10 kWh × 0.0 → 0.0."""
-        assert energy_cost(energy_kwh=10.0, price_per_kwh=0.0) == pytest.approx(0.0)
-
-    def test_negative_price(self) -> None:
-        """10 kWh × -0.10 → -1.0 (negative price = revenue)."""
-        assert energy_cost(energy_kwh=10.0, price_per_kwh=-0.10) == pytest.approx(-1.0)
-
-    def test_negative_energy(self) -> None:
-        """-5 kWh × 0.50 → -2.5 (export)."""
-        assert energy_cost(energy_kwh=-5.0, price_per_kwh=0.50) == pytest.approx(-2.5)
-
-
-class TestImpliedPricePerKwh:
-    """Tests for :func:`implied_price_per_kwh`."""
-
-    def test_typical_value(self) -> None:
-        """5.0 DKK ÷ 10 kWh → 0.50 DKK/kWh."""
-        assert implied_price_per_kwh(total_cost=5.0, energy_kwh=10.0) == pytest.approx(
-            0.50
-        )
-
-    def test_zero_energy_returns_zero(self) -> None:
-        """Division by zero guard: 5.0 ÷ 0 → 0.0."""
-        assert implied_price_per_kwh(total_cost=5.0, energy_kwh=0.0) == pytest.approx(
-            0.0
-        )
-
-    def test_negative_energy_returns_zero(self) -> None:
-        """Guard against nonsensical negative energy: 5.0 ÷ -1 → 0.0."""
-        assert implied_price_per_kwh(total_cost=5.0, energy_kwh=-1.0) == pytest.approx(
-            0.0
-        )
-
-    def test_zero_cost(self) -> None:
-        """0.0 ÷ 10 kWh → 0.0."""
-        assert implied_price_per_kwh(total_cost=0.0, energy_kwh=10.0) == pytest.approx(
-            0.0
-        )
-
-    def test_negative_cost(self) -> None:
-        """-5.0 ÷ 10 kWh → -0.50 (net revenue)."""
-        assert implied_price_per_kwh(total_cost=-5.0, energy_kwh=10.0) == pytest.approx(
-            -0.50
-        )
-
-
-# ---------------------------------------------------------------------------
-# Cross-category consistency
-# ---------------------------------------------------------------------------
-
-
-class TestCrossCategoryConsistency:
-    """Verify that related conversions produce consistent results."""
-
-    def test_kwh_to_cost_to_implied_price(self) -> None:
-        """energy_cost then implied_price_per_kwh recovers the original price."""
-        energy = 12.5
-        price = 0.45
-        cost = energy_cost(energy, price)
-        recovered = implied_price_per_kwh(cost, energy)
-        assert recovered == pytest.approx(price)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #891 — a manual dead-code sweep (AST-based duplicate-method-name detection,
grep-verified call sites; the same technique that found #888) turned up one
real functional bug plus several confirmed-dead symbols.

### Real bug fix

- **`async_unload_entry()` never called `async_unregister_services(hass)`**
  (`custom_components/hsem/__init__.py`), despite
  `async_unregister_services`'s own docstring claiming this happens
  (`services.py:393`). HSEM's registered HA services were left behind after
  the integration was unloaded or reloaded. Now calls
  `await async_unregister_services(hass)` after the platform-unload step.

### Confirmed dead code — resolved

| Symbol | Location | Disposition |
| --- | --- | --- |
| `IncumbentValidation.as_dict()` | `planner/milp/_incumbent.py` | Removed — never called; callers only read `.valid`/`.reason`. |
| `ForecastTracker.to_dict()` | `utils/forecast_tracker.py` | Removed — superseded by `to_persistence_dict()`, which is what `forecast_accuracy_sensor.py` actually uses. |
| `kilowatt_to_watt`, `energy_cost`, `implied_price_per_kwh` | `utils/units.py` | Removed — only referenced by their own unit tests, no production caller. |
| `validate_power_limits`, `validate_energy_limits` | `utils/config_validator.py` | **Wired in**, not removed — `validate_ev_planned_load_schema_input()` (shared by the primary and second EV planned-load config/options flow steps) was a no-op stub (`return {}`) that accepted any `battery_capacity_kwh` / `charger_min_power_w` value. Now validates both fields against the same bounds already enforced by their HA number selectors (0–200 kWh, 0–22000 W). |
| `is_time_in_window` | `utils/time_windows.py` | Removed — `discharge_scheduler.py` reimplements the same cross-midnight (`sched.end > sched.start`) branching inline and is covered by its own tests; consolidating would be a planner-logic change out of scope here. |

### Flagged, not acted on (posted as issue comments)

- `_apply_soc_plan()` (`planner/candidates/_soc_plan.py`) and the entire
  `CANDIDATE_SOC_*` constant family in `candidate_generator.py` appear to be a
  fully disconnected candidate-generation subsystem — confirmed via grep, no
  production caller anywhere. Per item 3 of #891 this needs a
  `docs/planner-spec.md`-informed decision, not a cleanup-pass fix. See
  [comment](https://github.com/woopstar/hsem/issues/891#issuecomment-5499460775).
- Adjacent finding: `interval_ends_before_window_start`'s formula is
  duplicated inline in a "fallback" branch of
  `planner/charging/pre_charge.py::apply_charge_schedules` that looks
  unreachable given the current `engine_core.py` call order. Also flagged,
  not touched. See
  [comment](https://github.com/woopstar/hsem/issues/891#issuecomment-5499463522).

## Files changed

- `custom_components/hsem/__init__.py` — the real bug fix
- `custom_components/hsem/planner/milp/_incumbent.py` — remove dead `as_dict()`
- `custom_components/hsem/utils/forecast_tracker.py` — remove dead `to_dict()`
- `custom_components/hsem/utils/units.py` — remove 3 dead conversion helpers
- `custom_components/hsem/flows/ev_planned_load_helpers.py` — wire in the two validators
- `custom_components/hsem/utils/time_windows.py` — remove dead `is_time_in_window`
- `docs/forecast-accuracy-tracking.md` — correct stale `to_dict()` references to `to_persistence_dict()`
- Tests: added `tests/test_init_unload.py` (new — end-to-end `async_unload_entry` coverage) and `tests/test_ev_planned_load_flow_validation.py` (new — validation now wired in); updated `tests/test_forecast_tracker.py`, `tests/test_unit_conversions.py`, `tests/test_midnight_rollover.py`, `tests/test_p0_regression_suite.py` to drop now-pointless direct unit tests for removed symbols while preserving real regression coverage (e.g. the `ForecastTracker` round-trip test was rewritten to go through `to_persistence_dict()`, the real production path, instead of the deleted `to_dict()`).

## Test plan

- [x] `./scripts/quality.sh lint` — clean (368 files unchanged, 0 ruff issues)
- [x] `./scripts/quality.sh typing` — 0 mypy errors
- [x] `./scripts/quality.sh quality` — 0 pyright errors, 0 vulture warnings
- [x] `./scripts/quality.sh test` — 2983 passed
- [x] New `tests/test_init_unload.py` asserts HSEM's services are actually removed from a stateful fake `hass.services` registry after `async_unload_entry()` runs (previously untested end-to-end)
- [x] New `tests/test_ev_planned_load_flow_validation.py` covers in-range/out-of-range `battery_capacity_kwh` and `charger_min_power_w` for both the primary and second EV planned-load flow steps

## Known limitations / open questions

- `_apply_soc_plan()` and `interval_ends_before_window_start`'s duplicated
  fallback logic are intentionally left untouched — see the issue comments
  linked above for a possible follow-up issue.
