### PR TITLE
fix(ev): auto-disable force-charge-now switch on EV disconnect

### DIFF
--- a/custom_components/hsem/coordinator_helpers.py
+++ b/custom_components/hsem/coordinator_helpers.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 
 from custom_components.hsem.models.hourly_recommendation import HourlyRecommendation
 from custom_components.hsem.models.live_state import LiveState
@@ -22,6 +23,7 @@ from custom_components.hsem.planner.ev_planner import (
     rebuild_ev_plan_from_slots,
 )
 from custom_components.hsem.utils.datetime_utils import slot_contains, utc_key
+from custom_components.hsem.utils.logger import async_log
 from custom_components.hsem.utils.misc import get_config_value
 from custom_components.hsem.utils.phase_power import charger_power_to_current_a
 from custom_components.hsem.utils.recommendations import Recommendations
@@ -325,6 +327,56 @@ def apply_force_charge_now(
         override_second=force_second,
         live=live,
     )
+
+
+def reset_force_charge_on_disconnect(
+    *,
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    was_connected: bool | None,
+    is_connected: bool | None,
+    option_key: str,
+    ev_label: str,
+) -> bool:
+    """Clear a force-charge-now option on a connected → disconnected transition.
+
+    ``apply_current_ev_power_override`` already zeroes the forced charger
+    power once an EV is disconnected, but leaves the switch itself (and its
+    config-entry option) on — so forced full-power charging silently re-arms
+    the moment the EV reconnects. This clears the option so the switch
+    entity (via its own config-update listener) reflects ``off`` and the
+    user must explicitly re-enable it.
+
+    Args:
+        hass: The Home Assistant instance, needed to persist the option.
+        config_entry: The HSEM config entry backing the force-charge switch.
+        was_connected: EV connection state as of the last accepted plan.
+        is_connected: EV connection state observed this cycle.
+        option_key: The force-charge-now option key to reset
+            (``hsem_ev_force_charge_now`` or ``hsem_ev_second_force_charge_now``).
+        ev_label: Human-readable EV label, used only in the log message.
+
+    Returns:
+        ``True`` if the option was reset, ``False`` for a no-op (no
+        disconnect transition, or the option was already ``False``).
+    """
+    if was_connected is not True or is_connected is not False:
+        return False
+    if not bool(get_config_value(config_entry, option_key)):
+        return False
+
+    hass.config_entries.async_update_entry(
+        config_entry,
+        options={**config_entry.options, option_key: False},
+    )
+    async_log(
+        "info",
+        "[ev] %s disconnected while force-charge-now was on — "
+        "automatically resetting %s to off.",
+        ev_label,
+        option_key,
+    )
+    return True
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/hsem/coordinator_planner_phase.py
+++ b/custom_components/hsem/coordinator_planner_phase.py
@@ -28,6 +28,7 @@ from custom_components.hsem.coordinator_helpers import (
     apply_load_forecast_hold,
     live_demand_contradicts_zero_profile,
     load_forecast_signatures_match,
+    reset_force_charge_on_disconnect,
 )
 from custom_components.hsem.coordinator_persistence import persist_all_trackers
 from custom_components.hsem.coordinator_state import (
@@ -285,7 +286,28 @@ class CoordinatorPlannerPhaseMixin(CoordinatorSharedState):
                     live=live,
                 )
 
-        # 8c. Force-charge-now override.
+        # 8c. Auto-disable force-charge-now on EV disconnect (issue #900).
+        # Must run before the force-charge-now override below so a
+        # disconnect and reset in the same cycle never leaves a stale
+        # forced-charge slot.
+        reset_force_charge_on_disconnect(
+            hass=self.hass,
+            config_entry=self._config_entry,
+            was_connected=getattr(self, "_last_plan_ev_connected", None),
+            is_connected=live.ev.is_connected,
+            option_key="hsem_ev_force_charge_now",
+            ev_label="EV1",
+        )
+        reset_force_charge_on_disconnect(
+            hass=self.hass,
+            config_entry=self._config_entry,
+            was_connected=getattr(self, "_last_plan_ev_second_connected", None),
+            is_connected=live.ev_second.is_connected,
+            option_key="hsem_ev_second_force_charge_now",
+            ev_label="EV2",
+        )
+
+        # 8d. Force-charge-now override.
         apply_force_charge_now(
             config_entry=self._config_entry,
             hourly_recommendations=self._hourly_recommendations,
@@ -295,7 +317,7 @@ class CoordinatorPlannerPhaseMixin(CoordinatorSharedState):
             live=live,
         )
 
