### PR TITLE
chore(planner): remove dead interval_ends_before_window_start helper

### DIFF
--- a/custom_components/hsem/planner/charging/pre_charge.py
+++ b/custom_components/hsem/planner/charging/pre_charge.py
@@ -101,7 +101,12 @@ def apply_charge_schedules(
             sched, "_occurrences", []
         )
         if not occurrences:
-            # Fallback for callers that didn't go through apply_discharge_schedules
+            # apply_discharge_schedules (always called first, see engine_core.py)
+            # unconditionally sets sched._occurrences for every enabled
+            # schedule, but that list is legitimately empty when no future
+            # occurrence of the window falls within the planning horizon.
+            # This branch covers that case, not a caller skipping the prior
+            # pass.
             needed_fb: float = getattr(sched, "_needed_capacity", 0.0)
             avg_price_fb: float = getattr(sched, "_avg_import_price", 0.0)
             if needed_fb > 0:
@@ -147,7 +152,14 @@ def apply_charge_schedules(
                 )
 
             # Eligible charge slots: future, unassigned, and ending before
-            # this specific occurrence's window start.
+            # this specific occurrence's window start. window_start_abs is
+            # already a resolved absolute datetime for *this* occurrence
+            # (day N of a recurring schedule), so this is a plain datetime
+            # comparison — not a candidate for the now-removed
+            # interval_ends_before_window_start(interval_end, window_start:
+            # time, now) helper, which only resolves the *first* future
+            # occurrence relative to `now` and would silently break
+            # multi-occurrence (day 2+) budgeting if substituted here.
             eligible = [
                 s
                 for s in slots

--- a/custom_components/hsem/utils/time_windows.py
+++ b/custom_components/hsem/utils/time_windows.py
@@ -1,8 +1,8 @@
 """Time-window helpers for comparing and advancing wall-clock times.
 
 Used by the planner engine to check whether a time falls within a
-charge/discharge window, calculate the next occurrence of a window
-start, and determine if an interval ends before a window begins.
+charge/discharge window and to calculate the next occurrence of a
+window start.
 """
 
 from datetime import datetime, time, timedelta
@@ -30,26 +30,3 @@ def next_window_start_dt(now: datetime, window_start: time) -> datetime:
     if candidate <= now:
         candidate += timedelta(days=1)
     return candidate
-
-
-def interval_ends_before_window_start(
-    interval_end: datetime,
-    window_start: time,
-    now: datetime,
-) -> bool:
-    """Return True when an *interval* ends strictly before a schedule *window* begins.
-
-    Resolves ``window_start`` to a timezone-aware :class:`datetime` on the
-    correct calendar date so that cross-midnight windows (e.g. a window that
-    starts at ``23:00`` today and ends at ``02:00`` tomorrow) are handled
-    without false positives.
-
-    Args:
-        interval_end: Timezone-aware end of the recommendation interval.
-        window_start: Wall-clock start time of the charge/discharge window.
-        now: Current timezone-aware datetime (used to anchor the date).
-
-    Returns:
-        True if the interval ends before the window starts.
-    """
-    return interval_end <= next_window_start_dt(now, window_start)

--- a/tests/planner/test_charge_scheduler_capacity.py
+++ b/tests/planner/test_charge_scheduler_capacity.py
@@ -260,3 +260,175 @@ class TestOpportunisticChargeCapacityCap:
             f"Total charged ({charged_after:.3f}) must not exceed "
             f"headroom ({headroom:.3f})"
         )
