### PR TITLE
chore(tests): centralize tracker persistence via a shared registry

### DIFF
--- a/custom_components/hsem/coordinator_cycle.py
+++ b/custom_components/hsem/coordinator_cycle.py
@@ -27,6 +27,7 @@ from custom_components.hsem.coordinator_helpers import (
     assess_load_forecast,
     ocpp_charge_target,
 )
+from custom_components.hsem.coordinator_persistence import persist_all_trackers
 from custom_components.hsem.coordinator_state import (
     CoordinatorSharedState,
 )
@@ -482,12 +483,8 @@ class CoordinatorCycleMixin(CoordinatorSharedState):
                 ),
                 last_planner_output=getattr(self, "_last_planner_output", None),
             )
-            if (
-                prediction_record_added
-                and self._prediction_tracker.history_file
-                and not await self._prediction_tracker.save_history()
-            ):
-                async_log("warning", "Failed to persist prediction tracker state")
+            if prediction_record_added:
+                await persist_all_trackers(self, only=["_prediction_tracker"])
 
             load_hold = apply_load_forecast_hold(
                 self._hourly_recommendations,

--- a/custom_components/hsem/coordinator_persistence.py
+++ b/custom_components/hsem/coordinator_persistence.py
@@ -1,0 +1,104 @@
+"""Central registry for coordinator tracker persistence (issue #890).
+
+Several coordinator-owned tracker classes each expose their own
+``save_history``/``load_history`` pair, persisted ad hoc from inside
+separate ``accumulate_*`` functions in :mod:`coordinator_tracking` and
+:mod:`coordinator_cycle`. Because more than one of them shares the exact
+same method name, ``vulture`` -- which matches unused code by name only,
+not by class -- sees one real call site for ``save_history`` and stops
+warning about *every* method sharing that name, including ones with zero
+callers. That blind spot let ``SavingsTracker.save_history()`` ship fully
+implemented and unit-tested but never called from production code
+(issue #888): the savings tracker lost all state on every Home Assistant
+restart.
+
+This module centralises the actual persistence calls into a single
+registry-driven loop so that adding a new tracker without wiring up its
+persistence is caught by a reflection test
+(``tests/test_coordinator_persistence_registry.py``) instead of relying
+on a name-matching static analyser.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import Protocol
+
+from custom_components.hsem.coordinator_state import CoordinatorSharedState
+from custom_components.hsem.utils.logger import async_log
+
+
+class Persistable(Protocol):
+    """Protocol for tracker classes that persist their own state to disk."""
+
+    async def save_history(self) -> bool:
+        """Persist current state to disk. Return ``True`` on success."""
+        ...
+
+
+def _get_savings_tracker(
+    coordinator: CoordinatorSharedState,
+) -> Persistable | None:
+    return coordinator._savings_tracker
+
+
+def _get_financial_tracker(
+    coordinator: CoordinatorSharedState,
+) -> Persistable | None:
+    return coordinator._financial_tracker
+
+
+def _get_prediction_tracker(
+    coordinator: CoordinatorSharedState,
+) -> Persistable | None:
+    """Return the prediction tracker only once its history file is set.
+
+    Mirrors the pre-refactor guard that skipped persistence before
+    ``init_prediction_tracker`` had run during coordinator setup.
+    """
+    tracker = coordinator._prediction_tracker
+    if not tracker.history_file:
+        return None
+    return tracker
+
+
+# Every field declared on ``CoordinatorSharedState`` (coordinator_state.py)
+# whose type exposes an ``async def save_history(self) -> bool`` method MUST
+# have a corresponding entry here, keyed by the exact attribute name.
+# Enforced by
+# tests/test_coordinator_persistence_registry.py::test_registry_covers_every_persistable_tracker.
+TRACKER_REGISTRY: dict[str, Callable[[CoordinatorSharedState], Persistable | None]] = {
+    "_savings_tracker": _get_savings_tracker,
+    "_financial_tracker": _get_financial_tracker,
+    "_prediction_tracker": _get_prediction_tracker,
+}
+
+
+async def persist_all_trackers(
+    coordinator: CoordinatorSharedState,
+    *,
+    only: Iterable[str] | None = None,
+) -> None:
+    """Persist tracker state through the shared registry.
+
+    Called from each point in the coordinator cycle where the
+    corresponding ``accumulate_*`` step just ran, replacing the scattered
+    per-``accumulate_*`` ``if not await tracker.save_history(): log
+    warning`` blocks with one shared loop.
+
+    Args:
+        coordinator: The running coordinator instance.
+        only: Registry keys to persist on this call, or ``None`` to
+            persist every registered tracker. Restricting the call lets
+            callers that don't share the same per-cycle cadence as the
+            rest (e.g. the prediction tracker only has new data on a
+            slot boundary) preserve their existing write cadence.
+    """
+    names = TRACKER_REGISTRY.keys() if only is None else only
+    for name in names:
+        tracker = TRACKER_REGISTRY[name](coordinator)
+        if tracker is None:
+            continue
+        if not await tracker.save_history():
+            label = name.lstrip("_").removesuffix("_tracker")
+            async_log("warning", "Failed to persist %s tracker state", label)

--- a/custom_components/hsem/coordinator_planner_phase.py
+++ b/custom_components/hsem/coordinator_planner_phase.py
@@ -29,6 +29,7 @@ from custom_components.hsem.coordinator_helpers import (
     live_demand_contradicts_zero_profile,
     load_forecast_signatures_match,
 )
+from custom_components.hsem.coordinator_persistence import persist_all_trackers
 from custom_components.hsem.coordinator_state import (
     CoordinatorSharedState,
 )
@@ -384,6 +385,19 @@ class CoordinatorPlannerPhaseMixin(CoordinatorSharedState):
             async_log(
                 "error",
                 "Savings tracker accumulation failed: %s",
+                e,
+            )
+
+        # Persist financial and savings tracker state (issues #599, #604,
+        # #890) through the shared registry -- see coordinator_persistence.py.
+        try:
+            await persist_all_trackers(
+                self, only=["_financial_tracker", "_savings_tracker"]
+            )
+        except Exception as e:
+            async_log(
+                "error",
+                "Tracker persistence failed: %s",
                 e,
             )
 

--- a/custom_components/hsem/coordinator_tracking.py
+++ b/custom_components/hsem/coordinator_tracking.py
@@ -337,16 +337,6 @@ async def _load_financial_tracker(tracker: FinancialTracker) -> None:
         async_log("error", "Failed to load financial tracker history")
 
 
-async def persist_financial_tracker(tracker: FinancialTracker) -> bool:
-    """Persist financial tracker state to disk atomically."""
-    if not tracker.history_file:
-        return False
-    data = tracker.as_dict()
-    path = Path(tracker.history_file)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    return await asyncio.to_thread(FinancialTracker._write_history_file, data, path)
-
-
 async def accumulate_financials(
     *,
     now: datetime,
@@ -392,9 +382,6 @@ async def accumulate_financials(
 
     # Price the interval ending at midnight before rolling to the new day.
     tracker.check_day_rollover(now)
-
-    if not await persist_financial_tracker(tracker):
-        async_log("warning", "Failed to persist financial tracker state")
 
 
 # ---------------------------------------------------------------------------
@@ -493,9 +480,6 @@ async def accumulate_savings(
         baseline_cost_delta=baseline_cost_delta,
         switch_on=switch_on,
     )
-
-    if not await st.save_history():
-        async_log("warning", "Failed to persist savings tracker state")
 
 
 async def _init_savings_tracker(

--- a/custom_components/hsem/models/financial_tracker.py
+++ b/custom_components/hsem/models/financial_tracker.py
@@ -6,9 +6,11 @@ rollups (today, last 7 days, last 30 days, this month, this year).
 
 from __future__ import annotations
 
+import asyncio
 import math
 from dataclasses import dataclass, field
 from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
 from typing import Any
 
 
@@ -485,6 +487,19 @@ class FinancialTracker:
                     tracker.daily_log[entry.date] = entry
 
         return tracker
+
+    async def save_history(self) -> bool:
+        """Persist tracker state to disk atomically.
+
+        Returns:
+            ``True`` if the state was successfully persisted to disk.
+        """
+        if not self.history_file:
+            return False
+        data = self.as_dict()
+        path = Path(self.history_file)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return await asyncio.to_thread(self._write_history_file, data, path)
 
     @staticmethod
     def _read_history_file(path: Any) -> dict[str, Any] | None:

--- a/scripts/quality.sh
+++ b/scripts/quality.sh
@@ -86,6 +86,11 @@ case "${1:-}" in
     quality)
         run python -m pyright
         run python -m vulture custom_components/hsem tests vulture_whitelist.py --min-confidence 80
+        echo ""
+        echo "[info] Supplementary vulture pass (custom_components/hsem only, tests"
+        echo "[info] excluded, --min-confidence 0). Informational only -- same-named"
+        echo "[info] methods across classes still won't be flagged (issue #890)."
+        run python -m vulture custom_components/hsem vulture_whitelist.py --min-confidence 0 || true
         ;;
     format-check)
         prettier_run --check
@@ -113,6 +118,11 @@ case "${1:-}" in
         echo "=== Quality ==="
         run python -m pyright
         run python -m vulture custom_components/hsem tests vulture_whitelist.py --min-confidence 80
+        echo ""
+        echo "[info] Supplementary vulture pass (custom_components/hsem only, tests"
+        echo "[info] excluded, --min-confidence 0). Informational only -- same-named"
+        echo "[info] methods across classes still won't be flagged (issue #890)."
+        run python -m vulture custom_components/hsem vulture_whitelist.py --min-confidence 0 || true
         echo ""
         echo "=== Tests ==="
         run python -m pytest tests/ \

--- a/tests/models/test_financial_tracker.py
+++ b/tests/models/test_financial_tracker.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
 
 import pytest
 
@@ -485,6 +486,35 @@ class TestFinancialTrackerPersistence:
         restored = FinancialTracker.from_dict(d)
         assert restored._last_import_energy_kwh is None
         assert restored._last_export_energy_kwh is None
+
+    @pytest.mark.asyncio
+    async def test_save_history_without_history_file_returns_false(self) -> None:
+        """save_history is a no-op returning False when history_file is unset."""
+        tracker = FinancialTracker()
+        assert await tracker.save_history() is False
+
+    @pytest.mark.asyncio
+    async def test_save_history_writes_to_disk(self, tmp_path: Path) -> None:
+        """save_history persists state that a fresh tracker can restore."""
+        history_path = tmp_path / "hsem_financial_history.json"
+        original = FinancialTracker(history_file=str(history_path))
+        original.accumulate(
+            grid_import_energy_kwh=100.0,
+            grid_export_energy_kwh=50.0,
+            import_price=2.0,
+            export_price=1.0,
+        )
+
+        assert await original.save_history() is True
+        assert history_path.exists()
+
+        restored = FinancialTracker.from_dict(
+            FinancialTracker._read_history_file(history_path) or {}
+        )
+        assert restored.import_cost_total == pytest.approx(original.import_cost_total)
+        assert restored.export_income_total == pytest.approx(
+            original.export_income_total
+        )
 
 
 class TestFinancialTrackerSensorAttributes:

--- a/tests/test_coordinator_persistence_registry.py
+++ b/tests/test_coordinator_persistence_registry.py
@@ -1,0 +1,102 @@
+"""Reflection test guarding the tracker-persistence registry (issue #890).
+
+``vulture`` cannot catch a tracker class that implements a fully-tested
+``save_history()`` method with zero production call sites when another
+tracker class happens to share that method name -- it matches unused code
+by name only, not by class (see :mod:`coordinator_persistence` for the
+full story, and issue #888 for the bug this blind spot let through).
+
+This test walks the type annotations declared on
+:class:`~custom_components.hsem.coordinator_state.CoordinatorSharedState`,
+finds every field whose type exposes an ``async def save_history(self) ->
+bool`` method, and asserts it has a corresponding entry in
+:data:`~custom_components.hsem.coordinator_persistence.TRACKER_REGISTRY`.
+Adding a new persistable tracker field without wiring it into the
+registry must fail this test immediately.
+"""
+
+from __future__ import annotations
+
+import types
+import typing
+
+from custom_components.hsem import coordinator_state
+from custom_components.hsem.coordinator_persistence import TRACKER_REGISTRY
+from custom_components.hsem.ml.consumption_predictor import ConsumptionPredictor
+
+
+def _unwrap_union(annotation: object) -> list[object]:
+    """Return the non-``None`` member types of a (possibly) union annotation."""
+    origin = typing.get_origin(annotation)
+    if origin is typing.Union or origin is types.UnionType:
+        return [a for a in typing.get_args(annotation) if a is not type(None)]
+    return [annotation]
+
+
+def _resolved_field_types() -> dict[str, list[object]]:
+    """Resolve every field annotation on ``CoordinatorSharedState``.
+
+    ``coordinator_state.py`` uses ``from __future__ import annotations``,
+    so annotations are strings until resolved with ``get_type_hints``.
+    ``ConsumptionPredictor`` is only imported under ``TYPE_CHECKING`` in
+    that module, so it is supplied explicitly via ``localns``.
+    """
+    hints = typing.get_type_hints(
+        coordinator_state.CoordinatorSharedState,
+        globalns=dict(vars(coordinator_state)),
+        localns={"ConsumptionPredictor": ConsumptionPredictor},
+    )
+    return {name: _unwrap_union(annotation) for name, annotation in hints.items()}
+
+
+def _fields_exposing_save_history() -> set[str]:
+    """Return every field name whose type defines ``save_history``."""
+    persistable: set[str] = set()
+    for name, types_ in _resolved_field_types().items():
+        if any(hasattr(t, "save_history") for t in types_):
+            persistable.add(name)
+    return persistable
+
+
+def test_registry_covers_every_persistable_tracker() -> None:
+    """Every ``save_history``-exposing tracker field must be registered.
+
+    This is the regression guard for issue #890: if a future tracker
+    field defines ``save_history`` but nobody adds a
+    ``TRACKER_REGISTRY`` entry for it, this test fails immediately
+    instead of silently shipping an orphaned persistence method the way
+    ``SavingsTracker.save_history()`` did in issue #888.
+    """
+    persistable_fields = _fields_exposing_save_history()
+    registered = set(TRACKER_REGISTRY.keys())
+
+    missing = persistable_fields - registered
+    assert not missing, (
+        "Coordinator field(s) expose save_history() but are missing from "
+        f"TRACKER_REGISTRY in coordinator_persistence.py: {sorted(missing)}"
+    )
+
+    stale = registered - persistable_fields
+    assert not stale, (
+        "TRACKER_REGISTRY references field(s) that no longer expose "
+        f"save_history() (or no longer exist): {sorted(stale)}"
+    )
+
+
+def test_registry_entries_are_real_coordinator_fields() -> None:
+    """Every registry key must match a real field on CoordinatorSharedState."""
+    declared_fields = set(_resolved_field_types().keys())
+    for name in TRACKER_REGISTRY:
+        assert name in declared_fields, (
+            f"TRACKER_REGISTRY key {name!r} is not a field on "
+            "CoordinatorSharedState (coordinator_state.py)"
+        )
+
+
+def test_known_persistable_trackers_are_registered() -> None:
+    """Sanity check pinning the trackers known to expose save_history() today."""
+    assert _fields_exposing_save_history() == {
+        "_savings_tracker",
+        "_financial_tracker",
+        "_prediction_tracker",
+    }

--- a/tests/test_coordinator_tracking_savings.py
+++ b/tests/test_coordinator_tracking_savings.py
@@ -2,8 +2,12 @@
 
 Regression coverage: the savings tracker sensor lost its state on every
 Home Assistant restart because ``accumulate_savings`` accumulated data in
-memory but never called ``SavingsTracker.save_history()``, unlike the
-sibling ``accumulate_financials`` helper which persists every cycle.
+memory but never triggered a save of ``SavingsTracker``. Since issue #890,
+persistence is centralised in
+:func:`~custom_components.hsem.coordinator_persistence.persist_all_trackers`,
+called once per cycle after ``accumulate_savings``/``accumulate_financials``
+run -- these tests exercise that combined flow rather than
+``accumulate_savings`` in isolation.
 """
 
 from __future__ import annotations
@@ -17,6 +21,8 @@ import pytest
 
 from homeassistant.core import HomeAssistant
 
+from custom_components.hsem.coordinator_persistence import persist_all_trackers
+from custom_components.hsem.coordinator_state import CoordinatorSharedState
 from custom_components.hsem.coordinator_tracking import accumulate_savings
 from custom_components.hsem.models.daily_plan_vs_actual_tracker import (
     DailyPlanVsActualTracker,
@@ -34,9 +40,17 @@ def _make_hass(config_dir: Path) -> HomeAssistant:
     )
 
 
+def _make_coordinator(savings_tracker: SavingsTracker) -> CoordinatorSharedState:
+    """Build a minimal fake coordinator exposing just the savings tracker."""
+    return cast(
+        CoordinatorSharedState,
+        SimpleNamespace(_savings_tracker=savings_tracker),
+    )
+
+
 @pytest.mark.asyncio
 async def test_accumulate_savings_persists_to_disk(tmp_path: Path) -> None:
-    """accumulate_savings must write the savings history file every cycle.
+    """accumulate_savings + persist_all_trackers must write the history file.
 
     Without this, the tracker's totals only ever live in memory and are
     lost whenever Home Assistant restarts, even though ``load_history``
@@ -57,10 +71,14 @@ async def test_accumulate_savings_persists_to_disk(tmp_path: Path) -> None:
         hourly_recommendation=None,
         hass=hass,
     )
+    await persist_all_trackers(
+        _make_coordinator(savings_tracker), only=["_savings_tracker"]
+    )
 
     history_path = tmp_path / ".storage" / "hsem_savings_history.json"
     assert history_path.exists(), (
-        "accumulate_savings did not persist the savings tracker state to disk"
+        "accumulate_savings + persist_all_trackers did not persist the "
+        "savings tracker state to disk"
     )
 
     # A tracker restored from that file should reflect the same totals,
@@ -99,6 +117,9 @@ async def test_accumulate_savings_survives_simulated_restart(tmp_path: Path) -> 
             daily_tracker=daily_tracker,
             hourly_recommendation=None,
             hass=hass,
+        )
+        await persist_all_trackers(
+            _make_coordinator(tracker_before_restart), only=["_savings_tracker"]
         )
 
     assert tracker_before_restart.baseline_cost > 0.0


### PR DESCRIPTION
## Summary

Issue #888 shipped because `SavingsTracker.save_history()` was fully implemented and
unit-tested but had zero production call sites. `vulture` didn't catch it because it
matches unused code by **method name only, not by class** — `PredictionTracker.save_history()`
(a genuinely-called method) suppressed the "unused method" warning for every method named
`save_history` in the codebase, including `SavingsTracker`'s.

This PR removes the ad-hoc, per-`accumulate_*` persistence calls and replaces them with a
single registry-driven loop, backed by a reflection test that fails immediately if a future
tracker's `save_history()` isn't wired up — independent of what `vulture` can or can't see.

## What changed

- **`custom_components/hsem/coordinator_persistence.py`** (new): a `Persistable` protocol
  (`async def save_history(self) -> bool`) and `TRACKER_REGISTRY`, a `dict[str, getter]`
  mapping each persistable tracker's `CoordinatorSharedState` attribute name to a function
  that fetches it off the coordinator. `persist_all_trackers(coordinator, only=...)` iterates
  the registry and logs a warning on failure — the single shared implementation of the
  `if not await tracker.save_history(): log warning` pattern that used to be duplicated
  three times.
- **`custom_components/hsem/models/financial_tracker.py`**: added `FinancialTracker.save_history()`,
  folding in the logic that used to live in the free function `persist_financial_tracker()`
  in `coordinator_tracking.py`. This makes `FinancialTracker` conform to the same
  `save_history()` interface as `SavingsTracker` and `PredictionTracker`.
- **`custom_components/hsem/coordinator_tracking.py`**: removed `persist_financial_tracker()`
  and the inline `st.save_history()` / persist calls from `accumulate_financials` /
  `accumulate_savings` — persistence now happens through the registry instead.
- **`custom_components/hsem/coordinator_planner_phase.py`**: after the existing
  `accumulate_daily_plan_actuals` / `accumulate_financials` / `accumulate_savings` calls in
  `_run_planner_phase`, added one `persist_all_trackers(self, only=["_financial_tracker", "_savings_tracker"])`
  call — same cadence as before (only when the planner phase runs), now from one place.
- **`custom_components/hsem/coordinator_cycle.py`**: replaced the inline prediction-tracker
  persist block with `persist_all_trackers(self, only=["_prediction_tracker"])`, gated on the
  same `prediction_record_added` condition as before (prediction tracker only has new data on
  a slot boundary, so it's `only`-scoped separately from financial/savings to preserve its
  distinct write cadence).
- **`tests/test_coordinator_persistence_registry.py`** (new): reflection test that walks
  `CoordinatorSharedState`'s type-hinted fields (resolving `X | None` unions), finds every
  field whose type exposes `save_history`, and asserts it has a `TRACKER_REGISTRY` entry (and
  vice versa — no stale entries). A pinned sanity-check test also asserts the exact set of
  persistable trackers today: `_savings_tracker`, `_financial_tracker`, `_prediction_tracker`.
  (`_daily_tracker` and `_forecast_tracker` don't expose `save_history` — the former only saves
  at midnight rollover via a private method, the latter is restored through the sensor's
  `RestoreEntity` state, not a JSON file — so neither needs a registry entry.)
- **`scripts/quality.sh`**: added a second, informational-only `vulture` pass
  (`custom_components/hsem` only, tests excluded, `--min-confidence 0`, `|| true` so it never
  fails the build) as a supplementary floor-raiser. It won't catch this exact same-named-method
  blind spot, but it surfaces uniquely-named orphaned methods that get lost in the noisier
  full-repo 80%-confidence scan.
- **Test updates**: `tests/test_coordinator_tracking_savings.py` now exercises
  `accumulate_savings` + `persist_all_trackers` together (previously `accumulate_savings` alone
  persisted). `tests/models/test_financial_tracker.py` gained disk round-trip tests for the new
  `FinancialTracker.save_history()`.

## Behavior preserved

All three currently-persisted trackers keep their exact file paths and write cadence:

- `SavingsTracker` → `hsem_savings_history.json`, every cycle the planner phase runs.
- `FinancialTracker` → `hsem_financial_history.json`, every cycle the planner phase runs.
- `PredictionTracker` → prediction history file, only on cycles where a new record was added.

`DailyPlanVsActualTracker` (midnight-only save) and `ForecastTracker` (restored via the sensor's
HA entity state, not a JSON file) are untouched — they don't expose `save_history()` so they're
correctly outside the registry's scope.

## Test plan

- [x] `./scripts/quality.sh lint` — clean
- [x] `./scripts/quality.sh typing` — 0 errors (365 source files)
- [x] `./scripts/quality.sh quality` — pyright 0 errors; vulture 0 warnings at the CI gate
      (`--min-confidence 80`); informational `--min-confidence 0` pass runs and does not fail
      the build
- [x] `./scripts/quality.sh test` — 3011 passed
- [x] New reflection test (`test_coordinator_persistence_registry.py`) verified to fail if a
      registry entry is removed, confirming it actually guards the failure mode from #888

Fixes #890