-        # 8d. Load-forecast fail-closed hold.
+        # 8e. Load-forecast fail-closed hold.
         if not consumption_ok or live_demand_contradicts_zero_profile(
             self._hourly_recommendations, live, now
         ):
@@ -313,7 +335,7 @@ class CoordinatorPlannerPhaseMixin(CoordinatorSharedState):
                     consumption_ok,
                 )
 
-        # 8e. EV charger command stability — damp integer-lattice churn and
+        # 8f. EV charger command stability — damp integer-lattice churn and
         # suppress a slot-tail stop.  Runs last so it smooths the command that
         # every earlier override has already had its say on.
         self._apply_ev_command_stability(now, live, cfg)

--- a/docs/ev-charge-plan-setup.md
+++ b/docs/ev-charge-plan-setup.md
@@ -258,6 +258,13 @@ reflect the forced session.
 Use this for ad-hoc "charge now" scenarios (e.g. unexpected trip) without
 enabling the full smart-charging schedule.
 
+**The switch auto-disables when the EV disconnects (issue #900).** If the
+EV is unplugged while force-charge-now is on, HSEM resets the switch to off
+as soon as the disconnect is detected, instead of leaving it armed. This
+prevents forced full-power charging from silently resuming the next time
+the EV is plugged in — you must re-enable the switch explicitly for another
+forced session.
+
 ### Session-aware EV demand
 
 When an EV is actively drawing power, HSEM distinguishes demand it can

--- a/tests/test_force_charge_disconnect_reset.py
+++ b/tests/test_force_charge_disconnect_reset.py
@@ -1,0 +1,226 @@
+"""Tests for issue #900 — auto-disable force-charge-now on EV disconnect.
+
+Covers :func:`reset_force_charge_on_disconnect` in isolation, plus a full
+disconnect → reconnect flow through :func:`apply_force_charge_now` to prove
+that a reconnect never silently re-arms forced charging.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import MagicMock
+
+from custom_components.hsem.const import DEFAULT_CONFIG_VALUES
+from custom_components.hsem.coordinator_helpers import (
+    apply_force_charge_now,
+    reset_force_charge_on_disconnect,
+)
+from custom_components.hsem.models.hourly_recommendation import HourlyRecommendation
+from custom_components.hsem.utils.recommendations import Recommendations
+
+
+def _make_fake_config_entry(overrides: dict[str, Any] | None = None) -> MagicMock:
+    """Build a minimal fake config entry backed by a real, mutable options dict."""
+    options = dict(DEFAULT_CONFIG_VALUES)
+    if overrides:
+        options.update(overrides)
+    config_entry = MagicMock()
+    config_entry.options = options
+    config_entry.data = {}
+    return config_entry
+
+
+def _make_fake_hass() -> MagicMock:
+    """Build a fake hass whose ``config_entries.async_update_entry`` actually
+    mutates the entry's ``options``, mirroring real Home Assistant behaviour.
+    """
+    hass = MagicMock()
+
+    def _update_entry(entry: MagicMock, *, options: dict[str, Any]) -> bool:
+        entry.options = options
+        return True
+
+    hass.config_entries.async_update_entry.side_effect = _update_entry
+    return hass
+
+
+def _make_rec(now: datetime) -> HourlyRecommendation:
+    return HourlyRecommendation(
+        start=now - timedelta(minutes=5),
+        end=now + timedelta(minutes=10),
+        avg_house_consumption_kwh=0.0,
+        avg_house_consumption_1d_kwh=0.0,
+        avg_house_consumption_3d_kwh=0.0,
+        avg_house_consumption_7d_kwh=0.0,
+        avg_house_consumption_14d_kwh=0.0,
+        batteries_charged_kwh=0.0,
+        batteries_discharged_kwh=0.0,
+        estimated_battery_capacity_kwh=0.0,
+        estimated_battery_soc_pct=0.0,
+        estimated_cost_currency=0.0,
+        estimated_net_consumption_kwh=0.0,
+        export_price=0.0,
+        grid_export_kwh=0.0,
+        grid_import_kwh=0.0,
+        import_price=0.0,
+        recommendation=Recommendations.BatteriesWaitMode.value,
+        solcast_pv_estimate_kwh=0.0,
+    )
+
+
+class TestResetForceChargeOnDisconnect:
+    """Unit tests for the standalone reset helper."""
+
+    def test_ev1_disconnect_resets_switch(self) -> None:
+        hass = _make_fake_hass()
+        config_entry = _make_fake_config_entry({"hsem_ev_force_charge_now": True})
+
+        result = reset_force_charge_on_disconnect(
+            hass=hass,
+            config_entry=config_entry,
+            was_connected=True,
+            is_connected=False,
+            option_key="hsem_ev_force_charge_now",
+            ev_label="EV1",
+        )
+
+        assert result is True
+        assert config_entry.options["hsem_ev_force_charge_now"] is False
+        hass.config_entries.async_update_entry.assert_called_once()
+
+    def test_ev2_disconnect_resets_switch(self) -> None:
+        hass = _make_fake_hass()
+        config_entry = _make_fake_config_entry(
+            {"hsem_ev_second_force_charge_now": True}
+        )
+
+        result = reset_force_charge_on_disconnect(
+            hass=hass,
+            config_entry=config_entry,
+            was_connected=True,
+            is_connected=False,
+            option_key="hsem_ev_second_force_charge_now",
+            ev_label="EV2",
+        )
+
+        assert result is True
+        assert config_entry.options["hsem_ev_second_force_charge_now"] is False
+        hass.config_entries.async_update_entry.assert_called_once()
+
+    def test_noop_when_already_off(self) -> None:
+        hass = _make_fake_hass()
+        config_entry = _make_fake_config_entry({"hsem_ev_force_charge_now": False})
+
+        result = reset_force_charge_on_disconnect(
+            hass=hass,
+            config_entry=config_entry,
+            was_connected=True,
+            is_connected=False,
+            option_key="hsem_ev_force_charge_now",
+            ev_label="EV1",
+        )
+
+        assert result is False
+        hass.config_entries.async_update_entry.assert_not_called()
+
+    def test_noop_when_still_connected(self) -> None:
+        """No transition (still connected) must never touch the option."""
+        hass = _make_fake_hass()
+        config_entry = _make_fake_config_entry({"hsem_ev_force_charge_now": True})
+
+        result = reset_force_charge_on_disconnect(
+            hass=hass,
+            config_entry=config_entry,
+            was_connected=True,
+            is_connected=True,
+            option_key="hsem_ev_force_charge_now",
+            ev_label="EV1",
+        )
+
+        assert result is False
+        assert config_entry.options["hsem_ev_force_charge_now"] is True
+        hass.config_entries.async_update_entry.assert_not_called()
+
+    def test_noop_on_reconnect_transition(self) -> None:
+        """A disconnected→connected transition must never turn the switch on."""
+        hass = _make_fake_hass()
+        config_entry = _make_fake_config_entry({"hsem_ev_force_charge_now": False})
+
+        result = reset_force_charge_on_disconnect(
+            hass=hass,
+            config_entry=config_entry,
+            was_connected=False,
+            is_connected=True,
+            option_key="hsem_ev_force_charge_now",
+            ev_label="EV1",
+        )
+
+        assert result is False
+        assert config_entry.options["hsem_ev_force_charge_now"] is False
+        hass.config_entries.async_update_entry.assert_not_called()
+
+    def test_noop_when_previous_state_unknown(self) -> None:
+        """First-plan cycle (``was_connected is None``) must not reset anything."""
+        hass = _make_fake_hass()
+        config_entry = _make_fake_config_entry({"hsem_ev_force_charge_now": True})
+
+        result = reset_force_charge_on_disconnect(
+            hass=hass,
+            config_entry=config_entry,
+            was_connected=None,
+            is_connected=False,
+            option_key="hsem_ev_force_charge_now",
+            ev_label="EV1",
+        )
+
+        assert result is False
+        assert config_entry.options["hsem_ev_force_charge_now"] is True
+        hass.config_entries.async_update_entry.assert_not_called()
+
+
+class TestReconnectDoesNotResumeForcedCharging:
+    """End-to-end: disconnect resets the switch; reconnecting stays off."""
+
+    def test_reconnect_after_disconnect_leaves_force_charge_off(self) -> None:
+        hass = _make_fake_hass()
+        config_entry = _make_fake_config_entry({"hsem_ev_force_charge_now": True})
+
+        # Cycle N: EV disconnects mid-session — switch auto-resets.
+        reset_force_charge_on_disconnect(
+            hass=hass,
+            config_entry=config_entry,
+            was_connected=True,
+            is_connected=False,
+            option_key="hsem_ev_force_charge_now",
+            ev_label="EV1",
+        )
+        assert config_entry.options["hsem_ev_force_charge_now"] is False
+
+        # Cycle N+1: EV reconnects — helper must not flip it back on, since
+        # only a user action (the switch itself) may set it True again.
+        result = reset_force_charge_on_disconnect(
+            hass=hass,
+            config_entry=config_entry,
+            was_connected=False,
+            is_connected=True,
+            option_key="hsem_ev_force_charge_now",
+            ev_label="EV1",
+        )
+        assert result is False
+        assert config_entry.options["hsem_ev_force_charge_now"] is False
+
+        # And the force-charge-now override itself must be a no-op now that
+        # the option is off — no forced full-power charging resumes.
+        now = datetime.now(UTC)
+        rec = _make_rec(now)
+        apply_force_charge_now(
+            config_entry=config_entry,
+            hourly_recommendations=[rec],
+            ev_plan=None,
+            ev_second_plan=None,
+            now=now,
+        )
+
+        assert rec.recommendation == Recommendations.BatteriesWaitMode.value
+        assert rec.ev_charger_calculated_power == 0.0


### PR DESCRIPTION
## Summary

- `hsem_ev_force_charge_now` / `hsem_ev_second_force_charge_now` are pure config-entry
  switches: `apply_current_ev_power_override` already zeroes forced charger *power* once
  `live.ev.is_connected` / `live.ev_second.is_connected` flips to `False`, but the switch
  option itself was never cleared — so it silently re-armed full-power forced charging
  the moment the EV reconnected.
- Adds `reset_force_charge_on_disconnect()` in `coordinator_helpers.py`, called
  independently for both EVs from `coordinator_planner_phase.py` (`_run_planner_phase`),
  right before `apply_force_charge_now` runs in the same cycle. It resets the option via
  `hass.config_entries.async_update_entry(...)` — the same key
  `HSEMSwitch._persist_state()` writes — so the switch entity reflects `off` automatically
  through its existing `_async_handle_config_update` listener.
- The reset only fires on a genuine connected→disconnected transition (comparing against
  the connection state recorded at the last accepted plan) and only when the option is
  currently `True`, so there is no spurious config-entry write or log noise when the
  switch is already off, and reconnecting afterward can never turn the switch back on —
  only an explicit user toggle can.
- Logs the automatic reset at `info` level.

## Branch

`fix/900-auto-disable-force-charge-on-disconnect`

## Files changed

- `custom_components/hsem/coordinator_helpers.py` — new `reset_force_charge_on_disconnect()` helper
- `custom_components/hsem/coordinator_planner_phase.py` — wires the helper in for EV1 and EV2 before `apply_force_charge_now`
- `docs/ev-charge-plan-setup.md` — documents the auto-disable-on-disconnect behavior
- `tests/test_force_charge_disconnect_reset.py` — new tests (see below)

## Tests added

- EV1 disconnect resets `hsem_ev_force_charge_now`
- EV2 disconnect resets `hsem_ev_second_force_charge_now`
- No-op (no config-entry write) when the switch is already off
- No-op when the EV stays connected (no transition)
- No-op on a disconnected→connected transition (reconnect never turns the switch on)
- No-op on the very first planner cycle (previous connection state unknown)
- End-to-end: disconnect resets the switch, then a subsequent reconnect does **not**
  resume forced charging via `apply_force_charge_now`

## Test / lint results

- `./scripts/quality.sh lint` — pass
- `./scripts/quality.sh typing` — pass (0 errors)
- `./scripts/quality.sh quality` — pass (pyright 0 errors; vulture output unchanged/pre-existing)
- `./scripts/quality.sh test` — 3029 passed, 1 pre-existing failure unrelated to this
  change (`test_milp_solves_96_slot_horizon_within_performance_budget`, a timing-budget
  test that also fails identically on a clean `main` checkout in this environment)

## Known limitations / open questions

None — behavior matches all acceptance criteria in #900.

Fixes #900