+
+
+def _slot_at(
+    start: datetime,
+    *,
+    hours: float = 1.0,
+    import_price: float = 0.30,
+    export_price: float = 0.05,
+    net_consumption: float = 0.0,
+    recommendation: str | None = None,
+) -> PlannedSlot:
+    """Build a PlannedSlot at an explicit start datetime (may cross midnight)."""
+    return PlannedSlot(
+        start=start,
+        end=start + timedelta(hours=hours),
+        price=SlotPrice(import_price=import_price, export_price=export_price),
+        estimated_net_consumption_kwh=net_consumption,
+        recommendation=recommendation,
+    )
+
+
+class TestEligibleSlotFilterCrossMidnight:
+    """Regression test for issue #898: apply_charge_schedules' eligible-slot
+    filter (``s.end <= window_start_abs``) must correctly resolve
+    cross-midnight windows and per-occurrence (day N) window starts using
+    the resolved absolute ``window_start_abs`` datetime — not a
+    time-of-day helper re-resolved against the original ``now`` (which
+    would collapse every occurrence onto the first one).
+
+    This exercises the real ``PlannedSlot``/``BatteryScheduleInput``
+    objects through ``apply_charge_schedules`` directly, rather than
+    testing a helper function in isolation.
+    """
+
+    def test_pre_midnight_and_post_midnight_slots_eligible_for_next_day_window(
+        self,
+    ) -> None:
+        """A charge slot crossing from 22:00 to 03:00 the next day is eligible
+        pre-charge for a discharge window starting at 07:00 the next day."""
+        now = datetime(2024, 6, 15, 21, 0, tzinfo=_TZ)
+
+        # Evening slot tonight (before midnight) — cheap.
+        evening_slot = _slot_at(
+            datetime(2024, 6, 15, 22, 0, tzinfo=_TZ), import_price=0.05
+        )
+        # Night slot crossing into the next calendar day — cheap.
+        night_slot = _slot_at(
+            datetime(2024, 6, 16, 2, 0, tzinfo=_TZ), import_price=0.05
+        )
+        # Discharge window slots (07:00-09:00 next day) — already assigned.
+        discharge_slots = [
+            _slot_at(
+                datetime(2024, 6, 16, h, 0, tzinfo=_TZ),
+                import_price=1.50,
+                net_consumption=4.0,
+                recommendation=Recommendations.BatteriesDischargeMode.value,
+            )
+            for h in (7, 8)
+        ]
+
+        slots = [evening_slot, night_slot, *discharge_slots]
+
+        sched = BatteryScheduleInput(
+            enabled=True,
+            start=datetime(2024, 6, 16, 7, 0, tzinfo=_TZ).time(),
+            end=datetime(2024, 6, 16, 9, 0, tzinfo=_TZ).time(),
+        )
+        sched._occurrences = [
+            (
+                datetime(2024, 6, 16, 7, 0, tzinfo=_TZ),
+                datetime(2024, 6, 16, 9, 0, tzinfo=_TZ),
+                6.0,
+                1.50,
+            ),
+        ]
+
+        apply_charge_schedules(
+            slots=slots,
+            battery_schedules=[sched],
+            now=now,
+            max_charge_per_interval=5.0,
+            current_kwh=0.0,
+            usable_kwh=10.0,
+            cycle_cost_per_kwh=0.0,
+            recommended_threshold=0.0,
+        )
+
+        assert evening_slot.recommendation is not None, (
+            "The 22:00-23:00 pre-midnight slot must be eligible for the "
+            "next day's 07:00 discharge window"
+        )
+        assert night_slot.recommendation is not None, (
+            "The 02:00-03:00 post-midnight slot must be eligible for the "
+            "same-day 07:00 discharge window"
+        )
+
+    def test_slot_between_occurrences_is_eligible_only_for_the_later_one(
+        self,
+    ) -> None:
+        """A slot ending after occurrence 1's window start but before
+        occurrence 2's window start must be budgeted against occurrence 2,
+        not silently excluded.
+
+        This is the scenario that makes the eligible-slot filter unsafe to
+        replace with a helper that re-resolves ``next_window_start_dt(now,
+        window_start)`` from the original ``now`` — that would always
+        resolve to occurrence 1's window start and wrongly exclude this
+        slot for every later occurrence.
+        """
+        now = datetime(2024, 6, 15, 22, 0, tzinfo=_TZ)
+
+        # Occurrence 1: discharge window 07:00-09:00 on 06-16.
+        occ1_discharge = [
+            _slot_at(
+                datetime(2024, 6, 16, h, 0, tzinfo=_TZ),
+                import_price=1.50,
+                net_consumption=4.0,
+                recommendation=Recommendations.BatteriesDischargeMode.value,
+            )
+            for h in (7, 8)
+        ]
+        # Slot after occurrence 1's window start, before occurrence 2's —
+        # must remain eligible for occurrence 2's budget.
+        mid_slot = _slot_at(datetime(2024, 6, 16, 12, 0, tzinfo=_TZ), import_price=0.05)
+        # Occurrence 2: discharge window 07:00-09:00 on 06-17.
+        occ2_discharge = [
+            _slot_at(
+                datetime(2024, 6, 17, h, 0, tzinfo=_TZ),
+                import_price=1.50,
+                net_consumption=4.0,
+                recommendation=Recommendations.BatteriesDischargeMode.value,
+            )
+            for h in (7, 8)
+        ]
+
+        slots = [*occ1_discharge, mid_slot, *occ2_discharge]
+
+        sched = BatteryScheduleInput(
+            enabled=True,
+            start=datetime(2024, 6, 16, 7, 0, tzinfo=_TZ).time(),
+            end=datetime(2024, 6, 16, 9, 0, tzinfo=_TZ).time(),
+        )
+        sched._occurrences = [
+            (
+                datetime(2024, 6, 16, 7, 0, tzinfo=_TZ),
+                datetime(2024, 6, 16, 9, 0, tzinfo=_TZ),
+                6.0,
+                1.50,
+            ),
+            (
+                datetime(2024, 6, 17, 7, 0, tzinfo=_TZ),
+                datetime(2024, 6, 17, 9, 0, tzinfo=_TZ),
+                6.0,
+                1.50,
+            ),
+        ]
+
+        apply_charge_schedules(
+            slots=slots,
+            battery_schedules=[sched],
+            now=now,
+            max_charge_per_interval=5.0,
+            current_kwh=0.0,
+            usable_kwh=10.0,
+            cycle_cost_per_kwh=0.0,
+            recommended_threshold=0.0,
+        )
+
+        assert mid_slot.recommendation is not None, (
+            "A slot between occurrence 1 and occurrence 2's window starts "
+            "must be assigned to occurrence 2's pre-charge budget"
+        )

--- a/tests/test_cross_day_charge_windows.py
+++ b/tests/test_cross_day_charge_windows.py
@@ -9,17 +9,15 @@ Acceptance criteria from issue #267:
 - HSEM can charge at night for morning peak use.
 - Tests cover cheap 02:00 grid charge and expensive 07:00 consumption.
 - ``next_window_start_dt`` resolves the next occurrence correctly.
-- ``interval_ends_before_window_start`` allows pre-midnight charge slots.
+- Comparing an interval's end against ``next_window_start_dt(...)`` allows
+  pre-midnight charge slots.
 - The discharge window on the next calendar day is correctly included in
   battery-schedule capacity planning.
 """
 
 from datetime import UTC, datetime, time, timedelta
 
-from custom_components.hsem.utils.time_windows import (
-    interval_ends_before_window_start,
-    next_window_start_dt,
-)
+from custom_components.hsem.utils.time_windows import next_window_start_dt
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -112,97 +110,6 @@ class TestNextWindowStartDt:
 
 
 # ---------------------------------------------------------------------------
-# Tests for interval_ends_before_window_start (cross-day scenarios)
-# ---------------------------------------------------------------------------
-
-
-class TestIntervalEndsBeforeWindowStartCrossDay:
-    """Cross-date-boundary tests for interval_ends_before_window_start.
-
-    These complement the existing TestIntervalEndsBeforeWindowStart tests in
-    test_midnight_rollover.py, focusing on the P0-03 scenario.
-    """
-
-    def test_night_charge_slot_before_next_day_morning_window(self):
-        """A 02:00-03:00 slot tonight ends before a 07:00 window tomorrow.
-
-        Scenario: now=22:00 day D, charge slot ends at 03:00 day D+1,
-        discharge window starts at 07:00 day D+1.
-        Expected: True — the slot is a valid pre-charge window.
-        """
-        now = _dt(22, 0)  # 22:00 tonight
-        charge_slot_end = _dt(3, 0, day_offset=1)  # 03:00 tomorrow
-        discharge_window_start = time(7, 0)  # 07:00
-
-        assert (
-            interval_ends_before_window_start(
-                charge_slot_end, discharge_window_start, now
-            )
-            is True
-        ), (
-            "A 03:00 charge slot end should be before a 07:00 discharge window "
-            "when it is currently 22:00"
-        )
-
-    def test_charge_slot_at_02_before_07_discharge(self):
-        """P0-03 acceptance criterion: cheap 02:00 charge before expensive 07:00 use.
-
-        Slot ends at 03:00 (UTC), window starts at 07:00.  With now=22:00 the
-        function should confirm 03:00 < 07:00 (next day).
-        """
-        now = _dt(22, 0)
-        charge_slot_end = _dt(3, 0, day_offset=1)  # 03:00 next day
-        discharge_window_start = time(7, 0)
-
-        result = interval_ends_before_window_start(
-            charge_slot_end, discharge_window_start, now
-        )
-        assert result is True, (
-            "02:00-03:00 grid charge must be flagged as 'before' the 07:00 "
-            "morning discharge window (cross-day boundary)"
-        )
-
-    def test_charge_slot_overlapping_discharge_window_excluded(self):
-        """A slot that ends at 08:00 is NOT before the 07:00 discharge window."""
-        now = _dt(22, 0)
-        charge_slot_end = _dt(8, 0, day_offset=1)  # 08:00 next day
-        discharge_window_start = time(7, 0)
-
-        assert (
-            interval_ends_before_window_start(
-                charge_slot_end, discharge_window_start, now
-            )
-            is False
-        ), "A slot ending at 08:00 must NOT be treated as 'before' the 07:00 window"
-
-    def test_same_evening_slot_before_next_morning_window(self):
-        """A 22:30-23:00 slot tonight is before the 07:00 window tomorrow."""
-        now = _dt(22, 0)
-        charge_slot_end = _dt(23, 0)  # 23:00 tonight
-        discharge_window_start = time(7, 0)
-
-        assert (
-            interval_ends_before_window_start(
-                charge_slot_end, discharge_window_start, now
-            )
-            is True
-        ), "A 22:30-23:00 slot tonight is before tomorrow's 07:00 discharge window"
-
-    def test_slot_after_current_time_but_past_window_start_excluded(self):
-        """A slot ending at 09:00 is after the 07:00 window → must be excluded."""
-        now = _dt(22, 0)
-        charge_slot_end = _dt(9, 0, day_offset=1)  # 09:00 next day
-        discharge_window_start = time(7, 0)
-
-        assert (
-            interval_ends_before_window_start(
-                charge_slot_end, discharge_window_start, now
-            )
-            is False
-        )
-
-
-# ---------------------------------------------------------------------------
 # Integration-style tests: simulate the full planning scenario
 # ---------------------------------------------------------------------------
 
@@ -273,10 +180,7 @@ class TestCrossDayChargePlanningIntegration:
 
         # Identify valid pre-charge intervals: not yet passed, before the window
         valid_charge_intervals = [
-            iv
-            for iv in intervals
-            if iv["end"] > now
-            and interval_ends_before_window_start(iv["end"], discharge_start, now)
+            iv for iv in intervals if iv["end"] > now and iv["end"] <= window_dt
         ]
 
         # The 02:00-03:00 slot must be among valid charge windows
@@ -332,11 +236,9 @@ class TestCrossDayChargePlanningIntegration:
         intervals = self._make_intervals(now, interval_minutes=60, total_hours=48)
 
         # No interval ending after the window start should be flagged as valid charge
+        window_dt = next_window_start_dt(now, discharge_start)
         post_window_slots = [
-            iv
-            for iv in intervals
-            if iv["end"] > next_window_start_dt(now, discharge_start)
-            and interval_ends_before_window_start(iv["end"], discharge_start, now)
+            iv for iv in intervals if iv["end"] > window_dt and iv["end"] <= window_dt
         ]
 
         assert post_window_slots == [], (
@@ -381,11 +283,9 @@ class TestCrossDayChargePlanningIntegration:
             tagged.append({**iv, "import_price": price})
 
         # Filter valid charge intervals
+        window_dt = next_window_start_dt(now, discharge_start)
         valid_charge = [
-            iv
-            for iv in tagged
-            if iv["end"] > now
-            and interval_ends_before_window_start(iv["end"], discharge_start, now)
+            iv for iv in tagged if iv["end"] > now and iv["end"] <= window_dt
         ]
 
         # Sort by cheapest first (mirrors planner logic)

--- a/tests/test_dst_transitions.py
+++ b/tests/test_dst_transitions.py
@@ -23,10 +23,7 @@ import pytest
 from custom_components.hsem.models.planner_input import PlannerInput
 from custom_components.hsem.planner.engine_core import _parse_now
 from custom_components.hsem.planner.slot_population import build_slots
-from custom_components.hsem.utils.time_windows import (
-    interval_ends_before_window_start,
-    next_window_start_dt,
-)
+from custom_components.hsem.utils.time_windows import next_window_start_dt
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -258,55 +255,7 @@ class TestNextWindowStartDstFallback:
 
 
 # ---------------------------------------------------------------------------
-# 4. interval_ends_before_window_start: correct across DST transitions
-# ---------------------------------------------------------------------------
-
-
-class TestIntervalEndsDst:
-    """interval_ends_before_window_start must be consistent across DST transitions."""
-
-    def test_spring_forward_interval_before_gap(self):
-        """An interval ending at 01:30 is before a 03:00 window on spring-forward day."""
-        now = _parse_now("2024-03-31T00:00:00+01:00")
-        # Interval ends at 01:30 UTC+1
-        interval_end = _parse_now("2024-03-31T01:30:00+01:00")
-        # Window starts at 03:00 (wall clock — UTC+2 after the spring-forward)
-        assert interval_ends_before_window_start(interval_end, time(3, 0), now)
-
-    def test_spring_forward_interval_after_gap(self):
-        """An interval ending at 04:00 UTC+2 is before tomorrow's 03:00 window.
-
-        When *now* is 03:30 UTC+2, the 03:00 wall-clock time has already passed
-        today, so ``next_window_start_dt`` advances to 03:00 tomorrow.
-        An interval ending at 04:00 *today* ends before 03:00 *tomorrow*, so
-        the function correctly returns ``True``.
-        """
-        now = _parse_now("2024-03-31T03:30:00+02:00")
-        interval_end = _parse_now("2024-03-31T04:00:00+02:00")
-        # 04:00 today < 03:00 tomorrow → interval ends before the (next-day) window
-        assert interval_ends_before_window_start(interval_end, time(3, 0), now)
-
-    def test_autumn_fallback_interval_before_fold(self):
-        """An interval ending at 01:30 UTC+2 is before a 03:00 window on fallback day."""
-        now = _parse_now("2024-10-27T00:00:00+02:00")
-        interval_end = _parse_now("2024-10-27T01:30:00+02:00")
-        assert interval_ends_before_window_start(interval_end, time(3, 0), now)
-
-    def test_autumn_fallback_interval_after_fold(self):
-        """An interval ending at 04:00 UTC+1 is before tomorrow's 03:00 window.
-
-        When *now* is 03:30 UTC+1 (post-fold), the 03:00 wall-clock time has
-        already passed today (03:00 == now's day, rolled to next-day).  An
-        interval ending at 04:00 today ends before 03:00 tomorrow.
-        """
-        now = _parse_now("2024-10-27T03:30:00+01:00")
-        interval_end = _parse_now("2024-10-27T04:00:00+01:00")
-        # 04:00 today < 03:00 tomorrow → interval ends before the (next-day) window
-        assert interval_ends_before_window_start(interval_end, time(3, 0), now)
-
-
-# ---------------------------------------------------------------------------
-# 5. Full planner run: planner executes without error on DST days
+# 4. Full planner run: planner executes without error on DST days
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_midnight_rollover.py
+++ b/tests/test_midnight_rollover.py
@@ -14,9 +14,7 @@ Windows.
 """
 
 import asyncio
-from datetime import UTC, datetime, time, timedelta
-
-from custom_components.hsem.utils.time_windows import interval_ends_before_window_start
+from datetime import UTC, datetime, timedelta
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -32,68 +30,15 @@ def _dt(hour: int, minute: int = 0, date_offset: int = 0) -> datetime:
 
 
 # ---------------------------------------------------------------------------
-# Tests for interval_ends_before_window_start
-#
-# Note: the sibling ``is_time_in_window`` helper (formerly tested here) was
-# removed as dead code in issue #891 — it had no production caller.
-# Production cross-midnight window handling lives inline in
-# ``planner/discharge_scheduler.py``, exercised by the planner test suite
-# and ``tests/test_cross_day_charge_windows.py``.
-# ---------------------------------------------------------------------------
-
-
-class TestIntervalEndsBeforeWindowStart:
-    """Unit tests for interval_ends_before_window_start helper."""
-
-    def test_interval_ends_before_same_day_window(self):
-        """Interval ending at 06:00 is before a same-day window at 07:00."""
-        now = _dt(5, 0)  # 05:00
-        interval_end = _dt(6, 0)  # 06:00
-        window_start = time(7, 0)
-        assert (
-            interval_ends_before_window_start(interval_end, window_start, now) is True
-        )
-
-    def test_interval_ends_after_same_day_window(self):
-        """Interval ending at 08:00 is NOT before a window starting at 07:00."""
-        now = _dt(5, 0)
-        interval_end = _dt(8, 0)
-        window_start = time(7, 0)
-        assert (
-            interval_ends_before_window_start(interval_end, window_start, now) is False
-        )
-
-    def test_interval_ends_before_cross_midnight_window(self):
-        """Interval ending at 22:00 is before a cross-midnight window at 23:00."""
-        now = _dt(21, 0)  # 21:00
-        interval_end = _dt(22, 0)  # 22:00
-        window_start = time(23, 0)  # tonight at 23:00
-        assert (
-            interval_ends_before_window_start(interval_end, window_start, now) is True
-        )
-
-    def test_interval_ends_after_cross_midnight_window_start(self):
-        """Interval ending at 23:30 is NOT before a cross-midnight window at 23:00."""
-        now = _dt(21, 0)
-        interval_end = _dt(23, 30)
-        window_start = time(23, 0)
-        assert (
-            interval_ends_before_window_start(interval_end, window_start, now) is False
-        )
-
-    def test_interval_next_day_before_midnight_window_start(self):
-        """Interval ending 00:30 tomorrow is NOT before a window at 23:00 today."""
-        now = _dt(21, 0)  # today 21:00
-        # interval ends tomorrow at 00:30
-        interval_end = _dt(0, 30, date_offset=1)
-        window_start = time(23, 0)  # tonight
-        assert (
-            interval_ends_before_window_start(interval_end, window_start, now) is False
-        )
-
-
-# ---------------------------------------------------------------------------
 # Tests for schedule validator (batteries_schedule_*.py)
+#
+# Note: the former ``interval_ends_before_window_start`` unit tests that
+# lived in this module were removed in issue #898 along with the helper
+# itself — it had no production caller and could not safely replace
+# ``pre_charge.py``'s per-occurrence eligible-slot filter (see that file's
+# comments). Cross-midnight eligible-slot filtering is now covered directly
+# via ``apply_charge_schedules`` in
+# ``tests/planner/test_charge_scheduler_capacity.py``.
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_p0_regression_suite.py
+++ b/tests/test_p0_regression_suite.py
@@ -147,43 +147,45 @@ class TestP001MonthMatching:
 
 
 class TestP002MidnightRollover:
-    """OLD BUG: ``interval_ends_before_window_start`` only handled same-day
-    windows (start < end).  A cross-midnight window such as 23:00-02:00 was
-    silently treated as always-false, causing HSEM to skip valid overnight
-    charge/discharge windows entirely.
+    """OLD BUG: the eligible-slot ``interval_end <= window_start`` comparison
+    only handled same-day windows (start < end).  A cross-midnight window
+    such as 23:00-02:00 was silently treated as always-false, causing HSEM
+    to skip valid overnight charge/discharge windows entirely.
 
-    FIX: The helper now detects when ``start > end`` (cross-midnight) and
-    uses the corresponding logic branch.
+    FIX: ``next_window_start_dt`` resolves ``window_start`` to a
+    timezone-aware datetime on the correct calendar date, so comparing
+    against it (as ``pre_charge.py``'s eligible-slot filter and
+    ``discharge_scheduler.py`` both do) handles cross-midnight windows
+    without false positives.
 
     Note: the sibling ``is_time_in_window`` helper covered by the original
-    fix was removed as dead code in issue #891 — it had no production
-    caller. Production cross-midnight window handling for discharge
-    schedules lives inline in ``planner/discharge_scheduler.py`` (the
-    ``sched.end > sched.start`` branch), exercised by
-    ``tests/test_cross_day_charge_windows.py`` and the planner test suite.
+    fix was removed as dead code in issue #891, and the thin
+    ``interval_ends_before_window_start`` wrapper (which had no production
+    caller and could not safely replace ``pre_charge.py``'s per-occurrence
+    filter) was removed in issue #898. Production cross-midnight window
+    handling lives inline in ``planner/discharge_scheduler.py`` (the
+    ``sched.end > sched.start`` branch) and
+    ``planner/charging/pre_charge.py``'s eligible-slot filter, exercised by
+    ``tests/test_cross_day_charge_windows.py``,
+    ``tests/planner/test_charge_scheduler_capacity.py``, and the planner
+    test suite.
     """
 
     def test_interval_ending_before_cross_midnight_window_start(self) -> None:
         """An interval ending at 22:00 is before a 23:00 cross-midnight window."""
-        from custom_components.hsem.utils.time_windows import (
-            interval_ends_before_window_start,
-        )
+        from custom_components.hsem.utils.time_windows import next_window_start_dt
 
         now = _dt(21, 0)
         interval_end = _dt(22, 0)
-        assert interval_ends_before_window_start(interval_end, time(23, 0), now) is True
+        assert interval_end <= next_window_start_dt(now, time(23, 0))
 
     def test_interval_ending_inside_cross_midnight_window_is_not_before(self) -> None:
         """An interval ending at 23:30 is NOT before the 23:00 window start."""
-        from custom_components.hsem.utils.time_windows import (
-            interval_ends_before_window_start,
-        )
+        from custom_components.hsem.utils.time_windows import next_window_start_dt
 
         now = _dt(21, 0)
         interval_end = _dt(23, 30)
-        assert (
-            interval_ends_before_window_start(interval_end, time(23, 0), now) is False
-        )
+        assert not (interval_end <= next_window_start_dt(now, time(23, 0)))
 
 
 # ===========================================================================
@@ -241,29 +243,21 @@ class TestP003NextDayCharging:
         This is the P0-03 key scenario: planning a 02:00 grid charge at 22:00
         to cover morning peak use the following day.
         """
-        from custom_components.hsem.utils.time_windows import (
-            interval_ends_before_window_start,
-        )
+        from custom_components.hsem.utils.time_windows import next_window_start_dt
 
         now = _dt(22, 0)
         charge_slot_end = _dt(3, 0, day_offset=1)  # 03:00 next day
-        assert (
-            interval_ends_before_window_start(charge_slot_end, time(7, 0), now) is True
-        ), (
+        assert charge_slot_end <= next_window_start_dt(now, time(7, 0)), (
             "02:00-03:00 charge slot must be flagged as 'before' the 07:00 discharge window"
         )
 
     def test_slot_after_discharge_window_excluded(self) -> None:
         """A slot ending at 08:00 is NOT before the 07:00 window."""
-        from custom_components.hsem.utils.time_windows import (
-            interval_ends_before_window_start,
-        )
+        from custom_components.hsem.utils.time_windows import next_window_start_dt
 
         now = _dt(22, 0)
         charge_slot_end = _dt(8, 0, day_offset=1)
-        assert (
-            interval_ends_before_window_start(charge_slot_end, time(7, 0), now) is False
-        )
+        assert not (charge_slot_end <= next_window_start_dt(now, time(7, 0)))
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Consolidation/documentation fix — no behaviour change to `apply_charge_schedules`'s scheduling output.

Follow-up from #891's second comment, which flagged `interval_ends_before_window_start()` in `custom_components/hsem/utils/time_windows.py` as having zero production callers, and its sibling inline comparison in `apply_charge_schedules()`'s eligible-slot filter (`custom_components/hsem/planner/charging/pre_charge.py:151-156`) as an apparent duplicate.

**Investigation result: the two formulas are only equivalent for the *first* occurrence of a discharge window.** `discharge_scheduler.py::apply_discharge_schedules` generates one `_occurrences` tuple per calendar day a recurring discharge window falls within the planning horizon, advancing `window_start_abs` by `timedelta(days=1)` per occurrence. `pre_charge.py`'s eligible-slot filter correctly compares against each occurrence's already-resolved absolute `window_start_abs`. `interval_ends_before_window_start(interval_end, window_start: time, now)`, however, always re-resolves to the *first* future occurrence of that wall-clock time relative to the original `now` — it has no way to express "occurrence N." Blindly replacing the inline comparison with a call to the helper (as one of the two options suggested in the issue) would have silently broken multi-day pre-charge budgeting (day 2+ occurrences would incorrectly reuse day 1's window start as the cutoff).

Given that, this PR takes the other documented option: delete the unused helper (it genuinely cannot be safely reused here) rather than force an unsafe consolidation, and documents why in code comments so this doesn't get "fixed" again the same way.

## Changes

- **`custom_components/hsem/utils/time_windows.py`** — removed `interval_ends_before_window_start()` (zero production callers; `next_window_start_dt()`, which is still genuinely used, is untouched).
- **`custom_components/hsem/planner/charging/pre_charge.py`**:
  - Added a comment on the eligible-slot filter explaining why it intentionally stays an inline datetime comparison against the per-occurrence `window_start_abs`, rather than calling the (now-removed) time-based helper.
  - Corrected the misleading `# Fallback for callers that didn't go through apply_discharge_schedules` comment on the `if not occurrences:` branch. In the real call order, `engine_core.py` always calls `apply_discharge_schedules` before `apply_charge_schedules` with the same `battery_schedules` list, and `apply_discharge_schedules` unconditionally sets `sched._occurrences` for every enabled schedule — even when it resolves to an empty list (no future occurrence of the window falls within the planning horizon). The comment now describes that actual trigger.
- **Tests** — removed the now-pointless direct unit tests for `interval_ends_before_window_start` from `tests/test_midnight_rollover.py`, `tests/test_p0_regression_suite.py`, `tests/test_dst_transitions.py`, and `tests/test_cross_day_charge_windows.py`, replacing call sites that modelled planner behaviour on dicts with the equivalent inline `interval_end <= next_window_start_dt(...)` comparison (same coverage, no dependency on the deleted helper).
- **`tests/planner/test_charge_scheduler_capacity.py`** — added `TestEligibleSlotFilterCrossMidnight`, a new regression test suite that exercises `apply_charge_schedules`'s real eligible-slot filter directly (via `PlannedSlot`/`BatteryScheduleInput`, not the helper in isolation):
  - A pre-midnight (22:00) and post-midnight (02:00) charge slot are both correctly assigned pre-charge for a discharge window starting 07:00 the next day.
  - A slot that ends after occurrence 1's window start but before occurrence 2's window start is correctly budgeted against occurrence 2 rather than silently excluded — the exact scenario that made the naive helper-based consolidation unsafe.

## Test plan

- [x] `./scripts/quality.sh lint` — pass
- [x] `./scripts/quality.sh typing` — pass
- [x] `./scripts/quality.sh quality` — pass
- [x] `./scripts/quality.sh test` — 3010 passed, 1 flaky pre-existing performance-budget test (`test_milp_solves_96_slot_horizon_within_performance_budget`) that fails under load and passes on its own; unrelated to this change (confirmed by re-running in isolation)

## Known limitations / open questions

None. `docs/planner-spec.md` was reviewed (scheduling/window sections) — it doesn't document per-occurrence budgeting at this implementation-detail level, and this PR doesn't change scheduling semantics, so no spec update was needed.

Fixes #898
