### PR TITLE
fix(sensor): unify translation-key naming and complete da/de/es translations

### DIFF
--- a/.claude/skills/hsem-doc-sync/SKILL.md
+++ b/.claude/skills/hsem-doc-sync/SKILL.md
@@ -11,16 +11,16 @@ Activate this skill **after making code changes** and **before opening a PR**. S
 
 When behaviour changes, check **every** file below. If it describes something you changed, update it:
 
-| File                            | When to check                                                                   |
-| ------------------------------- | ------------------------------------------------------------------------------- |
-| `docs/planner-guide.md`         | Planner inputs, outputs, cost function, or scenarios changed                    |
-| `docs/planner-spec.md`          | Planner semantics, invariants, formulas, or safety gates changed                |
-| `docs/config-flow-reference.md` | Config/options flow steps changed                                               |
-| `docs/ev-charge-plan-setup.md`  | EV planned load setup changed                                                   |
-| `docs/huawei_entities.md`       | New Huawei entities wired or existing ones changed                              |
-| `.github/memories.md`           | Canonical patterns, module map, open issues, or architectural decisions changed |
-| `README.md`                     | User-facing features, descriptions, or links changed                            |
-| `translations/en.json`          | Any user-facing string added, changed, or removed                               |
+| File                              | When to check                                                                   |
+| --------------------------------- | ------------------------------------------------------------------------------- |
+| `docs/planner-guide.md`           | Planner inputs, outputs, cost function, or scenarios changed                    |
+| `docs/planner-spec.md`            | Planner semantics, invariants, formulas, or safety gates changed                |
+| `docs/config-flow-reference.md`   | Config/options flow steps changed                                               |
+| `docs/ev-charge-plan-setup.md`    | EV planned load setup changed                                                   |
+| `docs/huawei_entities.md`         | New Huawei entities wired or existing ones changed                              |
+| `.github/memories.md`             | Canonical patterns, module map, open issues, or architectural decisions changed |
+| `README.md`                       | User-facing features, descriptions, or links changed                            |
+| `translations/{en,da,de,es}.json` | Any user-facing string added, changed, or removed — see `hsem-translation-sync` |
 
 ## Documentation Rules
 
@@ -42,6 +42,9 @@ When behaviour changes, check **every** file below. If it describes something yo
 - Every user-facing string (field labels, errors, aborts) must have a key in `translations/en.json`
 - Boolean/switch fields must have translation entries
 - For `huawei_solar` fields: update **both** `config.step.huawei_solar` and `options.step.huawei_solar`
+- `en.json` is the source of truth, but `da.json`, `de.json`, and `es.json` must be
+  kept in sync with it too — run the `hsem-translation-sync` skill (backed by
+  `scripts/validate_translations.py`) before opening the PR
 
 ### README.md
 

--- a/.claude/skills/hsem-pr-workflow/SKILL.md
+++ b/.claude/skills/hsem-pr-workflow/SKILL.md
@@ -30,6 +30,20 @@ Or run all at once:
 
 Verify: `git --no-optional-locks status` shows only intended changes.
 
+## Translation Sync
+
+Before opening a PR, run the `hsem-translation-sync` skill if any user-facing
+string changed (entity name, config/options flow label, selector, error,
+service):
+
+```bash
+python3 scripts/validate_translations.py
+```
+
+Must report 0 missing keys, 0 stale keys, 0 placeholder mismatches across
+`da.json`, `de.json`, and `es.json`. See `hsem-translation-sync` for the fix
+workflow and terminology glossary.
+
 ## Documentation Update
 
 Before opening a PR, check and update ALL documentation that describes changed behavior:
@@ -41,7 +55,8 @@ Before opening a PR, check and update ALL documentation that describes changed b
 - [ ] `.github/memories.md` — if canonical patterns or module map changed
 - [ ] `README.md` — if user-facing features changed
 - [ ] `docs/huawei_entities.md` — if new Huawei entities wired
-- [ ] `translations/en.json` — if user-facing strings changed
+- [ ] `translations/{en,da,de,es}.json` — if user-facing strings changed (see
+      `hsem-translation-sync`)
 
 **A PR is not done until all affected docs are consistent with the implementation.**
 

--- a/.claude/skills/hsem-translation-sync/SKILL.md
+++ b/.claude/skills/hsem-translation-sync/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: hsem-translation-sync
+description: Activate before opening or updating a pull request, and whenever a user-facing string (entity name, config/options flow label, selector option, error, service) is added, changed, or removed. Keeps translations/{en,da,de,es}.json in sync.
+---
+
+# HSEM Translation Sync — Keep en/da/de/es in Sync
+
+HSEM ships four languages: **English** (`en.json`, source of truth), **Danish**
+(`da.json`), **German** (`de.json`), and **Spanish** (`es.json`), all under
+`custom_components/hsem/translations/`. Every user-facing string — config/options
+flow step titles, field labels, field descriptions, error/abort messages, selector
+option labels, entity names, service names/descriptions — must exist and be
+genuinely translated in all four files.
+
+Activate this skill:
+
+- Before opening a new pull request (as part of `hsem-pr-workflow`)
+- Before updating an open PR after a follow-up commit that touches
+  `translations/en.json`, `config_flow.py`, `options_flow.py`, any `flows/*.py`,
+  or any file wiring an entity's `translation_key`
+- Any time you add, rename, or remove a config/options flow field, selector,
+  entity `translation_key`, error key, abort reason, or service
+
+## Step 1 — Run the validator
+
+```bash
+python3 scripts/validate_translations.py
+```
+
+This diffs `da.json`, `de.json`, `es.json` against `en.json` (the source of
+truth) and reports, per language:
+
+- **Missing keys** — present in English, absent in the target file. Hard error.
+- **Stale keys** — present in the target file, absent in English (leftover from
+  a removed/renamed field). Hard error.
+- **Placeholder mismatches** — `{placeholder}` tokens differ between English and
+  the target value. Hard error.
+- **Untranslated values (warning)** — the target value is byte-identical to the
+  English value. Not auto-failed, because short cognates are legitimate
+  (`"OCPP"`, `"SoC"`, `"Auto"`, and a few month names are spelled the same in
+  Danish/German/English). Review each one: if it's a multi-word phrase or a
+  sentence, it's almost always a missed translation, not a cognate.
+
+The script exits non-zero if there are any hard errors.
+
+## Step 2 — Fix what the validator finds
+
+- **Missing keys**: translate the English value into the target language. Check
+  whether the same field text already exists translated elsewhere in the file
+  first — `config.step.X` and `options.step.X` frequently duplicate the exact
+  same field label/description, and `options.step.ev_second_planned_load`
+  duplicates `options.step.ev_planned_load` with an "EV 2" prefix. Reuse the
+  existing translation rather than re-translating from scratch; this is the
+  fastest way to fix a batch of missing keys and keeps terminology consistent.
+- **Stale keys**: confirm the key has no corresponding code (`grep -rn
+"<leaf_key>" custom_components/hsem`). If genuinely dead, delete it. If it's a
+  key that's about to be reintroduced, leave a note in the PR instead of
+  deleting.
+- **Placeholder mismatches**: the target value must contain exactly the same
+  `{placeholder}` tokens as English, in whatever order reads naturally in that
+  language. Never drop or rename a placeholder.
+- **Untranslated warnings**: translate the ones that are real sentences/phrases.
+  Leave single-word cognates and acronyms as-is (do not force a translation
+  that doesn't exist, e.g. "Server", "Port", "SoC", "OCPP").
+
+## Step 3 — Terminology glossary
+
+Use this glossary consistently across all three target languages so the same
+English concept always renders the same way, instead of drifting between PRs:
+
+| English                 | Danish                      | German                     | Spanish                          |
+| ----------------------- | --------------------------- | -------------------------- | -------------------------------- |
+| State of Charge (SoC)   | SoC (keep)                  | SoC (keep)                 | SoC (keep)                       |
+| Working Mode            | Arbejdstilstand             | Arbeitsmodus               | Modo de funcionamiento           |
+| Planner                 | Planlægger                  | Planer                     | Planificador                     |
+| Grid charge             | Netopladning                | Netzladung                 | Carga desde la red               |
+| Self-consumption        | Selvforbrug                 | Eigenverbrauch             | Autoconsumo                      |
+| Export / feed-in        | Eksport                     | Einspeisung / Export       | Exportación                      |
+| Wait mode               | Ventetilstand               | Wartemodus                 | Modo de espera                   |
+| Hysteresis              | Hysterese                   | Hysterese                  | Histéresis                       |
+| Phase-aware charging    | Fasebevidst opladning       | Phasenbewusstes Laden      | Carga con reconocimiento de fase |
+| Fuse                    | Sikring                     | Sicherung                  | Fusible                          |
+| Charge Point / CPID     | Ladepunkt                   | Ladepunkt                  | Punto de carga                   |
+| EV charger              | EV-lader                    | EV-Ladegerät / Ladestation | Cargador de VE                   |
+| Degraded mode           | Degraderet tilstand         | Eingeschränkter Modus      | Modo degradado                   |
+| Read-only mode          | Skrivebeskyttet tilstand    | Nur-Lese-Modus             | Modo de solo lectura             |
+| Force mode              | Tvungen tilstand            | Erzwungener Modus          | Modo forzado                     |
+| Hardware writes         | Hardwareskrivninger         | Hardware-Schreibvorgänge   | Escrituras de hardware           |
+| Recommendation interval | Anbefalingsinterval         | Empfehlungsintervall       | Intervalo de recomendación       |
+| Forecast                | Prognose                    | Prognose                   | Previsión                        |
+| Discharge floor         | Afladningsgulv              | Entladeuntergrenze         | Límite mínimo de descarga        |
+| Temporary override      | Midlertidig tilsidesættelse | Temporäre Übersteuerung    | Anulación temporal               |
+| Battery / Batteries     | Batteri(er)                 | Batterie(n)                | Batería(s)                       |
+| Inverter                | Inverter                    | Wechselrichter             | Inversor                         |
+| End of discharge        | Afladningsstop              | Entladeschluss             | Fin de descarga                  |
+
+Keep product/protocol names and abbreviations untranslated everywhere: `HSEM`,
+`OCPP`, `MILP`, `TOU`, `Solcast`, `Huawei`, entity/field acronyms like `SoC`.
+
+**Tone**: imperative/infinitive, matching the English source ("Select the
+sensor…", "Enable this option…"). For German use informal _du_-form
+imperatives (Home Assistant's own translation convention), not formal _Sie_.
+For Spanish use informal _tú_-form imperatives, neutral international Spanish
+— no regional slang, no _vosotros_/_vos_.
+
+## Step 4 — Re-run the validator
+
+```bash
+python3 scripts/validate_translations.py
+```
+
+Must report 0 missing, 0 stale, 0 placeholder mismatches for every language
+before the PR is opened. Then format:
+
+```bash
+npx --yes prettier@3.1.0 --write custom_components/hsem/translations/*.json
+```
+
+## Known limitation — read before assuming a JSON fix is enough
+
+Not every `entity.sensor.*` key in the translation files actually drives the
+displayed entity name. Entities defined in `custom_sensors/*.py` generally
+hardcode their English display name via a `get_*_sensor_name()` helper in
+`utils/sensornames/` and override the HA `name` property directly — this wins
+over `_attr_translation_key`/HA's translation-driven naming even when both are
+set on the same class. Only entities using the `EntityDescription` +
+`translation_key` pattern with no custom `name` property override (switch,
+number, select, time platforms, and the two `custom_selectors/`) are actually
+localized through these JSON files today.
+
+Keeping `entity.sensor.*` translations complete and accurate in this skill is
+still correct — it keeps the files consistent and ready for the day that
+sensor-naming architecture is unified — but don't assume adding a translation
+here changes what a non-English user actually sees on a `custom_sensors/*.py`
+entity. If a task is specifically about localizing those sensor names, that
+requires a code change (removing the `name` property override in favor of
+`_attr_translation_key` + `_attr_has_entity_name`), which is a larger,
+separate change outside this skill's scope — flag it, don't silently attempt
+it as part of a translation-only PR.
+
+## Anti-Patterns to Avoid
+
+- ❌ Adding a new config/options flow field in English only
+- ❌ Copy-pasting the English value into `da`/`de`/`es.json` as a placeholder
+  and forgetting to translate it later
+- ❌ Translating `config.step.X` but not the duplicate `options.step.X`
+- ❌ Leaving a stale key behind after renaming a field
+- ❌ Inventing new terminology instead of reusing the glossary in Step 3
+- ❌ Assuming a `entity.sensor.*` translation fixes what users actually see —
+  check whether that entity's Python class overrides `name` (see "Known
+  limitation" above)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,16 @@ Quick checklist before opening a planner PR:
 - [ ] Spec updated if semantics changed
 - [ ] Tests added or updated
 
+## Translations (Mandatory)
+
+HSEM ships English, Danish, German, and Spanish
+(`custom_components/hsem/translations/{en,da,de,es}.json`). `en.json` is the
+source of truth. Any new or changed user-facing string (entity name,
+config/options flow label, selector option, error, service) must be added to
+**all four** files in the same PR — activate the `hsem-translation-sync` skill
+and run `python3 scripts/validate_translations.py` before opening the PR; it
+must report 0 missing/stale/placeholder-mismatch keys.
+
 ## Development Workflow
 
 ```bash
@@ -199,10 +209,13 @@ See `AGENTS.md` → **Home Assistant Compliance** section for detailed requireme
 # Step 4: Run tests with coverage
 ./scripts/quality.sh test
 
-# Step 5: Verify no unintended changes
+# Step 5: Translations — if any user-facing string changed
+python3 scripts/validate_translations.py
+
+# Step 6: Verify no unintended changes
 git status
 
-# Step 6: Use pre-commit hooks (optional, but recommended)
+# Step 7: Use pre-commit hooks (optional, but recommended)
 pre-commit run --all-files
 ```
 

--- a/custom_components/hsem/custom_sensors/applier_status_sensor.py
+++ b/custom_components/hsem/custom_sensors/applier_status_sensor.py
@@ -45,7 +45,6 @@ from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
 from custom_components.hsem.utils.inverter_verify import ApplyStatus
 from custom_components.hsem.utils.sensornames.diagnostics import (
     get_applier_status_sensor_entity_id,
-    get_applier_status_sensor_name,
     get_applier_status_sensor_unique_id,
 )
 
@@ -101,19 +100,12 @@ class HSEMApplierStatusSensor(
             config_entry.entry_id
         )
         self.entity_id = get_applier_status_sensor_entity_id()
-        self._name = get_applier_status_sensor_name()
 
         self._restored_state: str | None = None
 
     # ------------------------------------------------------------------
     # HA entity properties
     # ------------------------------------------------------------------
-
-    @property
-    @override
-    def name(self) -> str:
-        """Return the display name."""
-        return self._name
 
     @property
     @override

--- a/custom_components/hsem/custom_sensors/battery_soc_sensor.py
+++ b/custom_components/hsem/custom_sensors/battery_soc_sensor.py
@@ -37,7 +37,6 @@ from custom_components.hsem.coordinator import (
 from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
 from custom_components.hsem.utils.sensornames.diagnostics import (
     get_battery_soc_sensor_entity_id,
-    get_battery_soc_sensor_name,
     get_battery_soc_sensor_unique_id,
 )
 
@@ -59,6 +58,7 @@ class HSEMBatterySoCSensor(
 
     _attr_icon = "mdi:battery-high"
     _attr_has_entity_name = True
+    _attr_translation_key = "battery_soc"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_device_class = SensorDeviceClass.BATTERY
     _attr_native_unit_of_measurement = PERCENTAGE
@@ -82,19 +82,12 @@ class HSEMBatterySoCSensor(
 
         self._attr_unique_id = get_battery_soc_sensor_unique_id(config_entry.entry_id)
         self.entity_id = get_battery_soc_sensor_entity_id()
-        self._name = get_battery_soc_sensor_name()
 
         self._restored_state: str | None = None
 
     # ------------------------------------------------------------------
     # HA entity properties
     # ------------------------------------------------------------------
-
-    @property
-    @override
-    def name(self) -> str:
-        """Return the display name."""
-        return self._name
 
     @property
     @override

--- a/custom_components/hsem/custom_sensors/daily_plan_vs_actual_sensor.py
+++ b/custom_components/hsem/custom_sensors/daily_plan_vs_actual_sensor.py
@@ -39,7 +39,6 @@ from custom_components.hsem.models.daily_plan_vs_actual_tracker import (
 )
 from custom_components.hsem.utils.sensornames.diagnostics import (
     get_daily_plan_vs_actual_sensor_entity_id,
-    get_daily_plan_vs_actual_sensor_name,
     get_daily_plan_vs_actual_sensor_unique_id,
 )
 
@@ -58,6 +57,7 @@ class HSEMDailyPlanVsActualSensor(
 
     _attr_icon = "mdi:scale-balance"
     _attr_has_entity_name = True
+    _attr_translation_key = "daily_plan_vs_actual"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
@@ -76,7 +76,6 @@ class HSEMDailyPlanVsActualSensor(
         self._attr_unique_id = get_daily_plan_vs_actual_sensor_unique_id(
             config_entry.entry_id
         )
-        self._attr_name = get_daily_plan_vs_actual_sensor_name()
         self.entity_id = get_daily_plan_vs_actual_sensor_entity_id()
         self._restored_state: str | None = None
 

--- a/custom_components/hsem/custom_sensors/degraded_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/degraded_mode_sensor.py
@@ -48,7 +48,6 @@ from custom_components.hsem.utils.degraded_mode import (
 )
 from custom_components.hsem.utils.sensornames.diagnostics import (
     get_degraded_mode_sensor_entity_id,
-    get_degraded_mode_sensor_name,
     get_degraded_mode_sensor_unique_id,
 )
 
@@ -97,7 +96,6 @@ class HSEMDegradedModeSensor(
 
         self._attr_unique_id = get_degraded_mode_sensor_unique_id(config_entry.entry_id)
         self.entity_id = get_degraded_mode_sensor_entity_id()
-        self._name = get_degraded_mode_sensor_name()
 
         # Restored state used before the first coordinator cycle completes.
         self._restored_state: str | None = None
@@ -105,12 +103,6 @@ class HSEMDegradedModeSensor(
     # ------------------------------------------------------------------
     # HA entity properties
     # ------------------------------------------------------------------
-
-    @property
-    @override
-    def name(self) -> str:
-        """Return the display name."""
-        return self._name
 
     @property
     @override

--- a/custom_components/hsem/custom_sensors/effective_discharge_floor_sensor.py
+++ b/custom_components/hsem/custom_sensors/effective_discharge_floor_sensor.py
@@ -25,7 +25,6 @@ from custom_components.hsem.coordinator import (
 from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
 from custom_components.hsem.utils.sensornames.diagnostics import (
     get_effective_discharge_floor_sensor_entity_id,
-    get_effective_discharge_floor_sensor_name,
     get_effective_discharge_floor_sensor_unique_id,
 )
 
@@ -44,6 +43,7 @@ class HSEMEffectiveDischargeFloorSensor(
 
     _attr_icon = "mdi:battery-arrow-down"
     _attr_has_entity_name = True
+    _attr_translation_key = "effective_discharge_floor"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
@@ -66,19 +66,12 @@ class HSEMEffectiveDischargeFloorSensor(
             config_entry.entry_id
         )
         self.entity_id = get_effective_discharge_floor_sensor_entity_id()
-        self._name = get_effective_discharge_floor_sensor_name()
 
         self._restored_state: str | None = None
 
     # ------------------------------------------------------------------
     # HA entity properties
     # ------------------------------------------------------------------
-
-    @property
-    @override
-    def name(self) -> str:
-        """Return the display name."""
-        return self._name
 
     @property
     @override

--- a/custom_components/hsem/custom_sensors/ev_charger_calculated_power_sensor.py
+++ b/custom_components/hsem/custom_sensors/ev_charger_calculated_power_sensor.py
@@ -43,10 +43,8 @@ from custom_components.hsem.coordinator import (
 from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
 from custom_components.hsem.utils.sensornames.ev import (
     get_ev_charger_calculated_power_sensor_entity_id,
-    get_ev_charger_calculated_power_sensor_name,
     get_ev_charger_calculated_power_sensor_unique_id,
     get_ev_second_charger_calculated_power_sensor_entity_id,
-    get_ev_second_charger_calculated_power_sensor_name,
     get_ev_second_charger_calculated_power_sensor_unique_id,
 )
 
@@ -71,8 +69,6 @@ class HSEMEVChargerCalculatedPowerSensorBase(
     _attr_native_unit_of_measurement = UnitOfPower.WATT
     _attr_suggested_display_precision = 0
     _is_second: bool = False
-    # Set by concrete subclasses in __init__.
-    _name: str
 
     def __init__(
         self,
@@ -94,12 +90,6 @@ class HSEMEVChargerCalculatedPowerSensorBase(
     # ------------------------------------------------------------------
     # HA entity properties
     # ------------------------------------------------------------------
-
-    @property
-    @override
-    def name(self) -> str:
-        """Return the display name."""
-        return self._name
 
     @property
     @override
@@ -190,7 +180,6 @@ class HSEMEVChargerCalculatedPowerSensor(HSEMEVChargerCalculatedPowerSensorBase)
             config_entry.entry_id
         )
         self.entity_id = get_ev_charger_calculated_power_sensor_entity_id()
-        self._name = get_ev_charger_calculated_power_sensor_name()
 
 
 class HSEMEVSecondChargerCalculatedPowerSensor(HSEMEVChargerCalculatedPowerSensorBase):
@@ -210,4 +199,3 @@ class HSEMEVSecondChargerCalculatedPowerSensor(HSEMEVChargerCalculatedPowerSenso
             config_entry.entry_id
         )
         self.entity_id = get_ev_second_charger_calculated_power_sensor_entity_id()
-        self._name = get_ev_second_charger_calculated_power_sensor_name()

--- a/custom_components/hsem/custom_sensors/ev_charger_current_limit_sensor.py
+++ b/custom_components/hsem/custom_sensors/ev_charger_current_limit_sensor.py
@@ -52,10 +52,8 @@ from custom_components.hsem.utils.phase_power import (
 )
 from custom_components.hsem.utils.sensornames.ev import (
     get_ev_charger_current_limit_sensor_entity_id,
-    get_ev_charger_current_limit_sensor_name,
     get_ev_charger_current_limit_sensor_unique_id,
     get_ev_second_charger_current_limit_sensor_entity_id,
-    get_ev_second_charger_current_limit_sensor_name,
     get_ev_second_charger_current_limit_sensor_unique_id,
 )
 
@@ -85,8 +83,6 @@ class HSEMEVChargerCurrentLimitSensorBase(
     _attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
     _attr_state_class = SensorStateClass.MEASUREMENT
     _is_second: bool = False
-    # Set by concrete subclasses in __init__.
-    _name: str
 
     def __init__(
         self,
@@ -146,12 +142,6 @@ class HSEMEVChargerCurrentLimitSensorBase(
     # ------------------------------------------------------------------
     # HA entity properties
     # ------------------------------------------------------------------
-
-    @property
-    @override
-    def name(self) -> str:
-        """Return the display name."""
-        return self._name
 
     @property
     @override
@@ -241,7 +231,6 @@ class HSEMEVChargerCurrentLimitSensor(HSEMEVChargerCurrentLimitSensorBase):
             config_entry.entry_id
         )
         self.entity_id = get_ev_charger_current_limit_sensor_entity_id()
-        self._name = get_ev_charger_current_limit_sensor_name()
 
 
 class HSEMEVSecondChargerCurrentLimitSensor(HSEMEVChargerCurrentLimitSensorBase):
@@ -261,4 +250,3 @@ class HSEMEVSecondChargerCurrentLimitSensor(HSEMEVChargerCurrentLimitSensorBase)
             config_entry.entry_id
         )
         self.entity_id = get_ev_second_charger_current_limit_sensor_entity_id()
-        self._name = get_ev_second_charger_current_limit_sensor_name()

--- a/custom_components/hsem/custom_sensors/ev_charging_sensor.py
+++ b/custom_components/hsem/custom_sensors/ev_charging_sensor.py
@@ -32,7 +32,6 @@ from custom_components.hsem.coordinator import (
 from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
 from custom_components.hsem.utils.sensornames.ev import (
     get_ev_charging_sensor_entity_id,
-    get_ev_charging_sensor_name,
     get_ev_charging_sensor_unique_id,
 )
 
@@ -79,19 +78,12 @@ class HSEMEVChargingSensor(
 
         self._attr_unique_id = get_ev_charging_sensor_unique_id(config_entry.entry_id)
         self.entity_id = get_ev_charging_sensor_entity_id()
-        self._name = get_ev_charging_sensor_name()
 
         self._restored_state: str | None = None
 
     # ------------------------------------------------------------------
     # HA entity properties
     # ------------------------------------------------------------------
-
-    @property
-    @override
-    def name(self) -> str:
-        """Return the display name."""
-        return self._name
 
     @property
     @override

--- a/custom_components/hsem/custom_sensors/ev_optimal_charging_plan_sensor.py
+++ b/custom_components/hsem/custom_sensors/ev_optimal_charging_plan_sensor.py
@@ -38,7 +38,6 @@ from custom_components.hsem.coordinator import (
 from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
 from custom_components.hsem.utils.sensornames.ev import (
     get_ev_optimal_charging_plan_sensor_entity_id,
-    get_ev_optimal_charging_plan_sensor_name,
     get_ev_optimal_charging_plan_sensor_unique_id,
 )
 
@@ -90,19 +89,12 @@ class HSEMEVOptimalChargingPlanSensor(
             config_entry.entry_id
         )
         self.entity_id = get_ev_optimal_charging_plan_sensor_entity_id()
-        self._name = get_ev_optimal_charging_plan_sensor_name()
 
         self._restored_state: str | None = None
 
     # ------------------------------------------------------------------
     # HA entity properties
     # ------------------------------------------------------------------
-
-    @property
-    @override
-    def name(self) -> str:
-        """Return the display name."""
-        return self._name
 
     @property
     @override

--- a/custom_components/hsem/custom_sensors/ev_second_optimal_charging_plan_sensor.py
+++ b/custom_components/hsem/custom_sensors/ev_second_optimal_charging_plan_sensor.py
@@ -23,7 +23,6 @@ from custom_components.hsem.coordinator import (
 from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
 from custom_components.hsem.utils.sensornames.ev import (
     get_ev_second_optimal_charging_plan_sensor_entity_id,
-    get_ev_second_optimal_charging_plan_sensor_name,
     get_ev_second_optimal_charging_plan_sensor_unique_id,
 )
 
@@ -66,15 +65,8 @@ class HSEMEVSecondOptimalChargingPlanSensor(
             config_entry.entry_id
         )
         self.entity_id = get_ev_second_optimal_charging_plan_sensor_entity_id()
-        self._name = get_ev_second_optimal_charging_plan_sensor_name()
 
         self._restored_state: str | None = None
-
-    @property
-    @override
-    def name(self) -> str:
-        """Return the display name."""
-        return self._name
 
     @property
     @override

--- a/custom_components/hsem/custom_sensors/financial_sensors.py
+++ b/custom_components/hsem/custom_sensors/financial_sensors.py
@@ -38,13 +38,10 @@ from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
 from custom_components.hsem.models.financial_tracker import FinancialTracker
 from custom_components.hsem.utils.sensornames.financial import (
     get_export_income_entity_id,
-    get_export_income_name,
     get_export_income_unique_id,
     get_import_cost_entity_id,
-    get_import_cost_name,
     get_import_cost_unique_id,
     get_net_grid_balance_entity_id,
-    get_net_grid_balance_name,
     get_net_grid_balance_unique_id,
 )
 
@@ -148,6 +145,7 @@ class HSEMExportIncomeSensor(_FinancialSensorMixin):
 
     _attr_device_class = SensorDeviceClass.MONETARY
     _attr_state_class = SensorStateClass.TOTAL
+    _attr_translation_key = "export_income"
 
     def __init__(
         self,
@@ -162,7 +160,6 @@ class HSEMExportIncomeSensor(_FinancialSensorMixin):
         """
         super().__init__(config_entry, coordinator)
         self._attr_unique_id = get_export_income_unique_id(config_entry.entry_id)
-        self._attr_name = get_export_income_name()
         self.entity_id = get_export_income_entity_id()
 
     @property
@@ -193,6 +190,7 @@ class HSEMImportCostSensor(_FinancialSensorMixin):
 
     _attr_device_class = SensorDeviceClass.MONETARY
     _attr_state_class = SensorStateClass.TOTAL
+    _attr_translation_key = "import_cost"
 
     def __init__(
         self,
@@ -207,7 +205,6 @@ class HSEMImportCostSensor(_FinancialSensorMixin):
         """
         super().__init__(config_entry, coordinator)
         self._attr_unique_id = get_import_cost_unique_id(config_entry.entry_id)
-        self._attr_name = get_import_cost_name()
         self.entity_id = get_import_cost_entity_id()
 
     @property
@@ -238,6 +235,7 @@ class HSEMNetGridBalanceSensor(_FinancialSensorMixin):
 
     _attr_device_class = SensorDeviceClass.MONETARY
     _attr_state_class = SensorStateClass.TOTAL
+    _attr_translation_key = "net_grid_balance"
 
     def __init__(
         self,
@@ -252,7 +250,6 @@ class HSEMNetGridBalanceSensor(_FinancialSensorMixin):
         """
         super().__init__(config_entry, coordinator)
         self._attr_unique_id = get_net_grid_balance_unique_id(config_entry.entry_id)
-        self._attr_name = get_net_grid_balance_name()
         self.entity_id = get_net_grid_balance_entity_id()
 
     @property

--- a/custom_components/hsem/custom_sensors/force_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/force_mode_sensor.py
@@ -35,7 +35,6 @@ from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
 from custom_components.hsem.utils.recommendations import Recommendations
 from custom_components.hsem.utils.sensornames.diagnostics import (
     get_force_mode_sensor_entity_id,
-    get_force_mode_sensor_name,
     get_force_mode_sensor_unique_id,
 )
 
@@ -84,19 +83,12 @@ class HSEMForceModeSensor(
 
         self._attr_unique_id = get_force_mode_sensor_unique_id(config_entry.entry_id)
         self.entity_id = get_force_mode_sensor_entity_id()
-        self._name = get_force_mode_sensor_name()
 
         self._restored_state: str | None = None
 
     # ------------------------------------------------------------------
     # HA entity properties
     # ------------------------------------------------------------------
-
-    @property
-    @override
-    def name(self) -> str:
-        """Return the display name."""
-        return self._name
 
     @property
     @override

--- a/custom_components/hsem/custom_sensors/forecast_accuracy_sensor.py
+++ b/custom_components/hsem/custom_sensors/forecast_accuracy_sensor.py
@@ -44,7 +44,6 @@ from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
 from custom_components.hsem.utils.persistence import finite_float
 from custom_components.hsem.utils.sensornames.diagnostics import (
     get_forecast_accuracy_sensor_entity_id,
-    get_forecast_accuracy_sensor_name,
     get_forecast_accuracy_sensor_unique_id,
 )
 
@@ -63,6 +62,7 @@ class HSEMForecastAccuracySensor(
 
     _attr_icon = "mdi:chart-line"
     _attr_has_entity_name = True
+    _attr_translation_key = "forecast_accuracy"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
@@ -81,7 +81,6 @@ class HSEMForecastAccuracySensor(
         self._attr_unique_id = get_forecast_accuracy_sensor_unique_id(
             config_entry.entry_id
         )
-        self._attr_name = get_forecast_accuracy_sensor_name()
         self.entity_id = get_forecast_accuracy_sensor_entity_id()
         self._restored_state: str | None = None
 

--- a/custom_components/hsem/custom_sensors/hardware_writes_sensor.py
+++ b/custom_components/hsem/custom_sensors/hardware_writes_sensor.py
@@ -35,7 +35,6 @@ from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
 from custom_components.hsem.utils.degraded_mode import hardware_writes_allowed
 from custom_components.hsem.utils.sensornames.diagnostics import (
     get_hardware_writes_sensor_entity_id,
-    get_hardware_writes_sensor_name,
     get_hardware_writes_sensor_unique_id,
 )
 
@@ -86,19 +85,12 @@ class HSEMHardwareWritesSensor(
             config_entry.entry_id
         )
         self.entity_id = get_hardware_writes_sensor_entity_id()
-        self._name = get_hardware_writes_sensor_name()
 
         self._restored_state: str | None = None
 
     # ------------------------------------------------------------------
     # HA entity properties
     # ------------------------------------------------------------------
-
-    @property
-    @override
-    def name(self) -> str:
-        """Return the display name."""
-        return self._name
 
     @property
     @override

--- a/custom_components/hsem/custom_sensors/last_updated_sensor.py
+++ b/custom_components/hsem/custom_sensors/last_updated_sensor.py
@@ -28,7 +28,6 @@ from custom_components.hsem.coordinator import (
 from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
 from custom_components.hsem.utils.sensornames.diagnostics import (
     get_last_updated_sensor_entity_id,
-    get_last_updated_sensor_name,
     get_last_updated_sensor_unique_id,
 )
 
@@ -50,6 +49,7 @@ class HSEMLastUpdatedSensor(
 
     _attr_icon = "mdi:clock-check-outline"
     _attr_has_entity_name = True
+    _attr_translation_key = "last_updated"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
@@ -70,19 +70,12 @@ class HSEMLastUpdatedSensor(
 
         self._attr_unique_id = get_last_updated_sensor_unique_id(config_entry.entry_id)
         self.entity_id = get_last_updated_sensor_entity_id()
-        self._name = get_last_updated_sensor_name()
 
         self._restored_state: str | None = None
 
     # ------------------------------------------------------------------
     # HA entity properties
     # ------------------------------------------------------------------
-
-    @property
-    @override
-    def name(self) -> str:
-        """Return the display name."""
-        return self._name
 
     @property
     @override

--- a/custom_components/hsem/custom_sensors/missing_entities_sensor.py
+++ b/custom_components/hsem/custom_sensors/missing_entities_sensor.py
@@ -32,7 +32,6 @@ from custom_components.hsem.coordinator import (
 from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
 from custom_components.hsem.utils.sensornames.diagnostics import (
     get_missing_entities_sensor_entity_id,
-    get_missing_entities_sensor_name,
     get_missing_entities_sensor_unique_id,
 )
 
@@ -54,6 +53,7 @@ class HSEMMissingEntitiesSensor(
 
     _attr_icon = "mdi:alert-circle-outline"
     _attr_has_entity_name = True
+    _attr_translation_key = "missing_entities"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_native_unit_of_measurement = None
 
@@ -77,19 +77,12 @@ class HSEMMissingEntitiesSensor(
             config_entry.entry_id
         )
         self.entity_id = get_missing_entities_sensor_entity_id()
-        self._name = get_missing_entities_sensor_name()
 
         self._restored_state: str | None = None
 
     # ------------------------------------------------------------------
     # HA entity properties
     # ------------------------------------------------------------------
-
-    @property
-    @override
-    def name(self) -> str:
-        """Return the display name."""
-        return self._name
 
     @property
     @override

--- a/custom_components/hsem/custom_sensors/net_consumption_sensor.py
+++ b/custom_components/hsem/custom_sensors/net_consumption_sensor.py
@@ -37,7 +37,6 @@ from custom_components.hsem.coordinator import (
 from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
 from custom_components.hsem.utils.sensornames.diagnostics import (
     get_net_consumption_sensor_entity_id,
-    get_net_consumption_sensor_name,
     get_net_consumption_sensor_unique_id,
 )
 
@@ -60,6 +59,7 @@ class HSEMNetConsumptionSensor(
 
     _attr_icon = "mdi:home-lightning-bolt-outline"
     _attr_has_entity_name = True
+    _attr_translation_key = "net_consumption"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_device_class = SensorDeviceClass.POWER
     _attr_native_unit_of_measurement = UnitOfPower.WATT
@@ -85,19 +85,12 @@ class HSEMNetConsumptionSensor(
             config_entry.entry_id
         )
         self.entity_id = get_net_consumption_sensor_entity_id()
-        self._name = get_net_consumption_sensor_name()
 
         self._restored_state: str | None = None
 
     # ------------------------------------------------------------------
     # HA entity properties
     # ------------------------------------------------------------------
-
-    @property
-    @override
-    def name(self) -> str:
-        """Return the display name."""
-        return self._name
 
     @property
     @override

--- a/custom_components/hsem/custom_sensors/next_update_sensor.py
+++ b/custom_components/hsem/custom_sensors/next_update_sensor.py
@@ -28,7 +28,6 @@ from custom_components.hsem.coordinator import (
 from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
 from custom_components.hsem.utils.sensornames.diagnostics import (
     get_next_update_sensor_entity_id,
-    get_next_update_sensor_name,
     get_next_update_sensor_unique_id,
 )
 
@@ -50,6 +49,7 @@ class HSEMNextUpdateSensor(
 
     _attr_icon = "mdi:clock-outline"
     _attr_has_entity_name = True
+    _attr_translation_key = "next_update"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
@@ -70,19 +70,12 @@ class HSEMNextUpdateSensor(
 
         self._attr_unique_id = get_next_update_sensor_unique_id(config_entry.entry_id)
         self.entity_id = get_next_update_sensor_entity_id()
-        self._name = get_next_update_sensor_name()
 
         self._restored_state: str | None = None
 
     # ------------------------------------------------------------------
     # HA entity properties
     # ------------------------------------------------------------------
-
-    @property
-    @override
-    def name(self) -> str:
-        """Return the display name."""
-        return self._name
 
     @property
     @override

--- a/custom_components/hsem/custom_sensors/ocpp_sensors.py
+++ b/custom_components/hsem/custom_sensors/ocpp_sensors.py
@@ -39,16 +39,12 @@ from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
 from custom_components.hsem.models.sensor_config import SensorConfig
 from custom_components.hsem.utils.sensornames.ocpp import (
     get_ocpp_charger_info_sensor_entity_id,
-    get_ocpp_charger_info_sensor_name,
     get_ocpp_charger_info_sensor_unique_id,
     get_ocpp_charger_power_sensor_entity_id,
-    get_ocpp_charger_power_sensor_name,
     get_ocpp_charger_power_sensor_unique_id,
     get_ocpp_charger_sessions_sensor_entity_id,
-    get_ocpp_charger_sessions_sensor_name,
     get_ocpp_charger_sessions_sensor_unique_id,
     get_ocpp_charger_status_sensor_entity_id,
-    get_ocpp_charger_status_sensor_name,
     get_ocpp_charger_status_sensor_unique_id,
 )
 
@@ -203,14 +199,12 @@ class HSEMOCPPChargerStatusSensor(
         self.entity_id = get_ocpp_charger_status_sensor_entity_id(
             charger_index=charger_index
         )
-        self._name = get_ocpp_charger_status_sensor_name(charger_index)
+        self._attr_translation_key = (
+            "ocpp_charger_status"
+            if charger_index == 1
+            else "ocpp_second_charger_status"
+        )
         self._restored_state: str | None = None
-
-    @property
-    @override
-    def name(self) -> str:
-        """Return the display name."""
-        return self._name
 
     @property
     @override
@@ -355,14 +349,10 @@ class HSEMOCPPChargerPowerSensor(
         self.entity_id = get_ocpp_charger_power_sensor_entity_id(
             charger_index=charger_index
         )
-        self._name = get_ocpp_charger_power_sensor_name(charger_index)
+        self._attr_translation_key = (
+            "ocpp_charger_power" if charger_index == 1 else "ocpp_second_charger_power"
+        )
         self._restored_state: str | None = None
-
-    @property
-    @override
-    def name(self) -> str:
-        """Return the display name."""
-        return self._name
 
     @property
     @override
@@ -451,14 +441,10 @@ class HSEMOCPPChargerInfoSensor(
         self.entity_id = get_ocpp_charger_info_sensor_entity_id(
             charger_index=charger_index
         )
-        self._name = get_ocpp_charger_info_sensor_name(charger_index)
+        self._attr_translation_key = (
+            "ocpp_charger_info" if charger_index == 1 else "ocpp_second_charger_info"
+        )
         self._restored_state: str | None = None
-
-    @property
-    @override
-    def name(self) -> str:
-        """Return the display name."""
-        return self._name
 
     @property
     @override
@@ -565,14 +551,12 @@ class HSEMOCPPChargerSessionsSensor(
         self.entity_id = get_ocpp_charger_sessions_sensor_entity_id(
             charger_index=charger_index
         )
-        self._name = get_ocpp_charger_sessions_sensor_name(charger_index)
+        self._attr_translation_key = (
+            "ocpp_charger_sessions"
+            if charger_index == 1
+            else "ocpp_second_charger_sessions"
+        )
         self._restored_state: str | None = None
-
-    @property
-    @override
-    def name(self) -> str:
-        """Return the display name."""
-        return self._name
 
     @property
     @override

--- a/custom_components/hsem/custom_sensors/plan_explanation_sensor.py
+++ b/custom_components/hsem/custom_sensors/plan_explanation_sensor.py
@@ -56,7 +56,6 @@ from custom_components.hsem.models.plan_explanation import PlanExplanation
 from custom_components.hsem.utils.datetime_utils import now as hsem_now
 from custom_components.hsem.utils.sensornames.diagnostics import (
     get_plan_explanation_sensor_entity_id,
-    get_plan_explanation_sensor_name,
     get_plan_explanation_sensor_unique_id,
 )
 
@@ -91,6 +90,7 @@ class HSEMPlanExplanationSensor(
 
     _attr_icon = "mdi:chart-gantt"
     _attr_has_entity_name = True
+    _attr_translation_key = "plan_explanation"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
@@ -112,7 +112,6 @@ class HSEMPlanExplanationSensor(
             config_entry.entry_id
         )
         self.entity_id = get_plan_explanation_sensor_entity_id()
-        self._name = get_plan_explanation_sensor_name()
 
         # Restored state used before the first coordinator cycle completes.
         self._restored_state: str | None = None
@@ -120,12 +119,6 @@ class HSEMPlanExplanationSensor(
     # ------------------------------------------------------------------
     # HA entity properties
     # ------------------------------------------------------------------
-
-    @property
-    @override
-    def name(self) -> str:
-        """Return the display name."""
-        return self._name
 
     @property
     @override

--- a/custom_components/hsem/custom_sensors/prediction_accuracy_sensor.py
+++ b/custom_components/hsem/custom_sensors/prediction_accuracy_sensor.py
@@ -30,7 +30,6 @@ from custom_components.hsem.coordinator import HSEMDataUpdateCoordinator
 from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
 from custom_components.hsem.utils.sensornames.diagnostics import (
     get_prediction_accuracy_sensor_entity_id,
-    get_prediction_accuracy_sensor_name,
     get_prediction_accuracy_sensor_unique_id,
 )
 
@@ -50,6 +49,7 @@ class HSEMPredictionAccuracySensor(
 
     _attr_icon = "mdi:target"
     _attr_has_entity_name = True
+    _attr_translation_key = "prediction_accuracy"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
@@ -68,7 +68,6 @@ class HSEMPredictionAccuracySensor(
         self._attr_unique_id = get_prediction_accuracy_sensor_unique_id(
             config_entry.entry_id
         )
-        self._attr_name = get_prediction_accuracy_sensor_name()
         self.entity_id = get_prediction_accuracy_sensor_entity_id()
         self._restored_state: str | None = None
 

--- a/custom_components/hsem/custom_sensors/pv_curtailment_sensor.py
+++ b/custom_components/hsem/custom_sensors/pv_curtailment_sensor.py
@@ -33,7 +33,6 @@ from custom_components.hsem.coordinator import (
 from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
 from custom_components.hsem.utils.sensornames.diagnostics import (
     get_pv_curtailment_sensor_entity_id,
-    get_pv_curtailment_sensor_name,
     get_pv_curtailment_sensor_unique_id,
 )
 
@@ -74,6 +73,7 @@ class HSEMPVTailedSensor(
 
     _attr_icon = "mdi:solar-power"
     _attr_has_entity_name = True
+    _attr_translation_key = "pv_curtailment"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
@@ -96,7 +96,6 @@ class HSEMPVTailedSensor(
             config_entry.entry_id
         )
         self.entity_id = get_pv_curtailment_sensor_entity_id()
-        self._name = get_pv_curtailment_sensor_name()
 
         # Restored state used before the first coordinator cycle completes.
         self._restored_state: str | None = None
@@ -104,12 +103,6 @@ class HSEMPVTailedSensor(
     # ------------------------------------------------------------------
     # HA entity properties
     # ------------------------------------------------------------------
-
-    @property
-    @override
-    def name(self) -> str:
-        """Return the display name."""
-        return self._name
 
     @property
     @override

--- a/custom_components/hsem/custom_sensors/read_only_sensor.py
+++ b/custom_components/hsem/custom_sensors/read_only_sensor.py
@@ -31,7 +31,6 @@ from custom_components.hsem.coordinator import (
 from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
 from custom_components.hsem.utils.sensornames.diagnostics import (
     get_read_only_sensor_entity_id,
-    get_read_only_sensor_name,
     get_read_only_sensor_unique_id,
 )
 
@@ -76,7 +75,6 @@ class HSEMReadOnlySensor(
 
         self._attr_unique_id = get_read_only_sensor_unique_id(config_entry.entry_id)
         self.entity_id = get_read_only_sensor_entity_id()
-        self._name = get_read_only_sensor_name()
 
         # Restored state used before the first coordinator cycle completes.
         self._restored_state: str | None = None
@@ -84,12 +82,6 @@ class HSEMReadOnlySensor(
     # ------------------------------------------------------------------
     # HA entity properties
     # ------------------------------------------------------------------
-
-    @property
-    @override
-    def name(self) -> str:
-        """Return the display name."""
-        return self._name
 
     @property
     @override

--- a/custom_components/hsem/custom_sensors/recommendation_interval_sensor.py
+++ b/custom_components/hsem/custom_sensors/recommendation_interval_sensor.py
@@ -38,7 +38,6 @@ from custom_components.hsem.coordinator import (
 from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
 from custom_components.hsem.utils.sensornames.diagnostics import (
     get_recommendation_interval_sensor_entity_id,
-    get_recommendation_interval_sensor_name,
     get_recommendation_interval_sensor_unique_id,
 )
 
@@ -60,6 +59,7 @@ class HSEMRecommendationIntervalSensor(
 
     _attr_icon = "mdi:calendar-clock"
     _attr_has_entity_name = True
+    _attr_translation_key = "recommendation_interval"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_native_unit_of_measurement = UnitOfTime.MINUTES
     _attr_suggested_display_precision = 0
@@ -84,19 +84,12 @@ class HSEMRecommendationIntervalSensor(
             config_entry.entry_id
         )
         self.entity_id = get_recommendation_interval_sensor_entity_id()
-        self._name = get_recommendation_interval_sensor_name()
 
         self._restored_state: str | None = None
 
     # ------------------------------------------------------------------
     # HA entity properties
     # ------------------------------------------------------------------
-
-    @property
-    @override
-    def name(self) -> str:
-        """Return the display name."""
-        return self._name
 
     @property
     @override

--- a/custom_components/hsem/custom_sensors/savings_sensor.py
+++ b/custom_components/hsem/custom_sensors/savings_sensor.py
@@ -39,7 +39,6 @@ from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
 from custom_components.hsem.models.savings_tracker import SavingsTracker
 from custom_components.hsem.utils.sensornames.diagnostics import (
     get_savings_tracker_sensor_entity_id,
-    get_savings_tracker_sensor_name,
     get_savings_tracker_sensor_unique_id,
 )
 
@@ -58,6 +57,7 @@ class HSEMSavingsSensor(
 
     _attr_icon = "mdi:cash-plus"
     _attr_has_entity_name = True
+    _attr_translation_key = "savings_tracker"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_device_class = SensorDeviceClass.MONETARY
     _attr_state_class = SensorStateClass.TOTAL
@@ -78,7 +78,6 @@ class HSEMSavingsSensor(
         self._attr_unique_id = get_savings_tracker_sensor_unique_id(
             config_entry.entry_id
         )
-        self._attr_name = get_savings_tracker_sensor_name()
         self.entity_id = get_savings_tracker_sensor_entity_id()
 
         self._restored_state: str | None = None

--- a/custom_components/hsem/custom_sensors/solar_confidence_sensor.py
+++ b/custom_components/hsem/custom_sensors/solar_confidence_sensor.py
@@ -37,7 +37,6 @@ from custom_components.hsem.utils.logger import HSEM_LOGGER as _LOGGER
 from custom_components.hsem.utils.persistence import finite_float
 from custom_components.hsem.utils.sensornames.diagnostics import (
     get_solar_confidence_sensor_entity_id,
-    get_solar_confidence_sensor_name,
     get_solar_confidence_sensor_unique_id,
 )
 from custom_components.hsem.utils.solar_corrector import SolarForecastCorrector
@@ -57,6 +56,7 @@ class HSEMSolarConfidenceSensor(
 
     _attr_icon = "mdi:solar-power"
     _attr_has_entity_name = True
+    _attr_translation_key = "solar_confidence"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
@@ -75,7 +75,6 @@ class HSEMSolarConfidenceSensor(
         self._attr_unique_id = get_solar_confidence_sensor_unique_id(
             config_entry.entry_id
         )
-        self._attr_name = get_solar_confidence_sensor_name()
         self.entity_id = get_solar_confidence_sensor_entity_id()
         self._restored_state: str | None = None
 

--- a/custom_components/hsem/custom_sensors/update_interval_sensor.py
+++ b/custom_components/hsem/custom_sensors/update_interval_sensor.py
@@ -34,7 +34,6 @@ from custom_components.hsem.coordinator import (
 from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
 from custom_components.hsem.utils.sensornames.diagnostics import (
     get_update_interval_sensor_entity_id,
-    get_update_interval_sensor_name,
     get_update_interval_sensor_unique_id,
 )
 
@@ -57,6 +56,7 @@ class HSEMUpdateIntervalSensor(
 
     _attr_icon = "mdi:timer-outline"
     _attr_has_entity_name = True
+    _attr_translation_key = "update_interval"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_native_unit_of_measurement = UnitOfTime.MINUTES
     _attr_suggested_display_precision = 0
@@ -81,19 +81,12 @@ class HSEMUpdateIntervalSensor(
             config_entry.entry_id
         )
         self.entity_id = get_update_interval_sensor_entity_id()
-        self._name = get_update_interval_sensor_name()
 
         self._restored_state: str | None = None
 
     # ------------------------------------------------------------------
     # HA entity properties
     # ------------------------------------------------------------------
-
-    @property
-    @override
-    def name(self) -> str:
-        """Return the display name."""
-        return self._name
 
     @property
     @override

--- a/custom_components/hsem/custom_sensors/working_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/working_mode_sensor.py
@@ -51,7 +51,6 @@ from custom_components.hsem.utils.misc import (
 from custom_components.hsem.utils.recommendations import Recommendations
 from custom_components.hsem.utils.sensornames.diagnostics import (
     get_working_mode_sensor_entity_id,
-    get_working_mode_sensor_name,
     get_working_mode_sensor_unique_id,
 )
 
@@ -105,7 +104,6 @@ class HSEMWorkingModeSensor(
 
         self._attr_unique_id = get_working_mode_sensor_unique_id(config_entry.entry_id)
         self.entity_id = get_working_mode_sensor_entity_id()
-        self._name = get_working_mode_sensor_name()
 
         # Tracks the latest background update task so it can be cancelled on
         # unload.  Only the most-recent task is retained; prior tasks will
@@ -126,12 +124,6 @@ class HSEMWorkingModeSensor(
     # ------------------------------------------------------------------
     # HA entity properties
     # ------------------------------------------------------------------
-
-    @property
-    @override
-    def name(self) -> str:
-        """Return the display name."""
-        return self._name
 
     @property
     @override

--- a/custom_components/hsem/translations/da.json
+++ b/custom_components/hsem/translations/da.json
@@ -23,19 +23,23 @@
       "price_out_of_range": "Prisværdien er uden for det tilladte område.",
       "required": "Dette felt er påkrævet.",
       "start_time_after_end_time": "Starttidspunkt skal være før sluttidspunkt.",
-      "start_time_equals_end_time": "Starttidspunkt og sluttidspunkt kan ikke være ens - dette skaber et nul-længdevindue. Deaktiver tidsplanen i stedet."
+      "start_time_equals_end_time": "Starttidspunkt og sluttidspunkt kan ikke være ens - dette skaber et nul-længdevindue. Deaktiver tidsplanen i stedet.",
+      "invalid_wait_mode_behavior": "Ugyldig ventetilstand. Vælg Streng ventetilstand eller Selvforbrug med reserve.",
+      "port_conflict": "Den anden OCPP-port skal være forskellig fra den første OCPP-port."
     },
     "step": {
       "batteries_excess_export": {
         "data": {
           "hsem_batteries_enable_excess_export": "Aktiver overskuds-eksport",
           "hsem_batteries_excess_export_discharge_buffer": "Afladningsbuffer (%)",
-          "hsem_batteries_export_min_price": "Batterieksport Min. Pris"
+          "hsem_batteries_export_min_price": "Batterieksport Min. Pris",
+          "hsem_batteries_forecast_reserve_pct": "Batteri eksportprognose-reserve (+% SoC)"
         },
         "data_description": {
           "hsem_batteries_enable_excess_export": "Aktiver eller deaktiver eksport af overskydende batterikapacitet til nettet, når det er økonomisk fordelagtigt.",
           "hsem_batteries_excess_export_discharge_buffer": "Indstil sikkerhedsbufferprocenten for at opretholde minimum batterireserver (0-50%). Standard er 10% for at sikre tilstrækkelig kapacitet til uventet efterspørgsel.",
-          "hsem_batteries_export_min_price": "Hårdt prægulv per slot for tilsigtet batteri-til-net eksport (issue #752). Når værdien > 0, forbyder HSEM at markere et slot som force_batteries_discharge når eksportprisen er strengt under dette gulv — batteriet kan stadig betjene husforbruget i disse slots. At nå tærsklen udløser IKKE automatisk eksport; optimizeren bestemmer stadig, om salg er økonomisk fordelagtigt. Gælder kun for tilsigtet batteri-til-net eksport, ikke for normalt selvforbrug, PV-eksport eller PV-opladning. Sæt til 0 for at deaktivere (standard)."
+          "hsem_batteries_export_min_price": "Hårdt prægulv per slot for tilsigtet batteri-til-net eksport (issue #752). Når værdien > 0, forbyder HSEM at markere et slot som force_batteries_discharge når eksportprisen er strengt under dette gulv — batteriet kan stadig betjene husforbruget i disse slots. At nå tærsklen udløser IKKE automatisk eksport; optimizeren bestemmer stadig, om salg er økonomisk fordelagtigt. Gælder kun for tilsigtet batteri-til-net eksport, ikke for normalt selvforbrug, PV-eksport eller PV-opladning. Sæt til 0 for at deaktivere (standard).",
+          "hsem_batteries_forecast_reserve_pct": "Ekstra SoC-procentpoint over Huaweis afladningsstop-grænse, som bevidst batterieksport skal efterlade umiddelbart efter hvert eksportinterval. For eksempel beskytter en Huawei-grænse på 15 % plus en 5 % reserve 20 % SoC. Reserven forbliver tilgængelig til husforbrug, når det faktiske forbrug overstiger prognosen. Sæt til 0 for at deaktivere (standard)."
         },
         "description": "Konfigurer indstillinger for eksport af overskydende batterikapacitet til nettet, når det er økonomisk fordelagtigt.",
         "title": "Overskuds-eksport"
@@ -49,7 +53,8 @@
           "hsem_ev_planned_load_charger_min_power_w": "EV lader minimumseffekt (W)",
           "hsem_ev_planned_load_deadline_safety_margin_pct": "Sikkerhedsmargin til deadline (%)",
           "hsem_ev_planned_load_command_deadband_a": "Dødbånd for loft (A)",
-          "hsem_ev_planned_load_stub_floor_minutes": "Undertryk stop sidst i interval (min)"
+          "hsem_ev_planned_load_stub_floor_minutes": "Undertryk stop sidst i interval (min)",
+          "hsem_ev_planned_load_charger_phase_topology": "Laderens fasetopologi"
         },
         "data_description": {
           "hsem_ev_planned_load_enabled": "Aktiver eller deaktiver planlagt EV-opladningsbelastningsintegration.",
@@ -59,7 +64,8 @@
           "hsem_ev_planned_load_charger_min_power_w": "Minimum AC-effekt (W) som EV-laderen skal bruge for at starte opladning. Under dette niveau vil laderen ikke fungere. Standard: 1380 W (230 V × 6 A).",
           "hsem_ev_planned_load_deadline_safety_margin_pct": "Ekstra energi budgetteret ud over mål-SoC, som en procentdel af manglen, så normal opladningsfriktion (startforsinkelser, minimumseffektgrænser, gennemtvinget reduktion) ikke får deadline til at blive overskredet. Standard: 0% (deaktiveret).",
           "hsem_ev_planned_load_command_deadband_a": "Mindste sænkning af det offentliggjorte ladeloft, der faktisk gennemføres. Mindre sænkninger holdes, fordi konkurrerende hele-ampere-planer typisk ligger inden for en afrundingsfejl af hinanden på pris. En hævning af loftet forsinkes aldrig, og en sænkning, der forbedrer dette intervals ladeomkostning med mere end 5 %, slipper altid igennem. Standard: 3 A; 0 deaktiverer.",
-          "hsem_ev_planned_load_stub_floor_minutes": "Undertryk en stop-kommando i så mange minutter sidst i et interval, mens bilen stadig mangler energi. De sidste sekunder kan ikke rumme nok energi til at nå laderens minimum, så planen tildeler dem ingenting, og ladningen ville stoppe og starte igen uden gevinst. Standard: 2 minutter; 0 deaktiverer."
+          "hsem_ev_planned_load_stub_floor_minutes": "Undertryk en stop-kommando i så mange minutter sidst i et interval, mens bilen stadig mangler energi. De sidste sekunder kan ikke rumme nok energi til at nå laderens minimum, så planen tildeler dem ingenting, og ladningen ville stoppe og starte igen uden gevinst. Standard: 2 minutter; 0 deaktiverer.",
+          "hsem_ev_planned_load_charger_phase_topology": "Hvordan laderen fordeler sin belastning på forsyningens faser. Vælg 'Enfaset eller ukendt', medmindre du har bekræftet, at laderen trækker balanceret strøm på alle tre faser. Med per-fase-sikringsbeskyttelse aktiveret antager det sikre standardvalg, at hele laderkommandoen kan lande på én fase, hvilket begrænser planlagt opladning til den enfasede sikrings kapacitet."
         },
         "description": "Konfigurer valgfri planlagt EV-opladningsbelastningsintegration. Når aktiveret, tager HSEM højde for kommende EV-opladningsbehov pr. planslot.",
         "title": "EV-planlagt belastningsintegration"
@@ -73,7 +79,8 @@
           "hsem_ev_second_planned_load_charger_min_power_w": "EV 2 lader minimumseffekt (W)",
           "hsem_ev_second_planned_load_deadline_safety_margin_pct": "EV 2 sikkerhedsmargin til deadline (%)",
           "hsem_ev_second_planned_load_command_deadband_a": "EV 2 dødbånd for loft (A)",
-          "hsem_ev_second_planned_load_stub_floor_minutes": "EV 2 undertryk stop sidst i interval (min)"
+          "hsem_ev_second_planned_load_stub_floor_minutes": "EV 2 undertryk stop sidst i interval (min)",
+          "hsem_ev_second_planned_load_charger_phase_topology": "Laderens fasetopologi"
         },
         "data_description": {
           "hsem_ev_second_planned_load_enabled": "Aktiver eller deaktiver planlagt opladningsbelastningsintegration for den anden EV.",
@@ -83,7 +90,8 @@
           "hsem_ev_second_planned_load_charger_min_power_w": "Minimum AC-effekt (W) som den anden EV-lader skal bruge for at starte opladning. Standard: 1380 W (230 V × 6 A).",
           "hsem_ev_second_planned_load_deadline_safety_margin_pct": "Samme som den primære EVs sikkerhedsmargin til deadline, for den anden EV. Standard: 0% (deaktiveret).",
           "hsem_ev_second_planned_load_command_deadband_a": "Samme som den primære EVs dødbånd for loft, for den anden EV. Standard: 3 A; 0 deaktiverer.",
-          "hsem_ev_second_planned_load_stub_floor_minutes": "Samme som den primære EVs undertrykkelse af stop sidst i interval, for den anden EV. Standard: 2 minutter; 0 deaktiverer."
+          "hsem_ev_second_planned_load_stub_floor_minutes": "Samme som den primære EVs undertrykkelse af stop sidst i interval, for den anden EV. Standard: 2 minutter; 0 deaktiverer.",
+          "hsem_ev_second_planned_load_charger_phase_topology": "Hvordan laderen fordeler sin belastning på forsyningens faser. Vælg 'Enfaset eller ukendt', medmindre du har bekræftet, at laderen trækker balanceret strøm på alle tre faser. Med per-fase-sikringsbeskyttelse aktiveret antager det sikre standardvalg, at hele laderkommandoen kan lande på én fase, hvilket begrænser planlagt opladning til den enfasede sikrings kapacitet."
         },
         "description": "Konfigurer valgfri planlagt opladningsbelastningsintegration for den anden EV. Vises kun, når en anden EV-lader er aktiveret.",
         "title": "EV 2-planlagt belastningsintegration"
@@ -210,7 +218,9 @@
           "hsem_huawei_solar_device_id_inverter_1": "Huawei-vekselretter 1 enhed",
           "hsem_huawei_solar_device_id_inverter_2": "Huawei-vekselretter 2 enhed",
           "hsem_huawei_solar_inverter_active_power_control": "Huawei-vekselretter aktiv effektkontrolsensor",
-          "hsem_huawei_solar_batteries_forcible_charge": "Tvungen Opladning"
+          "hsem_huawei_solar_batteries_forcible_charge": "Tvungen Opladning",
+          "hsem_huawei_solar_batteries_charge_discharge_power": "Huawei batteri op-/afladningseffekt-sensor",
+          "hsem_huawei_solar_batteries_grid_charge_maximum_power": "Huawei-batterier maksimal netopladningseffekt (W)"
         },
         "data_description": {
           "hsem_batteries_charge_efficiency": "Angiv batteriets opladningseffektivitet som en procentdel (0-100). Energi lagret i batteriet = inputenergi × denne faktor. Typiske lithium-batterier opnår 95-98%. Standard: 98%.",
@@ -233,7 +243,9 @@
           "hsem_huawei_solar_device_id_inverter_1": "Vælg din primære Huawei-vekselretterenhed.",
           "hsem_huawei_solar_device_id_inverter_2": "Vælg din sekundære Huawei-vekselretterenhed, hvis relevant.",
           "hsem_huawei_solar_inverter_active_power_control": "Vælg den sensor, der styrer aktiv effektudgang for din Huawei-vekselretter.",
-          "hsem_huawei_solar_batteries_forcible_charge": "Vælg sensoren der angiver om tvungen opladning er aktiv."
+          "hsem_huawei_solar_batteries_forcible_charge": "Vælg sensoren der angiver om tvungen opladning er aktiv.",
+          "hsem_huawei_solar_batteries_charge_discharge_power": "Vælg sensoren, der rapporterer den fortegnsbestemte øjeblikkelige batteri op-/afladningseffekt (positiv = opladning, negativ = afladning). Kræves af den live fasebevidste opladningssikkerhedsbegrænser (issue #831) for at fjerne Huaweis eget bidrag fra det live faseøjebliksbillede, før rådighedsmargenen beregnes. Valgfrit — kræves kun når fasebevidst opladning er aktiveret.",
+          "hsem_huawei_solar_batteries_grid_charge_maximum_power": "Vælg tal-enheden, der sætter Huaweis maksimale loft for netopladningseffekt (W). Skrives af den live fasebevidste opladningssikkerhedsbegrænser (issue #831) for at holde netfinansieret opladning under hovedsikringens per-fase-grænse. Valgfrit — kræves kun når fasebevidst opladning er aktiveret."
         },
         "description": "Konfigurer arbejdstilstanden for Huawei-solcellebatterier.",
         "title": "Huawei Solar-sensorer"
@@ -245,7 +257,11 @@
           "hsem_batteries_cycle_cost": "Batteri-cyklusomkostning (pr. kWh)",
           "hsem_batteries_charge_efficiency": "Batteri-opladningseffektivitet (%)",
           "hsem_batteries_discharge_efficiency": "Batteri-afladningseffektivitet (%)",
-          "hsem_batteries_capacity_loss_pct": "Kapacitetstab (%)"
+          "hsem_batteries_capacity_loss_pct": "Kapacitetstab (%)",
+          "hsem_planner_hysteresis_absolute": "Hysterese absolut tærskel",
+          "hsem_planner_hysteresis_enabled": "Hysterese på plan-niveau",
+          "hsem_planner_hysteresis_percentage": "Hysterese procenttærskel (%)",
+          "hsem_planner_window_hysteresis_minutes": "Hysterese-holdetid for vindue (minutter)"
         },
         "data_description": {
           "hsem_batteries_purchase_price": "Indtast den samlede købspris for dit batterisystem. Bruges sammen med forventede cyklusser og brugbar kapacitet til at beregne afskrivningsomkostning pr. kWh.",
@@ -253,7 +269,11 @@
           "hsem_batteries_cycle_cost": "Valgfri ekstra per-kWh-omkostning ved at cykle batteriet (pr. kWh). Tilføjes oven på den automatisk beregnede afskrivningstærskel. Sæt til 0 for kun at stole på afskrivningsbeskyttelsen.",
           "hsem_batteries_charge_efficiency": "Angiv batteriets opladningseffektivitet som en procentdel (0-100). Energi lagret i batteriet = inputenergi × denne faktor. Typiske lithium-batterier opnår 95-98%. Standard: 98%.",
           "hsem_batteries_discharge_efficiency": "Angiv batteriets afladningseffektivitet som en procentdel (0-100). Energi leveret til huset = fjernet batterienergi × denne faktor. Typiske lithium-batterier opnår 95-98%. Standard: 98%.",
-          "hsem_batteries_capacity_loss_pct": "Forventet kapacitetstab ved end-of-life for batteriet (0-100%)."
+          "hsem_batteries_capacity_loss_pct": "Forventet kapacitetstab ved end-of-life for batteriet (0-100%).",
+          "hsem_planner_hysteresis_absolute": "Minimum absolut score-forbedring, der kræves for at skifte til en ny plan. 0,00 deaktiverer den absolutte tærskel. Scoren bruger samme valuta som dine elpriser, så en værdi på 0,01 kræver mindst 1 øre/kWh-ækvivalent forbedring, før der skiftes.",
+          "hsem_planner_hysteresis_enabled": "Når dette er aktiveret, beholder planlæggeren den aktive kandidatplan, medmindre en ny plan forbedrer scoren med mere end de konfigurerede tærskler. Forhindrer svingninger mellem ligestillede strategier.",
+          "hsem_planner_hysteresis_percentage": "Minimum procentvis score-forbedring, der kræves for at skifte til en ny plan. 0 % deaktiverer procenttærsklen. Standard 5 % forhindrer flapning mellem næsten identiske planer.",
+          "hsem_planner_window_hysteresis_minutes": "Minimumstid (minutter), en anbefaling skal fastholdes, før den kan ændres. Forhindrer hurtig veksling som f.eks. ev_smart_charging ↔ batteries_charge_solar. 0 deaktiverer funktionen. Standard 10."
         },
         "description": "Konfigurer batteriøkonomiske parametre, der påvirker afskrivningsberegninger og rundturseffektivitet.",
         "title": "Batteriøkonomi"
@@ -296,14 +316,22 @@
           "hsem_main_fuse_amps": "Hovedsikring (Ampere)",
           "hsem_main_fuse_phases": "Hovedsikringens faseantal",
           "hsem_max_grid_export_power_kw": "Maks. neteksporteffekt (kW)",
-          "hsem_solar_production_power": "Solproduktionseffektsensor"
+          "hsem_solar_production_power": "Solproduktionseffektsensor",
+          "hsem_huawei_solar_power_meter_phase_a_active_power": "Effektmåler fase A aktiv effekt-sensor",
+          "hsem_huawei_solar_power_meter_phase_b_active_power": "Effektmåler fase B aktiv effekt-sensor",
+          "hsem_huawei_solar_power_meter_phase_c_active_power": "Effektmåler fase C aktiv effekt-sensor",
+          "hsem_phase_aware_charging_enabled": "Aktiver live fasebevidst opladningssikkerhedsbegrænser"
         },
         "data_description": {
           "hsem_house_consumption_power": "Vælg den sensor, der måler husets samlede strømforbrug.",
           "hsem_main_fuse_amps": "Husets hovedsikringsstørrelse i ampere (25, 35, osv.).  MILP-optimeringsværktøjet respekterer denne grænse ved planlægning af batteri- og elbilopladning.  Sæt til 0 for at deaktivere.",
           "hsem_main_fuse_phases": "Din elinstallations faseantal.  Enfasede installationer SKAL sættes til 1 — at indstille 3 på en enfaset installation gør sikringsbeskyttelsen 3 gange for slap og giver ingen reel sikkerhedsgrænse.  Standard er 3 (trefaset).",
           "hsem_max_grid_export_power_kw": "Maksimal neteksporteffekt i kW — netoperatørens/inverterens eksportloft for eksportbegrænsede tilslutninger (f.eks. 5 kW).  MILP-planlæggeren planlægger aldrig eksport over denne grænse, så batterieksport og soleksport konkurrerer korrekt om det samme loft.  Sæt til 0 for at deaktivere.",
-          "hsem_solar_production_power": "Vælg den sensor, der måler strømmen genereret af dine solpaneler."
+          "hsem_solar_production_power": "Vælg den sensor, der måler strømmen genereret af dine solpaneler.",
+          "hsem_huawei_solar_power_meter_phase_a_active_power": "Vælg sensoren, der måler live aktiv effekt på fase A af din Huawei-effektmåler. Kræves kun når fasebevidst opladning er aktiveret.",
+          "hsem_huawei_solar_power_meter_phase_b_active_power": "Vælg sensoren, der måler live aktiv effekt på fase B af din Huawei-effektmåler. Kræves kun når fasebevidst opladning er aktiveret.",
+          "hsem_huawei_solar_power_meter_phase_c_active_power": "Vælg sensoren, der måler live aktiv effekt på fase C af din Huawei-effektmåler. Kræves kun når fasebevidst opladning er aktiveret.",
+          "hsem_phase_aware_charging_enabled": "Aktiver et live sikkerhedstjek umiddelbart før hver Huawei netopladnings-hardwareskrivning (issue #831). Bruger de tre effektmåler-fasesensorer nedenfor samt Huaweis maksimal-netopladningseffekt-enhed (huawei_solar-trinnet) til at begrænse netfinansieret opladning, så den aldrig presser nogen fase over hovedsikringens grænse, selv hvis belastningen ændrede sig efter planen blev løst. Kræver main_fuse_phases = 3 og alle fire enheder konfigureret. Deaktiveret som standard — fuldt bagudkompatibel."
         },
         "description": "Vælg effektsensorer til HSEM.",
         "title": "Effektsensorer"
@@ -444,14 +472,20 @@
           "hsem_ocpp_port": "OCPP Port",
           "hsem_ocpp_cpid": "Ladepunkt ID",
           "hsem_ocpp_start_window_s": "Startvindue (s)",
-          "hsem_ocpp_stop_window_s": "Stopvindue (s)"
+          "hsem_ocpp_stop_window_s": "Stopvindue (s)",
+          "hsem_ocpp_second_cpid": "Andet ladepunkt-ID",
+          "hsem_ocpp_second_enabled": "Aktiver anden OCPP-server",
+          "hsem_ocpp_second_port": "Anden OCPP-port"
         },
         "data_description": {
           "hsem_ocpp_enabled": "Aktiver den indbyggede OCPP 1.6 WebSocket-server til direkte EV-laderstyring. Kun LAN - eksponer ikke porten til internettet.",
           "hsem_ocpp_port": "TCP-port til OCPP WebSocket-serveren. Standard: 9000. Skal være over 1024.",
           "hsem_ocpp_cpid": "Forventet ladepunkt-identifikator for EV-laderen. Lad være tom for at acceptere enhver lader.",
           "hsem_ocpp_start_window_s": "Sekunder med vedvarende overskud før opladning starter. Forhindrer hurtig start-stop cykling. Standard: 60.",
-          "hsem_ocpp_stop_window_s": "Sekunder med vedvarende underskud før opladning stopper. Forhindrer hurtig stop-start cykling. Standard: 180."
+          "hsem_ocpp_stop_window_s": "Sekunder med vedvarende underskud før opladning stopper. Forhindrer hurtig stop-start cykling. Standard: 180.",
+          "hsem_ocpp_second_cpid": "Forventet ladepunkt-identifikator for den anden EV-lader. Lad være tom for at acceptere enhver lader.",
+          "hsem_ocpp_second_enabled": "Aktiver en anden, dedikeret OCPP-server til den anden EV. Kun tilgængelig når planlagt belastning for EV 2 er aktiveret.",
+          "hsem_ocpp_second_port": "TCP-port til den anden OCPP WebSocket-server. Standard: 9001. Skal være forskellig fra den første servers port."
         },
         "description": "Konfigurer den indbyggede OCPP 1.6 server til LAN-kun EV-laderstyring. Når aktiveret, sender HSEM SetChargingProfile-kommandoer direkte til din EV-lader baseret på opladeplanen.",
         "title": "OCPP Server"
@@ -462,7 +496,7 @@
           "working_mode": "Batterier Arbejdstilstand",
           "max_charge_power": "Maks Opladningseffekt",
           "max_discharge_power": "Maks Afladningseffekt",
-          "eod_soc": "End of Discharge SoC",
+          "eod_soc": "Afladningsstop SoC",
           "rated_capacity": "Batterier Nominel Kapacitet",
           "active_power_control": "Aktiv Effektstyring",
           "tou_periods": "TOU Opladning/Afladning Perioder",
@@ -479,7 +513,7 @@
           "working_mode": "Autodetekteret batterier arbejdstilstand enhed.",
           "max_charge_power": "Autodetekteret maksimal opladningseffekt enhed.",
           "max_discharge_power": "Autodetekteret maksimal afladningseffekt enhed.",
-          "eod_soc": "Autodetekteret end of discharge SoC enhed.",
+          "eod_soc": "Autodetekteret afladningsstop SoC-enhed.",
           "rated_capacity": "Autodetekteret batterier nominel kapacitet sensor.",
           "active_power_control": "Autodetekteret inverter aktiv effektstyring sensor.",
           "tou_periods": "Autodetekteret TOU opladning/afladning perioder sensor.",
@@ -516,48 +550,52 @@
       "price_out_of_range": "Prisværdien er uden for det tilladte område.",
       "required": "Dette felt er påkrævet.",
       "start_time_after_end_time": "Starttidspunkt skal være før sluttidspunkt.",
-      "start_time_equals_end_time": "Starttidspunkt og sluttidspunkt kan ikke være ens - dette skaber et nul-længdevindue. Deaktiver tidsplanen i stedet."
+      "start_time_equals_end_time": "Starttidspunkt og sluttidspunkt kan ikke være ens - dette skaber et nul-længdevindue. Deaktiver tidsplanen i stedet.",
+      "invalid_wait_mode_behavior": "Ugyldig ventetilstand. Vælg Streng ventetilstand eller Selvforbrug med reserve.",
+      "port_conflict": "Den anden OCPP-port skal være forskellig fra den første OCPP-port."
     },
     "step": {
       "batteries_excess_export": {
         "data": {
-          "hsem_batteries_enable_excess_export": "Enable Excess Battery Export",
-          "hsem_batteries_excess_export_discharge_buffer": "Discharge Buffer (%)",
-          "hsem_batteries_export_min_price": "Batterieksport Min. Pris"
+          "hsem_batteries_enable_excess_export": "Aktiver overskuds-eksport",
+          "hsem_batteries_excess_export_discharge_buffer": "Afladningsbuffer (%)",
+          "hsem_batteries_export_min_price": "Batterieksport Min. Pris",
+          "hsem_batteries_forecast_reserve_pct": "Batteri eksportprognose-reserve (+% SoC)"
         },
         "data_description": {
-          "hsem_batteries_enable_excess_export": "Enable or disable the excess battery export feature, which automatically exports excess battery capacity to the grid when economically beneficial.",
-          "hsem_batteries_excess_export_discharge_buffer": "Set the safety buffer percentage to maintain minimum battery reserves (0-50%). Default is 10% to ensure adequate capacity for unexpected demand.",
-          "hsem_batteries_export_min_price": "Hårdt prægulv per slot for tilsigtet batteri-til-net eksport (issue #752). Når værdien > 0, forbyder HSEM at markere et slot som force_batteries_discharge når eksportprisen er strengt under dette gulv — batteriet kan stadig betjene husforbruget i disse slots. At nå tærsklen udløser IKKE automatisk eksport; optimizeren bestemmer stadig, om salg er økonomisk fordelagtigt. Gælder kun for tilsigtet batteri-til-net eksport, ikke for normalt selvforbrug, PV-eksport eller PV-opladning. Sæt til 0 for at deaktivere (standard)."
+          "hsem_batteries_enable_excess_export": "Aktiver eller deaktiver eksport af overskydende batterikapacitet til nettet, når det er økonomisk fordelagtigt.",
+          "hsem_batteries_excess_export_discharge_buffer": "Indstil sikkerhedsbufferprocenten for at opretholde minimum batterireserver (0-50%). Standard er 10% for at sikre tilstrækkelig kapacitet til uventet efterspørgsel.",
+          "hsem_batteries_export_min_price": "Hårdt prægulv per slot for tilsigtet batteri-til-net eksport (issue #752). Når værdien > 0, forbyder HSEM at markere et slot som force_batteries_discharge når eksportprisen er strengt under dette gulv — batteriet kan stadig betjene husforbruget i disse slots. At nå tærsklen udløser IKKE automatisk eksport; optimizeren bestemmer stadig, om salg er økonomisk fordelagtigt. Gælder kun for tilsigtet batteri-til-net eksport, ikke for normalt selvforbrug, PV-eksport eller PV-opladning. Sæt til 0 for at deaktivere (standard).",
+          "hsem_batteries_forecast_reserve_pct": "Ekstra SoC-procentpoint over Huaweis afladningsstop-grænse, som bevidst batterieksport skal efterlade umiddelbart efter hvert eksportinterval. For eksempel beskytter en Huawei-grænse på 15 % plus en 5 % reserve 20 % SoC. Reserven forbliver tilgængelig til husforbrug, når det faktiske forbrug overstiger prognosen. Sæt til 0 for at deaktivere (standard)."
         },
-        "description": "Configure excess battery export settings to automatically sell excess energy to the grid when economically beneficial.",
-        "title": "Excess Battery Export"
+        "description": "Konfigurer indstillinger for eksport af overskydende batterikapacitet til nettet, når det er økonomisk fordelagtigt.",
+        "title": "Overskuds-eksport"
       },
       "batteries_schedules": {
         "data": {
-          "hsem_batteries_enable_batteries_schedule_1": "Enable Battery Schedule 1",
-          "hsem_batteries_enable_batteries_schedule_1_end": "Battery Schedule 1 End Time",
-          "hsem_batteries_enable_batteries_schedule_1_start": "Battery Schedule 1 Start Time",
-          "hsem_batteries_enable_batteries_schedule_2": "Enable Battery Schedule 2",
-          "hsem_batteries_enable_batteries_schedule_2_end": "Battery Schedule 2 End Time",
-          "hsem_batteries_enable_batteries_schedule_2_start": "Battery Schedule 2 Start Time",
-          "hsem_batteries_enable_batteries_schedule_3": "Enable Battery Schedule 3",
-          "hsem_batteries_enable_batteries_schedule_3_end": "Battery Schedule 3 End Time",
-          "hsem_batteries_enable_batteries_schedule_3_start": "Battery Schedule 3 Start Time"
+          "hsem_batteries_enable_batteries_schedule_1": "Aktiver batteritidsplan 1",
+          "hsem_batteries_enable_batteries_schedule_1_end": "Batteritidsplan 1 sluttid",
+          "hsem_batteries_enable_batteries_schedule_1_start": "Batteritidsplan 1 starttid",
+          "hsem_batteries_enable_batteries_schedule_2": "Aktiver batteritidsplan 2",
+          "hsem_batteries_enable_batteries_schedule_2_end": "Batteritidsplan 2 sluttid",
+          "hsem_batteries_enable_batteries_schedule_2_start": "Batteritidsplan 2 starttid",
+          "hsem_batteries_enable_batteries_schedule_3": "Aktiver batteritidsplan 3",
+          "hsem_batteries_enable_batteries_schedule_3_end": "Batteritidsplan 3 sluttid",
+          "hsem_batteries_enable_batteries_schedule_3_start": "Batteritidsplan 3 starttid"
         },
         "data_description": {
-          "hsem_batteries_enable_batteries_schedule_1": "Enable or disable the first battery discharge schedule.",
-          "hsem_batteries_enable_batteries_schedule_1_end": "Specify the end time for the first battery discharge schedule.",
-          "hsem_batteries_enable_batteries_schedule_1_start": "Specify the start time for the first battery discharge schedule.",
-          "hsem_batteries_enable_batteries_schedule_2": "Enable or disable the second battery discharge schedule.",
-          "hsem_batteries_enable_batteries_schedule_2_end": "Specify the end time for the second battery discharge schedule.",
-          "hsem_batteries_enable_batteries_schedule_2_start": "Specify the start time for the second battery discharge schedule.",
-          "hsem_batteries_enable_batteries_schedule_3": "Enable or disable the third battery discharge schedule.",
-          "hsem_batteries_enable_batteries_schedule_3_end": "Specify the end time for the third battery discharge schedule.",
-          "hsem_batteries_enable_batteries_schedule_3_start": "Specify the start time for the third battery discharge schedule."
+          "hsem_batteries_enable_batteries_schedule_1": "Aktiver eller deaktiver den første batteri-afladningstidsplan.",
+          "hsem_batteries_enable_batteries_schedule_1_end": "Angiv sluttidspunktet for den første batteri-afladningstidsplan.",
+          "hsem_batteries_enable_batteries_schedule_1_start": "Angiv starttidspunktet for den første batteri-afladningstidsplan.",
+          "hsem_batteries_enable_batteries_schedule_2": "Aktiver eller deaktiver den anden batteri-afladningstidsplan.",
+          "hsem_batteries_enable_batteries_schedule_2_end": "Angiv sluttidspunktet for den anden batteri-afladningstidsplan.",
+          "hsem_batteries_enable_batteries_schedule_2_start": "Angiv starttidspunktet for den anden batteri-afladningstidsplan.",
+          "hsem_batteries_enable_batteries_schedule_3": "Aktiver eller deaktiver den tredje batteri-afladningstidsplan.",
+          "hsem_batteries_enable_batteries_schedule_3_end": "Angiv sluttidspunktet for den tredje batteri-afladningstidsplan.",
+          "hsem_batteries_enable_batteries_schedule_3_start": "Angiv starttidspunktet for den tredje batteri-afladningstidsplan."
         },
-        "description": "Configure up to three battery discharge schedule windows, each with enable/disable toggle, start time, and end time. Schedules define when the battery may discharge to cover peak consumption or export to the grid.",
-        "title": "Battery Discharge Schedules"
+        "description": "Konfigurer op til tre batteri-afladningstidsplaner, hver med til/fra-knap, starttid og sluttid.",
+        "title": "Batteri-afladningstidsplaner"
       },
       "ev_planned_load": {
         "data": {
@@ -565,14 +603,22 @@
           "hsem_ev_planned_load_battery_capacity_kwh": "EV batterikapacitet (kWh)",
           "hsem_ev_planned_load_charger_power_kw": "EV lader-effekt (kW)",
           "hsem_ev_planned_load_charger_efficiency": "EV lader-efficiens",
-          "hsem_ev_planned_load_charger_min_power_w": "EV lader minimumseffekt (W)"
+          "hsem_ev_planned_load_charger_min_power_w": "EV lader minimumseffekt (W)",
+          "hsem_ev_planned_load_charger_phase_topology": "Laderens fasetopologi",
+          "hsem_ev_planned_load_command_deadband_a": "Dødbånd for loft (A)",
+          "hsem_ev_planned_load_deadline_safety_margin_pct": "Sikkerhedsmargin til deadline (%)",
+          "hsem_ev_planned_load_stub_floor_minutes": "Undertryk stop sidst i interval (min)"
         },
         "data_description": {
           "hsem_ev_planned_load_enabled": "Aktiver eller deaktiver planlagt EV-opladningsbelastningsintegration.",
           "hsem_ev_planned_load_battery_capacity_kwh": "EV-batteriets nominelle kapacitet i kWh.",
           "hsem_ev_planned_load_charger_power_kw": "AC-udgangseffekt for EV-laderen i kW.",
           "hsem_ev_planned_load_charger_efficiency": "Laderefficiens i procent (1-100). Standard: 100.",
-          "hsem_ev_planned_load_charger_min_power_w": "Minimum AC-effekt (W) som EV-laderen skal bruge for at starte opladning. Standard: 1380 W (230 V × 6 A)."
+          "hsem_ev_planned_load_charger_min_power_w": "Minimum AC-effekt (W) som EV-laderen skal bruge for at starte opladning. Standard: 1380 W (230 V × 6 A).",
+          "hsem_ev_planned_load_charger_phase_topology": "Hvordan laderen fordeler sin belastning på forsyningens faser. Vælg 'Enfaset eller ukendt', medmindre du har bekræftet, at laderen trækker balanceret strøm på alle tre faser. Med per-fase-sikringsbeskyttelse aktiveret antager det sikre standardvalg, at hele laderkommandoen kan lande på én fase, hvilket begrænser planlagt opladning til den enfasede sikrings kapacitet.",
+          "hsem_ev_planned_load_command_deadband_a": "Mindste sænkning af det offentliggjorte ladeloft, der faktisk gennemføres. Mindre sænkninger holdes, fordi konkurrerende hele-ampere-planer typisk ligger inden for en afrundingsfejl af hinanden på pris. En hævning af loftet forsinkes aldrig, og en sænkning, der forbedrer dette intervals ladeomkostning med mere end 5 %, slipper altid igennem. Standard: 3 A; 0 deaktiverer.",
+          "hsem_ev_planned_load_deadline_safety_margin_pct": "Ekstra energi budgetteret ud over mål-SoC, som en procentdel af manglen, så normal opladningsfriktion (startforsinkelser, minimumseffektgrænser, gennemtvinget reduktion) ikke får deadline til at blive overskredet. Standard: 0% (deaktiveret).",
+          "hsem_ev_planned_load_stub_floor_minutes": "Undertryk en stop-kommando i så mange minutter sidst i et interval, mens bilen stadig mangler energi. De sidste sekunder kan ikke rumme nok energi til at nå laderens minimum, så planen tildeler dem ingenting, og ladningen ville stoppe og starte igen uden gevinst. Standard: 2 minutter; 0 deaktiverer."
         },
         "description": "Konfigurer valgfri planlagt EV-opladningsbelastningsintegration. Når aktiveret, tager HSEM højde for kommende EV-opladningsbehov pr. planslot.",
         "title": "EV-planlagt belastningsintegration"
@@ -586,7 +632,8 @@
           "hsem_ev_second_planned_load_charger_min_power_w": "EV 2 lader minimumseffekt (W)",
           "hsem_ev_second_planned_load_deadline_safety_margin_pct": "EV 2 sikkerhedsmargin til deadline (%)",
           "hsem_ev_second_planned_load_command_deadband_a": "EV 2 dødbånd for loft (A)",
-          "hsem_ev_second_planned_load_stub_floor_minutes": "EV 2 undertryk stop sidst i interval (min)"
+          "hsem_ev_second_planned_load_stub_floor_minutes": "EV 2 undertryk stop sidst i interval (min)",
+          "hsem_ev_second_planned_load_charger_phase_topology": "Laderens fasetopologi"
         },
         "data_description": {
           "hsem_ev_second_planned_load_enabled": "Aktiver eller deaktiver planlagt opladningsbelastningsintegration for den anden EV.",
@@ -596,214 +643,227 @@
           "hsem_ev_second_planned_load_charger_min_power_w": "Minimum AC-effekt (W) som den anden EV-lader skal bruge for at starte opladning. Standard: 1380 W (230 V × 6 A).",
           "hsem_ev_second_planned_load_deadline_safety_margin_pct": "Samme som den primære EVs sikkerhedsmargin til deadline, for den anden EV. Standard: 0% (deaktiveret).",
           "hsem_ev_second_planned_load_command_deadband_a": "Samme som den primære EVs dødbånd for loft, for den anden EV. Standard: 3 A; 0 deaktiverer.",
-          "hsem_ev_second_planned_load_stub_floor_minutes": "Samme som den primære EVs undertrykkelse af stop sidst i interval, for den anden EV. Standard: 2 minutter; 0 deaktiverer."
+          "hsem_ev_second_planned_load_stub_floor_minutes": "Samme som den primære EVs undertrykkelse af stop sidst i interval, for den anden EV. Standard: 2 minutter; 0 deaktiverer.",
+          "hsem_ev_second_planned_load_charger_phase_topology": "Hvordan laderen fordeler sin belastning på forsyningens faser. Vælg 'Enfaset eller ukendt', medmindre du har bekræftet, at laderen trækker balanceret strøm på alle tre faser. Med per-fase-sikringsbeskyttelse aktiveret antager det sikre standardvalg, at hele laderkommandoen kan lande på én fase, hvilket begrænser planlagt opladning til den enfasede sikrings kapacitet."
         },
         "description": "Konfigurer valgfri planlagt opladningsbelastningsintegration for den anden EV. Vises kun, når en anden EV-lader er aktiveret.",
         "title": "EV 2-planlagt belastningsintegration"
       },
       "prices": {
         "data": {
-          "hsem_import_electricity_price_sensor": "Import Electricity Price Sensor",
-          "hsem_export_electricity_price_sensor": "Export Electricity Price Sensor",
-          "hsem_import_electricity_price_forecast_sensor": "Import Electricity Price Forecast Sensor (optional)",
-          "hsem_export_electricity_price_forecast_sensor": "Export Electricity Price Forecast Sensor (optional)",
-          "hsem_export_electricity_min_price": "Export Minimum Price Required",
-          "hsem_electricity_price_update_interval": "Electricity Price Update Interval (minutes)"
+          "hsem_import_electricity_price_sensor": "Import-elprissensor",
+          "hsem_export_electricity_price_sensor": "Eksport-elprissensor",
+          "hsem_import_electricity_price_forecast_sensor": "Import-elprisprognose-sensor (valgfri)",
+          "hsem_export_electricity_price_forecast_sensor": "Eksport-elprisprognose-sensor (valgfri)",
+          "hsem_export_electricity_min_price": "Minimum eksportpris påkrævet",
+          "hsem_electricity_price_update_interval": "Elpris opdateringsinterval (minutter)"
         },
         "data_description": {
-          "hsem_import_electricity_price_sensor": "Select the sensor that provides import electricity prices (e.g. Energi Data Service, Nordpool, Amber Electric).",
-          "hsem_export_electricity_price_sensor": "Select the sensor that provides export electricity prices.",
-          "hsem_import_electricity_price_forecast_sensor": "Optional: select a separate sensor for import price forecasts (used by Amber Electric and similar integrations).",
-          "hsem_export_electricity_price_forecast_sensor": "Optional: select a separate sensor for export price forecasts.",
-          "hsem_export_electricity_min_price": "Set the minimum export price. Exports below this price will be blocked.",
-          "hsem_electricity_price_update_interval": "How often your price sensor provides new data (15, 30, or 60 minutes)."
+          "hsem_import_electricity_price_sensor": "Vælg den sensor, der leverer import-elpriser (f.eks. Energi Data Service, Nordpool, Amber Electric).",
+          "hsem_export_electricity_price_sensor": "Vælg den sensor, der leverer eksport-elpriser.",
+          "hsem_import_electricity_price_forecast_sensor": "Valgfrit: vælg en separat sensor til importprisprognoser (bruges af Amber Electric og lignende integrationer).",
+          "hsem_export_electricity_price_forecast_sensor": "Valgfrit: vælg en separat sensor til eksportprisprognoser.",
+          "hsem_export_electricity_min_price": "Indstil minimumsprisen for eksport. Eksport under denne pris blokeres.",
+          "hsem_electricity_price_update_interval": "Hvor ofte din prissensor giver nye data (15, 30 eller 60 minutter)."
         },
-        "description": "Configure your electricity price sensors for import and export pricing.",
-        "title": "Electricity Prices"
+        "description": "Konfigurer dine elprissensorer til import- og eksportpriser.",
+        "title": "Elpriser"
       },
       "ev": {
         "data": {
-          "hsem_ev_allow_charge_past_target_soc": "Allow Charging Past Target SoC (Advanced)",
-          "hsem_ev_charger_force_max_discharge_power": "EV Charger Force Max Discharge Power",
-          "hsem_ev_charger_max_discharge_power": "EV Charger Max Discharge Power",
-          "hsem_ev_charger_power": "EV Charger Power Sensor",
-          "hsem_ev_charger_status": "EV Charger Status Sensor",
-          "hsem_ev_connected": "EV Connected Sensor",
-          "hsem_ev_second_enabled": "Enable Second EV Charger",
-          "hsem_ev_soc": "EV State of Charge (SoC) Sensor",
-          "hsem_house_power_includes_ev_charger_power": "House Power Includes EV Charger Power",
+          "hsem_ev_allow_charge_past_target_soc": "Tillad opladning ud over mål-SoC (Avanceret)",
+          "hsem_ev_charger_force_max_discharge_power": "EV-lader tving maks. afladningseffekt",
+          "hsem_ev_charger_max_discharge_power": "EV-lader maks. afladningseffekt",
+          "hsem_ev_charger_power": "EV-lader effektsensor",
+          "hsem_ev_charger_status": "EV-lader statussensor",
+          "hsem_ev_connected": "EV tilsluttet sensor",
+          "hsem_ev_second_enabled": "Aktiver anden EV-lader",
+          "hsem_ev_soc": "EV ladetilstand (SoC) sensor",
+          "hsem_house_power_includes_ev_charger_power": "Husets effekt inkluderer EV-ladereffekt",
           "hsem_ev_auto_full_negative_price": "Auto-Fuld EV ved negativ pris",
           "hsem_ev_past_target_confidence_factor": "EV opladning ud over mål-SoC - Konfidensfaktor (Avanceret)"
         },
         "data_description": {
-          "hsem_ev_allow_charge_past_target_soc": "Enable this option if you want to allow the system to continue charging the EV battery even after it has reached the target state of charge (SoC). This can be useful in scenarios where you want to ensure the EV is fully charged regardless of the target setting.",
-          "hsem_ev_charger_force_max_discharge_power": "Enable this if you want to force a specific maximum discharge power for the Huawei batteries while EV is charging.",
-          "hsem_ev_charger_max_discharge_power": "Set the maximum discharge power for the Huawei batteries while EV is charging.",
-          "hsem_ev_charger_power": "Select the sensor that measures the power consumption of your EV charger.",
-          "hsem_ev_charger_status": "Select the sensor or entity that indicates whether the EV charger is active (e.g., a switch or sensor).",
-          "hsem_ev_connected": "Select the sensor or entity that indicates whether the EV is connected to the charger.",
-          "hsem_ev_second_enabled": "Enable or disable the configuration for a second EV charger.",
-          "hsem_ev_soc": "Select the sensor that provides the current state of charge (SoC) of your EV battery.",
-          "hsem_house_power_includes_ev_charger_power": "Enable this if the house consumption power sensor already includes the EV charger power consumption.",
+          "hsem_ev_allow_charge_past_target_soc": "Aktiver denne mulighed, hvis du vil tillade systemet at fortsætte opladningen af EV-batteriet, selv efter det har nået mål-ladetilstanden (SoC).",
+          "hsem_ev_charger_force_max_discharge_power": "Aktiver dette, hvis du vil tvinge en specifik maks. afladningseffekt for Huawei-batterierne, mens EV oplader.",
+          "hsem_ev_charger_max_discharge_power": "Indstil den maksimale afladningseffekt for Huawei-batterierne, mens EV oplader.",
+          "hsem_ev_charger_power": "Vælg den sensor, der måler strømforbruget for din EV-lader.",
+          "hsem_ev_charger_status": "Vælg den sensor eller enhed, der angiver, om EV-laderen er aktiv.",
+          "hsem_ev_connected": "Vælg den sensor eller enhed, der angiver, om EV er tilsluttet laderen.",
+          "hsem_ev_second_enabled": "Aktiver eller deaktiver konfigurationen for en anden EV-lader.",
+          "hsem_ev_soc": "Vælg den sensor, der leverer den aktuelle ladetilstand (SoC) for dit EV-batteri.",
+          "hsem_house_power_includes_ev_charger_power": "Aktiver dette, hvis husets forbrugseffektsensor allerede inkluderer EV-laderens strømforbrug.",
           "hsem_ev_auto_full_negative_price": "Når aktiveret, sættes elbilen automatisk til fuld opladningseffekt, når elprisen er nul eller negativ. Den tidligere opladningstilstand gendannes, når prisen stiger over nul.",
           "hsem_ev_past_target_confidence_factor": "Konfidensmultiplikator (0.0-1.0) der anvendes på værdien af undgået fremtidig import når EV'en oplades ud over sin mål-SoC. Lavere værdier gør EV'en mindre konkurrencedygtig mod eksport af overskuds-PV, for at tage højde for usikkerhed om, om EV'en faktisk vil have brug for den ekstra energi før næste opladning. Standard 0.9."
         },
-        "description": "Configure EV Charger settings for HSEM.",
-        "title": "EV Charger Settings (Optional)"
+        "description": "Konfigurer EV-laderindstillinger for HSEM.",
+        "title": "EV-laderindstillinger (Valgfri)"
       },
       "ev_second": {
         "data": {
-          "hsem_ev_second_allow_charge_past_target_soc": "Allow Charging Past Target SoC For Second EV (Advanced)",
-          "hsem_ev_second_charger_force_max_discharge_power": "Second EV Charger Force Max Discharge Power",
-          "hsem_ev_second_charger_max_discharge_power": "Second EV Charger Max Discharge Power",
-          "hsem_ev_second_charger_power": "Second EV Charger Power Sensor",
-          "hsem_ev_second_charger_status": "Second EV Charger Status Sensor",
-          "hsem_ev_second_connected": "Second EV Connected Sensor",
-          "hsem_ev_second_soc": "Second EV State of Charge (SoC) Sensor",
+          "hsem_ev_second_allow_charge_past_target_soc": "Tillad opladning ud over mål-SoC for anden EV (Avanceret)",
+          "hsem_ev_second_charger_force_max_discharge_power": "Anden EV-lader tving maks. afladningseffekt",
+          "hsem_ev_second_charger_max_discharge_power": "Anden EV-lader maks. afladningseffekt",
+          "hsem_ev_second_charger_power": "Anden EV-lader effektsensor",
+          "hsem_ev_second_charger_status": "Anden EV-lader statussensor",
+          "hsem_ev_second_connected": "Anden EV tilsluttet sensor",
+          "hsem_ev_second_soc": "Anden EV ladetilstand (SoC) sensor",
           "hsem_ev_second_past_target_confidence_factor": "Anden EV opladning ud over mål-SoC - Konfidensfaktor (Avanceret)"
         },
         "data_description": {
-          "hsem_ev_second_allow_charge_past_target_soc": "Enable this option if you want to allow the system to continue charging the EV battery even after it has reached the target state of charge (SoC). This can be useful in scenarios where you want to ensure the EV is fully charged regardless of the target setting.",
-          "hsem_ev_second_charger_force_max_discharge_power": "Enable this if you want to force a specific maximum discharge power for the Huawei batteries while EV is charging.",
-          "hsem_ev_second_charger_max_discharge_power": "Set the maximum discharge power for the Huawei batteries while EV is charging.",
-          "hsem_ev_second_charger_power": "Select the sensor that measures the power consumption of your EV charger.",
-          "hsem_ev_second_charger_status": "Select the sensor or entity that indicates whether the EV charger is active (e.g., a switch or sensor).",
-          "hsem_ev_second_connected": "Select the sensor or entity that indicates whether the EV is connected to the charger.",
-          "hsem_ev_second_soc": "Select the sensor that provides the current state of charge (SoC) of your EV battery.",
+          "hsem_ev_second_allow_charge_past_target_soc": "Aktiver denne mulighed, hvis du vil tillade systemet at fortsætte opladningen af EV-batteriet, selv efter det har nået mål-ladetilstanden (SoC).",
+          "hsem_ev_second_charger_force_max_discharge_power": "Aktiver dette, hvis du vil tvinge en specifik maks. afladningseffekt for Huawei-batterierne, mens EV oplader.",
+          "hsem_ev_second_charger_max_discharge_power": "Indstil den maksimale afladningseffekt for Huawei-batterierne, mens EV oplader.",
+          "hsem_ev_second_charger_power": "Vælg den sensor, der måler strømforbruget for din EV-lader.",
+          "hsem_ev_second_charger_status": "Vælg den sensor eller enhed, der angiver, om EV-laderen er aktiv.",
+          "hsem_ev_second_connected": "Vælg den sensor eller enhed, der angiver, om EV er tilsluttet laderen.",
+          "hsem_ev_second_soc": "Vælg den sensor, der leverer den aktuelle ladetilstand (SoC) for dit EV-batteri.",
           "hsem_ev_second_past_target_confidence_factor": "Konfidensmultiplikator (0.0-1.0) der anvendes på værdien af undgået fremtidig import når den anden EV oplades ud over sin mål-SoC. Lavere værdier gør EV'en mindre konkurrencedygtig mod eksport af overskuds-PV, for at tage højde for usikkerhed om, om EV'en faktisk vil have brug for den ekstra energi før næste opladning. Standard 0.9."
         },
-        "description": "Configure Second EV Charger settings for HSEM.",
-        "title": "Second EV Charger Settings (Optional)"
+        "description": "Konfigurer anden EV-laderindstillinger for HSEM.",
+        "title": "Anden EV-laderindstillinger (Valgfri)"
       },
       "huawei_solar": {
         "data": {
-          "hsem_batteries_charge_efficiency": "Battery Charge Efficiency (%)",
+          "hsem_batteries_charge_efficiency": "Batteri-opladningseffektivitet (%)",
           "hsem_batteries_cycle_cost": "Battery Cycle Cost (pr. kWh)",
-          "hsem_batteries_discharge_efficiency": "Battery Discharge Efficiency (%)",
-          "hsem_batteries_expected_cycles": "Expected Battery Cycles",
-          "hsem_batteries_purchase_price": "Battery Purchase Price",
-          "hsem_huawei_solar_batteries_excess_pv_energy_use_in_tou": "Huawei Batteries Excess PV energy use in TOU",
-          "hsem_huawei_solar_batteries_forcible_charge": "Battery Forcible Charge State",
-          "hsem_huawei_solar_batteries_end_of_discharge_soc": "Huawei Batteries End of Discharge SOC (%)",
-          "hsem_huawei_solar_batteries_charging_cutoff_capacity": "Huawei Batteries Charging Cutoff Capacity (Max SoC %)",
-          "hsem_huawei_solar_batteries_grid_charge_cutoff_soc": "Huawei Batteries Grid Charge Cutoff SOC (%)",
-          "hsem_huawei_solar_batteries_maximum_charging_power": "Huawei Batteries Maximum Charging Power (W)",
-          "hsem_huawei_solar_batteries_maximum_discharging_power": "Huawei Batteries Maximum Discharging Power (W)",
+          "hsem_batteries_discharge_efficiency": "Batteri-afladningseffektivitet (%)",
+          "hsem_batteries_expected_cycles": "Forventede battericyklusser",
+          "hsem_batteries_purchase_price": "Batteri-købspris",
+          "hsem_huawei_solar_batteries_excess_pv_energy_use_in_tou": "Huawei-batterier overskydende PV-energianvendelse i TOU",
+          "hsem_huawei_solar_batteries_forcible_charge": "Tvungen Opladning",
+          "hsem_huawei_solar_batteries_end_of_discharge_soc": "Huawei-batterier afladningsstop SOC (%)",
+          "hsem_huawei_solar_batteries_charging_cutoff_capacity": "Huawei-batterier opladningsstopkapacitet (maks. SoC %)",
+          "hsem_huawei_solar_batteries_grid_charge_cutoff_soc": "Huawei-batterier netopladningsstop SOC (%)",
+          "hsem_huawei_solar_batteries_maximum_charging_power": "Huawei-batterier maks. opladningseffekt (W)",
+          "hsem_huawei_solar_batteries_maximum_discharging_power": "Huawei-batterier maks. afladningseffekt (W)",
           "hsem_huawei_solar_batteries_rated_capacity": "Battery Max Capacity (Watt)",
-          "hsem_huawei_solar_batteries_state_of_capacity": "Huawei Batteries State of Capacity Sensor",
-          "hsem_huawei_solar_batteries_tou_charging_and_discharging_periods": "Huawei Batteries TOU Charging and Discharging Periods",
-          "hsem_huawei_solar_batteries_working_mode": "Huawei Solar Batteries Working Mode Sensor",
-          "hsem_huawei_solar_device_id_batteries": "Huawei Batteries Device",
-          "hsem_huawei_solar_device_id_batteries_2": "Huawei Batteries 2 Device",
-          "hsem_huawei_solar_device_id_inverter_1": "Huawei Inverter 1 Device",
-          "hsem_huawei_solar_device_id_inverter_2": "Huawei Inverter 2 Device",
-          "hsem_huawei_solar_inverter_active_power_control": "Huawei Inverter Active Power Control Sensor"
+          "hsem_huawei_solar_batteries_state_of_capacity": "Huawei-batterier kapacitetstilstandssensor",
+          "hsem_huawei_solar_batteries_tou_charging_and_discharging_periods": "Huawei-batterier TOU-opladnings- og afladningsperioder",
+          "hsem_huawei_solar_batteries_working_mode": "Huawei Solar-batterier arbejdstilstandssensor",
+          "hsem_huawei_solar_device_id_batteries": "Huawei-batterienhed",
+          "hsem_huawei_solar_device_id_batteries_2": "Huawei-batterienhed 2",
+          "hsem_huawei_solar_device_id_inverter_1": "Huawei-vekselretter 1 enhed",
+          "hsem_huawei_solar_device_id_inverter_2": "Huawei-vekselretter 2 enhed",
+          "hsem_huawei_solar_inverter_active_power_control": "Huawei-vekselretter aktiv effektkontrolsensor",
+          "hsem_huawei_solar_batteries_charge_discharge_power": "Huawei batteri op-/afladningseffekt-sensor",
+          "hsem_huawei_solar_batteries_grid_charge_maximum_power": "Huawei-batterier maksimal netopladningseffekt (W)"
         },
         "data_description": {
-          "hsem_batteries_charge_efficiency": "Specify the charge-side efficiency of your battery as a percentage (0–100). Energy stored in the battery equals the input energy multiplied by this factor. Typical lithium batteries achieve 95–98 %. Defaults to 98 %.",
-          "hsem_batteries_discharge_efficiency": "Specify the discharge-side efficiency of your battery as a percentage (0–100). Energy delivered to the house equals the battery energy removed multiplied by this factor. Typical lithium batteries achieve 95–98 %. Defaults to 98 %.",
+          "hsem_batteries_charge_efficiency": "Angiv batteriets opladningseffektivitet som en procentdel (0-100). Energi lagret i batteriet = inputenergi × denne faktor. Typiske lithium-batterier opnår 95-98%. Standard: 98%.",
+          "hsem_batteries_discharge_efficiency": "Angiv batteriets afladningseffektivitet som en procentdel (0-100). Energi leveret til huset = fjernet batterienergi × denne faktor. Typiske lithium-batterier opnår 95-98%. Standard: 98%.",
           "hsem_batteries_cycle_cost": "Optional extra per-kWh cost of cycling the battery (pr. kWh). Added on top of the auto-calculated depreciation threshold. Set to 0 to rely solely on the depreciation guard. Example: 0.02 means the planner requires 2 cent extra spread per kWh cycled before approving grid charging.",
-          "hsem_batteries_expected_cycles": "Enter the expected number of full charge/discharge cycles over the battery's lifetime. Used to calculate depreciation cost per kWh and the recommended minimum export price threshold. Typical LiFePO4 batteries support 4000–8000 cycles.",
-          "hsem_batteries_purchase_price": "Enter the total purchase price of your battery system in your local currency. Used together with expected cycles and usable capacity to calculate the depreciation cost per kWh and the recommended minimum export price threshold.",
-          "hsem_huawei_solar_batteries_excess_pv_energy_use_in_tou": "Select the sensor that provides setting for excess PV energy use in TOU periods.",
-          "hsem_huawei_solar_batteries_forcible_charge": "Sensor showing current forcible charge/discharge state (e.g. Stopped, Discharging at 5000W for 60 minutes)",
-          "hsem_huawei_solar_batteries_end_of_discharge_soc": "Specify the end of discharge SOC percentage for your Huawei batteries. When the battery reaches this SOC level, it will stop discharging to prevent deep discharge and potential damage to the battery.",
-          "hsem_huawei_solar_batteries_charging_cutoff_capacity": "Select the entity that defines the maximum state of charge (SoC) the battery is allowed to reach during charging (register STORAGE_CHARGING_CUTOFF_CAPACITY). Typically 90–10 %. Used by the SoC simulation as the upper SoC ceiling so the planner never schedules charging beyond this limit.",
-          "hsem_huawei_solar_batteries_grid_charge_cutoff_soc": "Specify the grid charge cutoff SOC percentage for your Huawei batteries.",
+          "hsem_batteries_expected_cycles": "Indtast det forventede antal fulde opladnings-/afladningscyklusser i batteriets levetid. Bruges til at beregne afskrivningsomkostning pr. kWh. Typiske LiFePO4-batterier understøtter 4000-8000 cyklusser.",
+          "hsem_batteries_purchase_price": "Indtast den samlede købspris for dit batterisystem. Bruges sammen med forventede cyklusser og brugbar kapacitet til at beregne afskrivningsomkostning pr. kWh.",
+          "hsem_huawei_solar_batteries_excess_pv_energy_use_in_tou": "Vælg den sensor, der giver indstilling for overskydende PV-energianvendelse i TOU-perioder.",
+          "hsem_huawei_solar_batteries_forcible_charge": "Vælg sensoren der angiver om tvungen opladning er aktiv.",
+          "hsem_huawei_solar_batteries_end_of_discharge_soc": "Angiv afladningsstop SOC-procent for dine Huawei-batterier. Når batteriet når dette SOC-niveau, stopper det afladning for at forhindre dybdeafladning.",
+          "hsem_huawei_solar_batteries_charging_cutoff_capacity": "Vælg den enhed, der definerer den maksimale ladetilstand (SoC), batteriet må nå under opladning. Typisk 90-100%. Bruges af SoC-simuleringen som den øvre SoC-grænse.",
+          "hsem_huawei_solar_batteries_grid_charge_cutoff_soc": "Angiv netopladningsstop SOC-procent for dine Huawei-batterier.",
           "hsem_huawei_solar_batteries_maximum_charging_power": "Select the sensor that provides the maximum charging power for your Huawei batteries in kilowatts (W).",
-          "hsem_huawei_solar_batteries_maximum_discharging_power": "Select the sensor that provides the maximum discharging power for your Huawei batteries.",
+          "hsem_huawei_solar_batteries_maximum_discharging_power": "Vælg den sensor, der leverer den maksimale afladningseffekt for dine Huawei-batterier.",
           "hsem_huawei_solar_batteries_rated_capacity": "Select the sensor that provides the total rated capacity of your Huawei batteries in watts (W).",
-          "hsem_huawei_solar_batteries_state_of_capacity": "Select the sensor that provides the state of charge (SOC) of your Huawei batteries.",
-          "hsem_huawei_solar_batteries_tou_charging_and_discharging_periods": "Select the sensor that defines the Time-of-Use (TOU) charging and discharging periods for your Huawei batteries.",
-          "hsem_huawei_solar_batteries_working_mode": "Select the sensor that indicates the current working mode of your Huawei batteries.",
-          "hsem_huawei_solar_device_id_batteries": "Select your Huawei battery device.",
-          "hsem_huawei_solar_device_id_batteries_2": "Select your secondary Huawei battery device, if applicable.",
-          "hsem_huawei_solar_device_id_inverter_1": "Select your primary Huawei inverter device.",
-          "hsem_huawei_solar_device_id_inverter_2": "Select your secondary Huawei inverter device, if applicable.",
-          "hsem_huawei_solar_inverter_active_power_control": "Select the sensor that controls the active power output of your Huawei inverter."
+          "hsem_huawei_solar_batteries_state_of_capacity": "Vælg den sensor, der leverer ladetilstanden (SOC) for dine Huawei-batterier.",
+          "hsem_huawei_solar_batteries_tou_charging_and_discharging_periods": "Vælg den sensor, der definerer Time-of-Use (TOU) opladnings- og afladningsperioder for dine Huawei-batterier.",
+          "hsem_huawei_solar_batteries_working_mode": "Vælg den sensor, der angiver den aktuelle arbejdstilstand for dine Huawei-batterier.",
+          "hsem_huawei_solar_device_id_batteries": "Vælg din Huawei-batterienhed.",
+          "hsem_huawei_solar_device_id_batteries_2": "Vælg din sekundære Huawei-batterienhed, hvis relevant.",
+          "hsem_huawei_solar_device_id_inverter_1": "Vælg din primære Huawei-vekselretterenhed.",
+          "hsem_huawei_solar_device_id_inverter_2": "Vælg din sekundære Huawei-vekselretterenhed, hvis relevant.",
+          "hsem_huawei_solar_inverter_active_power_control": "Vælg den sensor, der styrer aktiv effektudgang for din Huawei-vekselretter.",
+          "hsem_huawei_solar_batteries_charge_discharge_power": "Vælg sensoren, der rapporterer den fortegnsbestemte øjeblikkelige batteri op-/afladningseffekt (positiv = opladning, negativ = afladning). Kræves af den live fasebevidste opladningssikkerhedsbegrænser (issue #831) for at fjerne Huaweis eget bidrag fra det live faseøjebliksbillede, før rådighedsmargenen beregnes. Valgfrit — kræves kun når fasebevidst opladning er aktiveret.",
+          "hsem_huawei_solar_batteries_grid_charge_maximum_power": "Vælg tal-enheden, der sætter Huaweis maksimale loft for netopladningseffekt (W). Skrives af den live fasebevidste opladningssikkerhedsbegrænser (issue #831) for at holde netfinansieret opladning under hovedsikringens per-fase-grænse. Valgfrit — kræves kun når fasebevidst opladning er aktiveret."
         },
-        "description": "Configure the working mode for Huawei solar batteries.",
-        "title": "Huawei Solar Sensors"
+        "description": "Konfigurer arbejdstilstanden for Huawei-solcellebatterier.",
+        "title": "Huawei Solar-sensorer"
       },
       "init": {
         "data": {
-          "device_name": "Name",
-          "hsem_extended_attributes": "Extended Attributes",
-          "hsem_read_only": "Read Only",
-          "hsem_recommendation_interval_length": "Recommendation Interval Length",
-          "hsem_recommendation_interval_minutes": "Recommendation Interval Minutes",
-          "hsem_update_interval": "Update interval",
-          "hsem_verbose_logging": "Verbose Logging"
+          "device_name": "Navn",
+          "hsem_extended_attributes": "Udvidede attributter",
+          "hsem_read_only": "Kun læsning",
+          "hsem_recommendation_interval_length": "Anbefalingsinterval-længde",
+          "hsem_recommendation_interval_minutes": "Anbefalingsinterval-minutter",
+          "hsem_update_interval": "Opdateringsinterval",
+          "hsem_verbose_logging": "Detaljeret logning"
         },
         "data_description": {
-          "device_name": "Enter a unique name for this device.",
-          "hsem_extended_attributes": "Enable this option to expose extra diagnostic attributes on the sensor entity.",
-          "hsem_read_only": "Enable this option to set the integration to read-only mode, preventing it from sending commands to devices.",
+          "device_name": "Indtast et unikt navn for denne enhed.",
+          "hsem_extended_attributes": "Aktiver denne mulighed for at eksponere ekstra diagnostiske attributter på sensorenheden.",
+          "hsem_read_only": "Aktiver denne mulighed for at sætte integrationen i skrivebeskyttet tilstand, så den ikke sender kommandoer til enheder.",
           "hsem_recommendation_interval_length": "The length in minutes of each recommendation interval used to calculate optimal battery usage.",
           "hsem_recommendation_interval_minutes": "The number of recommendation intervals to consider when calculating optimal battery usage.",
-          "hsem_update_interval": "The update interval in minutes for the working mode sensor.",
-          "hsem_verbose_logging": "Enable verbose debug logging for troubleshooting purposes."
+          "hsem_update_interval": "Opdateringsintervallet i minutter for arbejdstilstandssensoren.",
+          "hsem_verbose_logging": "Aktiver detaljeret fejlfindingslogning til fejlfinding."
         },
-        "description": "Update the settings for HSEM",
-        "title": "Update Huawei Solar Energy Management"
+        "description": "Opdater indstillingerne for HSEM",
+        "title": "Opdater Huawei Solar Energy Management"
       },
       "months": {
         "data": {
-          "hsem_months_winter": "Months considered as Winter/Spring"
+          "hsem_months_winter": "Måneder betragtet som vinter/forår"
         },
         "data_description": {
           "hsem_months_winter": "Select the months that should be considered as Winter/Spring for the seasonal working mode adjustments. You can select multiple months. Selecting all 12 months is allowed — this keeps Winter/Spring (TOU) mode active year-round."
         },
-        "description": "Configure the months that are considered as Winter/Spring. During these months, the system will prioritize charging the batteries from grid energy to ensure sufficient battery levels during periods of lower solar production. Remaining months will be considered as Summer/Autum months.",
-        "title": "Winter/Spring Months"
+        "description": "Konfigurer de måneder, der betragtes som vinter/forår. I disse måneder prioriterer systemet opladning af batterierne fra netstrøm.",
+        "title": "Vinter/forår-måneder"
       },
       "power": {
         "data": {
-          "hsem_house_consumption_power": "House Consumption Power Sensor",
-          "hsem_main_fuse_amps": "Main Fuse Rating (Amps)",
-          "hsem_main_fuse_phases": "Main Fuse Phase Count",
-          "hsem_max_grid_export_power_kw": "Max Grid Export Power (kW)",
-          "hsem_solar_production_power": "Solar Production Power Sensor"
+          "hsem_house_consumption_power": "Husets forbrugseffektsensor",
+          "hsem_main_fuse_amps": "Hovedsikring (Ampere)",
+          "hsem_main_fuse_phases": "Hovedsikringens faseantal",
+          "hsem_max_grid_export_power_kw": "Maks. neteksporteffekt (kW)",
+          "hsem_solar_production_power": "Solproduktionseffektsensor",
+          "hsem_huawei_solar_power_meter_phase_a_active_power": "Effektmåler fase A aktiv effekt-sensor",
+          "hsem_huawei_solar_power_meter_phase_b_active_power": "Effektmåler fase B aktiv effekt-sensor",
+          "hsem_huawei_solar_power_meter_phase_c_active_power": "Effektmåler fase C aktiv effekt-sensor",
+          "hsem_phase_aware_charging_enabled": "Aktiver live fasebevidst opladningssikkerhedsbegrænser"
         },
         "data_description": {
-          "hsem_house_consumption_power": "Select the sensor that measures your house's total power consumption.",
-          "hsem_main_fuse_amps": "Your house's main fuse/breaker rating in amps (25, 35, etc.).  The MILP optimizer will respect this limit when scheduling battery and EV charging.  Set to 0 to disable.",
-          "hsem_main_fuse_phases": "Your electrical installation's phase count.  Single-phase installations MUST set this to 1 — setting 3 on a single-phase install makes the fuse protection 3x too permissive and provides no real safety limit.  Defaults to 3 (three-phase).",
-          "hsem_max_grid_export_power_kw": "Maximum grid export power in kW — the DNO/inverter export cap for export-limited connections (e.g. 5 kW).  The MILP planner will never schedule export above this limit, so battery export and PV export correctly compete for the same cap.  Set to 0 to disable.",
-          "hsem_solar_production_power": "Select the sensor that measures the power generated by your solar panels."
+          "hsem_house_consumption_power": "Vælg den sensor, der måler husets samlede strømforbrug.",
+          "hsem_main_fuse_amps": "Husets hovedsikringsstørrelse i ampere (25, 35, osv.).  MILP-optimeringsværktøjet respekterer denne grænse ved planlægning af batteri- og elbilopladning.  Sæt til 0 for at deaktivere.",
+          "hsem_main_fuse_phases": "Din elinstallations faseantal.  Enfasede installationer SKAL sættes til 1 — at indstille 3 på en enfaset installation gør sikringsbeskyttelsen 3 gange for slap og giver ingen reel sikkerhedsgrænse.  Standard er 3 (trefaset).",
+          "hsem_max_grid_export_power_kw": "Maksimal neteksporteffekt i kW — netoperatørens/inverterens eksportloft for eksportbegrænsede tilslutninger (f.eks. 5 kW).  MILP-planlæggeren planlægger aldrig eksport over denne grænse, så batterieksport og soleksport konkurrerer korrekt om det samme loft.  Sæt til 0 for at deaktivere.",
+          "hsem_solar_production_power": "Vælg den sensor, der måler strømmen genereret af dine solpaneler.",
+          "hsem_huawei_solar_power_meter_phase_a_active_power": "Vælg sensoren, der måler live aktiv effekt på fase A af din Huawei-effektmåler. Kræves kun når fasebevidst opladning er aktiveret.",
+          "hsem_huawei_solar_power_meter_phase_b_active_power": "Vælg sensoren, der måler live aktiv effekt på fase B af din Huawei-effektmåler. Kræves kun når fasebevidst opladning er aktiveret.",
+          "hsem_huawei_solar_power_meter_phase_c_active_power": "Vælg sensoren, der måler live aktiv effekt på fase C af din Huawei-effektmåler. Kræves kun når fasebevidst opladning er aktiveret.",
+          "hsem_phase_aware_charging_enabled": "Aktiver et live sikkerhedstjek umiddelbart før hver Huawei netopladnings-hardwareskrivning (issue #831). Bruger de tre effektmåler-fasesensorer nedenfor samt Huaweis maksimal-netopladningseffekt-enhed (huawei_solar-trinnet) til at begrænse netfinansieret opladning, så den aldrig presser nogen fase over hovedsikringens grænse, selv hvis belastningen ændrede sig efter planen blev løst. Kræver main_fuse_phases = 3 og alle fire enheder konfigureret. Deaktiveret som standard — fuldt bagudkompatibel."
         },
-        "description": "Select power sensors for HSEM.",
-        "title": "Power Sensors"
+        "description": "Vælg effektsensorer til HSEM.",
+        "title": "Effektsensorer"
       },
       "solcast": {
         "data": {
-          "hsem_solcast_pv_forecast_forecast_likelihood": "Solcast PV Forecast Preferred forecast likelihood to use",
-          "hsem_solcast_pv_forecast_forecast_today": "Solcast PV Forecast Today Sensor",
-          "hsem_solcast_pv_forecast_forecast_tomorrow": "Solcast PV Forecast Tomorrow Sensor"
+          "hsem_solcast_pv_forecast_forecast_likelihood": "Solcast PV-prognose foretrukket sandsynlighed",
+          "hsem_solcast_pv_forecast_forecast_today": "Solcast PV-prognose i dag sensor",
+          "hsem_solcast_pv_forecast_forecast_tomorrow": "Solcast PV-prognose i morgen sensor"
         },
         "data_description": {
-          "hsem_solcast_pv_forecast_forecast_likelihood": "Select the preferred forecast likelihood to use for Solcast PV forecasts.",
-          "hsem_solcast_pv_forecast_forecast_today": "Select the sensor that provides today's PV production forecast from Solcast.",
-          "hsem_solcast_pv_forecast_forecast_tomorrow": "Select the sensor that provides tomorrow's PV production forecast from Solcast."
+          "hsem_solcast_pv_forecast_forecast_likelihood": "Vælg den foretrukne prognosesandsynlighed for Solcast PV-prognoser.",
+          "hsem_solcast_pv_forecast_forecast_today": "Vælg den sensor, der leverer dagens PV-produktionsprognose fra Solcast.",
+          "hsem_solcast_pv_forecast_forecast_tomorrow": "Vælg den sensor, der leverer morgendagens PV-produktionsprognose fra Solcast."
         },
-        "description": "Select Solcast forecast sensors.",
-        "title": "Solcast Sensors"
+        "description": "Vælg Solcast-prognosesensorer.",
+        "title": "Solcast-sensorer"
       },
       "weighted_values": {
         "data": {
-          "hsem_house_consumption_energy_weight_14d": "House Consumption Energy Weight 14 Days",
-          "hsem_house_consumption_energy_weight_1d": "House Consumption Energy Weight 1 Day",
-          "hsem_house_consumption_energy_weight_3d": "House Consumption Energy Weight 3 Days",
-          "hsem_house_consumption_energy_weight_7d": "House Consumption Energy Weight 7 Days"
+          "hsem_house_consumption_energy_weight_14d": "Husets energivægt 14 dage",
+          "hsem_house_consumption_energy_weight_1d": "Husets energivægt 1 dag",
+          "hsem_house_consumption_energy_weight_3d": "Husets energivægt 3 dage",
+          "hsem_house_consumption_energy_weight_7d": "Husets energivægt 7 dage"
         },
         "data_description": {
-          "hsem_house_consumption_energy_weight_14d": "Specify the weight percentage for the house consumption energy over the last 14 days.",
-          "hsem_house_consumption_energy_weight_1d": "Specify the weight percentage for the house consumption energy over the last 1 day.",
-          "hsem_house_consumption_energy_weight_3d": "Specify the weight percentage for the house consumption energy over the last 3 days.",
-          "hsem_house_consumption_energy_weight_7d": "Specify the weight percentage for the house consumption energy over the last 7 days."
+          "hsem_house_consumption_energy_weight_14d": "Angiv vægtprocenten for husets energiforbrug over de sidste 14 dage.",
+          "hsem_house_consumption_energy_weight_1d": "Angiv vægtprocenten for husets energiforbrug over de sidste 1 dag.",
+          "hsem_house_consumption_energy_weight_3d": "Angiv vægtprocenten for husets energiforbrug over de sidste 3 dage.",
+          "hsem_house_consumption_energy_weight_7d": "Angiv vægtprocenten for husets energiforbrug over de sidste 7 dage."
         },
-        "description": "Configure the weighted values for house consumption energy to estimate your average power usage. The system calculates the average consumption for each hour over 1, 3, 7, and 14 days. These averages are then weighted to provide a combined, weighted estimate. This approach helps to smooth out anomalies, such as unusually high consumption on a single day due to low prices, and provides a reliable prediction of your expected power usage in specific time intervals (e.g., between 16:00 and 17:00).",
-        "title": "Weighted Values"
+        "description": "Konfigurer vægtede værdier for husets energiforbrug til at estimere dit gennemsnitlige strømforbrug.",
+        "title": "Vægtede værdier"
       },
       "batteries_schedule_1": {
         "data": {
@@ -854,7 +914,11 @@
           "hsem_batteries_capacity_loss_pct": "Kapacitetstab procent",
           "hsem_batteries_charge_efficiency": "Opladningseffektivitet procent",
           "hsem_batteries_discharge_efficiency": "Afladningseffektivitet procent",
-          "hsem_batteries_cycle_cost": "Cyklusomkostning pr. kWh"
+          "hsem_batteries_cycle_cost": "Cyklusomkostning pr. kWh",
+          "hsem_planner_hysteresis_absolute": "Hysterese absolut tærskel",
+          "hsem_planner_hysteresis_enabled": "Hysterese på plan-niveau",
+          "hsem_planner_hysteresis_percentage": "Hysterese procenttærskel (%)",
+          "hsem_planner_window_hysteresis_minutes": "Hysterese-holdetid for vindue (minutter)"
         },
         "data_description": {
           "hsem_batteries_purchase_price": "Samlet købspris for batterisystemet (inkl. installation).",
@@ -862,7 +926,11 @@
           "hsem_batteries_capacity_loss_pct": "Procentdel af batteriværdi forbrugt over levetiden (standard 30 procent).",
           "hsem_batteries_charge_efficiency": "Opladningseffektivitet som procentdel (standard 95 procent).",
           "hsem_batteries_discharge_efficiency": "Afladningseffektivitet som procentdel (standard 95 procent).",
-          "hsem_batteries_cycle_cost": "Beregnet cyklusomkostning pr. kWh (vises kun, read-only)."
+          "hsem_batteries_cycle_cost": "Beregnet cyklusomkostning pr. kWh (vises kun, read-only).",
+          "hsem_planner_hysteresis_absolute": "Minimum absolut score-forbedring, der kræves for at skifte til en ny plan. 0,00 deaktiverer den absolutte tærskel. Scoren bruger samme valuta som dine elpriser, så en værdi på 0,01 kræver mindst 1 øre/kWh-ækvivalent forbedring, før der skiftes.",
+          "hsem_planner_hysteresis_enabled": "Når dette er aktiveret, beholder planlæggeren den aktive kandidatplan, medmindre en ny plan forbedrer scoren med mere end de konfigurerede tærskler. Forhindrer svingninger mellem ligestillede strategier.",
+          "hsem_planner_hysteresis_percentage": "Minimum procentvis score-forbedring, der kræves for at skifte til en ny plan. 0 % deaktiverer procenttærsklen. Standard 5 % forhindrer flapning mellem næsten identiske planer.",
+          "hsem_planner_window_hysteresis_minutes": "Minimumstid (minutter), en anbefaling skal fastholdes, før den kan ændres. Forhindrer hurtig veksling som f.eks. ev_smart_charging ↔ batteries_charge_solar. 0 deaktiverer funktionen. Standard 10."
         },
         "description": "Konfigurer batteriøkonomi-parametre til cyklusomkostningsberegning.",
         "title": "Batteriøkonomi"
@@ -909,14 +977,20 @@
           "hsem_ocpp_port": "OCPP Port",
           "hsem_ocpp_cpid": "Ladepunkt ID",
           "hsem_ocpp_start_window_s": "Startvindue (s)",
-          "hsem_ocpp_stop_window_s": "Stopvindue (s)"
+          "hsem_ocpp_stop_window_s": "Stopvindue (s)",
+          "hsem_ocpp_second_cpid": "Andet ladepunkt-ID",
+          "hsem_ocpp_second_enabled": "Aktiver anden OCPP-server",
+          "hsem_ocpp_second_port": "Anden OCPP-port"
         },
         "data_description": {
           "hsem_ocpp_enabled": "Aktiver den indbyggede OCPP 1.6 WebSocket-server til direkte EV-laderstyring. Kun LAN - eksponer ikke porten til internettet.",
           "hsem_ocpp_port": "TCP-port til OCPP WebSocket-serveren. Standard: 9000. Skal være over 1024.",
           "hsem_ocpp_cpid": "Forventet ladepunkt-identifikator for EV-laderen. Lad være tom for at acceptere enhver lader.",
           "hsem_ocpp_start_window_s": "Sekunder med vedvarende overskud før opladning starter. Standard: 60.",
-          "hsem_ocpp_stop_window_s": "Sekunder med vedvarende underskud før opladning stopper. Standard: 180."
+          "hsem_ocpp_stop_window_s": "Sekunder med vedvarende underskud før opladning stopper. Standard: 180.",
+          "hsem_ocpp_second_cpid": "Forventet ladepunkt-identifikator for den anden EV-lader. Lad være tom for at acceptere enhver lader.",
+          "hsem_ocpp_second_enabled": "Aktiver en anden, dedikeret OCPP-server til den anden EV. Kun tilgængelig når planlagt belastning for EV 2 er aktiveret.",
+          "hsem_ocpp_second_port": "TCP-port til den anden OCPP WebSocket-server. Standard: 9001. Skal være forskellig fra den første servers port."
         },
         "description": "Konfigurer den indbyggede OCPP 1.6 server til LAN-kun EV-laderstyring.",
         "title": "OCPP Server"
@@ -960,17 +1034,23 @@
     },
     "update_interval_length": {
       "options": {
-        "12": "12 hours",
-        "24": "24 hours",
-        "36": "36 hours",
-        "48": "48 hours",
-        "72": "72 hours"
+        "12": "12 timer",
+        "24": "24 timer",
+        "36": "36 timer",
+        "48": "48 timer",
+        "72": "72 timer"
       }
     },
     "batteries_wait_mode_behavior": {
       "options": {
         "strict": "Streng ventetilstand — batteriet forbliver inaktivt",
         "self_consumption_with_reserve": "Selvforbrug med reserve — brug overskud over planlæggerens reserve"
+      }
+    },
+    "ev_charger_phase_topology": {
+      "options": {
+        "single_phase": "Enfaset eller ukendt (sikkert standardvalg)",
+        "three_phase_balanced": "Trefaset, balanceret over L1/L2/L3"
       }
     }
   },
@@ -1043,27 +1123,13 @@
       "ev_second_target_soc": {
         "name": "EV 2 Mål SoC"
       },
-      "charge_rate_below_0": {
-        "name": "Maks. opladning (<0°C)"
-      },
-      "charge_rate_0_to_5": {
-        "name": "Maks. opladning (0-5°C)"
-      },
-      "charge_rate_6_to_15": {
-        "name": "Maks. opladning (6-15°C)"
-      },
-      "charge_rate_16_to_21": {
-        "name": "Maks. opladning (16-21°C)"
-      },
-      "charge_rate_21_to_35": {
-        "name": "Maks. opladning (21-35°C)"
-      },
-      "charge_rate_35_to_50": {
-        "name": "Maks. opladning (35-50°C)"
-      },
-      "charge_rate_above_50": {
-        "name": "Maks. opladning (>50°C)"
-      }
+      "charge_rate_below_0": {},
+      "charge_rate_0_to_5": {},
+      "charge_rate_6_to_15": {},
+      "charge_rate_16_to_21": {},
+      "charge_rate_21_to_35": {},
+      "charge_rate_35_to_50": {},
+      "charge_rate_above_50": {}
     },
     "time": {
       "schedule_1_start": {
@@ -1093,7 +1159,7 @@
     },
     "sensor": {
       "applier_status": {
-        "name": "Inverter-status",
+        "name": "Inverter-anvendelsesstatus",
         "state": {
           "ok": "OK",
           "unverified": "Ikke verificeret",
@@ -1224,6 +1290,51 @@
           "force_export": "Tving eksport",
           "batteries_wait_mode": "Vent"
         }
+      },
+      "ev_charger_calculated_power": {
+        "name": "EV-lader beregnet effekt"
+      },
+      "ev_charger_current_limit": {
+        "name": "EV-lader strømgrænse"
+      },
+      "ev_second_charger_calculated_power": {
+        "name": "EV 2-lader beregnet effekt"
+      },
+      "ev_second_charger_current_limit": {
+        "name": "EV 2-lader strømgrænse"
+      },
+      "export_income": {
+        "name": "Eksportindtægt"
+      },
+      "import_cost": {
+        "name": "Netimportomkostning"
+      },
+      "net_grid_balance": {
+        "name": "Netto nettobalance"
+      },
+      "prediction_accuracy": {
+        "name": "Forudsigelsesnøjagtighed"
+      },
+      "pv_curtailment": {
+        "name": "PV-begrænsning"
+      },
+      "savings_tracker": {
+        "name": "Besparelsessporing"
+      },
+      "solar_confidence": {
+        "name": "Solprognose-sikkerhed"
+      },
+      "ocpp_second_charger_status": {
+        "name": "OCPP Anden Lader-status"
+      },
+      "ocpp_second_charger_power": {
+        "name": "OCPP Anden Lader-effekt"
+      },
+      "ocpp_second_charger_info": {
+        "name": "OCPP Anden Lader-info"
+      },
+      "ocpp_second_charger_sessions": {
+        "name": "OCPP Anden Lader-sessioner"
       }
     }
   },

--- a/custom_components/hsem/translations/de.json
+++ b/custom_components/hsem/translations/de.json
@@ -1,0 +1,1362 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "HSEM Integration ist bereits konfiguriert",
+      "reconfigured_successfully": "HSEM Integration erfolgreich neu konfiguriert."
+    },
+    "error": {
+      "device_not_found": "Das ausgewählte Gerät wurde nicht gefunden.",
+      "energy_out_of_range": "Der Energiewert liegt außerhalb des zulässigen Bereichs.",
+      "entity_not_found": "Die ausgewählte Entität wurde nicht gefunden.",
+      "entity_unavailable": "Die ausgewählte Entität ist derzeit nicht verfügbar. Überprüfe das Gerät oder den Dienst.",
+      "hsem_house_consumption_energy_weight_total": "Die Summe der Gewichtungen für den Hausverbrauch muss 100 % betragen.",
+      "invalid_energy_value": "Ungültiger Energiewert — bitte eine Zahl eingeben.",
+      "invalid_entity_id": "Ungültiges Entitäts-ID-Format. Erwartet wird \"domain.object_id\" mit Kleinbuchstaben, Ziffern und Unterstrichen.",
+      "invalid_month_value": "Ein oder mehrere Monatswerte sind ungültig. Monate müssen ganze Zahlen zwischen 1 und 12 sein.",
+      "invalid_power_value": "Ungültiger Leistungswert — bitte eine Zahl eingeben.",
+      "invalid_price_value": "Ungültiger Preiswert — bitte eine Zahl eingeben.",
+      "invalid_sensor": "Ungültiger Eingabesensor. Bitte wähle einen gültigen Sensor.",
+      "invalid_time_format": "Ungültiges Zeitformat — erwartet wird HH:MM:SS.",
+      "months_winter_empty": "Die Wintersaison muss mindestens einen Monat enthalten.",
+      "only_one_entry_allowed": "Nur eine Konfiguration von HSEM ist zulässig.",
+      "power_out_of_range": "Der Leistungswert liegt außerhalb des zulässigen Bereichs.",
+      "price_out_of_range": "Der Preiswert liegt außerhalb des zulässigen Bereichs.",
+      "required": "Dieses Feld ist erforderlich.",
+      "start_time_after_end_time": "Die Startzeit muss vor der Endzeit liegen.",
+      "start_time_equals_end_time": "Start- und Endzeit dürfen nicht identisch sein — das ergibt ein Zeitfenster der Länge null. Deaktiviere stattdessen den Zeitplan.",
+      "invalid_wait_mode_behavior": "Ungültiges Wartemodus-Verhalten. Wähle Strenges Warten oder Eigenverbrauch mit Reserve.",
+      "port_conflict": "Der zweite OCPP-Port muss sich vom ersten OCPP-Port unterscheiden."
+    },
+    "step": {
+      "batteries_excess_export": {
+        "data": {
+          "hsem_batteries_enable_excess_export": "Batterie-Überschussexport aktivieren",
+          "hsem_batteries_excess_export_discharge_buffer": "Entladepuffer (%)",
+          "hsem_batteries_forecast_reserve_pct": "Batterieexport-Prognosereserve (+% SoC)",
+          "hsem_batteries_export_min_price": "Mindestpreis für Batterieexport"
+        },
+        "data_description": {
+          "hsem_batteries_enable_excess_export": "Aktiviere oder deaktiviere die Funktion für den Export überschüssiger Batteriekapazität, die überschüssige Batteriekapazität automatisch ins Netz einspeist, wenn es wirtschaftlich vorteilhaft ist.",
+          "hsem_batteries_excess_export_discharge_buffer": "Lege den Sicherheitspuffer in Prozent fest, um minimale Batteriereserven zu erhalten (0-50 %). Standard sind 10 %, um ausreichend Kapazität für unerwarteten Bedarf sicherzustellen.",
+          "hsem_batteries_forecast_reserve_pct": "Zusätzliche SoC-Prozentpunkte über der Huawei-Entladeschluss-Grenze, die der beabsichtigte Batterieexport unmittelbar nach jedem Export-Slot freihalten muss. Zum Beispiel schützt eine Huawei-Grenze von 15 % zuzüglich einer Reserve von 5 % einen SoC von 20 %. Die Reserve bleibt für die Hauslast verfügbar, wenn der tatsächliche Bedarf die Prognose übersteigt. Auf 0 setzen, um zu deaktivieren (Standard).",
+          "hsem_batteries_export_min_price": "Feste Preisuntergrenze pro Slot für beabsichtigten Batterie-zu-Netz-Export (issue #752). Bei Werten > 0 verbietet HSEM, einen Slot als force_batteries_discharge zu markieren, wenn der Exportpreis strikt unter dieser Untergrenze liegt — die Batterie kann in diesen Slots weiterhin die Hausversorgung übernehmen. Das Erreichen der Schwelle löst NICHT automatisch einen Export aus; der Optimierer entscheidet weiterhin, ob sich der Verkauf lohnt. Gilt nur für den beabsichtigten Batterie-zu-Netz-Export, nicht für normalen Eigenverbrauch, PV-Export oder PV-Ladung. Auf 0 setzen, um zu deaktivieren (Standard)."
+        },
+        "description": "Konfiguriere Einstellungen für den Export überschüssiger Batteriekapazität, um überschüssige Energie automatisch ins Netz zu verkaufen, wenn es wirtschaftlich vorteilhaft ist.",
+        "title": "Batterie-Überschussexport"
+      },
+      "ev_planned_load": {
+        "data": {
+          "hsem_ev_planned_load_enabled": "EV-Lastplanung-Integration aktivieren",
+          "hsem_ev_planned_load_battery_capacity_kwh": "EV-Batteriekapazität (kWh)",
+          "hsem_ev_planned_load_charger_power_kw": "EV-Ladegerät Leistung (kW)",
+          "hsem_ev_planned_load_charger_efficiency": "EV-Ladegerät Effizienz",
+          "hsem_ev_planned_load_charger_min_power_w": "EV-Ladegerät Mindestleistung (W)",
+          "hsem_ev_planned_load_charger_phase_topology": "Phasentopologie des Ladegeräts",
+          "hsem_ev_planned_load_deadline_safety_margin_pct": "Sicherheitsmarge für Frist (%)",
+          "hsem_ev_planned_load_command_deadband_a": "Totband für Obergrenze (A)",
+          "hsem_ev_planned_load_stub_floor_minutes": "Unterdrückung des Stopps am Slot-Ende (Min.)"
+        },
+        "data_description": {
+          "hsem_ev_planned_load_enabled": "Aktiviere oder deaktiviere die Integration der geplanten EV-Ladelast.",
+          "hsem_ev_planned_load_battery_capacity_kwh": "Nennkapazität der EV-Batterie in kWh.",
+          "hsem_ev_planned_load_charger_power_kw": "AC-Ausgangsleistung des EV-Ladegeräts in kW.",
+          "hsem_ev_planned_load_charger_efficiency": "Ladegerät-Effizienz in Prozent (1-100). Standard: 100.",
+          "hsem_ev_planned_load_charger_min_power_w": "Minimale AC-Leistung (W), die das EV-Ladegerät benötigt, um mit dem Laden zu beginnen. Darunter arbeitet das Ladegerät nicht. Standard: 1380 W (230 V × 6 A).",
+          "hsem_ev_planned_load_charger_phase_topology": "Wie das Ladegerät seine Last auf die Netzphasen verteilt. Wähle 'Einphasig oder unbekannt', sofern du nicht bestätigt hast, dass das Ladegerät auf allen drei Phasen einen ausgeglichenen Strom zieht. Bei aktiviertem phasenbezogenem Sicherungsschutz geht die sichere Standardannahme davon aus, dass der gesamte Ladebefehl auf einer Phase landen kann, was das geplante Laden auf den einphasigen Sicherungsspielraum begrenzt.",
+          "hsem_ev_planned_load_deadline_safety_margin_pct": "Zusätzliche Energie, die über dem Ziel-SoC hinaus als Prozentsatz des Fehlbetrags eingeplant wird, damit normale Ladereibung (Startverzögerungen, Mindestleistungsgrenzen, Drosselung) die Frist nicht verfehlt. Standard: 0 % (deaktiviert).",
+          "hsem_ev_planned_load_command_deadband_a": "Kleinste tatsächlich angewendete Reduzierung der veröffentlichten Ladeobergrenze. Kleinere Reduzierungen werden zurückgehalten, da konkurrierende Pläne mit ganzen Ampere-Werten kostenmäßig meist innerhalb eines Rundungsfehlers zueinander liegen. Eine Anhebung der Obergrenze wird nie verzögert, und eine Reduzierung, die die Ladekosten dieses Slots um mehr als 5 % verbessert, wird immer durchgeführt. Standard: 3 A; 0 deaktiviert.",
+          "hsem_ev_planned_load_stub_floor_minutes": "Unterdrückt am Ende eines Slots für diese Anzahl an Minuten einen Stoppbefehl, solange das Fahrzeug noch Energie benötigt. Die verbleibenden Sekunden reichen nicht aus, um genug Energie für die Ladegerät-Mindestleistung bereitzustellen, sodass der Plan ihnen nichts zuweist und die Sitzung ohne Nutzen stoppen und neu starten würde. Standard: 2 Minuten; 0 deaktiviert."
+        },
+        "description": "Konfiguriere die optionale Integration der geplanten EV-Ladelast. Wenn aktiviert, berücksichtigt HSEM den bevorstehenden EV-Ladebedarf pro Planer-Slot.",
+        "title": "EV-Lastplanung-Integration"
+      },
+      "ev_second_planned_load": {
+        "data": {
+          "hsem_ev_second_planned_load_enabled": "EV-2-Lastplanung-Integration aktivieren",
+          "hsem_ev_second_planned_load_battery_capacity_kwh": "EV 2 Batteriekapazität (kWh)",
+          "hsem_ev_second_planned_load_charger_power_kw": "EV 2 Ladegerät Leistung (kW)",
+          "hsem_ev_second_planned_load_charger_efficiency": "EV 2 Ladegerät Effizienz",
+          "hsem_ev_second_planned_load_charger_min_power_w": "EV 2 Ladegerät Mindestleistung (W)",
+          "hsem_ev_second_planned_load_charger_phase_topology": "Phasentopologie des Ladegeräts",
+          "hsem_ev_second_planned_load_deadline_safety_margin_pct": "EV 2 Sicherheitsmarge für Frist (%)",
+          "hsem_ev_second_planned_load_command_deadband_a": "EV 2 Totband für Obergrenze (A)",
+          "hsem_ev_second_planned_load_stub_floor_minutes": "EV 2 Unterdrückung des Stopps am Slot-Ende (Min.)"
+        },
+        "data_description": {
+          "hsem_ev_second_planned_load_enabled": "Aktiviere oder deaktiviere die Integration der geplanten Ladelast für das zweite EV.",
+          "hsem_ev_second_planned_load_battery_capacity_kwh": "Nennkapazität der Batterie des zweiten EVs in kWh.",
+          "hsem_ev_second_planned_load_charger_power_kw": "AC-Ausgangsleistung des zweiten EV-Ladegeräts in kW.",
+          "hsem_ev_second_planned_load_charger_efficiency": "Effizienz des zweiten EV-Ladegeräts in Prozent (1-100). Standard: 100.",
+          "hsem_ev_second_planned_load_charger_min_power_w": "Minimale AC-Leistung (W), die das zweite EV-Ladegerät zum Laden benötigt. Standard: 1380 W (230 V × 6 A).",
+          "hsem_ev_second_planned_load_charger_phase_topology": "Wie das Ladegerät seine Last auf die Netzphasen verteilt. Wähle 'Einphasig oder unbekannt', sofern du nicht bestätigt hast, dass das Ladegerät auf allen drei Phasen einen ausgeglichenen Strom zieht. Bei aktiviertem phasenbezogenem Sicherungsschutz geht die sichere Standardannahme davon aus, dass der gesamte Ladebefehl auf einer Phase landen kann, was das geplante Laden auf den einphasigen Sicherungsspielraum begrenzt.",
+          "hsem_ev_second_planned_load_deadline_safety_margin_pct": "Wie die Sicherheitsmarge für die Frist des primären EVs, für das zweite EV. Standard: 0 % (deaktiviert).",
+          "hsem_ev_second_planned_load_command_deadband_a": "Wie das Totband für die Obergrenze des primären EVs, für das zweite EV. Standard: 3 A; 0 deaktiviert.",
+          "hsem_ev_second_planned_load_stub_floor_minutes": "Wie die Unterdrückung des Stopps am Slot-Ende des primären EVs, für das zweite EV. Standard: 2 Minuten; 0 deaktiviert."
+        },
+        "description": "Konfiguriere die optionale Integration der geplanten Ladelast für das zweite EV. Wird nur angezeigt, wenn ein zweites EV-Ladegerät aktiviert ist.",
+        "title": "EV-2-Lastplanung-Integration"
+      },
+      "ocpp": {
+        "data": {
+          "hsem_ocpp_enabled": "OCPP-Server aktivieren",
+          "hsem_ocpp_port": "OCPP-Port",
+          "hsem_ocpp_cpid": "Ladepunkt-ID",
+          "hsem_ocpp_start_window_s": "Startfenster (s)",
+          "hsem_ocpp_stop_window_s": "Stoppfenster (s)",
+          "hsem_ocpp_second_enabled": "Zweiten OCPP-Server aktivieren",
+          "hsem_ocpp_second_port": "Zweiter OCPP-Port",
+          "hsem_ocpp_second_cpid": "Zweite Ladepunkt-ID"
+        },
+        "data_description": {
+          "hsem_ocpp_enabled": "Aktiviere den eingebetteten OCPP-1.6-WebSocket-Server für die direkte Steuerung des EV-Ladegeräts. Nur LAN — setze den Port nicht dem Internet aus.",
+          "hsem_ocpp_port": "TCP-Port für den OCPP-WebSocket-Server. Standard: 9000. Muss über 1024 liegen.",
+          "hsem_ocpp_cpid": "Erwartete Ladepunkt-Kennung des EV-Ladegeräts. Leer lassen, um jedes Ladegerät zu akzeptieren.",
+          "hsem_ocpp_start_window_s": "Sekunden anhaltenden Überschusses, die vor dem Start eines Ladevorgangs erforderlich sind. Verhindert schnelles Start-Stopp-Takten. Standard: 60.",
+          "hsem_ocpp_stop_window_s": "Sekunden anhaltenden Mangels, die vor dem Stoppen eines Ladevorgangs erforderlich sind. Verhindert schnelles Stopp-Start-Takten. Standard: 180.",
+          "hsem_ocpp_second_enabled": "Aktiviere einen zweiten, dedizierten OCPP-Server für das zweite EV. Nur verfügbar, wenn die EV-2-Lastplanung aktiviert ist.",
+          "hsem_ocpp_second_port": "TCP-Port für den zweiten OCPP-WebSocket-Server. Standard: 9001. Muss sich vom Port des ersten Servers unterscheiden.",
+          "hsem_ocpp_second_cpid": "Erwartete Ladepunkt-Kennung des zweiten EV-Ladegeräts. Leer lassen, um jedes Ladegerät zu akzeptieren."
+        },
+        "description": "Konfiguriere den eingebetteten OCPP-1.6-Server für die reine LAN-Steuerung von EV-Ladegeräten. Wenn aktiviert, sendet HSEM SetChargingProfile-Befehle direkt an dein EV-Ladegerät auf Basis des Ladeplans.",
+        "title": "OCPP-Server"
+      },
+      "batteries_schedule_1": {
+        "data": {
+          "hsem_batteries_enable_batteries_schedule_1": "Batterie-Zeitplan 1 aktivieren",
+          "hsem_batteries_enable_batteries_schedule_1_end": "Batterie-Zeitplan 1 Endzeit",
+          "hsem_batteries_enable_batteries_schedule_1_start": "Batterie-Zeitplan 1 Startzeit"
+        },
+        "data_description": {
+          "hsem_batteries_enable_batteries_schedule_1": "Aktiviere oder deaktiviere den ersten Batterie-Entladezeitplan.",
+          "hsem_batteries_enable_batteries_schedule_1_end": "Lege die Endzeit für den ersten Batterie-Entladezeitplan fest.",
+          "hsem_batteries_enable_batteries_schedule_1_start": "Lege die Startzeit für den ersten Batterie-Entladezeitplan fest."
+        },
+        "description": "Konfiguriere Batterie-Entladezeitplan 1, einschließlich seiner Aktivierungszeit.",
+        "title": "Batterie-Entladezeitplan 1"
+      },
+      "batteries_schedule_2": {
+        "data": {
+          "hsem_batteries_enable_batteries_schedule_2": "Batterie-Zeitplan 2 aktivieren",
+          "hsem_batteries_enable_batteries_schedule_2_end": "Batterie-Zeitplan 2 Endzeit",
+          "hsem_batteries_enable_batteries_schedule_2_start": "Batterie-Zeitplan 2 Startzeit"
+        },
+        "data_description": {
+          "hsem_batteries_enable_batteries_schedule_2": "Aktiviere oder deaktiviere den zweiten Batterie-Entladezeitplan.",
+          "hsem_batteries_enable_batteries_schedule_2_end": "Lege die Endzeit für den zweiten Batterie-Entladezeitplan fest.",
+          "hsem_batteries_enable_batteries_schedule_2_start": "Lege die Startzeit für den zweiten Batterie-Entladezeitplan fest."
+        },
+        "description": "Konfiguriere Batterie-Entladezeitplan 2, einschließlich seiner Aktivierungszeit.",
+        "title": "Batterie-Entladezeitplan 2"
+      },
+      "batteries_schedule_3": {
+        "data": {
+          "hsem_batteries_enable_batteries_schedule_3": "Batterie-Zeitplan 3 aktivieren",
+          "hsem_batteries_enable_batteries_schedule_3_end": "Batterie-Zeitplan 3 Endzeit",
+          "hsem_batteries_enable_batteries_schedule_3_start": "Batterie-Zeitplan 3 Startzeit"
+        },
+        "data_description": {
+          "hsem_batteries_enable_batteries_schedule_3": "Aktiviere oder deaktiviere den dritten Batterie-Entladezeitplan.",
+          "hsem_batteries_enable_batteries_schedule_3_end": "Lege die Endzeit für den dritten Batterie-Entladezeitplan fest.",
+          "hsem_batteries_enable_batteries_schedule_3_start": "Lege die Startzeit für den dritten Batterie-Entladezeitplan fest."
+        },
+        "description": "Konfiguriere Batterie-Entladezeitplan 3, einschließlich seiner Aktivierungszeit.",
+        "title": "Batterie-Entladezeitplan 3"
+      },
+      "prices": {
+        "data": {
+          "hsem_import_electricity_price_sensor": "Stromimportpreis-Sensor",
+          "hsem_export_electricity_price_sensor": "Stromexportpreis-Sensor",
+          "hsem_import_electricity_price_forecast_sensor": "Stromimportpreis-Prognosesensor (optional)",
+          "hsem_export_electricity_price_forecast_sensor": "Stromexportpreis-Prognosesensor (optional)",
+          "hsem_export_electricity_min_price": "Erforderlicher Mindestexportpreis",
+          "hsem_electricity_price_update_interval": "Strompreis-Aktualisierungsintervall (Minuten)"
+        },
+        "data_description": {
+          "hsem_import_electricity_price_sensor": "Wähle den Sensor, der Stromimportpreise liefert (z. B. Energi Data Service, Nordpool, Amber Electric).",
+          "hsem_export_electricity_price_sensor": "Wähle den Sensor, der Stromexportpreise liefert.",
+          "hsem_import_electricity_price_forecast_sensor": "Optional: Wähle einen separaten Sensor für Importpreis-Prognosen (verwendet von Amber Electric und ähnlichen Integrationen).",
+          "hsem_export_electricity_price_forecast_sensor": "Optional: Wähle einen separaten Sensor für Exportpreis-Prognosen.",
+          "hsem_export_electricity_min_price": "Lege den Mindestexportpreis fest. Exporte unterhalb dieses Preises werden blockiert.",
+          "hsem_electricity_price_update_interval": "Wie oft dein Preissensor neue Daten liefert (15, 30 oder 60 Minuten)."
+        },
+        "description": "Konfiguriere deine Strompreissensoren für Import- und Exportpreise.",
+        "title": "Strompreise"
+      },
+      "ev": {
+        "data": {
+          "hsem_ev_allow_charge_past_target_soc": "Laden über Ziel-SoC hinaus erlauben (Erweitert)",
+          "hsem_ev_charger_force_max_discharge_power": "EV-Ladegerät maximale Entladeleistung erzwingen",
+          "hsem_ev_charger_max_discharge_power": "EV-Ladegerät maximale Entladeleistung",
+          "hsem_ev_charger_power": "EV-Ladegerät Leistungssensor",
+          "hsem_ev_charger_status": "EV-Ladegerät Statussensor",
+          "hsem_ev_connected": "EV verbunden Sensor",
+          "hsem_ev_second_enabled": "Zweites EV-Ladegerät aktivieren",
+          "hsem_ev_soc": "EV-Ladezustand (SoC) Sensor",
+          "hsem_house_power_includes_ev_charger_power": "Hausleistung enthält EV-Ladegerät-Leistung",
+          "hsem_ev_auto_full_negative_price": "EV bei negativem Preis automatisch vollladen",
+          "hsem_ev_past_target_confidence_factor": "EV-Konfidenzfaktor für Laden über Ziel-SoC hinaus (Erweitert)"
+        },
+        "data_description": {
+          "hsem_ev_allow_charge_past_target_soc": "Aktiviere diese Option, wenn du zulassen möchtest, dass das System die EV-Batterie auch nach Erreichen des Ziel-Ladezustands (SoC) weiter lädt. Dies kann in Szenarien nützlich sein, in denen du sicherstellen möchtest, dass das EV unabhängig von der Zieleinstellung vollständig geladen wird.",
+          "hsem_ev_charger_force_max_discharge_power": "Aktiviere dies, wenn du eine bestimmte maximale Entladeleistung für die Huawei-Batterien erzwingen möchtest, während das EV lädt.",
+          "hsem_ev_charger_max_discharge_power": "Lege die maximale Entladeleistung für die Huawei-Batterien fest, während das EV lädt.",
+          "hsem_ev_charger_power": "Wähle den Sensor, der den Stromverbrauch deines EV-Ladegeräts misst.",
+          "hsem_ev_charger_status": "Wähle den Sensor oder die Entität, die anzeigt, ob das EV-Ladegerät aktiv ist (z. B. ein Schalter oder Sensor).",
+          "hsem_ev_connected": "Wähle den Sensor oder die Entität, die anzeigt, ob das EV mit dem Ladegerät verbunden ist.",
+          "hsem_ev_second_enabled": "Aktiviere oder deaktiviere die Konfiguration für ein zweites EV-Ladegerät.",
+          "hsem_ev_soc": "Wähle den Sensor, der den aktuellen Ladezustand (SoC) deiner EV-Batterie liefert.",
+          "hsem_house_power_includes_ev_charger_power": "Aktiviere dies, wenn der Hausverbrauchsleistungssensor die Leistung des EV-Ladegeräts bereits enthält.",
+          "hsem_ev_auto_full_negative_price": "Wenn aktiviert, wird das EV automatisch auf volle Ladeleistung gesetzt, sobald der Strompreis null oder negativ ist. Der vorherige Lademodus wird wiederhergestellt, sobald der Preis über null steigt.",
+          "hsem_ev_past_target_confidence_factor": "Konfidenzmultiplikator (0,0-1,0), der auf die Bewertung des vermiedenen zukünftigen Imports angewendet wird, wenn das EV über seinen Ziel-SoC hinaus geladen wird. Niedrigere Werte machen das EV im Vergleich zum Export von überschüssigem PV-Strom weniger konkurrenzfähig, um der Unsicherheit Rechnung zu tragen, ob das EV die zusätzliche Energie vor dem nächsten Ladevorgang tatsächlich benötigt. Standard 0,9."
+        },
+        "description": "Konfiguriere die EV-Ladegerät-Einstellungen für HSEM.",
+        "title": "EV-Ladegerät-Einstellungen (Optional)"
+      },
+      "ev_second": {
+        "data": {
+          "hsem_ev_second_allow_charge_past_target_soc": "Laden über Ziel-SoC hinaus für zweites EV erlauben (Erweitert)",
+          "hsem_ev_second_charger_force_max_discharge_power": "Zweites EV-Ladegerät maximale Entladeleistung erzwingen",
+          "hsem_ev_second_charger_max_discharge_power": "Zweites EV-Ladegerät maximale Entladeleistung",
+          "hsem_ev_second_charger_power": "Zweites EV-Ladegerät Leistungssensor",
+          "hsem_ev_second_charger_status": "Zweites EV-Ladegerät Statussensor",
+          "hsem_ev_second_connected": "Zweites EV verbunden Sensor",
+          "hsem_ev_second_soc": "Zweites EV-Ladezustand (SoC) Sensor",
+          "hsem_ev_second_past_target_confidence_factor": "Konfidenzfaktor für zweites EV Laden über Ziel-SoC hinaus (Erweitert)"
+        },
+        "data_description": {
+          "hsem_ev_second_allow_charge_past_target_soc": "Aktiviere diese Option, wenn du zulassen möchtest, dass das System die EV-Batterie auch nach Erreichen des Ziel-Ladezustands (SoC) weiter lädt. Dies kann in Szenarien nützlich sein, in denen du sicherstellen möchtest, dass das EV unabhängig von der Zieleinstellung vollständig geladen wird.",
+          "hsem_ev_second_charger_force_max_discharge_power": "Aktiviere dies, wenn du eine bestimmte maximale Entladeleistung für die Huawei-Batterien erzwingen möchtest, während das EV lädt.",
+          "hsem_ev_second_charger_max_discharge_power": "Lege die maximale Entladeleistung für die Huawei-Batterien fest, während das EV lädt.",
+          "hsem_ev_second_charger_power": "Wähle den Sensor, der den Stromverbrauch deines EV-Ladegeräts misst.",
+          "hsem_ev_second_charger_status": "Wähle den Sensor oder die Entität, die anzeigt, ob das EV-Ladegerät aktiv ist (z. B. ein Schalter oder Sensor).",
+          "hsem_ev_second_connected": "Wähle den Sensor oder die Entität, die anzeigt, ob das EV mit dem Ladegerät verbunden ist.",
+          "hsem_ev_second_soc": "Wähle den Sensor, der den aktuellen Ladezustand (SoC) deiner EV-Batterie liefert.",
+          "hsem_ev_second_past_target_confidence_factor": "Konfidenzmultiplikator (0,0-1,0), der auf die Bewertung des vermiedenen zukünftigen Imports angewendet wird, wenn das zweite EV über seinen Ziel-SoC hinaus geladen wird. Niedrigere Werte machen das EV im Vergleich zum Export von überschüssigem PV-Strom weniger konkurrenzfähig, um der Unsicherheit Rechnung zu tragen, ob das EV die zusätzliche Energie vor dem nächsten Ladevorgang tatsächlich benötigt. Standard 0,9."
+        },
+        "description": "Konfiguriere die Einstellungen für das zweite EV-Ladegerät für HSEM.",
+        "title": "Einstellungen für zweites EV-Ladegerät (Optional)"
+      },
+      "huawei_solar": {
+        "data": {
+          "hsem_batteries_charge_efficiency": "Batterie-Ladeeffizienz (%)",
+          "hsem_batteries_cycle_cost": "Batterie-Zykluskosten (pro kWh)",
+          "hsem_batteries_discharge_efficiency": "Batterie-Entladeeffizienz (%)",
+          "hsem_batteries_expected_cycles": "Erwartete Batteriezyklen",
+          "hsem_batteries_purchase_price": "Batterie-Kaufpreis",
+          "hsem_huawei_solar_batteries_excess_pv_energy_use_in_tou": "Huawei-Batterien Nutzung von überschüssiger PV-Energie in TOU",
+          "hsem_huawei_solar_batteries_forcible_charge": "Batterie-Zwangsladezustand",
+          "hsem_huawei_solar_batteries_end_of_discharge_soc": "Huawei-Batterien Entladeschluss-SOC (%)",
+          "hsem_huawei_solar_batteries_charging_cutoff_capacity": "Huawei-Batterien Ladeabschaltkapazität (max. SoC %)",
+          "hsem_huawei_solar_batteries_grid_charge_cutoff_soc": "Huawei-Batterien Netzladeabschaltung SOC (%)",
+          "hsem_huawei_solar_batteries_maximum_charging_power": "Huawei-Batterien maximale Ladeleistung (W)",
+          "hsem_huawei_solar_batteries_maximum_discharging_power": "Huawei-Batterien maximale Entladeleistung (W)",
+          "hsem_huawei_solar_batteries_grid_charge_maximum_power": "Huawei-Batterien maximale Netzladeleistung (W)",
+          "hsem_huawei_solar_batteries_charge_discharge_power": "Huawei Batterie Lade-/Entladeleistungssensor",
+          "hsem_huawei_solar_batteries_rated_capacity": "Batterie maximale Kapazität (Wh)",
+          "hsem_huawei_solar_batteries_state_of_capacity": "Huawei-Batterien Kapazitätszustand-Sensor",
+          "hsem_huawei_solar_batteries_tou_charging_and_discharging_periods": "Huawei-Batterien TOU-Lade- und Entladezeiträume",
+          "hsem_huawei_solar_batteries_working_mode": "Huawei Solar-Batterien Arbeitsmodus-Sensor",
+          "hsem_huawei_solar_device_id_batteries": "Huawei-Batteriegerät",
+          "hsem_huawei_solar_device_id_batteries_2": "Huawei-Batteriegerät 2",
+          "hsem_huawei_solar_device_id_inverter_1": "Huawei-Wechselrichter 1 Gerät",
+          "hsem_huawei_solar_device_id_inverter_2": "Huawei-Wechselrichter 2 Gerät",
+          "hsem_huawei_solar_inverter_active_power_control": "Huawei-Wechselrichter Wirkleistungssteuerung-Sensor"
+        },
+        "data_description": {
+          "hsem_batteries_charge_efficiency": "Gib die Ladeeffizienz deiner Batterie in Prozent an (0–100). Die in der Batterie gespeicherte Energie entspricht der eingehenden Energie multipliziert mit diesem Faktor. Typische Lithium-Batterien erreichen 95–98 %. Standard ist 98 %.",
+          "hsem_batteries_discharge_efficiency": "Gib die Entladeeffizienz deiner Batterie in Prozent an (0–100). Die an das Haus gelieferte Energie entspricht der entnommenen Batterieenergie multipliziert mit diesem Faktor. Typische Lithium-Batterien erreichen 95–98 %. Standard ist 98 %.",
+          "hsem_batteries_cycle_cost": "Optionale zusätzliche Kosten pro kWh für das Zyklieren der Batterie (pro kWh). Wird zusätzlich zur automatisch berechneten Abschreibungsschwelle addiert. Auf 0 setzen, um dich ausschließlich auf die Abschreibungssicherung zu verlassen. Beispiel: 0,02 bedeutet, dass der Planer 2 Cent zusätzliche Spanne pro zyklierter kWh benötigt, bevor er die Netzladung genehmigt.",
+          "hsem_batteries_expected_cycles": "Gib die erwartete Anzahl vollständiger Lade-/Entladezyklen über die Lebensdauer der Batterie ein. Wird verwendet, um die Abschreibungskosten pro kWh und den empfohlenen Mindestexportpreis zu berechnen. Typische LiFePO4-Batterien unterstützen 4000–8000 Zyklen.",
+          "hsem_batteries_purchase_price": "Gib den Gesamtkaufpreis deines Batteriesystems in deiner Landeswährung ein. Wird zusammen mit den erwarteten Zyklen und der nutzbaren Kapazität verwendet, um die Abschreibungskosten pro kWh und den empfohlenen Mindestexportpreis zu berechnen.",
+          "hsem_huawei_solar_batteries_excess_pv_energy_use_in_tou": "Wähle den Sensor, der die Einstellung für die Nutzung überschüssiger PV-Energie in TOU-Zeiträumen liefert.",
+          "hsem_huawei_solar_batteries_forcible_charge": "Sensor, der den aktuellen Zwangslade-/Entladezustand anzeigt (z. B. Gestoppt, Entladung mit 5000 W für 60 Minuten)",
+          "hsem_huawei_solar_batteries_end_of_discharge_soc": "Gib den Entladeschluss-SOC-Prozentsatz für deine Huawei-Batterien an. Wenn die Batterie diesen SOC-Wert erreicht, stoppt sie die Entladung, um Tiefentladung und mögliche Schäden an der Batterie zu verhindern.",
+          "hsem_huawei_solar_batteries_charging_cutoff_capacity": "Wähle die Entität, die den maximalen Ladezustand (SoC) definiert, den die Batterie während des Ladens erreichen darf (Register STORAGE_CHARGING_CUTOFF_CAPACITY). Typischerweise 90–10 %. Wird von der SoC-Simulation als obere SoC-Grenze verwendet, sodass der Planer das Laden nie über dieses Limit hinaus plant.",
+          "hsem_huawei_solar_batteries_grid_charge_cutoff_soc": "Gib den Netzladeabschaltung-SOC-Prozentsatz für deine Huawei-Batterien an.",
+          "hsem_huawei_solar_batteries_maximum_charging_power": "Wähle den Sensor, der die maximale Ladeleistung für deine Huawei-Batterien in Watt (W) liefert.",
+          "hsem_huawei_solar_batteries_maximum_discharging_power": "Wähle den Sensor, der die maximale Entladeleistung für deine Huawei-Batterien liefert.",
+          "hsem_huawei_solar_batteries_grid_charge_maximum_power": "Wähle die Zahlenentität, die die maximale Netzladeleistungsgrenze (W) von Huawei festlegt. Wird vom Live-Sicherheitsbegrenzer für phasenbewusstes Laden (issue #831) geschrieben, um netzfinanziertes Laden unterhalb der Phasengrenze der Hauptsicherung zu halten. Optional — nur erforderlich, wenn phasenbewusstes Laden aktiviert ist.",
+          "hsem_huawei_solar_batteries_charge_discharge_power": "Wähle den Sensor, der die vorzeichenbehaftete momentane Batterie-Lade-/Entladeleistung meldet (positiv = Laden, negativ = Entladen). Wird vom Live-Sicherheitsbegrenzer für phasenbewusstes Laden (issue #831) benötigt, um Huaweis eigenen Beitrag aus der Live-Phasen-Momentaufnahme zu entfernen, bevor der Spielraum berechnet wird. Optional — nur erforderlich, wenn phasenbewusstes Laden aktiviert ist.",
+          "hsem_huawei_solar_batteries_rated_capacity": "Wähle den Sensor, der die gesamte Nennkapazität deiner Huawei-Batterien in Wattstunden (Wh) liefert.",
+          "hsem_huawei_solar_batteries_state_of_capacity": "Wähle den Sensor, der den Ladezustand (SOC) deiner Huawei-Batterien liefert.",
+          "hsem_huawei_solar_batteries_tou_charging_and_discharging_periods": "Wähle den Sensor, der die Time-of-Use(TOU)-Lade- und Entladezeiträume für deine Huawei-Batterien definiert.",
+          "hsem_huawei_solar_batteries_working_mode": "Wähle den Sensor, der den aktuellen Arbeitsmodus deiner Huawei-Batterien anzeigt.",
+          "hsem_huawei_solar_device_id_batteries": "Wähle dein Huawei-Batteriegerät.",
+          "hsem_huawei_solar_device_id_batteries_2": "Wähle dein sekundäres Huawei-Batteriegerät, falls zutreffend.",
+          "hsem_huawei_solar_device_id_inverter_1": "Wähle dein primäres Huawei-Wechselrichtergerät.",
+          "hsem_huawei_solar_device_id_inverter_2": "Wähle dein sekundäres Huawei-Wechselrichtergerät, falls zutreffend.",
+          "hsem_huawei_solar_inverter_active_power_control": "Wähle den Sensor, der die Wirkleistungsabgabe deines Huawei-Wechselrichters steuert."
+        },
+        "description": "Konfiguriere den Arbeitsmodus für Huawei-Solarbatterien.",
+        "title": "Huawei Solar-Sensoren"
+      },
+      "battery_economics": {
+        "data": {
+          "hsem_batteries_purchase_price": "Batterie-Kaufpreis",
+          "hsem_batteries_expected_cycles": "Erwartete Batteriezyklen",
+          "hsem_batteries_cycle_cost": "Batterie-Zykluskosten (pro kWh)",
+          "hsem_batteries_capacity_loss_pct": "Batteriekapazitätsverlust am Lebensende (%)",
+          "hsem_batteries_charge_efficiency": "Batterie-Ladeeffizienz (%)",
+          "hsem_batteries_discharge_efficiency": "Batterie-Entladeeffizienz (%)",
+          "hsem_planner_hysteresis_enabled": "Hysterese auf Planebene",
+          "hsem_planner_hysteresis_absolute": "Absoluter Hysterese-Schwellenwert",
+          "hsem_planner_hysteresis_percentage": "Prozentualer Hysterese-Schwellenwert (%)",
+          "hsem_planner_window_hysteresis_minutes": "Hysterese-Haltezeit für Fenster (Minuten)"
+        },
+        "data_description": {
+          "hsem_batteries_purchase_price": "Gib den Gesamtkaufpreis deines Batteriesystems in deiner Landeswährung ein. Wird zusammen mit den erwarteten Zyklen und der nutzbaren Kapazität verwendet, um die Abschreibungskosten pro kWh und den empfohlenen Mindestexportpreis zu berechnen.",
+          "hsem_batteries_expected_cycles": "Gib die erwartete Anzahl vollständiger Lade-/Entladezyklen über die Lebensdauer der Batterie ein. Wird verwendet, um die Abschreibungskosten pro kWh und den empfohlenen Mindestexportpreis zu berechnen. Typische LiFePO4-Batterien unterstützen 4000–8000 Zyklen.",
+          "hsem_batteries_cycle_cost": "Optionale zusätzliche Kosten pro kWh für das Zyklieren der Batterie (pro kWh). Wird zusätzlich zur automatisch berechneten Abschreibungsschwelle addiert. Auf 0 setzen, um dich ausschließlich auf die Abschreibungssicherung zu verlassen. Beispiel: 0,02 bedeutet, dass der Planer 2 Cent zusätzliche Spanne pro zyklierter kWh benötigt, bevor er die Netzladung genehmigt.",
+          "hsem_batteries_capacity_loss_pct": "Erwarteter Kapazitätsverlust am Lebensende in Prozent. LiFePO4 erreicht typischerweise nach ~6000 Zyklen 80 % Kapazität (20 % Verlust). Der Standardwert von 30 % fügt eine Marge für kalendarische Alterung hinzu.",
+          "hsem_batteries_charge_efficiency": "Gib die Ladeeffizienz deiner Batterie in Prozent an (0–100). Die in der Batterie gespeicherte Energie entspricht der eingehenden Energie multipliziert mit diesem Faktor. Typische Lithium-Batterien erreichen 95–98 %. Standard ist 98 %.",
+          "hsem_batteries_discharge_efficiency": "Gib die Entladeeffizienz deiner Batterie in Prozent an (0–100). Die an das Haus gelieferte Energie entspricht der entnommenen Batterieenergie multipliziert mit diesem Faktor. Typische Lithium-Batterien erreichen 95–98 %. Standard ist 98 %.",
+          "hsem_planner_hysteresis_enabled": "Wenn aktiviert, behält der Planer den aktiven Kandidatenplan bei, sofern ein neuer Plan die Bewertung nicht um mehr als die konfigurierten Schwellenwerte verbessert. Verhindert Oszillation zwischen gleich bewerteten Strategien.",
+          "hsem_planner_hysteresis_absolute": "Minimale absolute Bewertungsverbesserung, die für einen Wechsel zu einem neuen Plan erforderlich ist. 0,00 deaktiviert den absoluten Schwellenwert. Die Bewertung verwendet dieselbe Währung wie deine Strompreise, sodass ein Wert von 0,01 mindestens 1 Cent/kWh-äquivalente Verbesserung vor einem Wechsel erfordert.",
+          "hsem_planner_hysteresis_percentage": "Minimale prozentuale Bewertungsverbesserung, die für einen Wechsel zu einem neuen Plan erforderlich ist. 0 % deaktiviert den prozentualen Schwellenwert. Der Standardwert von 5 % verhindert Flattern zwischen nahezu identischen Plänen.",
+          "hsem_planner_window_hysteresis_minutes": "Minimale Zeit (Minuten), die eine Empfehlung gehalten werden muss, bevor sie sich ändern kann. Verhindert schnelles Umschalten wie z. B. ev_smart_charging ↔ batteries_charge_solar. 0 deaktiviert die Funktion. Standard 10."
+        },
+        "description": "Konfiguriere Batteriewirtschaftlichkeitsparameter und Planer-Hysterese (Anti-Flattern).",
+        "title": "Batteriewirtschaftlichkeit & Hysterese"
+      },
+      "init": {
+        "data": {
+          "device_name": "Name",
+          "hsem_extended_attributes": "Erweiterte Attribute",
+          "hsem_read_only": "Nur Lesen",
+          "hsem_recommendation_interval_length": "Empfehlungsintervall-Länge",
+          "hsem_recommendation_interval_minutes": "Empfehlungsintervall-Minuten",
+          "hsem_update_interval": "Aktualisierungsintervall",
+          "hsem_verbose_logging": "Ausführliche Protokollierung"
+        },
+        "data_description": {
+          "device_name": "Gib einen eindeutigen Namen für dieses Gerät ein.",
+          "hsem_extended_attributes": "Aktiviere diese Option, um zusätzliche Diagnoseattribute auf der Sensor-Entität bereitzustellen.",
+          "hsem_read_only": "Aktiviere diese Option, um die Integration in den Nur-Lese-Modus zu versetzen und das Senden von Befehlen an Geräte zu verhindern.",
+          "hsem_recommendation_interval_length": "Die Anzahl der Empfehlungsintervalle, die bei der Berechnung der optimalen Batterienutzung berücksichtigt werden.",
+          "hsem_recommendation_interval_minutes": "Die Länge in Minuten jedes Empfehlungsintervalls, das zur Berechnung der optimalen Batterienutzung verwendet wird.",
+          "hsem_update_interval": "Das Aktualisierungsintervall in Minuten für den Arbeitsmodus-Sensor.",
+          "hsem_verbose_logging": "Aktiviere ausführliche Debug-Protokollierung zu Fehlerbehebungszwecken."
+        },
+        "description": "Aktualisiere die Einstellungen für HSEM",
+        "title": "Huawei Solar Energy Management aktualisieren"
+      },
+      "batteries_schedules": {
+        "data": {
+          "hsem_batteries_enable_batteries_schedule_1": "Batterie-Zeitplan 1 aktivieren",
+          "hsem_batteries_enable_batteries_schedule_1_end": "Batterie-Zeitplan 1 Endzeit",
+          "hsem_batteries_enable_batteries_schedule_1_start": "Batterie-Zeitplan 1 Startzeit",
+          "hsem_batteries_enable_batteries_schedule_2": "Batterie-Zeitplan 2 aktivieren",
+          "hsem_batteries_enable_batteries_schedule_2_end": "Batterie-Zeitplan 2 Endzeit",
+          "hsem_batteries_enable_batteries_schedule_2_start": "Batterie-Zeitplan 2 Startzeit",
+          "hsem_batteries_enable_batteries_schedule_3": "Batterie-Zeitplan 3 aktivieren",
+          "hsem_batteries_enable_batteries_schedule_3_end": "Batterie-Zeitplan 3 Endzeit",
+          "hsem_batteries_enable_batteries_schedule_3_start": "Batterie-Zeitplan 3 Startzeit"
+        },
+        "data_description": {
+          "hsem_batteries_enable_batteries_schedule_1": "Aktiviere oder deaktiviere den ersten Batterie-Entladezeitplan.",
+          "hsem_batteries_enable_batteries_schedule_1_end": "Lege die Endzeit für den ersten Batterie-Entladezeitplan fest.",
+          "hsem_batteries_enable_batteries_schedule_1_start": "Lege die Startzeit für den ersten Batterie-Entladezeitplan fest.",
+          "hsem_batteries_enable_batteries_schedule_2": "Aktiviere oder deaktiviere den zweiten Batterie-Entladezeitplan.",
+          "hsem_batteries_enable_batteries_schedule_2_end": "Lege die Endzeit für den zweiten Batterie-Entladezeitplan fest.",
+          "hsem_batteries_enable_batteries_schedule_2_start": "Lege die Startzeit für den zweiten Batterie-Entladezeitplan fest.",
+          "hsem_batteries_enable_batteries_schedule_3": "Aktiviere oder deaktiviere den dritten Batterie-Entladezeitplan.",
+          "hsem_batteries_enable_batteries_schedule_3_end": "Lege die Endzeit für den dritten Batterie-Entladezeitplan fest.",
+          "hsem_batteries_enable_batteries_schedule_3_start": "Lege die Startzeit für den dritten Batterie-Entladezeitplan fest."
+        },
+        "description": "Konfiguriere bis zu drei Batterie-Entladezeitplan-Fenster, jeweils mit Ein-/Aus-Schalter, Startzeit und Endzeit. Zeitpläne legen fest, wann die Batterie entladen darf, um Verbrauchsspitzen zu decken oder ins Netz einzuspeisen.",
+        "title": "Batterie-Entladezeitpläne"
+      },
+      "months": {
+        "data": {
+          "hsem_months_winter": "Als Winter/Frühling betrachtete Monate"
+        },
+        "data_description": {
+          "hsem_months_winter": "Wähle die Monate, die für die saisonale Anpassung des Arbeitsmodus als Winter/Frühling gelten sollen. Du kannst mehrere Monate auswählen. Die Auswahl aller 12 Monate ist zulässig — dies hält den Winter/Frühling-Modus (TOU) ganzjährig aktiv. Die Auswahl aller 12 Monate ist zulässig — dies hält den Winter/Frühling-Modus (TOU) ganzjährig aktiv."
+        },
+        "description": "Konfiguriere die Monate, die als Winter/Frühling gelten. In diesen Monaten priorisiert das System das Laden der Batterien aus Netzenergie, um während Zeiten geringerer Solarproduktion ausreichende Batteriestände sicherzustellen. Die übrigen Monate gelten als Sommer/Herbst-Monate.",
+        "title": "Winter/Frühling-Monate"
+      },
+      "power": {
+        "data": {
+          "hsem_house_consumption_power": "Hausverbrauchsleistungssensor",
+          "hsem_main_fuse_amps": "Hauptsicherung Nennwert (Ampere)",
+          "hsem_main_fuse_phases": "Hauptsicherung Phasenanzahl",
+          "hsem_max_grid_export_power_kw": "Maximale Netzeinspeiseleistung (kW)",
+          "hsem_solar_production_power": "Solarproduktionsleistungssensor",
+          "hsem_huawei_solar_power_meter_phase_a_active_power": "Stromzähler Phase A Wirkleistungssensor",
+          "hsem_huawei_solar_power_meter_phase_b_active_power": "Stromzähler Phase B Wirkleistungssensor",
+          "hsem_huawei_solar_power_meter_phase_c_active_power": "Stromzähler Phase C Wirkleistungssensor",
+          "hsem_phase_aware_charging_enabled": "Live-Sicherheitsbegrenzer für phasenbewusstes Laden aktivieren"
+        },
+        "data_description": {
+          "hsem_house_consumption_power": "Wähle den Sensor, der den Gesamtstromverbrauch deines Hauses misst.",
+          "hsem_main_fuse_amps": "Der Nennwert der Hauptsicherung/des Hauptschalters deines Hauses in Ampere (25, 35 usw.). Der MILP-Optimierer berücksichtigt diese Grenze bei der Planung von Batterie- und EV-Ladung. Auf 0 setzen, um zu deaktivieren.",
+          "hsem_main_fuse_phases": "Die Phasenanzahl deiner elektrischen Installation. Einphasige Installationen MÜSSEN auf 1 gesetzt werden — die Einstellung 3 bei einer einphasigen Installation macht den Sicherungsschutz 3-mal zu großzügig und bietet keine echte Sicherheitsgrenze. Standard ist 3 (dreiphasig).",
+          "hsem_max_grid_export_power_kw": "Maximale Netzeinspeiseleistung in kW — die Exportobergrenze des Netzbetreibers/Wechselrichters für exportbeschränkte Anschlüsse (z. B. 5 kW). Der MILP-Planer plant nie einen Export über diese Grenze hinaus, sodass Batterieexport und PV-Export korrekt um dieselbe Obergrenze konkurrieren. Auf 0 setzen, um zu deaktivieren.",
+          "hsem_solar_production_power": "Wähle den Sensor, der die von deinen Solarmodulen erzeugte Leistung misst.",
+          "hsem_huawei_solar_power_meter_phase_a_active_power": "Wähle den Sensor, der die Live-Wirkleistung auf Phase A deines Huawei-Stromzählers misst. Nur erforderlich, wenn phasenbewusstes Laden aktiviert ist.",
+          "hsem_huawei_solar_power_meter_phase_b_active_power": "Wähle den Sensor, der die Live-Wirkleistung auf Phase B deines Huawei-Stromzählers misst. Nur erforderlich, wenn phasenbewusstes Laden aktiviert ist.",
+          "hsem_huawei_solar_power_meter_phase_c_active_power": "Wähle den Sensor, der die Live-Wirkleistung auf Phase C deines Huawei-Stromzählers misst. Nur erforderlich, wenn phasenbewusstes Laden aktiviert ist.",
+          "hsem_phase_aware_charging_enabled": "Aktiviere eine Live-Sicherheitsprüfung unmittelbar vor jedem Huawei-Netzlade-Hardware-Schreibvorgang (issue #831). Verwendet die drei unten stehenden Stromzähler-Phasensensoren sowie die Huawei-Netzladeleistungs-Obergrenze-Entität (Schritt huawei_solar), um netzfinanziertes Laden so zu begrenzen, dass keine Phase die Hauptsicherungsgrenze überschreitet, selbst wenn sich die Last nach der Planlösung geändert hat. Erfordert main_fuse_phases = 3 und alle vier konfigurierten Entitäten. Standardmäßig deaktiviert — vollständig abwärtskompatibel."
+        },
+        "description": "Wähle Leistungssensoren für HSEM aus.",
+        "title": "Leistungssensoren"
+      },
+      "quick_setup": {
+        "data": {
+          "battery_soc": "Batterie-Ladezustand",
+          "working_mode": "Batterien Arbeitsmodus",
+          "max_charge_power": "Max. Ladeleistung",
+          "max_discharge_power": "Max. Entladeleistung",
+          "eod_soc": "Entladeschluss-SoC",
+          "rated_capacity": "Batterien Nennkapazität",
+          "active_power_control": "Wirkleistungssteuerung",
+          "tou_periods": "TOU-Lade-/Entladezeiträume",
+          "solcast_today": "Solcast-Prognose heute",
+          "solcast_tomorrow": "Solcast-Prognose morgen",
+          "import_price": "Stromimportpreis-Sensor",
+          "export_price": "Stromexportpreis-Sensor",
+          "house_power": "Hausverbrauchsleistung",
+          "solar_power": "Solarproduktionsleistung",
+          "use_quick_setup": "Schnelleinrichtung verwenden"
+        },
+        "data_description": {
+          "battery_soc": "Automatisch erkannter Batterie-Ladezustandssensor.",
+          "working_mode": "Automatisch erkannte Batterien-Arbeitsmodus-Entität.",
+          "max_charge_power": "Automatisch erkannte maximale Ladeleistungsentität.",
+          "max_discharge_power": "Automatisch erkannte maximale Entladeleistungsentität.",
+          "eod_soc": "Automatisch erkannte Entladeschluss-SoC-Entität.",
+          "rated_capacity": "Automatisch erkannter Batterien-Nennkapazitätssensor.",
+          "active_power_control": "Automatisch erkannter Wechselrichter-Wirkleistungssteuerungssensor.",
+          "tou_periods": "Automatisch erkannter TOU-Lade-/Entladezeiträume-Sensor.",
+          "solcast_today": "Automatisch erkannte Solcast-PV-Prognose für heute.",
+          "solcast_tomorrow": "Automatisch erkannte Solcast-PV-Prognose für morgen.",
+          "import_price": "Automatisch erkannter Stromimportpreissensor.",
+          "export_price": "Automatisch erkannter Stromexportpreissensor.",
+          "house_power": "Automatisch erkannter Hausverbrauchsleistungssensor.",
+          "solar_power": "Automatisch erkannter Solarproduktionsleistungssensor.",
+          "use_quick_setup": "Aktivieren, um automatisch erkannte Entitäten zu verwenden und den vollständigen Assistenten für die Einrichtung einzelner Entitäten zu überspringen. Für die erweiterte Einrichtung deaktivieren."
+        },
+        "description": "HSEM hat die folgenden Entitäten automatisch erkannt. {warning}Überprüfe die unten erkannten Entitäten. Du kannst sie bestätigen oder die erweiterte Einrichtung wählen, um Entitäten manuell auszuwählen.",
+        "title": "Schnelleinrichtung — Automatisch erkannte Entitäten"
+      },
+      "solcast": {
+        "data": {
+          "hsem_solcast_pv_forecast_forecast_likelihood": "Solcast PV-Prognose bevorzugte Prognosewahrscheinlichkeit",
+          "hsem_solcast_pv_forecast_forecast_today": "Solcast PV-Prognose heute Sensor",
+          "hsem_solcast_pv_forecast_forecast_tomorrow": "Solcast PV-Prognose morgen Sensor"
+        },
+        "data_description": {
+          "hsem_solcast_pv_forecast_forecast_likelihood": "Wähle die bevorzugte Prognosewahrscheinlichkeit für Solcast-PV-Prognosen.",
+          "hsem_solcast_pv_forecast_forecast_today": "Wähle den Sensor, der die heutige PV-Produktionsprognose von Solcast liefert.",
+          "hsem_solcast_pv_forecast_forecast_tomorrow": "Wähle den Sensor, der die morgige PV-Produktionsprognose von Solcast liefert."
+        },
+        "description": "Wähle Solcast-Prognosesensoren aus.",
+        "title": "Solcast-Sensoren"
+      },
+      "user": {
+        "data": {
+          "device_name": "Name",
+          "hsem_extended_attributes": "Erweiterte Attribute",
+          "hsem_read_only": "Nur Lesen",
+          "hsem_recommendation_interval_length": "Empfehlungsintervall-Länge",
+          "hsem_recommendation_interval_minutes": "Empfehlungsintervall-Minuten",
+          "hsem_update_interval": "Aktualisierungsintervall",
+          "hsem_verbose_logging": "Ausführliche Protokollierung"
+        },
+        "data_description": {
+          "device_name": "Gib einen eindeutigen Namen für dieses Gerät ein.",
+          "hsem_extended_attributes": "Aktiviere diese Option, um zusätzliche Diagnoseattribute auf der Sensor-Entität bereitzustellen.",
+          "hsem_read_only": "Aktiviere diese Option, um die Integration in den Nur-Lese-Modus zu versetzen und das Senden von Befehlen an Geräte zu verhindern.",
+          "hsem_recommendation_interval_length": "Die Anzahl der Empfehlungsintervalle, die bei der Berechnung der optimalen Batterienutzung berücksichtigt werden.",
+          "hsem_recommendation_interval_minutes": "Die Länge in Minuten jedes Empfehlungsintervalls, das zur Berechnung der optimalen Batterienutzung verwendet wird.",
+          "hsem_update_interval": "Das Aktualisierungsintervall in Minuten für den Arbeitsmodus-Sensor.",
+          "hsem_verbose_logging": "Aktiviere ausführliche Debug-Protokollierung zu Fehlerbehebungszwecken."
+        },
+        "description": "Konfiguriere die Einstellungen für HSEM",
+        "title": "Huawei Solar Energy Management konfigurieren"
+      },
+      "weighted_values": {
+        "data": {
+          "hsem_house_consumption_energy_weight_14d": "Hausverbrauchsenergie-Gewichtung 14 Tage",
+          "hsem_house_consumption_energy_weight_1d": "Hausverbrauchsenergie-Gewichtung 1 Tag",
+          "hsem_house_consumption_energy_weight_3d": "Hausverbrauchsenergie-Gewichtung 3 Tage",
+          "hsem_house_consumption_energy_weight_7d": "Hausverbrauchsenergie-Gewichtung 7 Tage"
+        },
+        "data_description": {
+          "hsem_house_consumption_energy_weight_14d": "Gib den Gewichtungsprozentsatz für den Hausverbrauch der letzten 14 Tage an.",
+          "hsem_house_consumption_energy_weight_1d": "Gib den Gewichtungsprozentsatz für den Hausverbrauch des letzten 1 Tages an.",
+          "hsem_house_consumption_energy_weight_3d": "Gib den Gewichtungsprozentsatz für den Hausverbrauch der letzten 3 Tage an.",
+          "hsem_house_consumption_energy_weight_7d": "Gib den Gewichtungsprozentsatz für den Hausverbrauch der letzten 7 Tage an."
+        },
+        "description": "Konfiguriere die gewichteten Werte für den Hausverbrauch, um deinen durchschnittlichen Stromverbrauch zu schätzen. Das System berechnet den durchschnittlichen Verbrauch für jede Stunde über 1, 3, 7 und 14 Tage. Diese Durchschnittswerte werden dann gewichtet, um eine kombinierte, gewichtete Schätzung zu liefern. Dieser Ansatz hilft, Anomalien auszugleichen, etwa einen ungewöhnlich hohen Verbrauch an einem einzelnen Tag aufgrund niedriger Preise, und liefert eine zuverlässige Vorhersage deines erwarteten Stromverbrauchs in bestimmten Zeitintervallen (z. B. zwischen 16:00 und 17:00 Uhr).",
+        "title": "Gewichtete Werte"
+      },
+      "energy_and_ml": {
+        "data": {
+          "hsem_grid_import_energy_entity": "Netzimport-Energiesensor",
+          "hsem_grid_export_energy_entity": "Netzeinspeisung-Energiesensor",
+          "hsem_pv_energy_entity": "PV-Produktions-Energiesensor",
+          "hsem_ml_consumption_enabled": "ML-Verbrauchsprognose aktivieren",
+          "hsem_ml_consumption_energy_entity": "Hausverbrauchs-Energiesensor (ohne Batterie & EV)",
+          "hsem_ml_consumption_history_days": "ML-Verlaufstage",
+          "hsem_ml_consumption_net_consumption": "Nettoverbrauch verwenden (Import - Export)",
+          "hsem_ml_consumption_temperature_entity": "Außentemperatursensor",
+          "hsem_ml_consumption_sequential": "Sequenzielle Vorhersage (Lag-Feature)"
+        },
+        "data_description": {
+          "hsem_grid_import_energy_entity": "Optional — kumulativer Netzimport-Energiezähler (kWh).",
+          "hsem_grid_export_energy_entity": "Optional — kumulativer Netzeinspeisung-Energiezähler (kWh).",
+          "hsem_pv_energy_entity": "Optional — kumulativer PV-Produktions-Energiezähler (kWh).",
+          "hsem_ml_consumption_enabled": "Wenn aktiviert, wird Ridge-Regression auf Basis der Recorder-Historie anstelle gleitender Durchschnitte verwendet. Erfordert mindestens 14 Tage Historie.",
+          "hsem_ml_consumption_energy_entity": "Kumulativer Hausverbrauchs-Energiezähler (kWh). Muss Batterie UND EV-Ladung ausschließen — verwende einen Sensor vor beiden. Fällt auf Netzimport zurück, falls nicht gesetzt.",
+          "hsem_ml_consumption_history_days": "Tage der Recorder-Historie für das ML-Training (7–90).",
+          "hsem_ml_consumption_net_consumption": "Ziehe Netzeinspeisung vom Import ab, um den Nettohausverbrauch zu erhalten.",
+          "hsem_ml_consumption_temperature_entity": "Optional — Außentemperatursensor in °C. Verwende einen Außensensor, keinen Innenraumthermostat.",
+          "hsem_ml_consumption_sequential": "Gibt jede Slot-Vorhersage als Eingabe für die nächste weiter. Erfasst untertägige Dynamik (z. B. wirken sich Kochspitzen weiter aus)."
+        },
+        "description": "Konfiguriere Energiezähler und aktiviere die ML-basierte Verbrauchsprognose.",
+        "title": "Energie & ML"
+      },
+      "batteries_wait_mode": {
+        "data": {
+          "hsem_batteries_wait_mode_behavior": "Wartemodus-Verhalten"
+        },
+        "data_description": {
+          "hsem_batteries_wait_mode_behavior": "Wähle, wie sich die Batterie verhält, wenn HSEM den Wartemodus auswählt. Strenges Warten hält die Batterie inaktiv. Eigenverbrauch mit Reserve erlaubt dem Haus, überschüssige Batterieenergie oberhalb der vom Planer benötigten Reserve zu nutzen, wodurch unnötiger Netzimport reduziert wird."
+        },
+        "description": "Konfiguriere, wie sich die Batterie im Wartemodus verhält.",
+        "title": "Batterie-Wartemodus-Verhalten"
+      }
+    }
+  },
+  "options": {
+    "error": {
+      "device_not_found": "Das ausgewählte Gerät wurde nicht gefunden.",
+      "energy_out_of_range": "Der Energiewert liegt außerhalb des zulässigen Bereichs.",
+      "entity_not_found": "Die ausgewählte Entität wurde nicht gefunden.",
+      "entity_unavailable": "Die ausgewählte Entität ist derzeit nicht verfügbar. Überprüfe das Gerät oder den Dienst.",
+      "hsem_house_consumption_energy_weight_total": "Die Summe der Gewichtungen für den Hausverbrauch muss 100 % betragen.",
+      "invalid_energy_value": "Ungültiger Energiewert — bitte eine Zahl eingeben.",
+      "invalid_entity_id": "Ungültiges Entitäts-ID-Format. Erwartet wird \"domain.object_id\" mit Kleinbuchstaben, Ziffern und Unterstrichen.",
+      "invalid_month_value": "Ein oder mehrere Monatswerte sind ungültig. Monate müssen ganze Zahlen zwischen 1 und 12 sein.",
+      "invalid_power_value": "Ungültiger Leistungswert — bitte eine Zahl eingeben.",
+      "invalid_price_value": "Ungültiger Preiswert — bitte eine Zahl eingeben.",
+      "invalid_sensor": "Ungültiger Eingabesensor. Bitte wähle einen gültigen Sensor.",
+      "invalid_time_format": "Ungültiges Zeitformat — erwartet wird HH:MM:SS.",
+      "months_winter_empty": "Die Wintersaison muss mindestens einen Monat enthalten.",
+      "only_one_entry_allowed": "Nur eine Konfiguration von HSEM ist zulässig.",
+      "power_out_of_range": "Der Leistungswert liegt außerhalb des zulässigen Bereichs.",
+      "price_out_of_range": "Der Preiswert liegt außerhalb des zulässigen Bereichs.",
+      "required": "Dieses Feld ist erforderlich.",
+      "start_time_after_end_time": "Die Startzeit muss vor der Endzeit liegen.",
+      "start_time_equals_end_time": "Start- und Endzeit dürfen nicht identisch sein — das ergibt ein Zeitfenster der Länge null. Deaktiviere stattdessen den Zeitplan.",
+      "invalid_wait_mode_behavior": "Ungültiges Wartemodus-Verhalten. Wähle Strenges Warten oder Eigenverbrauch mit Reserve.",
+      "port_conflict": "Der zweite OCPP-Port muss sich vom ersten OCPP-Port unterscheiden."
+    },
+    "step": {
+      "batteries_excess_export": {
+        "data": {
+          "hsem_batteries_enable_excess_export": "Batterie-Überschussexport aktivieren",
+          "hsem_batteries_excess_export_discharge_buffer": "Entladepuffer (%)",
+          "hsem_batteries_forecast_reserve_pct": "Batterieexport-Prognosereserve (+% SoC)",
+          "hsem_batteries_export_min_price": "Mindestpreis für Batterieexport"
+        },
+        "data_description": {
+          "hsem_batteries_enable_excess_export": "Aktiviere oder deaktiviere die Funktion für den Export überschüssiger Batteriekapazität, die überschüssige Batteriekapazität automatisch ins Netz einspeist, wenn es wirtschaftlich vorteilhaft ist.",
+          "hsem_batteries_excess_export_discharge_buffer": "Lege den Sicherheitspuffer in Prozent fest, um minimale Batteriereserven zu erhalten (0-50 %). Standard sind 10 %, um ausreichend Kapazität für unerwarteten Bedarf sicherzustellen.",
+          "hsem_batteries_forecast_reserve_pct": "Zusätzliche SoC-Prozentpunkte über der Huawei-Entladeschluss-Grenze, die der beabsichtigte Batterieexport unmittelbar nach jedem Export-Slot freihalten muss. Zum Beispiel schützt eine Huawei-Grenze von 15 % zuzüglich einer Reserve von 5 % einen SoC von 20 %. Die Reserve bleibt für die Hauslast verfügbar, wenn der tatsächliche Bedarf die Prognose übersteigt. Auf 0 setzen, um zu deaktivieren (Standard).",
+          "hsem_batteries_export_min_price": "Feste Preisuntergrenze pro Slot für beabsichtigten Batterie-zu-Netz-Export (issue #752). Bei Werten > 0 verbietet HSEM, einen Slot als force_batteries_discharge zu markieren, wenn der Exportpreis strikt unter dieser Untergrenze liegt — die Batterie kann in diesen Slots weiterhin die Hausversorgung übernehmen. Das Erreichen der Schwelle löst NICHT automatisch einen Export aus; der Optimierer entscheidet weiterhin, ob sich der Verkauf lohnt. Gilt nur für den beabsichtigten Batterie-zu-Netz-Export, nicht für normalen Eigenverbrauch, PV-Export oder PV-Ladung. Auf 0 setzen, um zu deaktivieren (Standard)."
+        },
+        "description": "Konfiguriere Einstellungen für den Export überschüssiger Batteriekapazität, um überschüssige Energie automatisch ins Netz zu verkaufen, wenn es wirtschaftlich vorteilhaft ist.",
+        "title": "Batterie-Überschussexport"
+      },
+      "ev_planned_load": {
+        "data": {
+          "hsem_ev_planned_load_enabled": "EV-Lastplanung-Integration aktivieren",
+          "hsem_ev_planned_load_battery_capacity_kwh": "EV-Batteriekapazität (kWh)",
+          "hsem_ev_planned_load_charger_power_kw": "EV-Ladegerät Leistung (kW)",
+          "hsem_ev_planned_load_charger_efficiency": "EV-Ladegerät Effizienz",
+          "hsem_ev_planned_load_charger_min_power_w": "EV-Ladegerät Mindestleistung (W)",
+          "hsem_ev_planned_load_charger_phase_topology": "Phasentopologie des Ladegeräts",
+          "hsem_ev_planned_load_deadline_safety_margin_pct": "Sicherheitsmarge für Frist (%)",
+          "hsem_ev_planned_load_command_deadband_a": "Totband für Obergrenze (A)",
+          "hsem_ev_planned_load_stub_floor_minutes": "Unterdrückung des Stopps am Slot-Ende (Min.)"
+        },
+        "data_description": {
+          "hsem_ev_planned_load_enabled": "Aktiviere oder deaktiviere die Integration der geplanten EV-Ladelast.",
+          "hsem_ev_planned_load_battery_capacity_kwh": "Nennkapazität der EV-Batterie in kWh.",
+          "hsem_ev_planned_load_charger_power_kw": "AC-Ausgangsleistung des EV-Ladegeräts in kW.",
+          "hsem_ev_planned_load_charger_efficiency": "Ladegerät-Effizienz in Prozent (1-100). Standard: 100.",
+          "hsem_ev_planned_load_charger_min_power_w": "Minimale AC-Leistung (W), die das EV-Ladegerät benötigt, um mit dem Laden zu beginnen. Darunter arbeitet das Ladegerät nicht. Standard: 1380 W (230 V × 6 A).",
+          "hsem_ev_planned_load_charger_phase_topology": "Wie das Ladegerät seine Last auf die Netzphasen verteilt. Wähle 'Einphasig oder unbekannt', sofern du nicht bestätigt hast, dass das Ladegerät auf allen drei Phasen einen ausgeglichenen Strom zieht. Bei aktiviertem phasenbezogenem Sicherungsschutz geht die sichere Standardannahme davon aus, dass der gesamte Ladebefehl auf einer Phase landen kann, was das geplante Laden auf den einphasigen Sicherungsspielraum begrenzt.",
+          "hsem_ev_planned_load_deadline_safety_margin_pct": "Zusätzliche Energie, die über dem Ziel-SoC hinaus als Prozentsatz des Fehlbetrags eingeplant wird, damit normale Ladereibung (Startverzögerungen, Mindestleistungsgrenzen, Drosselung) die Frist nicht verfehlt. Standard: 0 % (deaktiviert).",
+          "hsem_ev_planned_load_command_deadband_a": "Kleinste tatsächlich angewendete Reduzierung der veröffentlichten Ladeobergrenze. Kleinere Reduzierungen werden zurückgehalten, da konkurrierende Pläne mit ganzen Ampere-Werten kostenmäßig meist innerhalb eines Rundungsfehlers zueinander liegen. Eine Anhebung der Obergrenze wird nie verzögert, und eine Reduzierung, die die Ladekosten dieses Slots um mehr als 5 % verbessert, wird immer durchgeführt. Standard: 3 A; 0 deaktiviert.",
+          "hsem_ev_planned_load_stub_floor_minutes": "Unterdrückt am Ende eines Slots für diese Anzahl an Minuten einen Stoppbefehl, solange das Fahrzeug noch Energie benötigt. Die verbleibenden Sekunden reichen nicht aus, um genug Energie für die Ladegerät-Mindestleistung bereitzustellen, sodass der Plan ihnen nichts zuweist und die Sitzung ohne Nutzen stoppen und neu starten würde. Standard: 2 Minuten; 0 deaktiviert."
+        },
+        "description": "Konfiguriere die optionale Integration der geplanten EV-Ladelast. Wenn aktiviert, berücksichtigt HSEM den bevorstehenden EV-Ladebedarf pro Planer-Slot.",
+        "title": "EV-Lastplanung-Integration"
+      },
+      "ev_second_planned_load": {
+        "data": {
+          "hsem_ev_second_planned_load_enabled": "EV-2-Lastplanung-Integration aktivieren",
+          "hsem_ev_second_planned_load_battery_capacity_kwh": "EV 2 Batteriekapazität (kWh)",
+          "hsem_ev_second_planned_load_charger_power_kw": "EV 2 Ladegerät Leistung (kW)",
+          "hsem_ev_second_planned_load_charger_efficiency": "EV 2 Ladegerät Effizienz",
+          "hsem_ev_second_planned_load_charger_min_power_w": "EV 2 Ladegerät Mindestleistung (W)",
+          "hsem_ev_second_planned_load_charger_phase_topology": "Phasentopologie des Ladegeräts",
+          "hsem_ev_second_planned_load_deadline_safety_margin_pct": "EV 2 Sicherheitsmarge für Frist (%)",
+          "hsem_ev_second_planned_load_command_deadband_a": "EV 2 Totband für Obergrenze (A)",
+          "hsem_ev_second_planned_load_stub_floor_minutes": "EV 2 Unterdrückung des Stopps am Slot-Ende (Min.)"
+        },
+        "data_description": {
+          "hsem_ev_second_planned_load_enabled": "Aktiviere oder deaktiviere die Integration der geplanten Ladelast für das zweite EV.",
+          "hsem_ev_second_planned_load_battery_capacity_kwh": "Nennkapazität der Batterie des zweiten EVs in kWh.",
+          "hsem_ev_second_planned_load_charger_power_kw": "AC-Ausgangsleistung des zweiten EV-Ladegeräts in kW.",
+          "hsem_ev_second_planned_load_charger_efficiency": "Effizienz des zweiten EV-Ladegeräts in Prozent (1-100). Standard: 100.",
+          "hsem_ev_second_planned_load_charger_min_power_w": "Minimale AC-Leistung (W), die das zweite EV-Ladegerät zum Laden benötigt. Standard: 1380 W (230 V × 6 A).",
+          "hsem_ev_second_planned_load_charger_phase_topology": "Wie das Ladegerät seine Last auf die Netzphasen verteilt. Wähle 'Einphasig oder unbekannt', sofern du nicht bestätigt hast, dass das Ladegerät auf allen drei Phasen einen ausgeglichenen Strom zieht. Bei aktiviertem phasenbezogenem Sicherungsschutz geht die sichere Standardannahme davon aus, dass der gesamte Ladebefehl auf einer Phase landen kann, was das geplante Laden auf den einphasigen Sicherungsspielraum begrenzt.",
+          "hsem_ev_second_planned_load_deadline_safety_margin_pct": "Wie die Sicherheitsmarge für die Frist des primären EVs, für das zweite EV. Standard: 0 % (deaktiviert).",
+          "hsem_ev_second_planned_load_command_deadband_a": "Wie das Totband für die Obergrenze des primären EVs, für das zweite EV. Standard: 3 A; 0 deaktiviert.",
+          "hsem_ev_second_planned_load_stub_floor_minutes": "Wie die Unterdrückung des Stopps am Slot-Ende des primären EVs, für das zweite EV. Standard: 2 Minuten; 0 deaktiviert."
+        },
+        "description": "Konfiguriere die optionale Integration der geplanten Ladelast für das zweite EV. Wird nur angezeigt, wenn ein zweites EV-Ladegerät aktiviert ist.",
+        "title": "EV-2-Lastplanung-Integration"
+      },
+      "ocpp": {
+        "data": {
+          "hsem_ocpp_enabled": "OCPP-Server aktivieren",
+          "hsem_ocpp_port": "OCPP-Port",
+          "hsem_ocpp_cpid": "Ladepunkt-ID",
+          "hsem_ocpp_start_window_s": "Startfenster (s)",
+          "hsem_ocpp_stop_window_s": "Stoppfenster (s)",
+          "hsem_ocpp_second_enabled": "Zweiten OCPP-Server aktivieren",
+          "hsem_ocpp_second_port": "Zweiter OCPP-Port",
+          "hsem_ocpp_second_cpid": "Zweite Ladepunkt-ID"
+        },
+        "data_description": {
+          "hsem_ocpp_enabled": "Aktiviere den eingebetteten OCPP-1.6-WebSocket-Server für die direkte Steuerung des EV-Ladegeräts. Nur LAN — setze den Port nicht dem Internet aus.",
+          "hsem_ocpp_port": "TCP-Port für den OCPP-WebSocket-Server. Standard: 9000. Muss über 1024 liegen.",
+          "hsem_ocpp_cpid": "Erwartete Ladepunkt-Kennung des EV-Ladegeräts. Leer lassen, um jedes Ladegerät zu akzeptieren.",
+          "hsem_ocpp_start_window_s": "Sekunden anhaltenden Überschusses, die vor dem Start eines Ladevorgangs erforderlich sind. Verhindert schnelles Start-Stopp-Takten. Standard: 60.",
+          "hsem_ocpp_stop_window_s": "Sekunden anhaltenden Mangels, die vor dem Stoppen eines Ladevorgangs erforderlich sind. Verhindert schnelles Stopp-Start-Takten. Standard: 180.",
+          "hsem_ocpp_second_enabled": "Aktiviere einen zweiten, dedizierten OCPP-Server für das zweite EV. Nur verfügbar, wenn die EV-2-Lastplanung aktiviert ist.",
+          "hsem_ocpp_second_port": "TCP-Port für den zweiten OCPP-WebSocket-Server. Standard: 9001. Muss sich vom Port des ersten Servers unterscheiden.",
+          "hsem_ocpp_second_cpid": "Erwartete Ladepunkt-Kennung des zweiten EV-Ladegeräts. Leer lassen, um jedes Ladegerät zu akzeptieren."
+        },
+        "description": "Konfiguriere den eingebetteten OCPP-1.6-Server für die reine LAN-Steuerung von EV-Ladegeräten. Wenn aktiviert, sendet HSEM SetChargingProfile-Befehle direkt an dein EV-Ladegerät auf Basis des Ladeplans.",
+        "title": "OCPP-Server"
+      },
+      "batteries_schedule_1": {
+        "data": {
+          "hsem_batteries_enable_batteries_schedule_1": "Batterie-Zeitplan 1 aktivieren",
+          "hsem_batteries_enable_batteries_schedule_1_end": "Batterie-Zeitplan 1 Endzeit",
+          "hsem_batteries_enable_batteries_schedule_1_start": "Batterie-Zeitplan 1 Startzeit"
+        },
+        "data_description": {
+          "hsem_batteries_enable_batteries_schedule_1": "Aktiviere oder deaktiviere den ersten Batterie-Entladezeitplan.",
+          "hsem_batteries_enable_batteries_schedule_1_end": "Lege die Endzeit für den ersten Batterie-Entladezeitplan fest.",
+          "hsem_batteries_enable_batteries_schedule_1_start": "Lege die Startzeit für den ersten Batterie-Entladezeitplan fest."
+        },
+        "description": "Konfiguriere Batterie-Entladezeitplan 1, einschließlich seiner Aktivierungszeit.",
+        "title": "Batterie-Entladezeitplan 1"
+      },
+      "batteries_schedule_2": {
+        "data": {
+          "hsem_batteries_enable_batteries_schedule_2": "Batterie-Zeitplan 2 aktivieren",
+          "hsem_batteries_enable_batteries_schedule_2_end": "Batterie-Zeitplan 2 Endzeit",
+          "hsem_batteries_enable_batteries_schedule_2_start": "Batterie-Zeitplan 2 Startzeit"
+        },
+        "data_description": {
+          "hsem_batteries_enable_batteries_schedule_2": "Aktiviere oder deaktiviere den zweiten Batterie-Entladezeitplan.",
+          "hsem_batteries_enable_batteries_schedule_2_end": "Lege die Endzeit für den zweiten Batterie-Entladezeitplan fest.",
+          "hsem_batteries_enable_batteries_schedule_2_start": "Lege die Startzeit für den zweiten Batterie-Entladezeitplan fest."
+        },
+        "description": "Konfiguriere Batterie-Entladezeitplan 2, einschließlich seiner Aktivierungszeit.",
+        "title": "Batterie-Entladezeitplan 2"
+      },
+      "batteries_schedule_3": {
+        "data": {
+          "hsem_batteries_enable_batteries_schedule_3": "Batterie-Zeitplan 3 aktivieren",
+          "hsem_batteries_enable_batteries_schedule_3_end": "Batterie-Zeitplan 3 Endzeit",
+          "hsem_batteries_enable_batteries_schedule_3_start": "Batterie-Zeitplan 3 Startzeit"
+        },
+        "data_description": {
+          "hsem_batteries_enable_batteries_schedule_3": "Aktiviere oder deaktiviere den dritten Batterie-Entladezeitplan.",
+          "hsem_batteries_enable_batteries_schedule_3_end": "Lege die Endzeit für den dritten Batterie-Entladezeitplan fest.",
+          "hsem_batteries_enable_batteries_schedule_3_start": "Lege die Startzeit für den dritten Batterie-Entladezeitplan fest."
+        },
+        "description": "Konfiguriere Batterie-Entladezeitplan 3, einschließlich seiner Aktivierungszeit.",
+        "title": "Batterie-Entladezeitplan 3"
+      },
+      "prices": {
+        "data": {
+          "hsem_import_electricity_price_sensor": "Stromimportpreis-Sensor",
+          "hsem_export_electricity_price_sensor": "Stromexportpreis-Sensor",
+          "hsem_import_electricity_price_forecast_sensor": "Stromimportpreis-Prognosesensor (optional)",
+          "hsem_export_electricity_price_forecast_sensor": "Stromexportpreis-Prognosesensor (optional)",
+          "hsem_export_electricity_min_price": "Erforderlicher Mindestexportpreis",
+          "hsem_electricity_price_update_interval": "Strompreis-Aktualisierungsintervall (Minuten)"
+        },
+        "data_description": {
+          "hsem_import_electricity_price_sensor": "Wähle den Sensor, der Stromimportpreise liefert (z. B. Energi Data Service, Nordpool, Amber Electric).",
+          "hsem_export_electricity_price_sensor": "Wähle den Sensor, der Stromexportpreise liefert.",
+          "hsem_import_electricity_price_forecast_sensor": "Optional: Wähle einen separaten Sensor für Importpreis-Prognosen (verwendet von Amber Electric und ähnlichen Integrationen).",
+          "hsem_export_electricity_price_forecast_sensor": "Optional: Wähle einen separaten Sensor für Exportpreis-Prognosen.",
+          "hsem_export_electricity_min_price": "Lege den Mindestexportpreis fest. Exporte unterhalb dieses Preises werden blockiert.",
+          "hsem_electricity_price_update_interval": "Wie oft dein Preissensor neue Daten liefert (15, 30 oder 60 Minuten)."
+        },
+        "description": "Konfiguriere deine Strompreissensoren für Import- und Exportpreise.",
+        "title": "Strompreise"
+      },
+      "ev": {
+        "data": {
+          "hsem_ev_allow_charge_past_target_soc": "Laden über Ziel-SoC hinaus erlauben (Erweitert)",
+          "hsem_ev_charger_force_max_discharge_power": "EV-Ladegerät maximale Entladeleistung erzwingen",
+          "hsem_ev_charger_max_discharge_power": "EV-Ladegerät maximale Entladeleistung",
+          "hsem_ev_charger_power": "EV-Ladegerät Leistungssensor",
+          "hsem_ev_charger_status": "EV-Ladegerät Statussensor",
+          "hsem_ev_connected": "EV verbunden Sensor",
+          "hsem_ev_second_enabled": "Zweites EV-Ladegerät aktivieren",
+          "hsem_ev_soc": "EV-Ladezustand (SoC) Sensor",
+          "hsem_house_power_includes_ev_charger_power": "Hausleistung enthält EV-Ladegerät-Leistung",
+          "hsem_ev_auto_full_negative_price": "EV bei negativem Preis automatisch vollladen",
+          "hsem_ev_past_target_confidence_factor": "EV-Konfidenzfaktor für Laden über Ziel-SoC hinaus (Erweitert)"
+        },
+        "data_description": {
+          "hsem_ev_allow_charge_past_target_soc": "Aktiviere diese Option, wenn du zulassen möchtest, dass das System die EV-Batterie auch nach Erreichen des Ziel-Ladezustands (SoC) weiter lädt. Dies kann in Szenarien nützlich sein, in denen du sicherstellen möchtest, dass das EV unabhängig von der Zieleinstellung vollständig geladen wird.",
+          "hsem_ev_charger_force_max_discharge_power": "Aktiviere dies, wenn du eine bestimmte maximale Entladeleistung für die Huawei-Batterien erzwingen möchtest, während das EV lädt.",
+          "hsem_ev_charger_max_discharge_power": "Lege die maximale Entladeleistung für die Huawei-Batterien fest, während das EV lädt.",
+          "hsem_ev_charger_power": "Wähle den Sensor, der den Stromverbrauch deines EV-Ladegeräts misst.",
+          "hsem_ev_charger_status": "Wähle den Sensor oder die Entität, die anzeigt, ob das EV-Ladegerät aktiv ist (z. B. ein Schalter oder Sensor).",
+          "hsem_ev_connected": "Wähle den Sensor oder die Entität, die anzeigt, ob das EV mit dem Ladegerät verbunden ist.",
+          "hsem_ev_second_enabled": "Aktiviere oder deaktiviere die Konfiguration für ein zweites EV-Ladegerät.",
+          "hsem_ev_soc": "Wähle den Sensor, der den aktuellen Ladezustand (SoC) deiner EV-Batterie liefert.",
+          "hsem_house_power_includes_ev_charger_power": "Aktiviere dies, wenn der Hausverbrauchsleistungssensor die Leistung des EV-Ladegeräts bereits enthält.",
+          "hsem_ev_auto_full_negative_price": "Wenn aktiviert, wird das EV automatisch auf volle Ladeleistung gesetzt, sobald der Strompreis null oder negativ ist. Der vorherige Lademodus wird wiederhergestellt, sobald der Preis über null steigt.",
+          "hsem_ev_past_target_confidence_factor": "Konfidenzmultiplikator (0,0-1,0), der auf die Bewertung des vermiedenen zukünftigen Imports angewendet wird, wenn das EV über seinen Ziel-SoC hinaus geladen wird. Niedrigere Werte machen das EV im Vergleich zum Export von überschüssigem PV-Strom weniger konkurrenzfähig, um der Unsicherheit Rechnung zu tragen, ob das EV die zusätzliche Energie vor dem nächsten Ladevorgang tatsächlich benötigt. Standard 0,9."
+        },
+        "description": "Konfiguriere die EV-Ladegerät-Einstellungen für HSEM.",
+        "title": "EV-Ladegerät-Einstellungen (Optional)"
+      },
+      "ev_second": {
+        "data": {
+          "hsem_ev_second_allow_charge_past_target_soc": "Laden über Ziel-SoC hinaus für zweites EV erlauben (Erweitert)",
+          "hsem_ev_second_charger_force_max_discharge_power": "Zweites EV-Ladegerät maximale Entladeleistung erzwingen",
+          "hsem_ev_second_charger_max_discharge_power": "Zweites EV-Ladegerät maximale Entladeleistung",
+          "hsem_ev_second_charger_power": "Zweites EV-Ladegerät Leistungssensor",
+          "hsem_ev_second_charger_status": "Zweites EV-Ladegerät Statussensor",
+          "hsem_ev_second_connected": "Zweites EV verbunden Sensor",
+          "hsem_ev_second_soc": "Zweites EV-Ladezustand (SoC) Sensor",
+          "hsem_ev_second_past_target_confidence_factor": "Konfidenzfaktor für zweites EV Laden über Ziel-SoC hinaus (Erweitert)"
+        },
+        "data_description": {
+          "hsem_ev_second_allow_charge_past_target_soc": "Aktiviere diese Option, wenn du zulassen möchtest, dass das System die EV-Batterie auch nach Erreichen des Ziel-Ladezustands (SoC) weiter lädt. Dies kann in Szenarien nützlich sein, in denen du sicherstellen möchtest, dass das EV unabhängig von der Zieleinstellung vollständig geladen wird.",
+          "hsem_ev_second_charger_force_max_discharge_power": "Aktiviere dies, wenn du eine bestimmte maximale Entladeleistung für die Huawei-Batterien erzwingen möchtest, während das EV lädt.",
+          "hsem_ev_second_charger_max_discharge_power": "Lege die maximale Entladeleistung für die Huawei-Batterien fest, während das EV lädt.",
+          "hsem_ev_second_charger_power": "Wähle den Sensor, der den Stromverbrauch deines EV-Ladegeräts misst.",
+          "hsem_ev_second_charger_status": "Wähle den Sensor oder die Entität, die anzeigt, ob das EV-Ladegerät aktiv ist (z. B. ein Schalter oder Sensor).",
+          "hsem_ev_second_connected": "Wähle den Sensor oder die Entität, die anzeigt, ob das EV mit dem Ladegerät verbunden ist.",
+          "hsem_ev_second_soc": "Wähle den Sensor, der den aktuellen Ladezustand (SoC) deiner EV-Batterie liefert.",
+          "hsem_ev_second_past_target_confidence_factor": "Konfidenzmultiplikator (0,0-1,0), der auf die Bewertung des vermiedenen zukünftigen Imports angewendet wird, wenn das zweite EV über seinen Ziel-SoC hinaus geladen wird. Niedrigere Werte machen das EV im Vergleich zum Export von überschüssigem PV-Strom weniger konkurrenzfähig, um der Unsicherheit Rechnung zu tragen, ob das EV die zusätzliche Energie vor dem nächsten Ladevorgang tatsächlich benötigt. Standard 0,9."
+        },
+        "description": "Konfiguriere die Einstellungen für das zweite EV-Ladegerät für HSEM.",
+        "title": "Einstellungen für zweites EV-Ladegerät (Optional)"
+      },
+      "huawei_solar": {
+        "data": {
+          "hsem_batteries_charge_efficiency": "Batterie-Ladeeffizienz (%)",
+          "hsem_batteries_cycle_cost": "Batterie-Zykluskosten (pro kWh)",
+          "hsem_batteries_discharge_efficiency": "Batterie-Entladeeffizienz (%)",
+          "hsem_batteries_expected_cycles": "Erwartete Batteriezyklen",
+          "hsem_batteries_purchase_price": "Batterie-Kaufpreis",
+          "hsem_huawei_solar_batteries_excess_pv_energy_use_in_tou": "Huawei-Batterien Nutzung von überschüssiger PV-Energie in TOU",
+          "hsem_huawei_solar_batteries_forcible_charge": "Batterie-Zwangsladezustand",
+          "hsem_huawei_solar_batteries_end_of_discharge_soc": "Huawei-Batterien Entladeschluss-SOC (%)",
+          "hsem_huawei_solar_batteries_charging_cutoff_capacity": "Huawei-Batterien Ladeabschaltkapazität (max. SoC %)",
+          "hsem_huawei_solar_batteries_grid_charge_cutoff_soc": "Huawei-Batterien Netzladeabschaltung SOC (%)",
+          "hsem_huawei_solar_batteries_maximum_charging_power": "Huawei-Batterien maximale Ladeleistung (W)",
+          "hsem_huawei_solar_batteries_maximum_discharging_power": "Huawei-Batterien maximale Entladeleistung (W)",
+          "hsem_huawei_solar_batteries_grid_charge_maximum_power": "Huawei-Batterien maximale Netzladeleistung (W)",
+          "hsem_huawei_solar_batteries_charge_discharge_power": "Huawei Batterie Lade-/Entladeleistungssensor",
+          "hsem_huawei_solar_batteries_rated_capacity": "Batterie maximale Kapazität (Wh)",
+          "hsem_huawei_solar_batteries_state_of_capacity": "Huawei-Batterien Kapazitätszustand-Sensor",
+          "hsem_huawei_solar_batteries_tou_charging_and_discharging_periods": "Huawei-Batterien TOU-Lade- und Entladezeiträume",
+          "hsem_huawei_solar_batteries_working_mode": "Huawei Solar-Batterien Arbeitsmodus-Sensor",
+          "hsem_huawei_solar_device_id_batteries": "Huawei-Batteriegerät",
+          "hsem_huawei_solar_device_id_batteries_2": "Huawei-Batteriegerät 2",
+          "hsem_huawei_solar_device_id_inverter_1": "Huawei-Wechselrichter 1 Gerät",
+          "hsem_huawei_solar_device_id_inverter_2": "Huawei-Wechselrichter 2 Gerät",
+          "hsem_huawei_solar_inverter_active_power_control": "Huawei-Wechselrichter Wirkleistungssteuerung-Sensor"
+        },
+        "data_description": {
+          "hsem_batteries_charge_efficiency": "Gib die Ladeeffizienz deiner Batterie in Prozent an (0–100). Die in der Batterie gespeicherte Energie entspricht der eingehenden Energie multipliziert mit diesem Faktor. Typische Lithium-Batterien erreichen 95–98 %. Standard ist 98 %.",
+          "hsem_batteries_discharge_efficiency": "Gib die Entladeeffizienz deiner Batterie in Prozent an (0–100). Die an das Haus gelieferte Energie entspricht der entnommenen Batterieenergie multipliziert mit diesem Faktor. Typische Lithium-Batterien erreichen 95–98 %. Standard ist 98 %.",
+          "hsem_batteries_cycle_cost": "Optionale zusätzliche Kosten pro kWh für das Zyklieren der Batterie (pro kWh). Wird zusätzlich zur automatisch berechneten Abschreibungsschwelle addiert. Auf 0 setzen, um dich ausschließlich auf die Abschreibungssicherung zu verlassen. Beispiel: 0,02 bedeutet, dass der Planer 2 Cent zusätzliche Spanne pro zyklierter kWh benötigt, bevor er die Netzladung genehmigt.",
+          "hsem_batteries_expected_cycles": "Gib die erwartete Anzahl vollständiger Lade-/Entladezyklen über die Lebensdauer der Batterie ein. Wird verwendet, um die Abschreibungskosten pro kWh und den empfohlenen Mindestexportpreis zu berechnen. Typische LiFePO4-Batterien unterstützen 4000–8000 Zyklen.",
+          "hsem_batteries_purchase_price": "Gib den Gesamtkaufpreis deines Batteriesystems in deiner Landeswährung ein. Wird zusammen mit den erwarteten Zyklen und der nutzbaren Kapazität verwendet, um die Abschreibungskosten pro kWh und den empfohlenen Mindestexportpreis zu berechnen.",
+          "hsem_huawei_solar_batteries_excess_pv_energy_use_in_tou": "Wähle den Sensor, der die Einstellung für die Nutzung überschüssiger PV-Energie in TOU-Zeiträumen liefert.",
+          "hsem_huawei_solar_batteries_forcible_charge": "Sensor, der den aktuellen Zwangslade-/Entladezustand anzeigt (z. B. Gestoppt, Entladung mit 5000 W für 60 Minuten)",
+          "hsem_huawei_solar_batteries_end_of_discharge_soc": "Gib den Entladeschluss-SOC-Prozentsatz für deine Huawei-Batterien an. Wenn die Batterie diesen SOC-Wert erreicht, stoppt sie die Entladung, um Tiefentladung und mögliche Schäden an der Batterie zu verhindern.",
+          "hsem_huawei_solar_batteries_charging_cutoff_capacity": "Wähle die Entität, die den maximalen Ladezustand (SoC) definiert, den die Batterie während des Ladens erreichen darf (Register STORAGE_CHARGING_CUTOFF_CAPACITY). Typischerweise 90–10 %. Wird von der SoC-Simulation als obere SoC-Grenze verwendet, sodass der Planer das Laden nie über dieses Limit hinaus plant.",
+          "hsem_huawei_solar_batteries_grid_charge_cutoff_soc": "Gib den Netzladeabschaltung-SOC-Prozentsatz für deine Huawei-Batterien an.",
+          "hsem_huawei_solar_batteries_maximum_charging_power": "Wähle den Sensor, der die maximale Ladeleistung für deine Huawei-Batterien in Watt (W) liefert.",
+          "hsem_huawei_solar_batteries_maximum_discharging_power": "Wähle den Sensor, der die maximale Entladeleistung für deine Huawei-Batterien liefert.",
+          "hsem_huawei_solar_batteries_grid_charge_maximum_power": "Wähle die Zahlenentität, die die maximale Netzladeleistungsgrenze (W) von Huawei festlegt. Wird vom Live-Sicherheitsbegrenzer für phasenbewusstes Laden (issue #831) geschrieben, um netzfinanziertes Laden unterhalb der Phasengrenze der Hauptsicherung zu halten. Optional — nur erforderlich, wenn phasenbewusstes Laden aktiviert ist.",
+          "hsem_huawei_solar_batteries_charge_discharge_power": "Wähle den Sensor, der die vorzeichenbehaftete momentane Batterie-Lade-/Entladeleistung meldet (positiv = Laden, negativ = Entladen). Wird vom Live-Sicherheitsbegrenzer für phasenbewusstes Laden (issue #831) benötigt, um Huaweis eigenen Beitrag aus der Live-Phasen-Momentaufnahme zu entfernen, bevor der Spielraum berechnet wird. Optional — nur erforderlich, wenn phasenbewusstes Laden aktiviert ist.",
+          "hsem_huawei_solar_batteries_rated_capacity": "Wähle den Sensor, der die gesamte Nennkapazität deiner Huawei-Batterien in Wattstunden (Wh) liefert.",
+          "hsem_huawei_solar_batteries_state_of_capacity": "Wähle den Sensor, der den Ladezustand (SOC) deiner Huawei-Batterien liefert.",
+          "hsem_huawei_solar_batteries_tou_charging_and_discharging_periods": "Wähle den Sensor, der die Time-of-Use(TOU)-Lade- und Entladezeiträume für deine Huawei-Batterien definiert.",
+          "hsem_huawei_solar_batteries_working_mode": "Wähle den Sensor, der den aktuellen Arbeitsmodus deiner Huawei-Batterien anzeigt.",
+          "hsem_huawei_solar_device_id_batteries": "Wähle dein Huawei-Batteriegerät.",
+          "hsem_huawei_solar_device_id_batteries_2": "Wähle dein sekundäres Huawei-Batteriegerät, falls zutreffend.",
+          "hsem_huawei_solar_device_id_inverter_1": "Wähle dein primäres Huawei-Wechselrichtergerät.",
+          "hsem_huawei_solar_device_id_inverter_2": "Wähle dein sekundäres Huawei-Wechselrichtergerät, falls zutreffend.",
+          "hsem_huawei_solar_inverter_active_power_control": "Wähle den Sensor, der die Wirkleistungsabgabe deines Huawei-Wechselrichters steuert."
+        },
+        "description": "Konfiguriere den Arbeitsmodus für Huawei-Solarbatterien.",
+        "title": "Huawei Solar-Sensoren"
+      },
+      "battery_economics": {
+        "data": {
+          "hsem_batteries_purchase_price": "Batterie-Kaufpreis",
+          "hsem_batteries_expected_cycles": "Erwartete Batteriezyklen",
+          "hsem_batteries_cycle_cost": "Batterie-Zykluskosten (pro kWh)",
+          "hsem_batteries_capacity_loss_pct": "Batteriekapazitätsverlust am Lebensende (%)",
+          "hsem_batteries_charge_efficiency": "Batterie-Ladeeffizienz (%)",
+          "hsem_batteries_discharge_efficiency": "Batterie-Entladeeffizienz (%)",
+          "hsem_planner_hysteresis_enabled": "Hysterese auf Planebene",
+          "hsem_planner_hysteresis_absolute": "Absoluter Hysterese-Schwellenwert",
+          "hsem_planner_hysteresis_percentage": "Prozentualer Hysterese-Schwellenwert (%)",
+          "hsem_planner_window_hysteresis_minutes": "Hysterese-Haltezeit für Fenster (Minuten)"
+        },
+        "data_description": {
+          "hsem_batteries_purchase_price": "Gib den Gesamtkaufpreis deines Batteriesystems in deiner Landeswährung ein. Wird zusammen mit den erwarteten Zyklen und der nutzbaren Kapazität verwendet, um die Abschreibungskosten pro kWh und den empfohlenen Mindestexportpreis zu berechnen.",
+          "hsem_batteries_expected_cycles": "Gib die erwartete Anzahl vollständiger Lade-/Entladezyklen über die Lebensdauer der Batterie ein. Wird verwendet, um die Abschreibungskosten pro kWh und den empfohlenen Mindestexportpreis zu berechnen. Typische LiFePO4-Batterien unterstützen 4000–8000 Zyklen.",
+          "hsem_batteries_cycle_cost": "Optionale zusätzliche Kosten pro kWh für das Zyklieren der Batterie (pro kWh). Wird zusätzlich zur automatisch berechneten Abschreibungsschwelle addiert. Auf 0 setzen, um dich ausschließlich auf die Abschreibungssicherung zu verlassen. Beispiel: 0,02 bedeutet, dass der Planer 2 Cent zusätzliche Spanne pro zyklierter kWh benötigt, bevor er die Netzladung genehmigt.",
+          "hsem_batteries_capacity_loss_pct": "Erwarteter Kapazitätsverlust am Lebensende in Prozent. LiFePO4 erreicht typischerweise nach ~6000 Zyklen 80 % Kapazität (20 % Verlust). Der Standardwert von 30 % fügt eine Marge für kalendarische Alterung hinzu.",
+          "hsem_batteries_charge_efficiency": "Gib die Ladeeffizienz deiner Batterie in Prozent an (0–100). Die in der Batterie gespeicherte Energie entspricht der eingehenden Energie multipliziert mit diesem Faktor. Typische Lithium-Batterien erreichen 95–98 %. Standard ist 98 %.",
+          "hsem_batteries_discharge_efficiency": "Gib die Entladeeffizienz deiner Batterie in Prozent an (0–100). Die an das Haus gelieferte Energie entspricht der entnommenen Batterieenergie multipliziert mit diesem Faktor. Typische Lithium-Batterien erreichen 95–98 %. Standard ist 98 %.",
+          "hsem_planner_hysteresis_enabled": "Wenn aktiviert, behält der Planer den aktiven Kandidatenplan bei, sofern ein neuer Plan die Bewertung nicht um mehr als die konfigurierten Schwellenwerte verbessert. Verhindert Oszillation zwischen gleich bewerteten Strategien.",
+          "hsem_planner_hysteresis_absolute": "Minimale absolute Bewertungsverbesserung, die für einen Wechsel zu einem neuen Plan erforderlich ist. 0,00 deaktiviert den absoluten Schwellenwert. Die Bewertung verwendet dieselbe Währung wie deine Strompreise, sodass ein Wert von 0,01 mindestens 1 Cent/kWh-äquivalente Verbesserung vor einem Wechsel erfordert.",
+          "hsem_planner_hysteresis_percentage": "Minimale prozentuale Bewertungsverbesserung, die für einen Wechsel zu einem neuen Plan erforderlich ist. 0 % deaktiviert den prozentualen Schwellenwert. Der Standardwert von 5 % verhindert Flattern zwischen nahezu identischen Plänen.",
+          "hsem_planner_window_hysteresis_minutes": "Minimale Zeit (Minuten), die eine Empfehlung gehalten werden muss, bevor sie sich ändern kann. Verhindert schnelles Umschalten wie z. B. ev_smart_charging ↔ batteries_charge_solar. 0 deaktiviert die Funktion. Standard 10."
+        },
+        "description": "Konfiguriere Batteriewirtschaftlichkeitsparameter und Planer-Hysterese (Anti-Flattern).",
+        "title": "Batteriewirtschaftlichkeit & Hysterese"
+      },
+      "init": {
+        "data": {
+          "device_name": "Name",
+          "hsem_extended_attributes": "Erweiterte Attribute",
+          "hsem_read_only": "Nur Lesen",
+          "hsem_recommendation_interval_length": "Empfehlungsintervall-Länge",
+          "hsem_recommendation_interval_minutes": "Empfehlungsintervall-Minuten",
+          "hsem_update_interval": "Aktualisierungsintervall",
+          "hsem_verbose_logging": "Ausführliche Protokollierung"
+        },
+        "data_description": {
+          "device_name": "Gib einen eindeutigen Namen für dieses Gerät ein.",
+          "hsem_extended_attributes": "Aktiviere diese Option, um zusätzliche Diagnoseattribute auf der Sensor-Entität bereitzustellen.",
+          "hsem_read_only": "Aktiviere diese Option, um die Integration in den Nur-Lese-Modus zu versetzen und das Senden von Befehlen an Geräte zu verhindern.",
+          "hsem_recommendation_interval_length": "Die Anzahl der Empfehlungsintervalle, die bei der Berechnung der optimalen Batterienutzung berücksichtigt werden.",
+          "hsem_recommendation_interval_minutes": "Die Länge in Minuten jedes Empfehlungsintervalls, das zur Berechnung der optimalen Batterienutzung verwendet wird.",
+          "hsem_update_interval": "Das Aktualisierungsintervall in Minuten für den Arbeitsmodus-Sensor.",
+          "hsem_verbose_logging": "Aktiviere ausführliche Debug-Protokollierung zu Fehlerbehebungszwecken."
+        },
+        "description": "Aktualisiere die Einstellungen für HSEM",
+        "title": "Huawei Solar Energy Management aktualisieren"
+      },
+      "batteries_schedules": {
+        "data": {
+          "hsem_batteries_enable_batteries_schedule_1": "Batterie-Zeitplan 1 aktivieren",
+          "hsem_batteries_enable_batteries_schedule_1_end": "Batterie-Zeitplan 1 Endzeit",
+          "hsem_batteries_enable_batteries_schedule_1_start": "Batterie-Zeitplan 1 Startzeit",
+          "hsem_batteries_enable_batteries_schedule_2": "Batterie-Zeitplan 2 aktivieren",
+          "hsem_batteries_enable_batteries_schedule_2_end": "Batterie-Zeitplan 2 Endzeit",
+          "hsem_batteries_enable_batteries_schedule_2_start": "Batterie-Zeitplan 2 Startzeit",
+          "hsem_batteries_enable_batteries_schedule_3": "Batterie-Zeitplan 3 aktivieren",
+          "hsem_batteries_enable_batteries_schedule_3_end": "Batterie-Zeitplan 3 Endzeit",
+          "hsem_batteries_enable_batteries_schedule_3_start": "Batterie-Zeitplan 3 Startzeit"
+        },
+        "data_description": {
+          "hsem_batteries_enable_batteries_schedule_1": "Aktiviere oder deaktiviere den ersten Batterie-Entladezeitplan.",
+          "hsem_batteries_enable_batteries_schedule_1_end": "Lege die Endzeit für den ersten Batterie-Entladezeitplan fest.",
+          "hsem_batteries_enable_batteries_schedule_1_start": "Lege die Startzeit für den ersten Batterie-Entladezeitplan fest.",
+          "hsem_batteries_enable_batteries_schedule_2": "Aktiviere oder deaktiviere den zweiten Batterie-Entladezeitplan.",
+          "hsem_batteries_enable_batteries_schedule_2_end": "Lege die Endzeit für den zweiten Batterie-Entladezeitplan fest.",
+          "hsem_batteries_enable_batteries_schedule_2_start": "Lege die Startzeit für den zweiten Batterie-Entladezeitplan fest.",
+          "hsem_batteries_enable_batteries_schedule_3": "Aktiviere oder deaktiviere den dritten Batterie-Entladezeitplan.",
+          "hsem_batteries_enable_batteries_schedule_3_end": "Lege die Endzeit für den dritten Batterie-Entladezeitplan fest.",
+          "hsem_batteries_enable_batteries_schedule_3_start": "Lege die Startzeit für den dritten Batterie-Entladezeitplan fest."
+        },
+        "description": "Konfiguriere bis zu drei Batterie-Entladezeitplan-Fenster, jeweils mit Ein-/Aus-Schalter, Startzeit und Endzeit. Zeitpläne legen fest, wann die Batterie entladen darf, um Verbrauchsspitzen zu decken oder ins Netz einzuspeisen.",
+        "title": "Batterie-Entladezeitpläne"
+      },
+      "months": {
+        "data": {
+          "hsem_months_winter": "Als Winter/Frühling betrachtete Monate"
+        },
+        "data_description": {
+          "hsem_months_winter": "Wähle die Monate, die für die saisonale Anpassung des Arbeitsmodus als Winter/Frühling gelten sollen. Du kannst mehrere Monate auswählen. Die Auswahl aller 12 Monate ist zulässig — dies hält den Winter/Frühling-Modus (TOU) ganzjährig aktiv. Die Auswahl aller 12 Monate ist zulässig — dies hält den Winter/Frühling-Modus (TOU) ganzjährig aktiv."
+        },
+        "description": "Konfiguriere die Monate, die als Winter/Frühling gelten. In diesen Monaten priorisiert das System das Laden der Batterien aus Netzenergie, um während Zeiten geringerer Solarproduktion ausreichende Batteriestände sicherzustellen. Die übrigen Monate gelten als Sommer/Herbst-Monate.",
+        "title": "Winter/Frühling-Monate"
+      },
+      "power": {
+        "data": {
+          "hsem_house_consumption_power": "Hausverbrauchsleistungssensor",
+          "hsem_main_fuse_amps": "Hauptsicherung Nennwert (Ampere)",
+          "hsem_main_fuse_phases": "Hauptsicherung Phasenanzahl",
+          "hsem_max_grid_export_power_kw": "Maximale Netzeinspeiseleistung (kW)",
+          "hsem_solar_production_power": "Solarproduktionsleistungssensor",
+          "hsem_huawei_solar_power_meter_phase_a_active_power": "Stromzähler Phase A Wirkleistungssensor",
+          "hsem_huawei_solar_power_meter_phase_b_active_power": "Stromzähler Phase B Wirkleistungssensor",
+          "hsem_huawei_solar_power_meter_phase_c_active_power": "Stromzähler Phase C Wirkleistungssensor",
+          "hsem_phase_aware_charging_enabled": "Live-Sicherheitsbegrenzer für phasenbewusstes Laden aktivieren"
+        },
+        "data_description": {
+          "hsem_house_consumption_power": "Wähle den Sensor, der den Gesamtstromverbrauch deines Hauses misst.",
+          "hsem_main_fuse_amps": "Der Nennwert der Hauptsicherung/des Hauptschalters deines Hauses in Ampere (25, 35 usw.). Der MILP-Optimierer berücksichtigt diese Grenze bei der Planung von Batterie- und EV-Ladung. Auf 0 setzen, um zu deaktivieren.",
+          "hsem_main_fuse_phases": "Die Phasenanzahl deiner elektrischen Installation. Einphasige Installationen MÜSSEN auf 1 gesetzt werden — die Einstellung 3 bei einer einphasigen Installation macht den Sicherungsschutz 3-mal zu großzügig und bietet keine echte Sicherheitsgrenze. Standard ist 3 (dreiphasig).",
+          "hsem_max_grid_export_power_kw": "Maximale Netzeinspeiseleistung in kW — die Exportobergrenze des Netzbetreibers/Wechselrichters für exportbeschränkte Anschlüsse (z. B. 5 kW). Der MILP-Planer plant nie einen Export über diese Grenze hinaus, sodass Batterieexport und PV-Export korrekt um dieselbe Obergrenze konkurrieren. Auf 0 setzen, um zu deaktivieren.",
+          "hsem_solar_production_power": "Wähle den Sensor, der die von deinen Solarmodulen erzeugte Leistung misst.",
+          "hsem_huawei_solar_power_meter_phase_a_active_power": "Wähle den Sensor, der die Live-Wirkleistung auf Phase A deines Huawei-Stromzählers misst. Nur erforderlich, wenn phasenbewusstes Laden aktiviert ist.",
+          "hsem_huawei_solar_power_meter_phase_b_active_power": "Wähle den Sensor, der die Live-Wirkleistung auf Phase B deines Huawei-Stromzählers misst. Nur erforderlich, wenn phasenbewusstes Laden aktiviert ist.",
+          "hsem_huawei_solar_power_meter_phase_c_active_power": "Wähle den Sensor, der die Live-Wirkleistung auf Phase C deines Huawei-Stromzählers misst. Nur erforderlich, wenn phasenbewusstes Laden aktiviert ist.",
+          "hsem_phase_aware_charging_enabled": "Aktiviere eine Live-Sicherheitsprüfung unmittelbar vor jedem Huawei-Netzlade-Hardware-Schreibvorgang (issue #831). Verwendet die drei unten stehenden Stromzähler-Phasensensoren sowie die Huawei-Netzladeleistungs-Obergrenze-Entität (Schritt huawei_solar), um netzfinanziertes Laden so zu begrenzen, dass keine Phase die Hauptsicherungsgrenze überschreitet, selbst wenn sich die Last nach der Planlösung geändert hat. Erfordert main_fuse_phases = 3 und alle vier konfigurierten Entitäten. Standardmäßig deaktiviert — vollständig abwärtskompatibel."
+        },
+        "description": "Wähle Leistungssensoren für HSEM aus.",
+        "title": "Leistungssensoren"
+      },
+      "solcast": {
+        "data": {
+          "hsem_solcast_pv_forecast_forecast_likelihood": "Solcast PV-Prognose bevorzugte Prognosewahrscheinlichkeit",
+          "hsem_solcast_pv_forecast_forecast_today": "Solcast PV-Prognose heute Sensor",
+          "hsem_solcast_pv_forecast_forecast_tomorrow": "Solcast PV-Prognose morgen Sensor"
+        },
+        "data_description": {
+          "hsem_solcast_pv_forecast_forecast_likelihood": "Wähle die bevorzugte Prognosewahrscheinlichkeit für Solcast-PV-Prognosen.",
+          "hsem_solcast_pv_forecast_forecast_today": "Wähle den Sensor, der die heutige PV-Produktionsprognose von Solcast liefert.",
+          "hsem_solcast_pv_forecast_forecast_tomorrow": "Wähle den Sensor, der die morgige PV-Produktionsprognose von Solcast liefert."
+        },
+        "description": "Wähle Solcast-Prognosesensoren aus.",
+        "title": "Solcast-Sensoren"
+      },
+      "weighted_values": {
+        "data": {
+          "hsem_house_consumption_energy_weight_14d": "Hausverbrauchsenergie-Gewichtung 14 Tage",
+          "hsem_house_consumption_energy_weight_1d": "Hausverbrauchsenergie-Gewichtung 1 Tag",
+          "hsem_house_consumption_energy_weight_3d": "Hausverbrauchsenergie-Gewichtung 3 Tage",
+          "hsem_house_consumption_energy_weight_7d": "Hausverbrauchsenergie-Gewichtung 7 Tage"
+        },
+        "data_description": {
+          "hsem_house_consumption_energy_weight_14d": "Gib den Gewichtungsprozentsatz für den Hausverbrauch der letzten 14 Tage an.",
+          "hsem_house_consumption_energy_weight_1d": "Gib den Gewichtungsprozentsatz für den Hausverbrauch des letzten 1 Tages an.",
+          "hsem_house_consumption_energy_weight_3d": "Gib den Gewichtungsprozentsatz für den Hausverbrauch der letzten 3 Tage an.",
+          "hsem_house_consumption_energy_weight_7d": "Gib den Gewichtungsprozentsatz für den Hausverbrauch der letzten 7 Tage an."
+        },
+        "description": "Konfiguriere die gewichteten Werte für den Hausverbrauch, um deinen durchschnittlichen Stromverbrauch zu schätzen. Das System berechnet den durchschnittlichen Verbrauch für jede Stunde über 1, 3, 7 und 14 Tage. Diese Durchschnittswerte werden dann gewichtet, um eine kombinierte, gewichtete Schätzung zu liefern. Dieser Ansatz hilft, Anomalien auszugleichen, etwa einen ungewöhnlich hohen Verbrauch an einem einzelnen Tag aufgrund niedriger Preise, und liefert eine zuverlässige Vorhersage deines erwarteten Stromverbrauchs in bestimmten Zeitintervallen (z. B. zwischen 16:00 und 17:00 Uhr).",
+        "title": "Gewichtete Werte"
+      },
+      "energy_and_ml": {
+        "data": {
+          "hsem_grid_import_energy_entity": "Netzimport-Energiesensor",
+          "hsem_grid_export_energy_entity": "Netzeinspeisung-Energiesensor",
+          "hsem_pv_energy_entity": "PV-Produktions-Energiesensor",
+          "hsem_ml_consumption_enabled": "ML-Verbrauchsprognose aktivieren",
+          "hsem_ml_consumption_energy_entity": "Hausverbrauchs-Energiesensor (ohne Batterie & EV)",
+          "hsem_ml_consumption_history_days": "ML-Verlaufstage",
+          "hsem_ml_consumption_net_consumption": "Nettoverbrauch verwenden (Import - Export)",
+          "hsem_ml_consumption_temperature_entity": "Außentemperatursensor",
+          "hsem_ml_consumption_sequential": "Sequenzielle Vorhersage (Lag-Feature)"
+        },
+        "data_description": {
+          "hsem_grid_import_energy_entity": "Optional — kumulativer Netzimport-Energiezähler (kWh).",
+          "hsem_grid_export_energy_entity": "Optional — kumulativer Netzeinspeisung-Energiezähler (kWh).",
+          "hsem_pv_energy_entity": "Optional — kumulativer PV-Produktions-Energiezähler (kWh).",
+          "hsem_ml_consumption_enabled": "Wenn aktiviert, wird Ridge-Regression auf Basis der Recorder-Historie anstelle gleitender Durchschnitte verwendet. Erfordert mindestens 14 Tage Historie.",
+          "hsem_ml_consumption_energy_entity": "Kumulativer Hausverbrauchs-Energiezähler (kWh). Muss Batterie UND EV-Ladung ausschließen — verwende einen Sensor vor beiden. Fällt auf Netzimport zurück, falls nicht gesetzt.",
+          "hsem_ml_consumption_history_days": "Tage der Recorder-Historie für das ML-Training (7–90).",
+          "hsem_ml_consumption_net_consumption": "Ziehe Netzeinspeisung vom Import ab, um den Nettohausverbrauch zu erhalten.",
+          "hsem_ml_consumption_temperature_entity": "Optional — Außentemperatursensor in °C. Verwende einen Außensensor, keinen Innenraumthermostat.",
+          "hsem_ml_consumption_sequential": "Gibt jede Slot-Vorhersage als Eingabe für die nächste weiter. Erfasst untertägige Dynamik (z. B. wirken sich Kochspitzen weiter aus)."
+        },
+        "description": "Konfiguriere Energiezähler und aktiviere die ML-basierte Verbrauchsprognose.",
+        "title": "Energie & ML"
+      },
+      "batteries_wait_mode": {
+        "data": {
+          "hsem_batteries_wait_mode_behavior": "Wartemodus-Verhalten"
+        },
+        "data_description": {
+          "hsem_batteries_wait_mode_behavior": "Wähle, wie sich die Batterie verhält, wenn HSEM den Wartemodus auswählt. Strenges Warten hält die Batterie inaktiv. Eigenverbrauch mit Reserve erlaubt dem Haus, überschüssige Batterieenergie oberhalb der vom Planer benötigten Reserve zu nutzen, wodurch unnötiger Netzimport reduziert wird."
+        },
+        "description": "Konfiguriere, wie sich die Batterie im Wartemodus verhält.",
+        "title": "Batterie-Wartemodus-Verhalten"
+      }
+    }
+  },
+  "selector": {
+    "months": {
+      "options": {
+        "1": "Januar",
+        "10": "Oktober",
+        "11": "November",
+        "12": "Dezember",
+        "2": "Februar",
+        "3": "März",
+        "4": "April",
+        "5": "Mai",
+        "6": "Juni",
+        "7": "Juli",
+        "8": "August",
+        "9": "September"
+      }
+    },
+    "update_interval_minutes": {
+      "options": {
+        "1": "1 Minute",
+        "10": "10 Minuten",
+        "15": "15 Minuten",
+        "30": "30 Minuten",
+        "45": "45 Minuten",
+        "5": "5 Minuten",
+        "60": "60 Minuten"
+      }
+    },
+    "pv_estimate_likelihood": {
+      "options": {
+        "pv_estimate": "50 % Wahrscheinlichkeit",
+        "pv_estimate10": "10 % Wahrscheinlichkeit",
+        "pv_estimate90": "90 % Wahrscheinlichkeit"
+      }
+    },
+    "update_interval_length": {
+      "options": {
+        "12": "12 Stunden",
+        "24": "24 Stunden",
+        "36": "36 Stunden",
+        "48": "48 Stunden",
+        "72": "72 Stunden"
+      }
+    },
+    "batteries_wait_mode_behavior": {
+      "options": {
+        "strict": "Strenges Warten — Batterie bleibt inaktiv",
+        "self_consumption_with_reserve": "Eigenverbrauch mit Reserve — überschüssige Energie oberhalb der Planer-Reserve nutzen"
+      }
+    },
+    "ev_charger_phase_topology": {
+      "options": {
+        "single_phase": "Einphasig oder unbekannt (sicherer Standard)",
+        "three_phase_balanced": "Dreiphasig, ausgeglichen über L1/L2/L3"
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "applier_status": {
+        "name": "Anwendungsstatus",
+        "state": {
+          "ok": "OK",
+          "unverified": "Nicht verifiziert",
+          "failed": "Fehlgeschlagen",
+          "skipped": "Übersprungen",
+          "pending": "Ausstehend"
+        }
+      },
+      "battery_soc": {
+        "name": "Batterie-Ladezustand"
+      },
+      "daily_plan_vs_actual": {
+        "name": "Täglicher Plan vs. Tatsächlich"
+      },
+      "degraded_mode": {
+        "name": "Systemzustand",
+        "state": {
+          "ok": "OK",
+          "degraded": "Eingeschränkt",
+          "error": "Fehler"
+        }
+      },
+      "ev_charger_calculated_power": {
+        "name": "EV-Ladegerät berechnete Leistung"
+      },
+      "ev_charger_current_limit": {
+        "name": "EV-Ladegerät Stromgrenze"
+      },
+      "ev_charging": {
+        "name": "EV-Ladung aktiv",
+        "state": {
+          "on": "Ein",
+          "off": "Aus"
+        }
+      },
+      "ev_optimal_charging_plan": {
+        "name": "EV optimaler Ladeplan",
+        "state": {
+          "charging": "Lädt",
+          "fully_charged": "Vollständig geladen",
+          "not_connected": "Nicht verbunden",
+          "smart_charging_disabled": "Smart-Charging deaktiviert",
+          "waiting": "Wartet",
+          "unavailable": "Nicht verfügbar"
+        }
+      },
+      "ev_second_charger_calculated_power": {
+        "name": "EV 2 Ladegerät berechnete Leistung"
+      },
+      "ev_second_charger_current_limit": {
+        "name": "EV 2 Ladegerät Stromgrenze"
+      },
+      "ev_second_optimal_charging_plan": {
+        "name": "EV 2 optimaler Ladeplan",
+        "state": {
+          "charging": "Lädt",
+          "fully_charged": "Vollständig geladen",
+          "not_connected": "Nicht verbunden",
+          "smart_charging_disabled": "Smart-Charging deaktiviert",
+          "waiting": "Wartet",
+          "unavailable": "Nicht verfügbar"
+        }
+      },
+      "force_mode": {
+        "name": "Erzwungener Arbeitsmodus",
+        "state": {
+          "auto": "Auto",
+          "batteries_charge_grid": "Laden vom Netz",
+          "batteries_charge_solar": "Laden von Solar",
+          "ev_smart_charging": "EV Smart-Charging",
+          "batteries_discharge_mode": "Entladen",
+          "force_batteries_discharge": "Entladung erzwingen",
+          "force_export": "Export erzwingen",
+          "batteries_wait_mode": "Warten"
+        }
+      },
+      "forecast_accuracy": {
+        "name": "Prognosegenauigkeit"
+      },
+      "hardware_writes": {
+        "name": "Hardware-Schreibvorgänge",
+        "state": {
+          "allowed": "Erlaubt",
+          "blocked": "Blockiert"
+        }
+      },
+      "last_updated": {
+        "name": "Zuletzt aktualisiert"
+      },
+      "missing_entities": {
+        "name": "Fehlende Eingabeentitäten"
+      },
+      "net_consumption": {
+        "name": "Nettoverbrauch"
+      },
+      "next_update": {
+        "name": "Nächste Aktualisierung"
+      },
+      "plan_explanation": {
+        "name": "Planstrategie"
+      },
+      "read_only": {
+        "name": "Nur-Lese-Modus",
+        "state": {
+          "on": "Ein",
+          "off": "Aus"
+        }
+      },
+      "recommendation_interval": {
+        "name": "Empfehlungsintervall"
+      },
+      "update_interval": {
+        "name": "Aktualisierungsintervall"
+      },
+      "working_mode": {
+        "name": "Arbeitsmodus-Sensor",
+        "state": {
+          "time_passed": "Zeit verstrichen",
+          "missing_input_entities": "Fehlende Eingabeentitäten",
+          "batteries_charge_grid": "Laden vom Netz",
+          "batteries_charge_solar": "Laden von Solar",
+          "ev_smart_charging": "EV Smart-Charging",
+          "batteries_discharge_mode": "Entladen",
+          "force_batteries_discharge": "Entladung erzwingen",
+          "force_export": "Export erzwingen",
+          "batteries_wait_mode": "Warten"
+        }
+      },
+      "effective_discharge_floor": {
+        "name": "Effektive Entladeuntergrenze"
+      },
+      "ocpp_charger_status": {
+        "name": "OCPP-Ladegerät Status"
+      },
+      "ocpp_charger_power": {
+        "name": "OCPP-Ladegerät Leistung"
+      },
+      "ocpp_charger_info": {
+        "name": "OCPP-Ladegerät Info"
+      },
+      "ocpp_charger_sessions": {
+        "name": "OCPP-Ladegerät Sitzungen"
+      },
+      "export_income": {
+        "name": "Exporterlös"
+      },
+      "import_cost": {
+        "name": "Netzimportkosten"
+      },
+      "net_grid_balance": {
+        "name": "Netto-Netzbilanz"
+      },
+      "prediction_accuracy": {
+        "name": "Vorhersagegenauigkeit"
+      },
+      "pv_curtailment": {
+        "name": "PV-Abregelung"
+      },
+      "savings_tracker": {
+        "name": "Ersparnis-Tracker"
+      },
+      "solar_confidence": {
+        "name": "Solarprognose-Konfidenz"
+      },
+      "ocpp_second_charger_status": {
+        "name": "OCPP-Ladegerät 2 Status"
+      },
+      "ocpp_second_charger_power": {
+        "name": "OCPP-Ladegerät 2 Leistung"
+      },
+      "ocpp_second_charger_info": {
+        "name": "OCPP-Ladegerät 2 Info"
+      },
+      "ocpp_second_charger_sessions": {
+        "name": "OCPP-Ladegerät 2 Sitzungen"
+      }
+    },
+    "switch": {
+      "read_only": {
+        "name": "Nur-Lese-Modus"
+      },
+      "extended_attributes": {
+        "name": "Erweiterte Attribute"
+      },
+      "verbose_logging": {
+        "name": "Ausführliche Protokollierung"
+      },
+      "batteries_schedule_1": {
+        "name": "Batterie-Zeitplan 1"
+      },
+      "batteries_schedule_2": {
+        "name": "Batterie-Zeitplan 2"
+      },
+      "batteries_schedule_3": {
+        "name": "Batterie-Zeitplan 3"
+      },
+      "ev_force_discharge": {
+        "name": "EV maximale Entladeleistung erzwingen"
+      },
+      "ev_smart_charging": {
+        "name": "EV Smart-Charging"
+      },
+      "ev_force_charge_now": {
+        "name": "EV Laden jetzt erzwingen"
+      },
+      "ev_second_smart_charging": {
+        "name": "EV 2 Smart-Charging"
+      },
+      "ev_second_force_charge_now": {
+        "name": "EV 2 Laden jetzt erzwingen"
+      },
+      "ml_consumption": {
+        "name": "ML-Verbrauchsprognose"
+      },
+      "ml_sequential": {
+        "name": "ML-sequenzielle Vorhersage"
+      },
+      "dynamic_discharge_floor": {
+        "name": "Dynamische Entladeuntergrenze"
+      },
+      "ev_auto_full_negative_price": {
+        "name": "EV Auto-Vollladen bei negativem Preis"
+      }
+    },
+    "select": {
+      "force_working_mode": {
+        "name": "Erzwungener Arbeitsmodus"
+      },
+      "pv_estimate_likelihood": {
+        "name": "Solcast PV-Schätzung Wahrscheinlichkeit"
+      }
+    },
+    "number": {
+      "charge_efficiency": {
+        "name": "Batterie-Ladeeffizienz"
+      },
+      "discharge_efficiency": {
+        "name": "Batterie-Entladeeffizienz"
+      },
+      "ev_target_soc": {
+        "name": "EV Ziel-SoC"
+      },
+      "ev_second_target_soc": {
+        "name": "EV 2 Ziel-SoC"
+      }
+    },
+    "time": {
+      "schedule_1_start": {
+        "name": "Batterie-Entladezeitplan 1 Start"
+      },
+      "schedule_1_end": {
+        "name": "Batterie-Entladezeitplan 1 Ende"
+      },
+      "schedule_2_start": {
+        "name": "Batterie-Entladezeitplan 2 Start"
+      },
+      "schedule_2_end": {
+        "name": "Batterie-Entladezeitplan 2 Ende"
+      },
+      "schedule_3_start": {
+        "name": "Batterie-Entladezeitplan 3 Start"
+      },
+      "schedule_3_end": {
+        "name": "Batterie-Entladezeitplan 3 Ende"
+      },
+      "ev_deadline": {
+        "name": "EV Ladefrist"
+      },
+      "ev_second_deadline": {
+        "name": "EV 2 Ladefrist"
+      }
+    }
+  },
+  "services": {
+    "force_recalculation": {
+      "name": "Neuberechnung erzwingen",
+      "description": "Erzwingt, dass der HSEM-Koordinator sofort einen vollständigen Neuberechnungszyklus ausführt."
+    },
+    "set_temporary_override": {
+      "name": "Temporäre Übersteuerung festlegen",
+      "description": "Übersteuert vorübergehend den automatischen Planer, indem ein bestimmter Arbeitsmodus erzwungen wird.",
+      "fields": {
+        "working_mode": {
+          "name": "Arbeitsmodus",
+          "description": "Der zu erzwingende Arbeitsmodus. Muss einer der unterstützten Übersteuerungsmodi sein."
+        }
+      }
+    },
+    "clear_override": {
+      "name": "Übersteuerung löschen",
+      "description": "Löscht jede aktive temporäre Arbeitsmodus-Übersteuerung und kehrt zur automatischen Planersteuerung zurück."
+    },
+    "export_diagnostics": {
+      "name": "Diagnose exportieren",
+      "description": "Exportiert einen strukturierten Diagnose-Dump für die HSEM-Integration mit allen geschwärzten Entitäts-IDs."
+    },
+    "create_dashboard": {
+      "name": "Dashboard erstellen",
+      "description": "Erstellt oder aktualisiert das HSEM-Lovelace-Dashboard. Setze force auf true, um zu überschreiben."
+    }
+  }
+}

--- a/custom_components/hsem/translations/en.json
+++ b/custom_components/hsem/translations/en.json
@@ -1057,7 +1057,7 @@
   "entity": {
     "sensor": {
       "applier_status": {
-        "name": "Applier Status",
+        "name": "Inverter Apply Status",
         "state": {
           "ok": "OK",
           "unverified": "Unverified",
@@ -1200,6 +1200,39 @@
       },
       "ocpp_charger_sessions": {
         "name": "OCPP Charger Sessions"
+      },
+      "export_income": {
+        "name": "Export Income"
+      },
+      "import_cost": {
+        "name": "Grid Import Cost"
+      },
+      "net_grid_balance": {
+        "name": "Net Grid Balance"
+      },
+      "prediction_accuracy": {
+        "name": "Prediction Accuracy"
+      },
+      "pv_curtailment": {
+        "name": "PV Curtailment"
+      },
+      "savings_tracker": {
+        "name": "Savings Tracker"
+      },
+      "solar_confidence": {
+        "name": "Solar Forecast Confidence"
+      },
+      "ocpp_second_charger_status": {
+        "name": "OCPP Charger Second Status"
+      },
+      "ocpp_second_charger_power": {
+        "name": "OCPP Charger Second Power"
+      },
+      "ocpp_second_charger_info": {
+        "name": "OCPP Charger Second Info"
+      },
+      "ocpp_second_charger_sessions": {
+        "name": "OCPP Charger Second Sessions"
       }
     },
     "switch": {

--- a/custom_components/hsem/translations/es.json
+++ b/custom_components/hsem/translations/es.json
@@ -1,0 +1,1362 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "La integración HSEM ya está configurada",
+      "reconfigured_successfully": "Integración HSEM reconfigurada correctamente."
+    },
+    "error": {
+      "device_not_found": "No se encontró el dispositivo seleccionado.",
+      "energy_out_of_range": "El valor de energía está fuera del rango permitido.",
+      "entity_not_found": "No se encontró la entidad seleccionada.",
+      "entity_unavailable": "La entidad seleccionada no está disponible en este momento. Comprueba el dispositivo o el servicio.",
+      "hsem_house_consumption_energy_weight_total": "El total de los pesos de energía de consumo de la vivienda debe ser 100 %.",
+      "invalid_energy_value": "Valor de energía no válido: introduce un número.",
+      "invalid_entity_id": "Formato de ID de entidad no válido. Se espera \"domain.object_id\" con letras minúsculas, dígitos y guiones bajos.",
+      "invalid_month_value": "Uno o más valores de mes no son válidos. Los meses deben ser números enteros entre 1 y 12.",
+      "invalid_power_value": "Valor de potencia no válido: introduce un número.",
+      "invalid_price_value": "Valor de precio no válido: introduce un número.",
+      "invalid_sensor": "Sensor de entrada no válido. Elige un sensor válido.",
+      "invalid_time_format": "Formato de hora no válido: se espera HH:MM:SS.",
+      "months_winter_empty": "La temporada de invierno debe tener al menos un mes.",
+      "only_one_entry_allowed": "Solo se permite una configuración de HSEM.",
+      "power_out_of_range": "El valor de potencia está fuera del rango permitido.",
+      "price_out_of_range": "El valor de precio está fuera del rango permitido.",
+      "required": "Este campo es obligatorio.",
+      "start_time_after_end_time": "La hora de inicio debe ser anterior a la hora de fin.",
+      "start_time_equals_end_time": "La hora de inicio y la hora de fin no pueden ser iguales, ya que esto crea una ventana de duración cero. Desactiva la programación en su lugar.",
+      "invalid_wait_mode_behavior": "Comportamiento de modo de espera no válido. Elige Espera estricta o Autoconsumo con reserva.",
+      "port_conflict": "El segundo puerto OCPP debe ser diferente del primer puerto OCPP."
+    },
+    "step": {
+      "batteries_excess_export": {
+        "data": {
+          "hsem_batteries_enable_excess_export": "Activar exportación de batería excedente",
+          "hsem_batteries_excess_export_discharge_buffer": "Búfer de descarga (%)",
+          "hsem_batteries_forecast_reserve_pct": "Reserva de previsión para exportación de batería (+% SoC)",
+          "hsem_batteries_export_min_price": "Precio mínimo de exportación de batería"
+        },
+        "data_description": {
+          "hsem_batteries_enable_excess_export": "Activa o desactiva la función de exportación de batería excedente, que exporta automáticamente la capacidad de batería excedente a la red cuando resulta económicamente beneficioso.",
+          "hsem_batteries_excess_export_discharge_buffer": "Define el porcentaje del búfer de seguridad para mantener las reservas mínimas de batería (0-50 %). El valor predeterminado es 10 % para garantizar capacidad suficiente ante una demanda inesperada.",
+          "hsem_batteries_forecast_reserve_pct": "Puntos porcentuales adicionales de SoC por encima del límite de fin de descarga de Huawei que la exportación intencionada de batería debe dejar inmediatamente después de cada intervalo de exportación. Por ejemplo, un límite de Huawei del 15 % más una reserva del 5 % protege un 20 % de SoC. La reserva sigue disponible para la carga de la vivienda cuando la demanda real supera la previsión. Ajusta a 0 para desactivar (predeterminado).",
+          "hsem_batteries_export_min_price": "Límite mínimo estricto por intervalo para la exportación intencionada de batería a la red (issue #752). Cuando es > 0, HSEM prohíbe marcar un intervalo como force_batteries_discharge cuando el precio de exportación está estrictamente por debajo de este límite; la batería puede seguir sirviendo la carga de la vivienda en esos intervalos. Alcanzar el umbral NO activa automáticamente la exportación; el optimizador sigue decidiendo si vender resulta rentable. Se aplica únicamente a la exportación intencionada de batería a la red, no al autoconsumo normal, la exportación de PV ni la carga de PV. Ajusta a 0 para desactivar (predeterminado)."
+        },
+        "description": "Configura los ajustes de exportación de batería excedente para vender automáticamente el exceso de energía a la red cuando resulte económicamente beneficioso.",
+        "title": "Exportación de batería excedente"
+      },
+      "ev_planned_load": {
+        "data": {
+          "hsem_ev_planned_load_enabled": "Activar integración de carga planificada del VE",
+          "hsem_ev_planned_load_battery_capacity_kwh": "Capacidad de batería del VE (kWh)",
+          "hsem_ev_planned_load_charger_power_kw": "Potencia del cargador de VE (kW)",
+          "hsem_ev_planned_load_charger_efficiency": "Eficiencia del cargador de VE",
+          "hsem_ev_planned_load_charger_min_power_w": "Potencia mínima del cargador de VE (W)",
+          "hsem_ev_planned_load_charger_phase_topology": "Topología de fases del cargador",
+          "hsem_ev_planned_load_deadline_safety_margin_pct": "Margen de seguridad para la fecha límite (%)",
+          "hsem_ev_planned_load_command_deadband_a": "Banda muerta del límite máximo (A)",
+          "hsem_ev_planned_load_stub_floor_minutes": "Supresión de parada al final del intervalo (min)"
+        },
+        "data_description": {
+          "hsem_ev_planned_load_enabled": "Activa o desactiva la integración de carga planificada del VE.",
+          "hsem_ev_planned_load_battery_capacity_kwh": "Capacidad nominal de la batería del VE en kWh.",
+          "hsem_ev_planned_load_charger_power_kw": "Potencia de salida de CA del cargador de VE en kW.",
+          "hsem_ev_planned_load_charger_efficiency": "Eficiencia del cargador como porcentaje (1-100). Predeterminado: 100.",
+          "hsem_ev_planned_load_charger_min_power_w": "Potencia de CA mínima (W) que necesita el cargador de VE para empezar a cargar. Por debajo de este valor, el cargador no funcionará. Predeterminado: 1380 W (230 V × 6 A).",
+          "hsem_ev_planned_load_charger_phase_topology": "Cómo distribuye el cargador su carga entre las fases de la red eléctrica. Elige \"Monofásico o desconocido\" a menos que hayas confirmado que el cargador consume corriente equilibrada en las tres fases. Con la protección de fusible por fase activada, el valor predeterminado seguro asume que toda la orden del cargador puede recaer en una sola fase, lo que limita la carga planificada al margen del fusible monofásico.",
+          "hsem_ev_planned_load_deadline_safety_margin_pct": "Energía adicional presupuestada por encima del SoC objetivo, como porcentaje del déficit, para que la fricción normal de la carga (retrasos de inicio, límites mínimos de potencia, limitación) no provoque el incumplimiento de la fecha límite. Predeterminado: 0 % (desactivado).",
+          "hsem_ev_planned_load_command_deadband_a": "Reducción mínima del límite de carga publicado que se aplica realmente. Las reducciones menores se retienen, porque los planes competidores en amperios enteros suelen diferir entre sí por un margen de error de redondeo en el coste. Aumentar el límite nunca se retrasa, y una reducción que mejore el coste de carga de este intervalo en más del 5 % siempre se aplica. Predeterminado: 3 A; 0 desactiva.",
+          "hsem_ev_planned_load_stub_floor_minutes": "Al final de un intervalo, suprime la orden de parada durante estos minutos mientras el coche todavía necesite energía. Los segundos restantes no pueden contener suficiente energía para superar el mínimo del cargador, por lo que el plan no les asigna nada y la sesión se detendría y reiniciaría sin ninguna ventaja. Predeterminado: 2 minutos; 0 desactiva."
+        },
+        "description": "Configura la integración opcional de carga planificada del VE. Cuando está activada, HSEM tiene en cuenta la demanda de carga del VE prevista en cada intervalo del planificador.",
+        "title": "Integración de carga planificada del VE"
+      },
+      "ev_second_planned_load": {
+        "data": {
+          "hsem_ev_second_planned_load_enabled": "Activar integración de carga planificada del VE 2",
+          "hsem_ev_second_planned_load_battery_capacity_kwh": "Capacidad de batería del VE 2 (kWh)",
+          "hsem_ev_second_planned_load_charger_power_kw": "Potencia del cargador del VE 2 (kW)",
+          "hsem_ev_second_planned_load_charger_efficiency": "Eficiencia del cargador del VE 2",
+          "hsem_ev_second_planned_load_charger_min_power_w": "Potencia mínima del cargador del VE 2 (W)",
+          "hsem_ev_second_planned_load_charger_phase_topology": "Topología de fases del cargador",
+          "hsem_ev_second_planned_load_deadline_safety_margin_pct": "Margen de seguridad para la fecha límite del VE 2 (%)",
+          "hsem_ev_second_planned_load_command_deadband_a": "Banda muerta del límite máximo del VE 2 (A)",
+          "hsem_ev_second_planned_load_stub_floor_minutes": "Supresión de parada al final del intervalo del VE 2 (min)"
+        },
+        "data_description": {
+          "hsem_ev_second_planned_load_enabled": "Activa o desactiva la integración de carga planificada para el segundo VE.",
+          "hsem_ev_second_planned_load_battery_capacity_kwh": "Capacidad nominal de la batería del segundo VE en kWh.",
+          "hsem_ev_second_planned_load_charger_power_kw": "Potencia de salida de CA del cargador del segundo VE en kW.",
+          "hsem_ev_second_planned_load_charger_efficiency": "Eficiencia del cargador del segundo VE como porcentaje (1-100). Predeterminado: 100.",
+          "hsem_ev_second_planned_load_charger_min_power_w": "Potencia de CA mínima (W) que necesita el cargador del segundo VE para empezar a cargar. Predeterminado: 1380 W (230 V × 6 A).",
+          "hsem_ev_second_planned_load_charger_phase_topology": "Cómo distribuye el cargador su carga entre las fases de la red eléctrica. Elige \"Monofásico o desconocido\" a menos que hayas confirmado que el cargador consume corriente equilibrada en las tres fases. Con la protección de fusible por fase activada, el valor predeterminado seguro asume que toda la orden del cargador puede recaer en una sola fase, lo que limita la carga planificada al margen del fusible monofásico.",
+          "hsem_ev_second_planned_load_deadline_safety_margin_pct": "Igual que el margen de seguridad de fecha límite del VE principal, para el segundo VE. Predeterminado: 0 % (desactivado).",
+          "hsem_ev_second_planned_load_command_deadband_a": "Igual que la banda muerta del límite máximo del VE principal, para el segundo VE. Predeterminado: 3 A; 0 desactiva.",
+          "hsem_ev_second_planned_load_stub_floor_minutes": "Igual que la supresión de parada al final del intervalo del VE principal, para el segundo VE. Predeterminado: 2 minutos; 0 desactiva."
+        },
+        "description": "Configura la integración opcional de carga planificada para el segundo VE. Solo se muestra cuando el segundo cargador de VE está activado.",
+        "title": "Integración de carga planificada del VE 2"
+      },
+      "ocpp": {
+        "data": {
+          "hsem_ocpp_enabled": "Activar servidor OCPP",
+          "hsem_ocpp_port": "Puerto OCPP",
+          "hsem_ocpp_cpid": "ID del punto de carga",
+          "hsem_ocpp_start_window_s": "Ventana de inicio (s)",
+          "hsem_ocpp_stop_window_s": "Ventana de parada (s)",
+          "hsem_ocpp_second_enabled": "Activar segundo servidor OCPP",
+          "hsem_ocpp_second_port": "Segundo puerto OCPP",
+          "hsem_ocpp_second_cpid": "ID del segundo punto de carga"
+        },
+        "data_description": {
+          "hsem_ocpp_enabled": "Activa el servidor WebSocket OCPP 1.6 integrado para el control directo del cargador de VE. Solo para red local: no expongas el puerto a internet.",
+          "hsem_ocpp_port": "Puerto TCP para el servidor WebSocket OCPP. Predeterminado: 9000. Debe ser superior a 1024.",
+          "hsem_ocpp_cpid": "Identificador de punto de carga esperado del cargador de VE. Déjalo vacío para aceptar cualquier cargador.",
+          "hsem_ocpp_start_window_s": "Segundos de excedente sostenido necesarios antes de iniciar una carga. Evita ciclos rápidos de arranque y parada. Predeterminado: 60.",
+          "hsem_ocpp_stop_window_s": "Segundos de déficit sostenido necesarios antes de detener una carga. Evita ciclos rápidos de parada y arranque. Predeterminado: 180.",
+          "hsem_ocpp_second_enabled": "Activa un segundo servidor OCPP dedicado para el segundo VE. Solo disponible cuando la carga planificada del VE 2 está activada.",
+          "hsem_ocpp_second_port": "Puerto TCP para el segundo servidor WebSocket OCPP. Predeterminado: 9001. Debe ser diferente del puerto del primer servidor.",
+          "hsem_ocpp_second_cpid": "Identificador de punto de carga esperado del segundo cargador de VE. Déjalo vacío para aceptar cualquier cargador."
+        },
+        "description": "Configura el servidor OCPP 1.6 integrado para el control del cargador de VE únicamente en red local. Cuando está activado, HSEM envía órdenes SetChargingProfile directamente a tu cargador de VE según el plan de carga.",
+        "title": "Servidor OCPP"
+      },
+      "batteries_schedule_1": {
+        "data": {
+          "hsem_batteries_enable_batteries_schedule_1": "Activar programación de batería 1",
+          "hsem_batteries_enable_batteries_schedule_1_end": "Hora de fin de la programación de batería 1",
+          "hsem_batteries_enable_batteries_schedule_1_start": "Hora de inicio de la programación de batería 1"
+        },
+        "data_description": {
+          "hsem_batteries_enable_batteries_schedule_1": "Activa o desactiva la primera programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_1_end": "Especifica la hora de fin de la primera programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_1_start": "Especifica la hora de inicio de la primera programación de descarga de batería."
+        },
+        "description": "Configura la programación de descarga de batería 1, incluida su hora de activación.",
+        "title": "Programación de descarga de batería 1"
+      },
+      "batteries_schedule_2": {
+        "data": {
+          "hsem_batteries_enable_batteries_schedule_2": "Activar programación de batería 2",
+          "hsem_batteries_enable_batteries_schedule_2_end": "Hora de fin de la programación de batería 2",
+          "hsem_batteries_enable_batteries_schedule_2_start": "Hora de inicio de la programación de batería 2"
+        },
+        "data_description": {
+          "hsem_batteries_enable_batteries_schedule_2": "Activa o desactiva la segunda programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_2_end": "Especifica la hora de fin de la segunda programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_2_start": "Especifica la hora de inicio de la segunda programación de descarga de batería."
+        },
+        "description": "Configura la programación de descarga de batería 2, incluida su hora de activación.",
+        "title": "Programación de descarga de batería 2"
+      },
+      "batteries_schedule_3": {
+        "data": {
+          "hsem_batteries_enable_batteries_schedule_3": "Activar programación de batería 3",
+          "hsem_batteries_enable_batteries_schedule_3_end": "Hora de fin de la programación de batería 3",
+          "hsem_batteries_enable_batteries_schedule_3_start": "Hora de inicio de la programación de batería 3"
+        },
+        "data_description": {
+          "hsem_batteries_enable_batteries_schedule_3": "Activa o desactiva la tercera programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_3_end": "Especifica la hora de fin de la tercera programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_3_start": "Especifica la hora de inicio de la tercera programación de descarga de batería."
+        },
+        "description": "Configura la programación de descarga de batería 3, incluida su hora de activación.",
+        "title": "Programación de descarga de batería 3"
+      },
+      "prices": {
+        "data": {
+          "hsem_import_electricity_price_sensor": "Sensor de precio de electricidad de importación",
+          "hsem_export_electricity_price_sensor": "Sensor de precio de electricidad de exportación",
+          "hsem_import_electricity_price_forecast_sensor": "Sensor de previsión de precio de importación (opcional)",
+          "hsem_export_electricity_price_forecast_sensor": "Sensor de previsión de precio de exportación (opcional)",
+          "hsem_export_electricity_min_price": "Precio mínimo de exportación requerido",
+          "hsem_electricity_price_update_interval": "Intervalo de actualización del precio de electricidad (minutos)"
+        },
+        "data_description": {
+          "hsem_import_electricity_price_sensor": "Selecciona el sensor que proporciona los precios de electricidad de importación (p. ej. Energi Data Service, Nordpool, Amber Electric).",
+          "hsem_export_electricity_price_sensor": "Selecciona el sensor que proporciona los precios de electricidad de exportación.",
+          "hsem_import_electricity_price_forecast_sensor": "Opcional: selecciona un sensor independiente para las previsiones de precio de importación (usado por Amber Electric e integraciones similares).",
+          "hsem_export_electricity_price_forecast_sensor": "Opcional: selecciona un sensor independiente para las previsiones de precio de exportación.",
+          "hsem_export_electricity_min_price": "Define el precio mínimo de exportación. Las exportaciones por debajo de este precio se bloquearán.",
+          "hsem_electricity_price_update_interval": "Con qué frecuencia proporciona nuevos datos tu sensor de precios (15, 30 o 60 minutos)."
+        },
+        "description": "Configura tus sensores de precio de electricidad para los precios de importación y exportación.",
+        "title": "Precios de electricidad"
+      },
+      "ev": {
+        "data": {
+          "hsem_ev_allow_charge_past_target_soc": "Permitir carga más allá del SoC objetivo (avanzado)",
+          "hsem_ev_charger_force_max_discharge_power": "Forzar potencia máxima de descarga del cargador de VE",
+          "hsem_ev_charger_max_discharge_power": "Potencia máxima de descarga del cargador de VE",
+          "hsem_ev_charger_power": "Sensor de potencia del cargador de VE",
+          "hsem_ev_charger_status": "Sensor de estado del cargador de VE",
+          "hsem_ev_connected": "Sensor de conexión del VE",
+          "hsem_ev_second_enabled": "Activar segundo cargador de VE",
+          "hsem_ev_soc": "Sensor de estado de carga (SoC) del VE",
+          "hsem_house_power_includes_ev_charger_power": "La potencia de la vivienda incluye la potencia del cargador de VE",
+          "hsem_ev_auto_full_negative_price": "Carga completa automática del VE con precio negativo",
+          "hsem_ev_past_target_confidence_factor": "Factor de confianza de carga del VE más allá del objetivo (avanzado)"
+        },
+        "data_description": {
+          "hsem_ev_allow_charge_past_target_soc": "Activa esta opción si quieres permitir que el sistema siga cargando la batería del VE incluso después de haber alcanzado el estado de carga (SoC) objetivo. Esto puede resultar útil en situaciones en las que quieras asegurarte de que el VE quede completamente cargado, independientemente del ajuste del objetivo.",
+          "hsem_ev_charger_force_max_discharge_power": "Activa esto si quieres forzar una potencia máxima de descarga específica para las baterías Huawei mientras el VE se está cargando.",
+          "hsem_ev_charger_max_discharge_power": "Define la potencia máxima de descarga de las baterías Huawei mientras el VE se está cargando.",
+          "hsem_ev_charger_power": "Selecciona el sensor que mide el consumo de potencia de tu cargador de VE.",
+          "hsem_ev_charger_status": "Selecciona el sensor o la entidad que indica si el cargador de VE está activo (p. ej., un interruptor o un sensor).",
+          "hsem_ev_connected": "Selecciona el sensor o la entidad que indica si el VE está conectado al cargador.",
+          "hsem_ev_second_enabled": "Activa o desactiva la configuración de un segundo cargador de VE.",
+          "hsem_ev_soc": "Selecciona el sensor que proporciona el estado de carga (SoC) actual de la batería de tu VE.",
+          "hsem_house_power_includes_ev_charger_power": "Activa esto si el sensor de potencia de consumo de la vivienda ya incluye el consumo de potencia del cargador de VE.",
+          "hsem_ev_auto_full_negative_price": "Cuando está activado, el VE se ajusta automáticamente a la potencia de carga máxima cuando el precio de la electricidad es cero o negativo. El modo de carga anterior se restaura cuando el precio sube por encima de cero.",
+          "hsem_ev_past_target_confidence_factor": "Multiplicador de confianza (0.0-1.0) aplicado a la valoración de importación futura evitada que se usa al cargar el VE más allá de su SoC objetivo. Valores más bajos hacen que el VE compita peor frente a la exportación del excedente de PV, para tener en cuenta la incertidumbre sobre si el VE realmente necesitará la energía adicional antes de su próxima carga. Predeterminado 0.9."
+        },
+        "description": "Configura los ajustes del cargador de VE para HSEM.",
+        "title": "Ajustes del cargador de VE (opcional)"
+      },
+      "ev_second": {
+        "data": {
+          "hsem_ev_second_allow_charge_past_target_soc": "Permitir carga más allá del SoC objetivo para el segundo VE (avanzado)",
+          "hsem_ev_second_charger_force_max_discharge_power": "Forzar potencia máxima de descarga del segundo cargador de VE",
+          "hsem_ev_second_charger_max_discharge_power": "Potencia máxima de descarga del segundo cargador de VE",
+          "hsem_ev_second_charger_power": "Sensor de potencia del segundo cargador de VE",
+          "hsem_ev_second_charger_status": "Sensor de estado del segundo cargador de VE",
+          "hsem_ev_second_connected": "Sensor de conexión del segundo VE",
+          "hsem_ev_second_soc": "Sensor de estado de carga (SoC) del segundo VE",
+          "hsem_ev_second_past_target_confidence_factor": "Factor de confianza de carga del segundo VE más allá del objetivo (avanzado)"
+        },
+        "data_description": {
+          "hsem_ev_second_allow_charge_past_target_soc": "Activa esta opción si quieres permitir que el sistema siga cargando la batería del VE incluso después de haber alcanzado el estado de carga (SoC) objetivo. Esto puede resultar útil en situaciones en las que quieras asegurarte de que el VE quede completamente cargado, independientemente del ajuste del objetivo.",
+          "hsem_ev_second_charger_force_max_discharge_power": "Activa esto si quieres forzar una potencia máxima de descarga específica para las baterías Huawei mientras el VE se está cargando.",
+          "hsem_ev_second_charger_max_discharge_power": "Define la potencia máxima de descarga de las baterías Huawei mientras el VE se está cargando.",
+          "hsem_ev_second_charger_power": "Selecciona el sensor que mide el consumo de potencia de tu cargador de VE.",
+          "hsem_ev_second_charger_status": "Selecciona el sensor o la entidad que indica si el cargador de VE está activo (p. ej., un interruptor o un sensor).",
+          "hsem_ev_second_connected": "Selecciona el sensor o la entidad que indica si el VE está conectado al cargador.",
+          "hsem_ev_second_soc": "Selecciona el sensor que proporciona el estado de carga (SoC) actual de la batería de tu VE.",
+          "hsem_ev_second_past_target_confidence_factor": "Multiplicador de confianza (0.0-1.0) aplicado a la valoración de importación futura evitada que se usa al cargar el segundo VE más allá de su SoC objetivo. Valores más bajos hacen que el VE compita peor frente a la exportación del excedente de PV, para tener en cuenta la incertidumbre sobre si el VE realmente necesitará la energía adicional antes de su próxima carga. Predeterminado 0.9."
+        },
+        "description": "Configura los ajustes del segundo cargador de VE para HSEM.",
+        "title": "Ajustes del segundo cargador de VE (opcional)"
+      },
+      "huawei_solar": {
+        "data": {
+          "hsem_batteries_charge_efficiency": "Eficiencia de carga de la batería (%)",
+          "hsem_batteries_cycle_cost": "Coste de ciclo de batería (por kWh)",
+          "hsem_batteries_discharge_efficiency": "Eficiencia de descarga de la batería (%)",
+          "hsem_batteries_expected_cycles": "Ciclos de batería esperados",
+          "hsem_batteries_purchase_price": "Precio de compra de la batería",
+          "hsem_huawei_solar_batteries_excess_pv_energy_use_in_tou": "Uso del excedente de energía PV en TOU de las baterías Huawei",
+          "hsem_huawei_solar_batteries_forcible_charge": "Estado de carga forzada de la batería",
+          "hsem_huawei_solar_batteries_end_of_discharge_soc": "SOC de fin de descarga de las baterías Huawei (%)",
+          "hsem_huawei_solar_batteries_charging_cutoff_capacity": "Capacidad de corte de carga de las baterías Huawei (SoC máx. %)",
+          "hsem_huawei_solar_batteries_grid_charge_cutoff_soc": "SOC de corte de carga desde la red de las baterías Huawei (%)",
+          "hsem_huawei_solar_batteries_maximum_charging_power": "Potencia máxima de carga de las baterías Huawei (W)",
+          "hsem_huawei_solar_batteries_maximum_discharging_power": "Potencia máxima de descarga de las baterías Huawei (W)",
+          "hsem_huawei_solar_batteries_grid_charge_maximum_power": "Potencia máxima de carga desde la red de las baterías Huawei (W)",
+          "hsem_huawei_solar_batteries_charge_discharge_power": "Sensor de potencia de carga/descarga de la batería Huawei",
+          "hsem_huawei_solar_batteries_rated_capacity": "Capacidad máxima de la batería (Wh)",
+          "hsem_huawei_solar_batteries_state_of_capacity": "Sensor de estado de capacidad de las baterías Huawei",
+          "hsem_huawei_solar_batteries_tou_charging_and_discharging_periods": "Períodos de carga y descarga TOU de las baterías Huawei",
+          "hsem_huawei_solar_batteries_working_mode": "Sensor de modo de funcionamiento de las baterías Huawei Solar",
+          "hsem_huawei_solar_device_id_batteries": "Dispositivo de baterías Huawei",
+          "hsem_huawei_solar_device_id_batteries_2": "Dispositivo de baterías Huawei 2",
+          "hsem_huawei_solar_device_id_inverter_1": "Dispositivo del inversor Huawei 1",
+          "hsem_huawei_solar_device_id_inverter_2": "Dispositivo del inversor Huawei 2",
+          "hsem_huawei_solar_inverter_active_power_control": "Sensor de control de potencia activa del inversor Huawei"
+        },
+        "data_description": {
+          "hsem_batteries_charge_efficiency": "Especifica la eficiencia de carga de tu batería como porcentaje (0-100). La energía almacenada en la batería equivale a la energía de entrada multiplicada por este factor. Las baterías de litio habituales alcanzan un 95-98 %. Predeterminado: 98 %.",
+          "hsem_batteries_discharge_efficiency": "Especifica la eficiencia de descarga de tu batería como porcentaje (0-100). La energía entregada a la vivienda equivale a la energía extraída de la batería multiplicada por este factor. Las baterías de litio habituales alcanzan un 95-98 %. Predeterminado: 98 %.",
+          "hsem_batteries_cycle_cost": "Coste adicional opcional por kWh de ciclado de la batería (por kWh). Se suma al umbral de depreciación calculado automáticamente. Ajusta a 0 para depender únicamente de la protección de depreciación. Ejemplo: 0.02 significa que el planificador requiere 2 céntimos adicionales de margen por kWh ciclado antes de aprobar la carga desde la red.",
+          "hsem_batteries_expected_cycles": "Introduce el número esperado de ciclos completos de carga/descarga durante la vida útil de la batería. Se usa para calcular el coste de depreciación por kWh y el umbral de precio mínimo de exportación recomendado. Las baterías LiFePO4 habituales admiten entre 4000 y 8000 ciclos.",
+          "hsem_batteries_purchase_price": "Introduce el precio de compra total de tu sistema de baterías en tu moneda local. Se usa junto con los ciclos esperados y la capacidad utilizable para calcular el coste de depreciación por kWh y el umbral de precio mínimo de exportación recomendado.",
+          "hsem_huawei_solar_batteries_excess_pv_energy_use_in_tou": "Selecciona el sensor que proporciona el ajuste de uso del excedente de energía PV en los períodos TOU.",
+          "hsem_huawei_solar_batteries_forcible_charge": "Sensor que muestra el estado actual de carga/descarga forzada (p. ej. Detenido, Descargando a 5000 W durante 60 minutos)",
+          "hsem_huawei_solar_batteries_end_of_discharge_soc": "Especifica el porcentaje de SOC de fin de descarga para tus baterías Huawei. Cuando la batería alcanza este nivel de SOC, dejará de descargarse para evitar una descarga profunda y posibles daños a la batería.",
+          "hsem_huawei_solar_batteries_charging_cutoff_capacity": "Selecciona la entidad que define el estado de carga (SoC) máximo que la batería puede alcanzar durante la carga (registro STORAGE_CHARGING_CUTOFF_CAPACITY). Normalmente 90-100 %. Usado por la simulación de SoC como límite superior de SoC para que el planificador nunca programe carga por encima de este límite.",
+          "hsem_huawei_solar_batteries_grid_charge_cutoff_soc": "Especifica el porcentaje de SOC de corte de carga desde la red para tus baterías Huawei.",
+          "hsem_huawei_solar_batteries_maximum_charging_power": "Selecciona el sensor que proporciona la potencia máxima de carga de tus baterías Huawei en vatios (W).",
+          "hsem_huawei_solar_batteries_maximum_discharging_power": "Selecciona el sensor que proporciona la potencia máxima de descarga de tus baterías Huawei.",
+          "hsem_huawei_solar_batteries_grid_charge_maximum_power": "Selecciona la entidad numérica que establece el límite máximo de potencia de carga desde la red de Huawei (W). Escrita por el limitador de seguridad de carga con reconocimiento de fase en tiempo real (issue #831) para mantener la carga financiada por la red por debajo del límite por fase del fusible principal. Opcional; solo se requiere cuando la carga con reconocimiento de fase está activada.",
+          "hsem_huawei_solar_batteries_charge_discharge_power": "Selecciona el sensor que informa de la potencia instantánea de carga/descarga de la batería con signo (positivo = cargando, negativo = descargando). Necesario para el limitador de seguridad de carga con reconocimiento de fase en tiempo real (issue #831), para eliminar la propia contribución de Huawei de la instantánea de fase en tiempo real antes de calcular el margen disponible. Opcional; solo se requiere cuando la carga con reconocimiento de fase está activada.",
+          "hsem_huawei_solar_batteries_rated_capacity": "Selecciona el sensor que proporciona la capacidad nominal total de tus baterías Huawei en vatios-hora (Wh).",
+          "hsem_huawei_solar_batteries_state_of_capacity": "Selecciona el sensor que proporciona el estado de carga (SOC) de tus baterías Huawei.",
+          "hsem_huawei_solar_batteries_tou_charging_and_discharging_periods": "Selecciona el sensor que define los períodos de carga y descarga por franja horaria (TOU) de tus baterías Huawei.",
+          "hsem_huawei_solar_batteries_working_mode": "Selecciona el sensor que indica el modo de funcionamiento actual de tus baterías Huawei.",
+          "hsem_huawei_solar_device_id_batteries": "Selecciona tu dispositivo de batería Huawei.",
+          "hsem_huawei_solar_device_id_batteries_2": "Selecciona tu dispositivo de batería Huawei secundario, si corresponde.",
+          "hsem_huawei_solar_device_id_inverter_1": "Selecciona tu dispositivo de inversor Huawei principal.",
+          "hsem_huawei_solar_device_id_inverter_2": "Selecciona tu dispositivo de inversor Huawei secundario, si corresponde.",
+          "hsem_huawei_solar_inverter_active_power_control": "Selecciona el sensor que controla la salida de potencia activa de tu inversor Huawei."
+        },
+        "description": "Configura el modo de funcionamiento de las baterías solares Huawei.",
+        "title": "Sensores de Huawei Solar"
+      },
+      "battery_economics": {
+        "data": {
+          "hsem_batteries_purchase_price": "Precio de compra de la batería",
+          "hsem_batteries_expected_cycles": "Ciclos de batería esperados",
+          "hsem_batteries_cycle_cost": "Coste de ciclo de batería (por kWh)",
+          "hsem_batteries_capacity_loss_pct": "Pérdida de capacidad de la batería al final de su vida útil (%)",
+          "hsem_batteries_charge_efficiency": "Eficiencia de carga de la batería (%)",
+          "hsem_batteries_discharge_efficiency": "Eficiencia de descarga de la batería (%)",
+          "hsem_planner_hysteresis_enabled": "Histéresis a nivel de plan",
+          "hsem_planner_hysteresis_absolute": "Umbral absoluto de histéresis",
+          "hsem_planner_hysteresis_percentage": "Umbral porcentual de histéresis (%)",
+          "hsem_planner_window_hysteresis_minutes": "Tiempo de retención de histéresis de ventana (minutos)"
+        },
+        "data_description": {
+          "hsem_batteries_purchase_price": "Introduce el precio de compra total de tu sistema de baterías en tu moneda local. Se usa junto con los ciclos esperados y la capacidad utilizable para calcular el coste de depreciación por kWh y el umbral de precio mínimo de exportación recomendado.",
+          "hsem_batteries_expected_cycles": "Introduce el número esperado de ciclos completos de carga/descarga durante la vida útil de la batería. Se usa para calcular el coste de depreciación por kWh y el umbral de precio mínimo de exportación recomendado. Las baterías LiFePO4 habituales admiten entre 4000 y 8000 ciclos.",
+          "hsem_batteries_cycle_cost": "Coste adicional opcional por kWh de ciclado de la batería (por kWh). Se suma al umbral de depreciación calculado automáticamente. Ajusta a 0 para depender únicamente de la protección de depreciación. Ejemplo: 0.02 significa que el planificador requiere 2 céntimos adicionales de margen por kWh ciclado antes de aprobar la carga desde la red.",
+          "hsem_batteries_capacity_loss_pct": "Pérdida de capacidad esperada al final de la vida útil, como porcentaje. Las baterías LiFePO4 suelen alcanzar un 80 % de capacidad tras ~6000 ciclos (20 % de pérdida). El valor predeterminado del 30 % añade margen para el envejecimiento por calendario.",
+          "hsem_batteries_charge_efficiency": "Especifica la eficiencia de carga de tu batería como porcentaje (0-100). La energía almacenada en la batería equivale a la energía de entrada multiplicada por este factor. Las baterías de litio habituales alcanzan un 95-98 %. Predeterminado: 98 %.",
+          "hsem_batteries_discharge_efficiency": "Especifica la eficiencia de descarga de tu batería como porcentaje (0-100). La energía entregada a la vivienda equivale a la energía extraída de la batería multiplicada por este factor. Las baterías de litio habituales alcanzan un 95-98 %. Predeterminado: 98 %.",
+          "hsem_planner_hysteresis_enabled": "Cuando está activada, el planificador mantiene el plan candidato activo a menos que un nuevo plan mejore la puntuación por encima de los umbrales configurados. Evita la oscilación entre estrategias con puntuaciones equivalentes.",
+          "hsem_planner_hysteresis_absolute": "Mejora mínima absoluta de la puntuación necesaria para cambiar a un nuevo plan. 0.00 desactiva el umbral absoluto. La puntuación usa la misma moneda que tus precios de electricidad, por lo que un valor de 0.01 requiere una mejora de al menos 1 céntimo/kWh equivalente antes de cambiar.",
+          "hsem_planner_hysteresis_percentage": "Mejora mínima porcentual de la puntuación necesaria para cambiar a un nuevo plan. 0 % desactiva el umbral porcentual. El valor predeterminado del 5 % evita las oscilaciones entre planes casi idénticos.",
+          "hsem_planner_window_hysteresis_minutes": "Tiempo mínimo (minutos) que debe mantenerse una recomendación antes de poder cambiar. Evita alternancias rápidas como ev_smart_charging ↔ batteries_charge_solar. 0 desactiva la función. Predeterminado: 10."
+        },
+        "description": "Configura los parámetros económicos de la batería y la histéresis del planificador (anti-oscilación).",
+        "title": "Economía de la batería e histéresis"
+      },
+      "init": {
+        "data": {
+          "device_name": "Nombre",
+          "hsem_extended_attributes": "Atributos ampliados",
+          "hsem_read_only": "Solo lectura",
+          "hsem_recommendation_interval_length": "Duración del intervalo de recomendación",
+          "hsem_recommendation_interval_minutes": "Minutos del intervalo de recomendación",
+          "hsem_update_interval": "Intervalo de actualización",
+          "hsem_verbose_logging": "Registro detallado"
+        },
+        "data_description": {
+          "device_name": "Introduce un nombre único para este dispositivo.",
+          "hsem_extended_attributes": "Activa esta opción para exponer atributos de diagnóstico adicionales en la entidad del sensor.",
+          "hsem_read_only": "Activa esta opción para poner la integración en modo de solo lectura, evitando que envíe órdenes a los dispositivos.",
+          "hsem_recommendation_interval_length": "El número de intervalos de recomendación que se tienen en cuenta al calcular el uso óptimo de la batería.",
+          "hsem_recommendation_interval_minutes": "La duración en minutos de cada intervalo de recomendación utilizado para calcular el uso óptimo de la batería.",
+          "hsem_update_interval": "El intervalo de actualización en minutos del sensor de modo de funcionamiento.",
+          "hsem_verbose_logging": "Activa el registro de depuración detallado con fines de solución de problemas."
+        },
+        "description": "Actualiza los ajustes de HSEM",
+        "title": "Actualizar Huawei Solar Energy Management"
+      },
+      "batteries_schedules": {
+        "data": {
+          "hsem_batteries_enable_batteries_schedule_1": "Activar programación de batería 1",
+          "hsem_batteries_enable_batteries_schedule_1_end": "Hora de fin de la programación de batería 1",
+          "hsem_batteries_enable_batteries_schedule_1_start": "Hora de inicio de la programación de batería 1",
+          "hsem_batteries_enable_batteries_schedule_2": "Activar programación de batería 2",
+          "hsem_batteries_enable_batteries_schedule_2_end": "Hora de fin de la programación de batería 2",
+          "hsem_batteries_enable_batteries_schedule_2_start": "Hora de inicio de la programación de batería 2",
+          "hsem_batteries_enable_batteries_schedule_3": "Activar programación de batería 3",
+          "hsem_batteries_enable_batteries_schedule_3_end": "Hora de fin de la programación de batería 3",
+          "hsem_batteries_enable_batteries_schedule_3_start": "Hora de inicio de la programación de batería 3"
+        },
+        "data_description": {
+          "hsem_batteries_enable_batteries_schedule_1": "Activa o desactiva la primera programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_1_end": "Especifica la hora de fin de la primera programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_1_start": "Especifica la hora de inicio de la primera programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_2": "Activa o desactiva la segunda programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_2_end": "Especifica la hora de fin de la segunda programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_2_start": "Especifica la hora de inicio de la segunda programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_3": "Activa o desactiva la tercera programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_3_end": "Especifica la hora de fin de la tercera programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_3_start": "Especifica la hora de inicio de la tercera programación de descarga de batería."
+        },
+        "description": "Configura hasta tres ventanas de programación de descarga de batería, cada una con un interruptor de activación/desactivación, hora de inicio y hora de fin. Las programaciones definen cuándo puede descargarse la batería para cubrir picos de consumo o exportar a la red.",
+        "title": "Programaciones de descarga de batería"
+      },
+      "months": {
+        "data": {
+          "hsem_months_winter": "Meses considerados como invierno/primavera"
+        },
+        "data_description": {
+          "hsem_months_winter": "Selecciona los meses que deben considerarse invierno/primavera para los ajustes estacionales del modo de funcionamiento. Puedes seleccionar varios meses. Seleccionar los 12 meses está permitido: esto mantiene el modo invierno/primavera (TOU) activo todo el año."
+        },
+        "description": "Configura los meses que se consideran invierno/primavera. Durante estos meses, el sistema priorizará la carga de las baterías desde la energía de la red para garantizar niveles de batería suficientes en los períodos de menor producción solar. Los meses restantes se considerarán meses de verano/otoño.",
+        "title": "Meses de invierno/primavera"
+      },
+      "power": {
+        "data": {
+          "hsem_house_consumption_power": "Sensor de potencia de consumo de la vivienda",
+          "hsem_main_fuse_amps": "Valor nominal del fusible principal (amperios)",
+          "hsem_main_fuse_phases": "Número de fases del fusible principal",
+          "hsem_max_grid_export_power_kw": "Potencia máxima de exportación a la red (kW)",
+          "hsem_solar_production_power": "Sensor de potencia de producción solar",
+          "hsem_huawei_solar_power_meter_phase_a_active_power": "Sensor de potencia activa del medidor, fase A",
+          "hsem_huawei_solar_power_meter_phase_b_active_power": "Sensor de potencia activa del medidor, fase B",
+          "hsem_huawei_solar_power_meter_phase_c_active_power": "Sensor de potencia activa del medidor, fase C",
+          "hsem_phase_aware_charging_enabled": "Activar limitador de seguridad de carga con reconocimiento de fase en tiempo real"
+        },
+        "data_description": {
+          "hsem_house_consumption_power": "Selecciona el sensor que mide el consumo total de potencia de tu vivienda.",
+          "hsem_main_fuse_amps": "El valor nominal del fusible/interruptor principal de tu vivienda en amperios (25, 35, etc.). El optimizador MILP respetará este límite al programar la carga de la batería y del VE. Ajusta a 0 para desactivar.",
+          "hsem_main_fuse_phases": "El número de fases de tu instalación eléctrica. Las instalaciones monofásicas DEBEN configurar este valor en 1; establecer 3 en una instalación monofásica hace que la protección del fusible sea 3 veces demasiado permisiva y no proporciona un límite de seguridad real. Predeterminado: 3 (trifásico).",
+          "hsem_max_grid_export_power_kw": "Potencia máxima de exportación a la red en kW: el límite de exportación del operador de red/inversor para conexiones con exportación limitada (p. ej., 5 kW). El planificador MILP nunca programará una exportación por encima de este límite, de modo que la exportación de batería y la exportación de PV compiten correctamente por el mismo límite. Ajusta a 0 para desactivar.",
+          "hsem_solar_production_power": "Selecciona el sensor que mide la potencia generada por tus paneles solares.",
+          "hsem_huawei_solar_power_meter_phase_a_active_power": "Selecciona el sensor que mide la potencia activa en tiempo real en la fase A de tu medidor de potencia Huawei. Solo se requiere cuando la carga con reconocimiento de fase está activada.",
+          "hsem_huawei_solar_power_meter_phase_b_active_power": "Selecciona el sensor que mide la potencia activa en tiempo real en la fase B de tu medidor de potencia Huawei. Solo se requiere cuando la carga con reconocimiento de fase está activada.",
+          "hsem_huawei_solar_power_meter_phase_c_active_power": "Selecciona el sensor que mide la potencia activa en tiempo real en la fase C de tu medidor de potencia Huawei. Solo se requiere cuando la carga con reconocimiento de fase está activada.",
+          "hsem_phase_aware_charging_enabled": "Activa una comprobación de seguridad en tiempo real inmediatamente antes de cada escritura de hardware de carga desde la red de Huawei (issue #831). Usa los tres sensores de fase del medidor de potencia indicados a continuación, junto con la entidad de potencia máxima de carga desde la red de Huawei (paso huawei_solar), para limitar la carga financiada por la red de modo que nunca supere el valor nominal del fusible principal en ninguna fase, incluso si la carga cambió después de resolver el plan. Requiere main_fuse_phases = 3 y las cuatro entidades configuradas. Desactivado de forma predeterminada; totalmente compatible con versiones anteriores."
+        },
+        "description": "Selecciona los sensores de potencia para HSEM.",
+        "title": "Sensores de potencia"
+      },
+      "quick_setup": {
+        "data": {
+          "battery_soc": "Estado de capacidad de la batería",
+          "working_mode": "Modo de funcionamiento de las baterías",
+          "max_charge_power": "Potencia máxima de carga",
+          "max_discharge_power": "Potencia máxima de descarga",
+          "eod_soc": "SoC de fin de descarga",
+          "rated_capacity": "Capacidad nominal de las baterías",
+          "active_power_control": "Control de potencia activa",
+          "tou_periods": "Períodos de carga/descarga TOU",
+          "solcast_today": "Previsión de Solcast de hoy",
+          "solcast_tomorrow": "Previsión de Solcast de mañana",
+          "import_price": "Sensor de precio de electricidad de importación",
+          "export_price": "Sensor de precio de electricidad de exportación",
+          "house_power": "Potencia de consumo de la vivienda",
+          "solar_power": "Potencia de producción solar",
+          "use_quick_setup": "Usar configuración rápida"
+        },
+        "data_description": {
+          "battery_soc": "Sensor de estado de capacidad de la batería detectado automáticamente.",
+          "working_mode": "Entidad de modo de funcionamiento de las baterías detectada automáticamente.",
+          "max_charge_power": "Entidad de potencia máxima de carga detectada automáticamente.",
+          "max_discharge_power": "Entidad de potencia máxima de descarga detectada automáticamente.",
+          "eod_soc": "Entidad de SoC de fin de descarga detectada automáticamente.",
+          "rated_capacity": "Sensor de capacidad nominal de las baterías detectado automáticamente.",
+          "active_power_control": "Sensor de control de potencia activa del inversor detectado automáticamente.",
+          "tou_periods": "Sensor de períodos de carga/descarga TOU detectado automáticamente.",
+          "solcast_today": "Previsión PV de Solcast para hoy, detectada automáticamente.",
+          "solcast_tomorrow": "Previsión PV de Solcast para mañana, detectada automáticamente.",
+          "import_price": "Sensor de precio de electricidad de importación detectado automáticamente.",
+          "export_price": "Sensor de precio de electricidad de exportación detectado automáticamente.",
+          "house_power": "Sensor de potencia de consumo de la vivienda detectado automáticamente.",
+          "solar_power": "Sensor de potencia de producción solar detectado automáticamente.",
+          "use_quick_setup": "Actívalo para usar las entidades detectadas automáticamente y omitir el asistente de configuración completo entidad por entidad. Desactívalo para la configuración avanzada."
+        },
+        "description": "HSEM ha detectado automáticamente las siguientes entidades. {warning}Revisa las entidades detectadas a continuación. Puedes confirmar su uso o elegir la configuración avanzada para seleccionar las entidades manualmente.",
+        "title": "Configuración rápida: entidades detectadas automáticamente"
+      },
+      "solcast": {
+        "data": {
+          "hsem_solcast_pv_forecast_forecast_likelihood": "Probabilidad de previsión preferida para usar en la previsión PV de Solcast",
+          "hsem_solcast_pv_forecast_forecast_today": "Sensor de previsión PV de Solcast de hoy",
+          "hsem_solcast_pv_forecast_forecast_tomorrow": "Sensor de previsión PV de Solcast de mañana"
+        },
+        "data_description": {
+          "hsem_solcast_pv_forecast_forecast_likelihood": "Selecciona la probabilidad de previsión preferida para las previsiones PV de Solcast.",
+          "hsem_solcast_pv_forecast_forecast_today": "Selecciona el sensor que proporciona la previsión de producción PV de hoy de Solcast.",
+          "hsem_solcast_pv_forecast_forecast_tomorrow": "Selecciona el sensor que proporciona la previsión de producción PV de mañana de Solcast."
+        },
+        "description": "Selecciona los sensores de previsión de Solcast.",
+        "title": "Sensores de Solcast"
+      },
+      "user": {
+        "data": {
+          "device_name": "Nombre",
+          "hsem_extended_attributes": "Atributos ampliados",
+          "hsem_read_only": "Solo lectura",
+          "hsem_recommendation_interval_length": "Duración del intervalo de recomendación",
+          "hsem_recommendation_interval_minutes": "Minutos del intervalo de recomendación",
+          "hsem_update_interval": "Intervalo de actualización",
+          "hsem_verbose_logging": "Registro detallado"
+        },
+        "data_description": {
+          "device_name": "Introduce un nombre único para este dispositivo.",
+          "hsem_extended_attributes": "Activa esta opción para exponer atributos de diagnóstico adicionales en la entidad del sensor.",
+          "hsem_read_only": "Activa esta opción para poner la integración en modo de solo lectura, evitando que envíe órdenes a los dispositivos.",
+          "hsem_recommendation_interval_length": "El número de intervalos de recomendación que se tienen en cuenta al calcular el uso óptimo de la batería.",
+          "hsem_recommendation_interval_minutes": "La duración en minutos de cada intervalo de recomendación utilizado para calcular el uso óptimo de la batería.",
+          "hsem_update_interval": "El intervalo de actualización en minutos del sensor de modo de funcionamiento.",
+          "hsem_verbose_logging": "Activa el registro de depuración detallado con fines de solución de problemas."
+        },
+        "description": "Configura los ajustes de HSEM",
+        "title": "Configurar Huawei Solar Energy Management"
+      },
+      "weighted_values": {
+        "data": {
+          "hsem_house_consumption_energy_weight_14d": "Peso de energía de consumo de la vivienda a 14 días",
+          "hsem_house_consumption_energy_weight_1d": "Peso de energía de consumo de la vivienda a 1 día",
+          "hsem_house_consumption_energy_weight_3d": "Peso de energía de consumo de la vivienda a 3 días",
+          "hsem_house_consumption_energy_weight_7d": "Peso de energía de consumo de la vivienda a 7 días"
+        },
+        "data_description": {
+          "hsem_house_consumption_energy_weight_14d": "Especifica el porcentaje de peso para la energía de consumo de la vivienda de los últimos 14 días.",
+          "hsem_house_consumption_energy_weight_1d": "Especifica el porcentaje de peso para la energía de consumo de la vivienda del último día.",
+          "hsem_house_consumption_energy_weight_3d": "Especifica el porcentaje de peso para la energía de consumo de la vivienda de los últimos 3 días.",
+          "hsem_house_consumption_energy_weight_7d": "Especifica el porcentaje de peso para la energía de consumo de la vivienda de los últimos 7 días."
+        },
+        "description": "Configura los valores ponderados de la energía de consumo de la vivienda para estimar tu uso medio de potencia. El sistema calcula el consumo medio de cada hora a lo largo de 1, 3, 7 y 14 días. Estas medias se ponderan después para ofrecer una estimación combinada y ponderada. Este enfoque ayuda a suavizar anomalías, como un consumo inusualmente alto en un solo día debido a precios bajos, y proporciona una predicción fiable de tu uso de potencia esperado en intervalos de tiempo específicos (p. ej., entre las 16:00 y las 17:00).",
+        "title": "Valores ponderados"
+      },
+      "energy_and_ml": {
+        "data": {
+          "hsem_grid_import_energy_entity": "Sensor de energía de importación de la red",
+          "hsem_grid_export_energy_entity": "Sensor de energía de exportación a la red",
+          "hsem_pv_energy_entity": "Sensor de energía de producción PV",
+          "hsem_ml_consumption_enabled": "Activar predicción de consumo mediante ML",
+          "hsem_ml_consumption_energy_entity": "Sensor de energía de consumo de la vivienda (excl. batería y VE)",
+          "hsem_ml_consumption_history_days": "Días de historial para ML",
+          "hsem_ml_consumption_net_consumption": "Usar consumo neto (importación - exportación)",
+          "hsem_ml_consumption_temperature_entity": "Sensor de temperatura exterior",
+          "hsem_ml_consumption_sequential": "Predicción secuencial (función de retardo)"
+        },
+        "data_description": {
+          "hsem_grid_import_energy_entity": "Opcional: medidor acumulado de energía de importación de la red (kWh).",
+          "hsem_grid_export_energy_entity": "Opcional: medidor acumulado de energía de exportación a la red (kWh).",
+          "hsem_pv_energy_entity": "Opcional: medidor acumulado de energía de producción PV (kWh).",
+          "hsem_ml_consumption_enabled": "Cuando está activado, usa regresión ridge sobre el historial del recorder en lugar de medias móviles. Requiere 14 días o más de historial.",
+          "hsem_ml_consumption_energy_entity": "Medidor acumulado de energía de consumo de la vivienda (kWh). Debe excluir la batería Y la carga del VE; usa un sensor situado antes de ambos. Si no se configura, se recurre a la importación de red.",
+          "hsem_ml_consumption_history_days": "Días de historial del recorder para el entrenamiento de ML (7-90).",
+          "hsem_ml_consumption_net_consumption": "Resta la exportación a la red de la importación para obtener el consumo neto de la vivienda.",
+          "hsem_ml_consumption_temperature_entity": "Opcional: sensor de temperatura exterior en °C. Usa un sensor exterior, no un termostato interior.",
+          "hsem_ml_consumption_sequential": "Introduce cada predicción de intervalo como entrada de la siguiente. Captura la dinámica dentro de la hora (p. ej., los picos de cocina se propagan hacia adelante)."
+        },
+        "description": "Configura los medidores de energía y activa la predicción de consumo basada en ML.",
+        "title": "Energía y ML"
+      },
+      "batteries_wait_mode": {
+        "data": {
+          "hsem_batteries_wait_mode_behavior": "Comportamiento del modo de espera"
+        },
+        "data_description": {
+          "hsem_batteries_wait_mode_behavior": "Elige cómo se comporta la batería cuando HSEM selecciona el modo de espera. La espera estricta mantiene la batería inactiva. El autoconsumo con reserva permite que la vivienda use el excedente de energía de la batería por encima de la reserva requerida por el planificador, reduciendo la importación innecesaria de red."
+        },
+        "description": "Configura cómo se comporta la batería durante el modo de espera.",
+        "title": "Comportamiento de la batería en modo de espera"
+      }
+    }
+  },
+  "options": {
+    "error": {
+      "device_not_found": "No se encontró el dispositivo seleccionado.",
+      "energy_out_of_range": "El valor de energía está fuera del rango permitido.",
+      "entity_not_found": "No se encontró la entidad seleccionada.",
+      "entity_unavailable": "La entidad seleccionada no está disponible en este momento. Comprueba el dispositivo o el servicio.",
+      "hsem_house_consumption_energy_weight_total": "El total de los pesos de energía de consumo de la vivienda debe ser 100 %.",
+      "invalid_energy_value": "Valor de energía no válido: introduce un número.",
+      "invalid_entity_id": "Formato de ID de entidad no válido. Se espera \"domain.object_id\" con letras minúsculas, dígitos y guiones bajos.",
+      "invalid_month_value": "Uno o más valores de mes no son válidos. Los meses deben ser números enteros entre 1 y 12.",
+      "invalid_power_value": "Valor de potencia no válido: introduce un número.",
+      "invalid_price_value": "Valor de precio no válido: introduce un número.",
+      "invalid_sensor": "Sensor de entrada no válido. Elige un sensor válido.",
+      "invalid_time_format": "Formato de hora no válido: se espera HH:MM:SS.",
+      "months_winter_empty": "La temporada de invierno debe tener al menos un mes.",
+      "only_one_entry_allowed": "Solo se permite una configuración de HSEM.",
+      "power_out_of_range": "El valor de potencia está fuera del rango permitido.",
+      "price_out_of_range": "El valor de precio está fuera del rango permitido.",
+      "required": "Este campo es obligatorio.",
+      "start_time_after_end_time": "La hora de inicio debe ser anterior a la hora de fin.",
+      "start_time_equals_end_time": "La hora de inicio y la hora de fin no pueden ser iguales, ya que esto crea una ventana de duración cero. Desactiva la programación en su lugar.",
+      "invalid_wait_mode_behavior": "Comportamiento de modo de espera no válido. Elige Espera estricta o Autoconsumo con reserva.",
+      "port_conflict": "El segundo puerto OCPP debe ser diferente del primer puerto OCPP."
+    },
+    "step": {
+      "batteries_excess_export": {
+        "data": {
+          "hsem_batteries_enable_excess_export": "Activar exportación de batería excedente",
+          "hsem_batteries_excess_export_discharge_buffer": "Búfer de descarga (%)",
+          "hsem_batteries_forecast_reserve_pct": "Reserva de previsión para exportación de batería (+% SoC)",
+          "hsem_batteries_export_min_price": "Precio mínimo de exportación de batería"
+        },
+        "data_description": {
+          "hsem_batteries_enable_excess_export": "Activa o desactiva la función de exportación de batería excedente, que exporta automáticamente la capacidad de batería excedente a la red cuando resulta económicamente beneficioso.",
+          "hsem_batteries_excess_export_discharge_buffer": "Define el porcentaje del búfer de seguridad para mantener las reservas mínimas de batería (0-50 %). El valor predeterminado es 10 % para garantizar capacidad suficiente ante una demanda inesperada.",
+          "hsem_batteries_forecast_reserve_pct": "Puntos porcentuales adicionales de SoC por encima del límite de fin de descarga de Huawei que la exportación intencionada de batería debe dejar inmediatamente después de cada intervalo de exportación. Por ejemplo, un límite de Huawei del 15 % más una reserva del 5 % protege un 20 % de SoC. La reserva sigue disponible para la carga de la vivienda cuando la demanda real supera la previsión. Ajusta a 0 para desactivar (predeterminado).",
+          "hsem_batteries_export_min_price": "Límite mínimo estricto por intervalo para la exportación intencionada de batería a la red (issue #752). Cuando es > 0, HSEM prohíbe marcar un intervalo como force_batteries_discharge cuando el precio de exportación está estrictamente por debajo de este límite; la batería puede seguir sirviendo la carga de la vivienda en esos intervalos. Alcanzar el umbral NO activa automáticamente la exportación; el optimizador sigue decidiendo si vender resulta rentable. Se aplica únicamente a la exportación intencionada de batería a la red, no al autoconsumo normal, la exportación de PV ni la carga de PV. Ajusta a 0 para desactivar (predeterminado)."
+        },
+        "description": "Configura los ajustes de exportación de batería excedente para vender automáticamente el exceso de energía a la red cuando resulte económicamente beneficioso.",
+        "title": "Exportación de batería excedente"
+      },
+      "ev_planned_load": {
+        "data": {
+          "hsem_ev_planned_load_enabled": "Activar integración de carga planificada del VE",
+          "hsem_ev_planned_load_battery_capacity_kwh": "Capacidad de batería del VE (kWh)",
+          "hsem_ev_planned_load_charger_power_kw": "Potencia del cargador de VE (kW)",
+          "hsem_ev_planned_load_charger_efficiency": "Eficiencia del cargador de VE",
+          "hsem_ev_planned_load_charger_min_power_w": "Potencia mínima del cargador de VE (W)",
+          "hsem_ev_planned_load_charger_phase_topology": "Topología de fases del cargador",
+          "hsem_ev_planned_load_deadline_safety_margin_pct": "Margen de seguridad para la fecha límite (%)",
+          "hsem_ev_planned_load_command_deadband_a": "Banda muerta del límite máximo (A)",
+          "hsem_ev_planned_load_stub_floor_minutes": "Supresión de parada al final del intervalo (min)"
+        },
+        "data_description": {
+          "hsem_ev_planned_load_enabled": "Activa o desactiva la integración de carga planificada del VE.",
+          "hsem_ev_planned_load_battery_capacity_kwh": "Capacidad nominal de la batería del VE en kWh.",
+          "hsem_ev_planned_load_charger_power_kw": "Potencia de salida de CA del cargador de VE en kW.",
+          "hsem_ev_planned_load_charger_efficiency": "Eficiencia del cargador como porcentaje (1-100). Predeterminado: 100.",
+          "hsem_ev_planned_load_charger_min_power_w": "Potencia de CA mínima (W) que necesita el cargador de VE para empezar a cargar. Por debajo de este valor, el cargador no funcionará. Predeterminado: 1380 W (230 V × 6 A).",
+          "hsem_ev_planned_load_charger_phase_topology": "Cómo distribuye el cargador su carga entre las fases de la red eléctrica. Elige \"Monofásico o desconocido\" a menos que hayas confirmado que el cargador consume corriente equilibrada en las tres fases. Con la protección de fusible por fase activada, el valor predeterminado seguro asume que toda la orden del cargador puede recaer en una sola fase, lo que limita la carga planificada al margen del fusible monofásico.",
+          "hsem_ev_planned_load_deadline_safety_margin_pct": "Energía adicional presupuestada por encima del SoC objetivo, como porcentaje del déficit, para que la fricción normal de la carga (retrasos de inicio, límites mínimos de potencia, limitación) no provoque el incumplimiento de la fecha límite. Predeterminado: 0 % (desactivado).",
+          "hsem_ev_planned_load_command_deadband_a": "Reducción mínima del límite de carga publicado que se aplica realmente. Las reducciones menores se retienen, porque los planes competidores en amperios enteros suelen diferir entre sí por un margen de error de redondeo en el coste. Aumentar el límite nunca se retrasa, y una reducción que mejore el coste de carga de este intervalo en más del 5 % siempre se aplica. Predeterminado: 3 A; 0 desactiva.",
+          "hsem_ev_planned_load_stub_floor_minutes": "Al final de un intervalo, suprime la orden de parada durante estos minutos mientras el coche todavía necesite energía. Los segundos restantes no pueden contener suficiente energía para superar el mínimo del cargador, por lo que el plan no les asigna nada y la sesión se detendría y reiniciaría sin ninguna ventaja. Predeterminado: 2 minutos; 0 desactiva."
+        },
+        "description": "Configura la integración opcional de carga planificada del VE. Cuando está activada, HSEM tiene en cuenta la demanda de carga del VE prevista en cada intervalo del planificador.",
+        "title": "Integración de carga planificada del VE"
+      },
+      "ev_second_planned_load": {
+        "data": {
+          "hsem_ev_second_planned_load_enabled": "Activar integración de carga planificada del VE 2",
+          "hsem_ev_second_planned_load_battery_capacity_kwh": "Capacidad de batería del VE 2 (kWh)",
+          "hsem_ev_second_planned_load_charger_power_kw": "Potencia del cargador del VE 2 (kW)",
+          "hsem_ev_second_planned_load_charger_efficiency": "Eficiencia del cargador del VE 2",
+          "hsem_ev_second_planned_load_charger_min_power_w": "Potencia mínima del cargador del VE 2 (W)",
+          "hsem_ev_second_planned_load_charger_phase_topology": "Topología de fases del cargador",
+          "hsem_ev_second_planned_load_deadline_safety_margin_pct": "Margen de seguridad para la fecha límite del VE 2 (%)",
+          "hsem_ev_second_planned_load_command_deadband_a": "Banda muerta del límite máximo del VE 2 (A)",
+          "hsem_ev_second_planned_load_stub_floor_minutes": "Supresión de parada al final del intervalo del VE 2 (min)"
+        },
+        "data_description": {
+          "hsem_ev_second_planned_load_enabled": "Activa o desactiva la integración de carga planificada para el segundo VE.",
+          "hsem_ev_second_planned_load_battery_capacity_kwh": "Capacidad nominal de la batería del segundo VE en kWh.",
+          "hsem_ev_second_planned_load_charger_power_kw": "Potencia de salida de CA del cargador del segundo VE en kW.",
+          "hsem_ev_second_planned_load_charger_efficiency": "Eficiencia del cargador del segundo VE como porcentaje (1-100). Predeterminado: 100.",
+          "hsem_ev_second_planned_load_charger_min_power_w": "Potencia de CA mínima (W) que necesita el cargador del segundo VE para empezar a cargar. Predeterminado: 1380 W (230 V × 6 A).",
+          "hsem_ev_second_planned_load_charger_phase_topology": "Cómo distribuye el cargador su carga entre las fases de la red eléctrica. Elige \"Monofásico o desconocido\" a menos que hayas confirmado que el cargador consume corriente equilibrada en las tres fases. Con la protección de fusible por fase activada, el valor predeterminado seguro asume que toda la orden del cargador puede recaer en una sola fase, lo que limita la carga planificada al margen del fusible monofásico.",
+          "hsem_ev_second_planned_load_deadline_safety_margin_pct": "Igual que el margen de seguridad de fecha límite del VE principal, para el segundo VE. Predeterminado: 0 % (desactivado).",
+          "hsem_ev_second_planned_load_command_deadband_a": "Igual que la banda muerta del límite máximo del VE principal, para el segundo VE. Predeterminado: 3 A; 0 desactiva.",
+          "hsem_ev_second_planned_load_stub_floor_minutes": "Igual que la supresión de parada al final del intervalo del VE principal, para el segundo VE. Predeterminado: 2 minutos; 0 desactiva."
+        },
+        "description": "Configura la integración opcional de carga planificada para el segundo VE. Solo se muestra cuando el segundo cargador de VE está activado.",
+        "title": "Integración de carga planificada del VE 2"
+      },
+      "ocpp": {
+        "data": {
+          "hsem_ocpp_enabled": "Activar servidor OCPP",
+          "hsem_ocpp_port": "Puerto OCPP",
+          "hsem_ocpp_cpid": "ID del punto de carga",
+          "hsem_ocpp_start_window_s": "Ventana de inicio (s)",
+          "hsem_ocpp_stop_window_s": "Ventana de parada (s)",
+          "hsem_ocpp_second_enabled": "Activar segundo servidor OCPP",
+          "hsem_ocpp_second_port": "Segundo puerto OCPP",
+          "hsem_ocpp_second_cpid": "ID del segundo punto de carga"
+        },
+        "data_description": {
+          "hsem_ocpp_enabled": "Activa el servidor WebSocket OCPP 1.6 integrado para el control directo del cargador de VE. Solo para red local: no expongas el puerto a internet.",
+          "hsem_ocpp_port": "Puerto TCP para el servidor WebSocket OCPP. Predeterminado: 9000. Debe ser superior a 1024.",
+          "hsem_ocpp_cpid": "Identificador de punto de carga esperado del cargador de VE. Déjalo vacío para aceptar cualquier cargador.",
+          "hsem_ocpp_start_window_s": "Segundos de excedente sostenido necesarios antes de iniciar una carga. Evita ciclos rápidos de arranque y parada. Predeterminado: 60.",
+          "hsem_ocpp_stop_window_s": "Segundos de déficit sostenido necesarios antes de detener una carga. Evita ciclos rápidos de parada y arranque. Predeterminado: 180.",
+          "hsem_ocpp_second_enabled": "Activa un segundo servidor OCPP dedicado para el segundo VE. Solo disponible cuando la carga planificada del VE 2 está activada.",
+          "hsem_ocpp_second_port": "Puerto TCP para el segundo servidor WebSocket OCPP. Predeterminado: 9001. Debe ser diferente del puerto del primer servidor.",
+          "hsem_ocpp_second_cpid": "Identificador de punto de carga esperado del segundo cargador de VE. Déjalo vacío para aceptar cualquier cargador."
+        },
+        "description": "Configura el servidor OCPP 1.6 integrado para el control del cargador de VE únicamente en red local. Cuando está activado, HSEM envía órdenes SetChargingProfile directamente a tu cargador de VE según el plan de carga.",
+        "title": "Servidor OCPP"
+      },
+      "batteries_schedule_1": {
+        "data": {
+          "hsem_batteries_enable_batteries_schedule_1": "Activar programación de batería 1",
+          "hsem_batteries_enable_batteries_schedule_1_end": "Hora de fin de la programación de batería 1",
+          "hsem_batteries_enable_batteries_schedule_1_start": "Hora de inicio de la programación de batería 1"
+        },
+        "data_description": {
+          "hsem_batteries_enable_batteries_schedule_1": "Activa o desactiva la primera programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_1_end": "Especifica la hora de fin de la primera programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_1_start": "Especifica la hora de inicio de la primera programación de descarga de batería."
+        },
+        "description": "Configura la programación de descarga de batería 1, incluida su hora de activación.",
+        "title": "Programación de descarga de batería 1"
+      },
+      "batteries_schedule_2": {
+        "data": {
+          "hsem_batteries_enable_batteries_schedule_2": "Activar programación de batería 2",
+          "hsem_batteries_enable_batteries_schedule_2_end": "Hora de fin de la programación de batería 2",
+          "hsem_batteries_enable_batteries_schedule_2_start": "Hora de inicio de la programación de batería 2"
+        },
+        "data_description": {
+          "hsem_batteries_enable_batteries_schedule_2": "Activa o desactiva la segunda programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_2_end": "Especifica la hora de fin de la segunda programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_2_start": "Especifica la hora de inicio de la segunda programación de descarga de batería."
+        },
+        "description": "Configura la programación de descarga de batería 2, incluida su hora de activación.",
+        "title": "Programación de descarga de batería 2"
+      },
+      "batteries_schedule_3": {
+        "data": {
+          "hsem_batteries_enable_batteries_schedule_3": "Activar programación de batería 3",
+          "hsem_batteries_enable_batteries_schedule_3_end": "Hora de fin de la programación de batería 3",
+          "hsem_batteries_enable_batteries_schedule_3_start": "Hora de inicio de la programación de batería 3"
+        },
+        "data_description": {
+          "hsem_batteries_enable_batteries_schedule_3": "Activa o desactiva la tercera programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_3_end": "Especifica la hora de fin de la tercera programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_3_start": "Especifica la hora de inicio de la tercera programación de descarga de batería."
+        },
+        "description": "Configura la programación de descarga de batería 3, incluida su hora de activación.",
+        "title": "Programación de descarga de batería 3"
+      },
+      "prices": {
+        "data": {
+          "hsem_import_electricity_price_sensor": "Sensor de precio de electricidad de importación",
+          "hsem_export_electricity_price_sensor": "Sensor de precio de electricidad de exportación",
+          "hsem_import_electricity_price_forecast_sensor": "Sensor de previsión de precio de importación (opcional)",
+          "hsem_export_electricity_price_forecast_sensor": "Sensor de previsión de precio de exportación (opcional)",
+          "hsem_export_electricity_min_price": "Precio mínimo de exportación requerido",
+          "hsem_electricity_price_update_interval": "Intervalo de actualización del precio de electricidad (minutos)"
+        },
+        "data_description": {
+          "hsem_import_electricity_price_sensor": "Selecciona el sensor que proporciona los precios de electricidad de importación (p. ej. Energi Data Service, Nordpool, Amber Electric).",
+          "hsem_export_electricity_price_sensor": "Selecciona el sensor que proporciona los precios de electricidad de exportación.",
+          "hsem_import_electricity_price_forecast_sensor": "Opcional: selecciona un sensor independiente para las previsiones de precio de importación (usado por Amber Electric e integraciones similares).",
+          "hsem_export_electricity_price_forecast_sensor": "Opcional: selecciona un sensor independiente para las previsiones de precio de exportación.",
+          "hsem_export_electricity_min_price": "Define el precio mínimo de exportación. Las exportaciones por debajo de este precio se bloquearán.",
+          "hsem_electricity_price_update_interval": "Con qué frecuencia proporciona nuevos datos tu sensor de precios (15, 30 o 60 minutos)."
+        },
+        "description": "Configura tus sensores de precio de electricidad para los precios de importación y exportación.",
+        "title": "Precios de electricidad"
+      },
+      "ev": {
+        "data": {
+          "hsem_ev_allow_charge_past_target_soc": "Permitir carga más allá del SoC objetivo (avanzado)",
+          "hsem_ev_charger_force_max_discharge_power": "Forzar potencia máxima de descarga del cargador de VE",
+          "hsem_ev_charger_max_discharge_power": "Potencia máxima de descarga del cargador de VE",
+          "hsem_ev_charger_power": "Sensor de potencia del cargador de VE",
+          "hsem_ev_charger_status": "Sensor de estado del cargador de VE",
+          "hsem_ev_connected": "Sensor de conexión del VE",
+          "hsem_ev_second_enabled": "Activar segundo cargador de VE",
+          "hsem_ev_soc": "Sensor de estado de carga (SoC) del VE",
+          "hsem_house_power_includes_ev_charger_power": "La potencia de la vivienda incluye la potencia del cargador de VE",
+          "hsem_ev_auto_full_negative_price": "Carga completa automática del VE con precio negativo",
+          "hsem_ev_past_target_confidence_factor": "Factor de confianza de carga del VE más allá del objetivo (avanzado)"
+        },
+        "data_description": {
+          "hsem_ev_allow_charge_past_target_soc": "Activa esta opción si quieres permitir que el sistema siga cargando la batería del VE incluso después de haber alcanzado el estado de carga (SoC) objetivo. Esto puede resultar útil en situaciones en las que quieras asegurarte de que el VE quede completamente cargado, independientemente del ajuste del objetivo.",
+          "hsem_ev_charger_force_max_discharge_power": "Activa esto si quieres forzar una potencia máxima de descarga específica para las baterías Huawei mientras el VE se está cargando.",
+          "hsem_ev_charger_max_discharge_power": "Define la potencia máxima de descarga de las baterías Huawei mientras el VE se está cargando.",
+          "hsem_ev_charger_power": "Selecciona el sensor que mide el consumo de potencia de tu cargador de VE.",
+          "hsem_ev_charger_status": "Selecciona el sensor o la entidad que indica si el cargador de VE está activo (p. ej., un interruptor o un sensor).",
+          "hsem_ev_connected": "Selecciona el sensor o la entidad que indica si el VE está conectado al cargador.",
+          "hsem_ev_second_enabled": "Activa o desactiva la configuración de un segundo cargador de VE.",
+          "hsem_ev_soc": "Selecciona el sensor que proporciona el estado de carga (SoC) actual de la batería de tu VE.",
+          "hsem_house_power_includes_ev_charger_power": "Activa esto si el sensor de potencia de consumo de la vivienda ya incluye el consumo de potencia del cargador de VE.",
+          "hsem_ev_auto_full_negative_price": "Cuando está activado, el VE se ajusta automáticamente a la potencia de carga máxima cuando el precio de la electricidad es cero o negativo. El modo de carga anterior se restaura cuando el precio sube por encima de cero.",
+          "hsem_ev_past_target_confidence_factor": "Multiplicador de confianza (0.0-1.0) aplicado a la valoración de importación futura evitada que se usa al cargar el VE más allá de su SoC objetivo. Valores más bajos hacen que el VE compita peor frente a la exportación del excedente de PV, para tener en cuenta la incertidumbre sobre si el VE realmente necesitará la energía adicional antes de su próxima carga. Predeterminado 0.9."
+        },
+        "description": "Configura los ajustes del cargador de VE para HSEM.",
+        "title": "Ajustes del cargador de VE (opcional)"
+      },
+      "ev_second": {
+        "data": {
+          "hsem_ev_second_allow_charge_past_target_soc": "Permitir carga más allá del SoC objetivo para el segundo VE (avanzado)",
+          "hsem_ev_second_charger_force_max_discharge_power": "Forzar potencia máxima de descarga del segundo cargador de VE",
+          "hsem_ev_second_charger_max_discharge_power": "Potencia máxima de descarga del segundo cargador de VE",
+          "hsem_ev_second_charger_power": "Sensor de potencia del segundo cargador de VE",
+          "hsem_ev_second_charger_status": "Sensor de estado del segundo cargador de VE",
+          "hsem_ev_second_connected": "Sensor de conexión del segundo VE",
+          "hsem_ev_second_soc": "Sensor de estado de carga (SoC) del segundo VE",
+          "hsem_ev_second_past_target_confidence_factor": "Factor de confianza de carga del segundo VE más allá del objetivo (avanzado)"
+        },
+        "data_description": {
+          "hsem_ev_second_allow_charge_past_target_soc": "Activa esta opción si quieres permitir que el sistema siga cargando la batería del VE incluso después de haber alcanzado el estado de carga (SoC) objetivo. Esto puede resultar útil en situaciones en las que quieras asegurarte de que el VE quede completamente cargado, independientemente del ajuste del objetivo.",
+          "hsem_ev_second_charger_force_max_discharge_power": "Activa esto si quieres forzar una potencia máxima de descarga específica para las baterías Huawei mientras el VE se está cargando.",
+          "hsem_ev_second_charger_max_discharge_power": "Define la potencia máxima de descarga de las baterías Huawei mientras el VE se está cargando.",
+          "hsem_ev_second_charger_power": "Selecciona el sensor que mide el consumo de potencia de tu cargador de VE.",
+          "hsem_ev_second_charger_status": "Selecciona el sensor o la entidad que indica si el cargador de VE está activo (p. ej., un interruptor o un sensor).",
+          "hsem_ev_second_connected": "Selecciona el sensor o la entidad que indica si el VE está conectado al cargador.",
+          "hsem_ev_second_soc": "Selecciona el sensor que proporciona el estado de carga (SoC) actual de la batería de tu VE.",
+          "hsem_ev_second_past_target_confidence_factor": "Multiplicador de confianza (0.0-1.0) aplicado a la valoración de importación futura evitada que se usa al cargar el segundo VE más allá de su SoC objetivo. Valores más bajos hacen que el VE compita peor frente a la exportación del excedente de PV, para tener en cuenta la incertidumbre sobre si el VE realmente necesitará la energía adicional antes de su próxima carga. Predeterminado 0.9."
+        },
+        "description": "Configura los ajustes del segundo cargador de VE para HSEM.",
+        "title": "Ajustes del segundo cargador de VE (opcional)"
+      },
+      "huawei_solar": {
+        "data": {
+          "hsem_batteries_charge_efficiency": "Eficiencia de carga de la batería (%)",
+          "hsem_batteries_cycle_cost": "Coste de ciclo de batería (por kWh)",
+          "hsem_batteries_discharge_efficiency": "Eficiencia de descarga de la batería (%)",
+          "hsem_batteries_expected_cycles": "Ciclos de batería esperados",
+          "hsem_batteries_purchase_price": "Precio de compra de la batería",
+          "hsem_huawei_solar_batteries_excess_pv_energy_use_in_tou": "Uso del excedente de energía PV en TOU de las baterías Huawei",
+          "hsem_huawei_solar_batteries_forcible_charge": "Estado de carga forzada de la batería",
+          "hsem_huawei_solar_batteries_end_of_discharge_soc": "SOC de fin de descarga de las baterías Huawei (%)",
+          "hsem_huawei_solar_batteries_charging_cutoff_capacity": "Capacidad de corte de carga de las baterías Huawei (SoC máx. %)",
+          "hsem_huawei_solar_batteries_grid_charge_cutoff_soc": "SOC de corte de carga desde la red de las baterías Huawei (%)",
+          "hsem_huawei_solar_batteries_maximum_charging_power": "Potencia máxima de carga de las baterías Huawei (W)",
+          "hsem_huawei_solar_batteries_maximum_discharging_power": "Potencia máxima de descarga de las baterías Huawei (W)",
+          "hsem_huawei_solar_batteries_grid_charge_maximum_power": "Potencia máxima de carga desde la red de las baterías Huawei (W)",
+          "hsem_huawei_solar_batteries_charge_discharge_power": "Sensor de potencia de carga/descarga de la batería Huawei",
+          "hsem_huawei_solar_batteries_rated_capacity": "Capacidad máxima de la batería (Wh)",
+          "hsem_huawei_solar_batteries_state_of_capacity": "Sensor de estado de capacidad de las baterías Huawei",
+          "hsem_huawei_solar_batteries_tou_charging_and_discharging_periods": "Períodos de carga y descarga TOU de las baterías Huawei",
+          "hsem_huawei_solar_batteries_working_mode": "Sensor de modo de funcionamiento de las baterías Huawei Solar",
+          "hsem_huawei_solar_device_id_batteries": "Dispositivo de baterías Huawei",
+          "hsem_huawei_solar_device_id_batteries_2": "Dispositivo de baterías Huawei 2",
+          "hsem_huawei_solar_device_id_inverter_1": "Dispositivo del inversor Huawei 1",
+          "hsem_huawei_solar_device_id_inverter_2": "Dispositivo del inversor Huawei 2",
+          "hsem_huawei_solar_inverter_active_power_control": "Sensor de control de potencia activa del inversor Huawei"
+        },
+        "data_description": {
+          "hsem_batteries_charge_efficiency": "Especifica la eficiencia de carga de tu batería como porcentaje (0-100). La energía almacenada en la batería equivale a la energía de entrada multiplicada por este factor. Las baterías de litio habituales alcanzan un 95-98 %. Predeterminado: 98 %.",
+          "hsem_batteries_discharge_efficiency": "Especifica la eficiencia de descarga de tu batería como porcentaje (0-100). La energía entregada a la vivienda equivale a la energía extraída de la batería multiplicada por este factor. Las baterías de litio habituales alcanzan un 95-98 %. Predeterminado: 98 %.",
+          "hsem_batteries_cycle_cost": "Coste adicional opcional por kWh de ciclado de la batería (por kWh). Se suma al umbral de depreciación calculado automáticamente. Ajusta a 0 para depender únicamente de la protección de depreciación. Ejemplo: 0.02 significa que el planificador requiere 2 céntimos adicionales de margen por kWh ciclado antes de aprobar la carga desde la red.",
+          "hsem_batteries_expected_cycles": "Introduce el número esperado de ciclos completos de carga/descarga durante la vida útil de la batería. Se usa para calcular el coste de depreciación por kWh y el umbral de precio mínimo de exportación recomendado. Las baterías LiFePO4 habituales admiten entre 4000 y 8000 ciclos.",
+          "hsem_batteries_purchase_price": "Introduce el precio de compra total de tu sistema de baterías en tu moneda local. Se usa junto con los ciclos esperados y la capacidad utilizable para calcular el coste de depreciación por kWh y el umbral de precio mínimo de exportación recomendado.",
+          "hsem_huawei_solar_batteries_excess_pv_energy_use_in_tou": "Selecciona el sensor que proporciona el ajuste de uso del excedente de energía PV en los períodos TOU.",
+          "hsem_huawei_solar_batteries_forcible_charge": "Sensor que muestra el estado actual de carga/descarga forzada (p. ej. Detenido, Descargando a 5000 W durante 60 minutos)",
+          "hsem_huawei_solar_batteries_end_of_discharge_soc": "Especifica el porcentaje de SOC de fin de descarga para tus baterías Huawei. Cuando la batería alcanza este nivel de SOC, dejará de descargarse para evitar una descarga profunda y posibles daños a la batería.",
+          "hsem_huawei_solar_batteries_charging_cutoff_capacity": "Selecciona la entidad que define el estado de carga (SoC) máximo que la batería puede alcanzar durante la carga (registro STORAGE_CHARGING_CUTOFF_CAPACITY). Normalmente 90-100 %. Usado por la simulación de SoC como límite superior de SoC para que el planificador nunca programe carga por encima de este límite.",
+          "hsem_huawei_solar_batteries_grid_charge_cutoff_soc": "Especifica el porcentaje de SOC de corte de carga desde la red para tus baterías Huawei.",
+          "hsem_huawei_solar_batteries_maximum_charging_power": "Selecciona el sensor que proporciona la potencia máxima de carga de tus baterías Huawei en vatios (W).",
+          "hsem_huawei_solar_batteries_maximum_discharging_power": "Selecciona el sensor que proporciona la potencia máxima de descarga de tus baterías Huawei.",
+          "hsem_huawei_solar_batteries_grid_charge_maximum_power": "Selecciona la entidad numérica que establece el límite máximo de potencia de carga desde la red de Huawei (W). Escrita por el limitador de seguridad de carga con reconocimiento de fase en tiempo real (issue #831) para mantener la carga financiada por la red por debajo del límite por fase del fusible principal. Opcional; solo se requiere cuando la carga con reconocimiento de fase está activada.",
+          "hsem_huawei_solar_batteries_charge_discharge_power": "Selecciona el sensor que informa de la potencia instantánea de carga/descarga de la batería con signo (positivo = cargando, negativo = descargando). Necesario para el limitador de seguridad de carga con reconocimiento de fase en tiempo real (issue #831), para eliminar la propia contribución de Huawei de la instantánea de fase en tiempo real antes de calcular el margen disponible. Opcional; solo se requiere cuando la carga con reconocimiento de fase está activada.",
+          "hsem_huawei_solar_batteries_rated_capacity": "Selecciona el sensor que proporciona la capacidad nominal total de tus baterías Huawei en vatios-hora (Wh).",
+          "hsem_huawei_solar_batteries_state_of_capacity": "Selecciona el sensor que proporciona el estado de carga (SOC) de tus baterías Huawei.",
+          "hsem_huawei_solar_batteries_tou_charging_and_discharging_periods": "Selecciona el sensor que define los períodos de carga y descarga por franja horaria (TOU) de tus baterías Huawei.",
+          "hsem_huawei_solar_batteries_working_mode": "Selecciona el sensor que indica el modo de funcionamiento actual de tus baterías Huawei.",
+          "hsem_huawei_solar_device_id_batteries": "Selecciona tu dispositivo de batería Huawei.",
+          "hsem_huawei_solar_device_id_batteries_2": "Selecciona tu dispositivo de batería Huawei secundario, si corresponde.",
+          "hsem_huawei_solar_device_id_inverter_1": "Selecciona tu dispositivo de inversor Huawei principal.",
+          "hsem_huawei_solar_device_id_inverter_2": "Selecciona tu dispositivo de inversor Huawei secundario, si corresponde.",
+          "hsem_huawei_solar_inverter_active_power_control": "Selecciona el sensor que controla la salida de potencia activa de tu inversor Huawei."
+        },
+        "description": "Configura el modo de funcionamiento de las baterías solares Huawei.",
+        "title": "Sensores de Huawei Solar"
+      },
+      "battery_economics": {
+        "data": {
+          "hsem_batteries_purchase_price": "Precio de compra de la batería",
+          "hsem_batteries_expected_cycles": "Ciclos de batería esperados",
+          "hsem_batteries_cycle_cost": "Coste de ciclo de batería (por kWh)",
+          "hsem_batteries_capacity_loss_pct": "Pérdida de capacidad de la batería al final de su vida útil (%)",
+          "hsem_batteries_charge_efficiency": "Eficiencia de carga de la batería (%)",
+          "hsem_batteries_discharge_efficiency": "Eficiencia de descarga de la batería (%)",
+          "hsem_planner_hysteresis_enabled": "Histéresis a nivel de plan",
+          "hsem_planner_hysteresis_absolute": "Umbral absoluto de histéresis",
+          "hsem_planner_hysteresis_percentage": "Umbral porcentual de histéresis (%)",
+          "hsem_planner_window_hysteresis_minutes": "Tiempo de retención de histéresis de ventana (minutos)"
+        },
+        "data_description": {
+          "hsem_batteries_purchase_price": "Introduce el precio de compra total de tu sistema de baterías en tu moneda local. Se usa junto con los ciclos esperados y la capacidad utilizable para calcular el coste de depreciación por kWh y el umbral de precio mínimo de exportación recomendado.",
+          "hsem_batteries_expected_cycles": "Introduce el número esperado de ciclos completos de carga/descarga durante la vida útil de la batería. Se usa para calcular el coste de depreciación por kWh y el umbral de precio mínimo de exportación recomendado. Las baterías LiFePO4 habituales admiten entre 4000 y 8000 ciclos.",
+          "hsem_batteries_cycle_cost": "Coste adicional opcional por kWh de ciclado de la batería (por kWh). Se suma al umbral de depreciación calculado automáticamente. Ajusta a 0 para depender únicamente de la protección de depreciación. Ejemplo: 0.02 significa que el planificador requiere 2 céntimos adicionales de margen por kWh ciclado antes de aprobar la carga desde la red.",
+          "hsem_batteries_capacity_loss_pct": "Pérdida de capacidad esperada al final de la vida útil, como porcentaje. Las baterías LiFePO4 suelen alcanzar un 80 % de capacidad tras ~6000 ciclos (20 % de pérdida). El valor predeterminado del 30 % añade margen para el envejecimiento por calendario.",
+          "hsem_batteries_charge_efficiency": "Especifica la eficiencia de carga de tu batería como porcentaje (0-100). La energía almacenada en la batería equivale a la energía de entrada multiplicada por este factor. Las baterías de litio habituales alcanzan un 95-98 %. Predeterminado: 98 %.",
+          "hsem_batteries_discharge_efficiency": "Especifica la eficiencia de descarga de tu batería como porcentaje (0-100). La energía entregada a la vivienda equivale a la energía extraída de la batería multiplicada por este factor. Las baterías de litio habituales alcanzan un 95-98 %. Predeterminado: 98 %.",
+          "hsem_planner_hysteresis_enabled": "Cuando está activada, el planificador mantiene el plan candidato activo a menos que un nuevo plan mejore la puntuación por encima de los umbrales configurados. Evita la oscilación entre estrategias con puntuaciones equivalentes.",
+          "hsem_planner_hysteresis_absolute": "Mejora mínima absoluta de la puntuación necesaria para cambiar a un nuevo plan. 0.00 desactiva el umbral absoluto. La puntuación usa la misma moneda que tus precios de electricidad, por lo que un valor de 0.01 requiere una mejora de al menos 1 céntimo/kWh equivalente antes de cambiar.",
+          "hsem_planner_hysteresis_percentage": "Mejora mínima porcentual de la puntuación necesaria para cambiar a un nuevo plan. 0 % desactiva el umbral porcentual. El valor predeterminado del 5 % evita las oscilaciones entre planes casi idénticos.",
+          "hsem_planner_window_hysteresis_minutes": "Tiempo mínimo (minutos) que debe mantenerse una recomendación antes de poder cambiar. Evita alternancias rápidas como ev_smart_charging ↔ batteries_charge_solar. 0 desactiva la función. Predeterminado: 10."
+        },
+        "description": "Configura los parámetros económicos de la batería y la histéresis del planificador (anti-oscilación).",
+        "title": "Economía de la batería e histéresis"
+      },
+      "init": {
+        "data": {
+          "device_name": "Nombre",
+          "hsem_extended_attributes": "Atributos ampliados",
+          "hsem_read_only": "Solo lectura",
+          "hsem_recommendation_interval_length": "Duración del intervalo de recomendación",
+          "hsem_recommendation_interval_minutes": "Minutos del intervalo de recomendación",
+          "hsem_update_interval": "Intervalo de actualización",
+          "hsem_verbose_logging": "Registro detallado"
+        },
+        "data_description": {
+          "device_name": "Introduce un nombre único para este dispositivo.",
+          "hsem_extended_attributes": "Activa esta opción para exponer atributos de diagnóstico adicionales en la entidad del sensor.",
+          "hsem_read_only": "Activa esta opción para poner la integración en modo de solo lectura, evitando que envíe órdenes a los dispositivos.",
+          "hsem_recommendation_interval_length": "El número de intervalos de recomendación que se tienen en cuenta al calcular el uso óptimo de la batería.",
+          "hsem_recommendation_interval_minutes": "La duración en minutos de cada intervalo de recomendación utilizado para calcular el uso óptimo de la batería.",
+          "hsem_update_interval": "El intervalo de actualización en minutos del sensor de modo de funcionamiento.",
+          "hsem_verbose_logging": "Activa el registro de depuración detallado con fines de solución de problemas."
+        },
+        "description": "Actualiza los ajustes de HSEM",
+        "title": "Actualizar Huawei Solar Energy Management"
+      },
+      "batteries_schedules": {
+        "data": {
+          "hsem_batteries_enable_batteries_schedule_1": "Activar programación de batería 1",
+          "hsem_batteries_enable_batteries_schedule_1_end": "Hora de fin de la programación de batería 1",
+          "hsem_batteries_enable_batteries_schedule_1_start": "Hora de inicio de la programación de batería 1",
+          "hsem_batteries_enable_batteries_schedule_2": "Activar programación de batería 2",
+          "hsem_batteries_enable_batteries_schedule_2_end": "Hora de fin de la programación de batería 2",
+          "hsem_batteries_enable_batteries_schedule_2_start": "Hora de inicio de la programación de batería 2",
+          "hsem_batteries_enable_batteries_schedule_3": "Activar programación de batería 3",
+          "hsem_batteries_enable_batteries_schedule_3_end": "Hora de fin de la programación de batería 3",
+          "hsem_batteries_enable_batteries_schedule_3_start": "Hora de inicio de la programación de batería 3"
+        },
+        "data_description": {
+          "hsem_batteries_enable_batteries_schedule_1": "Activa o desactiva la primera programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_1_end": "Especifica la hora de fin de la primera programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_1_start": "Especifica la hora de inicio de la primera programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_2": "Activa o desactiva la segunda programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_2_end": "Especifica la hora de fin de la segunda programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_2_start": "Especifica la hora de inicio de la segunda programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_3": "Activa o desactiva la tercera programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_3_end": "Especifica la hora de fin de la tercera programación de descarga de batería.",
+          "hsem_batteries_enable_batteries_schedule_3_start": "Especifica la hora de inicio de la tercera programación de descarga de batería."
+        },
+        "description": "Configura hasta tres ventanas de programación de descarga de batería, cada una con un interruptor de activación/desactivación, hora de inicio y hora de fin. Las programaciones definen cuándo puede descargarse la batería para cubrir picos de consumo o exportar a la red.",
+        "title": "Programaciones de descarga de batería"
+      },
+      "months": {
+        "data": {
+          "hsem_months_winter": "Meses considerados como invierno/primavera"
+        },
+        "data_description": {
+          "hsem_months_winter": "Selecciona los meses que deben considerarse invierno/primavera para los ajustes estacionales del modo de funcionamiento. Puedes seleccionar varios meses. Seleccionar los 12 meses está permitido: esto mantiene el modo invierno/primavera (TOU) activo todo el año."
+        },
+        "description": "Configura los meses que se consideran invierno/primavera. Durante estos meses, el sistema priorizará la carga de las baterías desde la energía de la red para garantizar niveles de batería suficientes en los períodos de menor producción solar. Los meses restantes se considerarán meses de verano/otoño.",
+        "title": "Meses de invierno/primavera"
+      },
+      "power": {
+        "data": {
+          "hsem_house_consumption_power": "Sensor de potencia de consumo de la vivienda",
+          "hsem_main_fuse_amps": "Valor nominal del fusible principal (amperios)",
+          "hsem_main_fuse_phases": "Número de fases del fusible principal",
+          "hsem_max_grid_export_power_kw": "Potencia máxima de exportación a la red (kW)",
+          "hsem_solar_production_power": "Sensor de potencia de producción solar",
+          "hsem_huawei_solar_power_meter_phase_a_active_power": "Sensor de potencia activa del medidor, fase A",
+          "hsem_huawei_solar_power_meter_phase_b_active_power": "Sensor de potencia activa del medidor, fase B",
+          "hsem_huawei_solar_power_meter_phase_c_active_power": "Sensor de potencia activa del medidor, fase C",
+          "hsem_phase_aware_charging_enabled": "Activar limitador de seguridad de carga con reconocimiento de fase en tiempo real"
+        },
+        "data_description": {
+          "hsem_house_consumption_power": "Selecciona el sensor que mide el consumo total de potencia de tu vivienda.",
+          "hsem_main_fuse_amps": "El valor nominal del fusible/interruptor principal de tu vivienda en amperios (25, 35, etc.). El optimizador MILP respetará este límite al programar la carga de la batería y del VE. Ajusta a 0 para desactivar.",
+          "hsem_main_fuse_phases": "El número de fases de tu instalación eléctrica. Las instalaciones monofásicas DEBEN configurar este valor en 1; establecer 3 en una instalación monofásica hace que la protección del fusible sea 3 veces demasiado permisiva y no proporciona un límite de seguridad real. Predeterminado: 3 (trifásico).",
+          "hsem_max_grid_export_power_kw": "Potencia máxima de exportación a la red en kW: el límite de exportación del operador de red/inversor para conexiones con exportación limitada (p. ej., 5 kW). El planificador MILP nunca programará una exportación por encima de este límite, de modo que la exportación de batería y la exportación de PV compiten correctamente por el mismo límite. Ajusta a 0 para desactivar.",
+          "hsem_solar_production_power": "Selecciona el sensor que mide la potencia generada por tus paneles solares.",
+          "hsem_huawei_solar_power_meter_phase_a_active_power": "Selecciona el sensor que mide la potencia activa en tiempo real en la fase A de tu medidor de potencia Huawei. Solo se requiere cuando la carga con reconocimiento de fase está activada.",
+          "hsem_huawei_solar_power_meter_phase_b_active_power": "Selecciona el sensor que mide la potencia activa en tiempo real en la fase B de tu medidor de potencia Huawei. Solo se requiere cuando la carga con reconocimiento de fase está activada.",
+          "hsem_huawei_solar_power_meter_phase_c_active_power": "Selecciona el sensor que mide la potencia activa en tiempo real en la fase C de tu medidor de potencia Huawei. Solo se requiere cuando la carga con reconocimiento de fase está activada.",
+          "hsem_phase_aware_charging_enabled": "Activa una comprobación de seguridad en tiempo real inmediatamente antes de cada escritura de hardware de carga desde la red de Huawei (issue #831). Usa los tres sensores de fase del medidor de potencia indicados a continuación, junto con la entidad de potencia máxima de carga desde la red de Huawei (paso huawei_solar), para limitar la carga financiada por la red de modo que nunca supere el valor nominal del fusible principal en ninguna fase, incluso si la carga cambió después de resolver el plan. Requiere main_fuse_phases = 3 y las cuatro entidades configuradas. Desactivado de forma predeterminada; totalmente compatible con versiones anteriores."
+        },
+        "description": "Selecciona los sensores de potencia para HSEM.",
+        "title": "Sensores de potencia"
+      },
+      "solcast": {
+        "data": {
+          "hsem_solcast_pv_forecast_forecast_likelihood": "Probabilidad de previsión preferida para usar en la previsión PV de Solcast",
+          "hsem_solcast_pv_forecast_forecast_today": "Sensor de previsión PV de Solcast de hoy",
+          "hsem_solcast_pv_forecast_forecast_tomorrow": "Sensor de previsión PV de Solcast de mañana"
+        },
+        "data_description": {
+          "hsem_solcast_pv_forecast_forecast_likelihood": "Selecciona la probabilidad de previsión preferida para las previsiones PV de Solcast.",
+          "hsem_solcast_pv_forecast_forecast_today": "Selecciona el sensor que proporciona la previsión de producción PV de hoy de Solcast.",
+          "hsem_solcast_pv_forecast_forecast_tomorrow": "Selecciona el sensor que proporciona la previsión de producción PV de mañana de Solcast."
+        },
+        "description": "Selecciona los sensores de previsión de Solcast.",
+        "title": "Sensores de Solcast"
+      },
+      "weighted_values": {
+        "data": {
+          "hsem_house_consumption_energy_weight_14d": "Peso de energía de consumo de la vivienda a 14 días",
+          "hsem_house_consumption_energy_weight_1d": "Peso de energía de consumo de la vivienda a 1 día",
+          "hsem_house_consumption_energy_weight_3d": "Peso de energía de consumo de la vivienda a 3 días",
+          "hsem_house_consumption_energy_weight_7d": "Peso de energía de consumo de la vivienda a 7 días"
+        },
+        "data_description": {
+          "hsem_house_consumption_energy_weight_14d": "Especifica el porcentaje de peso para la energía de consumo de la vivienda de los últimos 14 días.",
+          "hsem_house_consumption_energy_weight_1d": "Especifica el porcentaje de peso para la energía de consumo de la vivienda del último día.",
+          "hsem_house_consumption_energy_weight_3d": "Especifica el porcentaje de peso para la energía de consumo de la vivienda de los últimos 3 días.",
+          "hsem_house_consumption_energy_weight_7d": "Especifica el porcentaje de peso para la energía de consumo de la vivienda de los últimos 7 días."
+        },
+        "description": "Configura los valores ponderados de la energía de consumo de la vivienda para estimar tu uso medio de potencia. El sistema calcula el consumo medio de cada hora a lo largo de 1, 3, 7 y 14 días. Estas medias se ponderan después para ofrecer una estimación combinada y ponderada. Este enfoque ayuda a suavizar anomalías, como un consumo inusualmente alto en un solo día debido a precios bajos, y proporciona una predicción fiable de tu uso de potencia esperado en intervalos de tiempo específicos (p. ej., entre las 16:00 y las 17:00).",
+        "title": "Valores ponderados"
+      },
+      "energy_and_ml": {
+        "data": {
+          "hsem_grid_import_energy_entity": "Sensor de energía de importación de la red",
+          "hsem_grid_export_energy_entity": "Sensor de energía de exportación a la red",
+          "hsem_pv_energy_entity": "Sensor de energía de producción PV",
+          "hsem_ml_consumption_enabled": "Activar predicción de consumo mediante ML",
+          "hsem_ml_consumption_energy_entity": "Sensor de energía de consumo de la vivienda (excl. batería y VE)",
+          "hsem_ml_consumption_history_days": "Días de historial para ML",
+          "hsem_ml_consumption_net_consumption": "Usar consumo neto (importación - exportación)",
+          "hsem_ml_consumption_temperature_entity": "Sensor de temperatura exterior",
+          "hsem_ml_consumption_sequential": "Predicción secuencial (función de retardo)"
+        },
+        "data_description": {
+          "hsem_grid_import_energy_entity": "Opcional: medidor acumulado de energía de importación de la red (kWh).",
+          "hsem_grid_export_energy_entity": "Opcional: medidor acumulado de energía de exportación a la red (kWh).",
+          "hsem_pv_energy_entity": "Opcional: medidor acumulado de energía de producción PV (kWh).",
+          "hsem_ml_consumption_enabled": "Cuando está activado, usa regresión ridge sobre el historial del recorder en lugar de medias móviles. Requiere 14 días o más de historial.",
+          "hsem_ml_consumption_energy_entity": "Medidor acumulado de energía de consumo de la vivienda (kWh). Debe excluir la batería Y la carga del VE; usa un sensor situado antes de ambos. Si no se configura, se recurre a la importación de red.",
+          "hsem_ml_consumption_history_days": "Días de historial del recorder para el entrenamiento de ML (7-90).",
+          "hsem_ml_consumption_net_consumption": "Resta la exportación a la red de la importación para obtener el consumo neto de la vivienda.",
+          "hsem_ml_consumption_temperature_entity": "Opcional: sensor de temperatura exterior en °C. Usa un sensor exterior, no un termostato interior.",
+          "hsem_ml_consumption_sequential": "Introduce cada predicción de intervalo como entrada de la siguiente. Captura la dinámica dentro de la hora (p. ej., los picos de cocina se propagan hacia adelante)."
+        },
+        "description": "Configura los medidores de energía y activa la predicción de consumo basada en ML.",
+        "title": "Energía y ML"
+      },
+      "batteries_wait_mode": {
+        "data": {
+          "hsem_batteries_wait_mode_behavior": "Comportamiento del modo de espera"
+        },
+        "data_description": {
+          "hsem_batteries_wait_mode_behavior": "Elige cómo se comporta la batería cuando HSEM selecciona el modo de espera. La espera estricta mantiene la batería inactiva. El autoconsumo con reserva permite que la vivienda use el excedente de energía de la batería por encima de la reserva requerida por el planificador, reduciendo la importación innecesaria de red."
+        },
+        "description": "Configura cómo se comporta la batería durante el modo de espera.",
+        "title": "Comportamiento de la batería en modo de espera"
+      }
+    }
+  },
+  "selector": {
+    "months": {
+      "options": {
+        "1": "enero",
+        "2": "febrero",
+        "3": "marzo",
+        "4": "abril",
+        "5": "mayo",
+        "6": "junio",
+        "7": "julio",
+        "8": "agosto",
+        "9": "septiembre",
+        "10": "octubre",
+        "11": "noviembre",
+        "12": "diciembre"
+      }
+    },
+    "update_interval_minutes": {
+      "options": {
+        "1": "1 minuto",
+        "5": "5 minutos",
+        "10": "10 minutos",
+        "15": "15 minutos",
+        "30": "30 minutos",
+        "45": "45 minutos",
+        "60": "60 minutos"
+      }
+    },
+    "pv_estimate_likelihood": {
+      "options": {
+        "pv_estimate": "50 % de probabilidad",
+        "pv_estimate10": "10 % de probabilidad",
+        "pv_estimate90": "90 % de probabilidad"
+      }
+    },
+    "update_interval_length": {
+      "options": {
+        "12": "12 horas",
+        "24": "24 horas",
+        "36": "36 horas",
+        "48": "48 horas",
+        "72": "72 horas"
+      }
+    },
+    "batteries_wait_mode_behavior": {
+      "options": {
+        "strict": "Espera estricta: la batería permanece inactiva",
+        "self_consumption_with_reserve": "Autoconsumo con reserva: usa el excedente por encima de la reserva del planificador"
+      }
+    },
+    "ev_charger_phase_topology": {
+      "options": {
+        "single_phase": "Monofásico o desconocido (valor predeterminado seguro)",
+        "three_phase_balanced": "Trifásico, equilibrado entre L1/L2/L3"
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "applier_status": {
+        "name": "Estado de aplicación del inversor",
+        "state": {
+          "ok": "OK",
+          "unverified": "Sin verificar",
+          "failed": "Fallido",
+          "skipped": "Omitido",
+          "pending": "Pendiente"
+        }
+      },
+      "battery_soc": {
+        "name": "Estado de carga de la batería"
+      },
+      "daily_plan_vs_actual": {
+        "name": "Plan diario frente a real"
+      },
+      "degraded_mode": {
+        "name": "Estado del sistema",
+        "state": {
+          "ok": "OK",
+          "degraded": "Degradado",
+          "error": "Error"
+        }
+      },
+      "ev_charger_calculated_power": {
+        "name": "Potencia calculada del cargador de VE"
+      },
+      "ev_charger_current_limit": {
+        "name": "Límite de corriente del cargador de VE"
+      },
+      "ev_charging": {
+        "name": "Carga del VE activa",
+        "state": {
+          "on": "Activado",
+          "off": "Desactivado"
+        }
+      },
+      "ev_optimal_charging_plan": {
+        "name": "Plan de carga óptimo del VE",
+        "state": {
+          "charging": "Cargando",
+          "fully_charged": "Completamente cargado",
+          "not_connected": "No conectado",
+          "smart_charging_disabled": "Carga inteligente desactivada",
+          "waiting": "En espera",
+          "unavailable": "No disponible"
+        }
+      },
+      "ev_second_charger_calculated_power": {
+        "name": "Potencia calculada del cargador de VE 2"
+      },
+      "ev_second_charger_current_limit": {
+        "name": "Límite de corriente del cargador de VE 2"
+      },
+      "ev_second_optimal_charging_plan": {
+        "name": "Plan de carga óptimo del VE 2",
+        "state": {
+          "charging": "Cargando",
+          "fully_charged": "Completamente cargado",
+          "not_connected": "No conectado",
+          "smart_charging_disabled": "Carga inteligente desactivada",
+          "waiting": "En espera",
+          "unavailable": "No disponible"
+        }
+      },
+      "force_mode": {
+        "name": "Forzar modo de funcionamiento",
+        "state": {
+          "auto": "Auto",
+          "batteries_charge_grid": "Cargar desde la red",
+          "batteries_charge_solar": "Cargar desde solar",
+          "ev_smart_charging": "Carga inteligente del VE",
+          "batteries_discharge_mode": "Descarga",
+          "force_batteries_discharge": "Forzar descarga",
+          "force_export": "Forzar exportación",
+          "batteries_wait_mode": "Espera"
+        }
+      },
+      "forecast_accuracy": {
+        "name": "Precisión de la previsión"
+      },
+      "hardware_writes": {
+        "name": "Escrituras de hardware",
+        "state": {
+          "allowed": "Permitidas",
+          "blocked": "Bloqueadas"
+        }
+      },
+      "last_updated": {
+        "name": "Última actualización"
+      },
+      "missing_entities": {
+        "name": "Entidades de entrada faltantes"
+      },
+      "net_consumption": {
+        "name": "Consumo neto"
+      },
+      "next_update": {
+        "name": "Próxima actualización"
+      },
+      "plan_explanation": {
+        "name": "Estrategia del plan"
+      },
+      "read_only": {
+        "name": "Modo de solo lectura",
+        "state": {
+          "on": "Activado",
+          "off": "Desactivado"
+        }
+      },
+      "recommendation_interval": {
+        "name": "Intervalo de recomendación"
+      },
+      "update_interval": {
+        "name": "Intervalo de actualización"
+      },
+      "working_mode": {
+        "name": "Sensor de modo de funcionamiento",
+        "state": {
+          "time_passed": "Tiempo transcurrido",
+          "missing_input_entities": "Entidades de entrada faltantes",
+          "batteries_charge_grid": "Cargar desde la red",
+          "batteries_charge_solar": "Cargar desde solar",
+          "ev_smart_charging": "Carga inteligente del VE",
+          "batteries_discharge_mode": "Descarga",
+          "force_batteries_discharge": "Forzar descarga",
+          "force_export": "Forzar exportación",
+          "batteries_wait_mode": "Espera"
+        }
+      },
+      "effective_discharge_floor": {
+        "name": "Límite de descarga efectivo"
+      },
+      "ocpp_charger_status": {
+        "name": "Estado del cargador OCPP"
+      },
+      "ocpp_charger_power": {
+        "name": "Potencia del cargador OCPP"
+      },
+      "ocpp_charger_info": {
+        "name": "Información del cargador OCPP"
+      },
+      "ocpp_charger_sessions": {
+        "name": "Sesiones del cargador OCPP"
+      },
+      "export_income": {
+        "name": "Ingresos por exportación"
+      },
+      "import_cost": {
+        "name": "Coste de importación de red"
+      },
+      "net_grid_balance": {
+        "name": "Balance neto de red"
+      },
+      "prediction_accuracy": {
+        "name": "Precisión de la predicción"
+      },
+      "pv_curtailment": {
+        "name": "Recorte de PV"
+      },
+      "savings_tracker": {
+        "name": "Seguimiento de ahorro"
+      },
+      "solar_confidence": {
+        "name": "Confianza de la previsión solar"
+      },
+      "ocpp_second_charger_status": {
+        "name": "Estado del segundo cargador OCPP"
+      },
+      "ocpp_second_charger_power": {
+        "name": "Potencia del segundo cargador OCPP"
+      },
+      "ocpp_second_charger_info": {
+        "name": "Información del segundo cargador OCPP"
+      },
+      "ocpp_second_charger_sessions": {
+        "name": "Sesiones del segundo cargador OCPP"
+      }
+    },
+    "switch": {
+      "read_only": {
+        "name": "Modo de solo lectura"
+      },
+      "extended_attributes": {
+        "name": "Atributos ampliados"
+      },
+      "verbose_logging": {
+        "name": "Registro detallado"
+      },
+      "batteries_schedule_1": {
+        "name": "Programación de baterías 1"
+      },
+      "batteries_schedule_2": {
+        "name": "Programación de baterías 2"
+      },
+      "batteries_schedule_3": {
+        "name": "Programación de baterías 3"
+      },
+      "ev_force_discharge": {
+        "name": "Forzar potencia máxima de descarga del VE"
+      },
+      "ev_smart_charging": {
+        "name": "Carga inteligente del VE"
+      },
+      "ev_force_charge_now": {
+        "name": "Forzar carga del VE ahora"
+      },
+      "ev_second_smart_charging": {
+        "name": "Carga inteligente del VE 2"
+      },
+      "ev_second_force_charge_now": {
+        "name": "Forzar carga del VE 2 ahora"
+      },
+      "ml_consumption": {
+        "name": "Predicción de consumo mediante ML"
+      },
+      "ml_sequential": {
+        "name": "Predicción secuencial mediante ML"
+      },
+      "dynamic_discharge_floor": {
+        "name": "Límite de descarga dinámico"
+      },
+      "ev_auto_full_negative_price": {
+        "name": "Carga completa automática del VE con precio negativo"
+      }
+    },
+    "select": {
+      "force_working_mode": {
+        "name": "Forzar modo de funcionamiento"
+      },
+      "pv_estimate_likelihood": {
+        "name": "Probabilidad de estimación PV de Solcast"
+      }
+    },
+    "number": {
+      "charge_efficiency": {
+        "name": "Eficiencia de carga de la batería"
+      },
+      "discharge_efficiency": {
+        "name": "Eficiencia de descarga de la batería"
+      },
+      "ev_target_soc": {
+        "name": "SoC objetivo del VE"
+      },
+      "ev_second_target_soc": {
+        "name": "SoC objetivo del VE 2"
+      }
+    },
+    "time": {
+      "schedule_1_start": {
+        "name": "Inicio de la programación de descarga de baterías 1"
+      },
+      "schedule_1_end": {
+        "name": "Fin de la programación de descarga de baterías 1"
+      },
+      "schedule_2_start": {
+        "name": "Inicio de la programación de descarga de baterías 2"
+      },
+      "schedule_2_end": {
+        "name": "Fin de la programación de descarga de baterías 2"
+      },
+      "schedule_3_start": {
+        "name": "Inicio de la programación de descarga de baterías 3"
+      },
+      "schedule_3_end": {
+        "name": "Fin de la programación de descarga de baterías 3"
+      },
+      "ev_deadline": {
+        "name": "Fecha límite de carga del VE"
+      },
+      "ev_second_deadline": {
+        "name": "Fecha límite de carga del VE 2"
+      }
+    }
+  },
+  "services": {
+    "force_recalculation": {
+      "name": "Forzar recálculo",
+      "description": "Fuerza al coordinador de HSEM a ejecutar inmediatamente un ciclo completo de recálculo."
+    },
+    "set_temporary_override": {
+      "name": "Establecer anulación temporal",
+      "description": "Anula temporalmente el planificador automático forzando un modo de funcionamiento específico.",
+      "fields": {
+        "working_mode": {
+          "name": "Modo de funcionamiento",
+          "description": "El modo de funcionamiento que se va a forzar. Debe ser uno de los modos de anulación admitidos."
+        }
+      }
+    },
+    "clear_override": {
+      "name": "Borrar anulación",
+      "description": "Borra cualquier anulación temporal activa del modo de funcionamiento y vuelve al control automático del planificador."
+    },
+    "export_diagnostics": {
+      "name": "Exportar diagnósticos",
+      "description": "Exporta un volcado de diagnóstico estructurado de la integración HSEM con todos los ID de entidad ocultos."
+    },
+    "create_dashboard": {
+      "name": "Crear panel",
+      "description": "Crea o actualiza el panel Lovelace de HSEM. Establece force en true para sobrescribirlo."
+    }
+  }
+}

--- a/custom_components/hsem/utils/sensornames/diagnostics.py
+++ b/custom_components/hsem/utils/sensornames/diagnostics.py
@@ -1,27 +1,18 @@
-"""Diagnostic and meta sensor name generators.
+"""Diagnostic and meta sensor unique-ID and entity-ID generators.
 
-Provides getter functions for working mode, degraded mode, read-only,
-next update, missing entities, hardware writes, net consumption, force mode,
-update interval, last updated, battery SoC, recommendation interval,
-plan explanation, applier status, forecast accuracy, daily plan-vs-actual,
-force working mode selector, and solcast likelihood selector names,
-unique IDs, and entity IDs.
+Display names for these sensors come from Home Assistant's translation
+system (``_attr_translation_key`` + ``translations/*.json``), not from
+functions in this module. Provides getter functions for working mode,
+degraded mode, read-only, next update, missing entities, hardware writes,
+net consumption, force mode, update interval, last updated, battery SoC,
+recommendation interval, plan explanation, applier status, forecast
+accuracy, daily plan-vs-actual, force working mode selector, and solcast
+likelihood selector unique IDs and entity IDs.
 """
 
 from homeassistant.util import slugify as s
 
 from custom_components.hsem.const import DOMAIN
-
-
-# Working Mode Sensor
-def get_working_mode_sensor_name() -> str:
-    """Generate the display name for the working mode sensor.
-
-    Returns:
-        str: Display name of the working mode sensor.
-
-    """
-    return "Working Mode Sensor"
 
 
 def get_working_mode_sensor_unique_id(entry_id: str) -> str:
@@ -47,17 +38,6 @@ def get_working_mode_sensor_entity_id() -> str:
     return f"sensor.{s(f'{DOMAIN}_workingmode_sensor')}"
 
 
-# Degraded Mode Sensor
-def get_degraded_mode_sensor_name() -> str:
-    """Return the display name for the degraded-mode diagnostic sensor.
-
-    Returns:
-        str: Display name.
-
-    """
-    return "System Health"
-
-
 def get_degraded_mode_sensor_unique_id(entry_id: str) -> str:
     """Return a unique ID for the degraded-mode sensor.
 
@@ -79,17 +59,6 @@ def get_degraded_mode_sensor_entity_id() -> str:
 
     """
     return f"sensor.{s(f'{DOMAIN}_degraded_mode_sensor')}"
-
-
-# Read-Only Mode Sensor
-def get_read_only_sensor_name() -> str:
-    """Return the display name for the read-only mode diagnostic sensor.
-
-    Returns:
-        str: Display name.
-
-    """
-    return "Read-Only Mode"
 
 
 def get_read_only_sensor_unique_id(entry_id: str) -> str:
@@ -115,12 +84,6 @@ def get_read_only_sensor_entity_id() -> str:
     return f"sensor.{s(f'{DOMAIN}_read_only_sensor')}"
 
 
-# Next Update Sensor
-def get_next_update_sensor_name() -> str:
-    """Return the display name for the next-update diagnostic sensor."""
-    return "Next Update"
-
-
 def get_next_update_sensor_unique_id(entry_id: str) -> str:
     """Return a unique ID for the next-update sensor.
 
@@ -133,12 +96,6 @@ def get_next_update_sensor_unique_id(entry_id: str) -> str:
 def get_next_update_sensor_entity_id() -> str:
     """Return the entity_id for the next-update sensor."""
     return f"sensor.{s(f'{DOMAIN}_next_update_sensor')}"
-
-
-# Missing Entities Sensor
-def get_missing_entities_sensor_name() -> str:
-    """Return the display name for the missing-entities count diagnostic sensor."""
-    return "Missing Input Entities"
 
 
 def get_missing_entities_sensor_unique_id(entry_id: str) -> str:
@@ -155,12 +112,6 @@ def get_missing_entities_sensor_entity_id() -> str:
     return f"sensor.{s(f'{DOMAIN}_missing_entities_sensor')}"
 
 
-# Hardware Writes Blocked Sensor
-def get_hardware_writes_sensor_name() -> str:
-    """Return the display name for the hardware-writes-blocked diagnostic sensor."""
-    return "Hardware Writes"
-
-
 def get_hardware_writes_sensor_unique_id(entry_id: str) -> str:
     """Return a unique ID for the hardware-writes-blocked sensor.
 
@@ -173,12 +124,6 @@ def get_hardware_writes_sensor_unique_id(entry_id: str) -> str:
 def get_hardware_writes_sensor_entity_id() -> str:
     """Return the entity_id for the hardware-writes-blocked sensor."""
     return f"sensor.{s(f'{DOMAIN}_hardware_writes_sensor')}"
-
-
-# Net Consumption Sensor
-def get_net_consumption_sensor_name() -> str:
-    """Return the display name for the net-consumption diagnostic sensor."""
-    return "Net Consumption"
 
 
 def get_net_consumption_sensor_unique_id(entry_id: str) -> str:
@@ -195,12 +140,6 @@ def get_net_consumption_sensor_entity_id() -> str:
     return f"sensor.{s(f'{DOMAIN}_net_consumption_sensor')}"
 
 
-# Force Working Mode Sensor
-def get_force_mode_sensor_name() -> str:
-    """Return the display name for the force-working-mode diagnostic sensor."""
-    return "Force Working Mode"
-
-
 def get_force_mode_sensor_unique_id(entry_id: str) -> str:
     """Return a unique ID for the force-working-mode sensor.
 
@@ -213,12 +152,6 @@ def get_force_mode_sensor_unique_id(entry_id: str) -> str:
 def get_force_mode_sensor_entity_id() -> str:
     """Return the entity_id for the force-working-mode sensor."""
     return f"sensor.{s(f'{DOMAIN}_force_mode_sensor')}"
-
-
-# Update Interval Sensor
-def get_update_interval_sensor_name() -> str:
-    """Return the display name for the update-interval diagnostic sensor."""
-    return "Update Interval"
 
 
 def get_update_interval_sensor_unique_id(entry_id: str) -> str:
@@ -235,12 +168,6 @@ def get_update_interval_sensor_entity_id() -> str:
     return f"sensor.{s(f'{DOMAIN}_update_interval_sensor')}"
 
 
-# Last Updated Sensor
-def get_last_updated_sensor_name() -> str:
-    """Return the display name for the last-updated diagnostic sensor."""
-    return "Last Updated"
-
-
 def get_last_updated_sensor_unique_id(entry_id: str) -> str:
     """Return a unique ID for the last-updated sensor.
 
@@ -253,12 +180,6 @@ def get_last_updated_sensor_unique_id(entry_id: str) -> str:
 def get_last_updated_sensor_entity_id() -> str:
     """Return the entity_id for the last-updated sensor."""
     return f"sensor.{s(f'{DOMAIN}_last_updated_sensor')}"
-
-
-# Battery SoC Sensor
-def get_battery_soc_sensor_name() -> str:
-    """Return the display name for the battery-SoC diagnostic sensor."""
-    return "Battery State of Charge"
 
 
 def get_battery_soc_sensor_unique_id(entry_id: str) -> str:
@@ -275,12 +196,6 @@ def get_battery_soc_sensor_entity_id() -> str:
     return f"sensor.{s(f'{DOMAIN}_battery_soc_sensor')}"
 
 
-# Recommendation Interval Sensor
-def get_recommendation_interval_sensor_name() -> str:
-    """Return the display name for the recommendation-interval diagnostic sensor."""
-    return "Recommendation Interval"
-
-
 def get_recommendation_interval_sensor_unique_id(entry_id: str) -> str:
     """Return a unique ID for the recommendation-interval sensor.
 
@@ -293,12 +208,6 @@ def get_recommendation_interval_sensor_unique_id(entry_id: str) -> str:
 def get_recommendation_interval_sensor_entity_id() -> str:
     """Return the entity_id for the recommendation-interval sensor."""
     return f"sensor.{s(f'{DOMAIN}_recommendation_interval_sensor')}"
-
-
-# Plan Explanation Sensor
-def get_plan_explanation_sensor_name() -> str:
-    """Return the display name for the plan-explanation diagnostic sensor."""
-    return "Plan Strategy"
 
 
 def get_plan_explanation_sensor_unique_id(entry_id: str) -> str:
@@ -355,12 +264,6 @@ def get_solcast_likelihood_selector_entity_id() -> str:
     return f"select.{s(get_solcast_likelihood_selector_key())}"
 
 
-# Applier Status Sensor
-def get_applier_status_sensor_name() -> str:
-    """Return the display name for the applier-status diagnostic sensor."""
-    return "Inverter Apply Status"
-
-
 def get_applier_status_sensor_unique_id(entry_id: str) -> str:
     """Return a unique ID for the applier-status sensor.
 
@@ -373,12 +276,6 @@ def get_applier_status_sensor_unique_id(entry_id: str) -> str:
 def get_applier_status_sensor_entity_id() -> str:
     """Return the entity_id for the applier-status sensor."""
     return f"sensor.{s(f'{DOMAIN}_applier_status_sensor')}"
-
-
-# Forecast Accuracy Sensor
-def get_forecast_accuracy_sensor_name() -> str:
-    """Return the display name for the forecast accuracy diagnostic sensor."""
-    return "Forecast Accuracy"
 
 
 def get_forecast_accuracy_sensor_unique_id(entry_id: str) -> str:
@@ -401,11 +298,6 @@ def get_daily_plan_vs_actual_sensor_key() -> str:
     return "daily_plan_vs_actual"
 
 
-def get_daily_plan_vs_actual_sensor_name() -> str:
-    """Return the display name for the daily plan-vs-actual sensor."""
-    return "Daily Plan vs Actual"
-
-
 def get_daily_plan_vs_actual_sensor_unique_id(entry_id: str) -> str:
     """Return the unique_id for the daily plan-vs-actual sensor.
 
@@ -418,12 +310,6 @@ def get_daily_plan_vs_actual_sensor_unique_id(entry_id: str) -> str:
 def get_daily_plan_vs_actual_sensor_entity_id() -> str:
     """Return the entity_id for the daily plan-vs-actual sensor."""
     return f"sensor.{s(get_daily_plan_vs_actual_sensor_key())}"
-
-
-# Effective Discharge Floor Sensor
-def get_effective_discharge_floor_sensor_name() -> str:
-    """Return the display name for the effective discharge floor sensor."""
-    return "Effective Discharge Floor"
 
 
 def get_effective_discharge_floor_sensor_unique_id(entry_id: str) -> str:
@@ -443,11 +329,6 @@ def get_effective_discharge_floor_sensor_entity_id() -> str:
 # Solar Confidence Sensor
 
 
-def get_solar_confidence_sensor_name() -> str:
-    """Return the display name for the solar confidence diagnostic sensor."""
-    return "Solar Forecast Confidence"
-
-
 def get_solar_confidence_sensor_unique_id(entry_id: str) -> str:
     """Return a unique ID for the solar confidence sensor.
 
@@ -460,12 +341,6 @@ def get_solar_confidence_sensor_unique_id(entry_id: str) -> str:
 def get_solar_confidence_sensor_entity_id() -> str:
     """Return the entity_id for the solar confidence sensor."""
     return f"sensor.{s(f'{DOMAIN}_solar_confidence_sensor')}"
-
-
-# Savings Tracker Sensor
-def get_savings_tracker_sensor_name() -> str:
-    """Return the display name for the savings tracker sensor."""
-    return "Savings Tracker"
 
 
 def get_savings_tracker_sensor_unique_id(entry_id: str) -> str:
@@ -482,12 +357,6 @@ def get_savings_tracker_sensor_entity_id() -> str:
     return f"sensor.{s(f'{DOMAIN}_savings_tracker_sensor')}"
 
 
-# Prediction Accuracy Sensor
-def get_prediction_accuracy_sensor_name() -> str:
-    """Return the display name for the prediction accuracy sensor."""
-    return "Prediction Accuracy"
-
-
 def get_prediction_accuracy_sensor_unique_id(entry_id: str) -> str:
     """Return a unique ID for the prediction accuracy sensor.
 
@@ -500,12 +369,6 @@ def get_prediction_accuracy_sensor_unique_id(entry_id: str) -> str:
 def get_prediction_accuracy_sensor_entity_id() -> str:
     """Return the entity_id for the prediction accuracy sensor."""
     return f"sensor.{s(f'{DOMAIN}_prediction_accuracy_sensor')}"
-
-
-# PV Curtailment Sensor (issue #611)
-def get_pv_curtailment_sensor_name() -> str:
-    """Return the display name for the PV curtailment sensor."""
-    return "PV Curtailment"
 
 
 def get_pv_curtailment_sensor_unique_id(entry_id: str) -> str:

--- a/custom_components/hsem/utils/sensornames/ev.py
+++ b/custom_components/hsem/utils/sensornames/ev.py
@@ -1,21 +1,17 @@
-"""EV-related sensor, switch, number, and time name generators.
+"""EV-related sensor, switch, number, and time unique-ID and entity-ID generators.
 
-Provides getter functions for EV charging, EV optimal charging plan
-(primary and second), EV target SoC (primary and second), EV force discharge,
-EV smart charging switches (primary and second), EV force charge now switches
-(primary and second), and EV deadline time entities (primary and second)
-names, unique IDs, and entity IDs.
+Display names for these entities come from Home Assistant's translation
+system (``_attr_translation_key`` + ``translations/*.json``), not from
+functions in this module. Provides getter functions for EV charging, EV
+optimal charging plan (primary and second), EV target SoC (primary and
+second), EV force discharge, EV smart charging switches (primary and
+second), EV force charge now switches (primary and second), and EV
+deadline time entities (primary and second) unique IDs and entity IDs.
 """
 
 from homeassistant.util import slugify as s
 
 from custom_components.hsem.const import DOMAIN
-
-
-# EV Charging Active Sensor
-def get_ev_charging_sensor_name() -> str:
-    """Return the display name for the EV-charging-active diagnostic sensor."""
-    return "EV Charging Active"
 
 
 def get_ev_charging_sensor_unique_id(entry_id: str) -> str:
@@ -32,12 +28,6 @@ def get_ev_charging_sensor_entity_id() -> str:
     return f"sensor.{s(f'{DOMAIN}_ev_charging_sensor')}"
 
 
-# EV Optimal Charging Plan Sensor
-def get_ev_optimal_charging_plan_sensor_name() -> str:
-    """Return the display name for the EV optimal charging plan sensor."""
-    return "EV Optimal Charging Plan"
-
-
 def get_ev_optimal_charging_plan_sensor_unique_id(entry_id: str) -> str:
     """Return a unique ID for the EV optimal charging plan sensor.
 
@@ -50,12 +40,6 @@ def get_ev_optimal_charging_plan_sensor_unique_id(entry_id: str) -> str:
 def get_ev_optimal_charging_plan_sensor_entity_id() -> str:
     """Return the entity_id for the EV optimal charging plan sensor."""
     return f"sensor.{s(f'{DOMAIN}_ev_optimal_charging_plan')}"
-
-
-# EV Second Optimal Charging Plan Sensor
-def get_ev_second_optimal_charging_plan_sensor_name() -> str:
-    """Return the display name for the second EV optimal charging plan sensor."""
-    return "EV 2 Optimal Charging Plan"
 
 
 def get_ev_second_optimal_charging_plan_sensor_unique_id(entry_id: str) -> str:
@@ -72,12 +56,6 @@ def get_ev_second_optimal_charging_plan_sensor_entity_id() -> str:
     return f"sensor.{s(f'{DOMAIN}_ev_second_optimal_charging_plan')}"
 
 
-# EV Charger Calculated Power Sensor
-def get_ev_charger_calculated_power_sensor_name() -> str:
-    """Return the display name for the EV charger calculated power sensor."""
-    return "EV Charger Calculated Power"
-
-
 def get_ev_charger_calculated_power_sensor_unique_id(entry_id: str) -> str:
     """Return a unique ID for the EV charger calculated power sensor.
 
@@ -90,12 +68,6 @@ def get_ev_charger_calculated_power_sensor_unique_id(entry_id: str) -> str:
 def get_ev_charger_calculated_power_sensor_entity_id() -> str:
     """Return the entity_id for the EV charger calculated power sensor."""
     return f"sensor.{s(f'{DOMAIN}_ev_charger_calculated_power')}"
-
-
-# EV Charger Current Limit Sensor
-def get_ev_charger_current_limit_sensor_name() -> str:
-    """Return the display name for the EV charger current limit sensor."""
-    return "EV Charger Current Limit"
 
 
 def get_ev_charger_current_limit_sensor_unique_id(entry_id: str) -> str:
@@ -112,12 +84,6 @@ def get_ev_charger_current_limit_sensor_entity_id() -> str:
     return f"sensor.{s(f'{DOMAIN}_ev_charger_current_limit')}"
 
 
-# EV Second Charger Current Limit Sensor
-def get_ev_second_charger_current_limit_sensor_name() -> str:
-    """Return the display name for the second EV charger current limit sensor."""
-    return "EV 2 Charger Current Limit"
-
-
 def get_ev_second_charger_current_limit_sensor_unique_id(entry_id: str) -> str:
     """Return a unique ID for the second EV charger current limit sensor.
 
@@ -130,12 +96,6 @@ def get_ev_second_charger_current_limit_sensor_unique_id(entry_id: str) -> str:
 def get_ev_second_charger_current_limit_sensor_entity_id() -> str:
     """Return the entity_id for the second EV charger current limit sensor."""
     return f"sensor.{s(f'{DOMAIN}_ev_second_charger_current_limit')}"
-
-
-# EV Second Charger Calculated Power Sensor
-def get_ev_second_charger_calculated_power_sensor_name() -> str:
-    """Return the display name for the second EV charger calculated power sensor."""
-    return "EV 2 Charger Calculated Power"
 
 
 def get_ev_second_charger_calculated_power_sensor_unique_id(entry_id: str) -> str:

--- a/custom_components/hsem/utils/sensornames/financial.py
+++ b/custom_components/hsem/utils/sensornames/financial.py
@@ -1,23 +1,14 @@
-"""Financial sensor name generators.
+"""Financial sensor unique-ID and entity-ID generators.
 
-Provides getter functions for export income, import cost, and net grid
-balance sensor names, unique IDs, and entity IDs.
+Display names for these sensors come from Home Assistant's translation
+system (``_attr_translation_key`` + ``translations/*.json``), not from
+functions in this module. Provides getter functions for export income,
+import cost, and net grid balance sensor unique IDs and entity IDs.
 """
 
 from homeassistant.util import slugify as s
 
 from custom_components.hsem.const import DOMAIN
-
-
-# Export Income Sensor
-def get_export_income_name() -> str:
-    """Generate the display name for the export income sensor.
-
-    Returns:
-        str: Display name of the export income sensor.
-
-    """
-    return "Export Income"
 
 
 def get_export_income_unique_id(entry_id: str) -> str:
@@ -43,17 +34,6 @@ def get_export_income_entity_id() -> str:
     return f"sensor.{s(f'{DOMAIN}_export_income')}"
 
 
-# Import Cost Sensor
-def get_import_cost_name() -> str:
-    """Generate the display name for the import cost sensor.
-
-    Returns:
-        str: Display name of the import cost sensor.
-
-    """
-    return "Grid Import Cost"
-
-
 def get_import_cost_unique_id(entry_id: str) -> str:
     """Generate a unique ID for the import cost sensor.
 
@@ -75,17 +55,6 @@ def get_import_cost_entity_id() -> str:
 
     """
     return f"sensor.{s(f'{DOMAIN}_import_cost')}"
-
-
-# Net Grid Balance Sensor
-def get_net_grid_balance_name() -> str:
-    """Generate the display name for the net grid balance sensor.
-
-    Returns:
-        str: Display name of the net grid balance sensor.
-
-    """
-    return "Net Grid Balance"
 
 
 def get_net_grid_balance_unique_id(entry_id: str) -> str:

--- a/custom_components/hsem/utils/sensornames/ocpp.py
+++ b/custom_components/hsem/utils/sensornames/ocpp.py
@@ -1,9 +1,11 @@
-"""OCPP-related sensor name generators.
+"""OCPP-related sensor unique-ID and entity-ID generators.
 
-Provides getter functions for OCPP charger status, power, info, and
-sessions sensor names, unique IDs, and entity IDs.  Each OCPP server
-(one per EV) exposes its own set of sensors; ``charger_index`` selects
-between the primary (``1``) and second (``2``) EV's server.
+Display names for these sensors come from Home Assistant's translation
+system (``_attr_translation_key`` + ``translations/*.json``), not from
+functions in this module. Provides getter functions for OCPP charger
+status, power, info, and sessions sensor unique IDs and entity IDs.  Each
+OCPP server (one per EV) exposes its own set of sensors; ``charger_index``
+selects between the primary (``1``) and second (``2``) EV's server.
 """
 
 from homeassistant.util import slugify as s
@@ -18,12 +20,6 @@ from custom_components.hsem.const import DOMAIN
 def _suffix(charger_index: int) -> str:
     """Return the name/entity suffix for a charger index."""
     return "" if charger_index == 1 else "_second"
-
-
-def get_ocpp_charger_status_sensor_name(charger_index: int = 1) -> str:
-    """Return the display name for the OCPP charger status sensor."""
-    suffix = " Second" if charger_index == 2 else ""
-    return f"OCPP Charger{suffix} Status"
 
 
 def get_ocpp_charger_status_sensor_unique_id(
@@ -48,12 +44,6 @@ def get_ocpp_charger_status_sensor_entity_id(charger_index: int = 1) -> str:
 # ---------------------------------------------------------------------------
 
 
-def get_ocpp_charger_power_sensor_name(charger_index: int = 1) -> str:
-    """Return the display name for the OCPP charger power sensor."""
-    suffix = " Second" if charger_index == 2 else ""
-    return f"OCPP Charger{suffix} Power"
-
-
 def get_ocpp_charger_power_sensor_unique_id(
     entry_id: str, charger_index: int = 1
 ) -> str:
@@ -76,12 +66,6 @@ def get_ocpp_charger_power_sensor_entity_id(charger_index: int = 1) -> str:
 # ---------------------------------------------------------------------------
 
 
-def get_ocpp_charger_info_sensor_name(charger_index: int = 1) -> str:
-    """Return the display name for the OCPP charger info sensor."""
-    suffix = " Second" if charger_index == 2 else ""
-    return f"OCPP Charger{suffix} Info"
-
-
 def get_ocpp_charger_info_sensor_unique_id(
     entry_id: str, charger_index: int = 1
 ) -> str:
@@ -102,12 +86,6 @@ def get_ocpp_charger_info_sensor_entity_id(charger_index: int = 1) -> str:
 # ---------------------------------------------------------------------------
 # OCPP Charger Sessions Sensor
 # ---------------------------------------------------------------------------
-
-
-def get_ocpp_charger_sessions_sensor_name(charger_index: int = 1) -> str:
-    """Return the display name for the OCPP charger sessions sensor."""
-    suffix = " Second" if charger_index == 2 else ""
-    return f"OCPP Charger{suffix} Sessions"
 
 
 def get_ocpp_charger_sessions_sensor_unique_id(

--- a/scripts/validate_translations.py
+++ b/scripts/validate_translations.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Validate HSEM translation files against the English source of truth.
+
+``translations/en.json`` is the source of truth for every user-facing string
+(config/options flow steps, selectors, entity names, service definitions).
+Every other language file must have exactly the same set of keys, and no
+value should be left as an unmodified copy of the English text unless it is
+a genuine cognate (see ``_is_number`` and the untranslated-value check below).
+
+Checks performed per target language:
+
+- Missing keys: present in en.json, absent in the target file.
+- Stale keys: present in the target file, absent in en.json (usually a
+  leftover from a removed/renamed feature).
+- Untranslated values: the target value is byte-for-byte identical to the
+  English value. Flagged as a warning (not an error) because short cognates
+  ("November" / "november", acronyms like "OCPP", "SoC") are legitimately
+  identical across languages. Longer strings that match are almost always a
+  missed translation.
+- Placeholder mismatch: ``{placeholder}`` tokens in the value must match
+  exactly between English and the target language (order-independent).
+
+Exit code is non-zero if any missing key, stale key, or placeholder
+mismatch is found. Untranslated-value warnings do not fail the build --
+they are printed for manual review, since some are legitimate cognates.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+TRANSLATIONS_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "custom_components"
+    / "hsem"
+    / "translations"
+)
+SOURCE_LANGUAGE = "en"
+TARGET_LANGUAGES = ["da", "de", "es"]
+
+# Strings that are allowed to be identical to the English source without
+# being flagged as untranslated: numbers-only values, and known cognates
+# that are spelled the same across all four supported languages.
+_PLACEHOLDER_RE = re.compile(r"\{[a-zA-Z0-9_]+\}")
+
+
+def _is_number(value: str) -> bool:
+    return bool(re.fullmatch(r"[\d.,%\s-]+", value))
+
+
+def flatten(data: dict, prefix: str = "") -> dict[str, str]:
+    """Flatten a nested translation dict into ``dotted.key -> value`` pairs."""
+    items: dict[str, str] = {}
+    for key, value in data.items():
+        full_key = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, dict):
+            items.update(flatten(value, full_key))
+        else:
+            items[full_key] = value
+    return items
+
+
+def load(language: str) -> dict[str, str]:
+    path = TRANSLATIONS_DIR / f"{language}.json"
+    with path.open(encoding="utf-8") as f:
+        return flatten(json.load(f))
+
+
+def main() -> int:
+    source = load(SOURCE_LANGUAGE)
+    errors = 0
+    warnings = 0
+
+    for lang in TARGET_LANGUAGES:
+        path = TRANSLATIONS_DIR / f"{lang}.json"
+        if not path.exists():
+            print(f"ERR  {lang}.json does not exist")
+            errors += 1
+            continue
+
+        target = load(lang)
+
+        missing = sorted(set(source) - set(target))
+        stale = sorted(set(target) - set(source))
+        untranslated = []
+        placeholder_mismatch = []
+
+        for key in sorted(set(source) & set(target)):
+            en_value = source[key]
+            target_value = target[key]
+            if not isinstance(en_value, str) or not isinstance(target_value, str):
+                continue
+
+            en_placeholders = set(_PLACEHOLDER_RE.findall(en_value))
+            target_placeholders = set(_PLACEHOLDER_RE.findall(target_value))
+            if en_placeholders != target_placeholders:
+                placeholder_mismatch.append((key, en_placeholders, target_placeholders))
+
+            if (
+                en_value == target_value
+                and len(en_value) > 2
+                and not _is_number(en_value)
+            ):
+                untranslated.append(key)
+
+        print(f"=== {lang}.json ===")
+        print(f"  missing keys:          {len(missing)}")
+        print(f"  stale keys:            {len(stale)}")
+        print(f"  placeholder mismatches:{len(placeholder_mismatch)}")
+        print(f"  untranslated (warn):   {len(untranslated)}")
+
+        for key in missing:
+            print(f"  MISSING  {key} = {source[key]!r}")
+        for key in stale:
+            print(f"  STALE    {key} = {target[key]!r}")
+        for key, en_ph, target_ph in placeholder_mismatch:
+            print(
+                f"  PLACEHOLDER  {key}: en={sorted(en_ph)} {lang}={sorted(target_ph)}"
+            )
+        for key in untranslated:
+            print(f"  UNTRANSLATED  {key} = {source[key]!r}")
+
+        errors += len(missing) + len(stale) + len(placeholder_mismatch)
+        warnings += len(untranslated)
+        print()
+
+    print(f"Total errors: {errors}, warnings (review): {warnings}")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/custom_sensors/test_ocpp_per_ev.py
+++ b/tests/custom_sensors/test_ocpp_per_ev.py
@@ -22,7 +22,6 @@ from custom_components.hsem.flows.ocpp import (
 )
 from custom_components.hsem.utils.sensornames.ocpp import (
     get_ocpp_charger_power_sensor_entity_id,
-    get_ocpp_charger_power_sensor_name,
     get_ocpp_charger_power_sensor_unique_id,
     get_ocpp_charger_status_sensor_entity_id,
     get_ocpp_charger_status_sensor_unique_id,
@@ -48,11 +47,9 @@ def test_second_sensor_names_are_distinct():
     """charger_index=2 produces distinct, slugified second-server entities."""
     entity_id = get_ocpp_charger_power_sensor_entity_id(charger_index=2)
     unique_id = get_ocpp_charger_power_sensor_unique_id("entry", charger_index=2)
-    name = get_ocpp_charger_power_sensor_name(2)
 
     assert entity_id == "sensor.hsem_ocpp_charger_power_sensor_second"
     assert unique_id == "hsem_entry_ocpp_charger_power_sensor_second"
-    assert name == "OCPP Charger Second Power"
     assert entity_id != get_ocpp_charger_power_sensor_entity_id()
 
 

--- a/tests/sensors/test_plan_explanation_sensor.py
+++ b/tests/sensors/test_plan_explanation_sensor.py
@@ -172,7 +172,6 @@ def _make_sensor(data: CoordinatorData | None = None) -> HSEMPlanExplanationSens
     sensor._config_entry = config_entry
     sensor._attr_unique_id = "hsem_plan_explanation_sensor"
     sensor.entity_id = "sensor.hsem_plan_explanation_sensor"
-    sensor._name = "Plan Strategy"
     sensor._restored_state = None
     return sensor
 


### PR DESCRIPTION
## Summary

Fixes #911. Two related translation defects:

1. **`da.json` had drifted from `en.json`**: 80 keys missing (recent OCPP
   second-charger, battery export forecast reserve, planner hysteresis, and
   phase-aware-charging features), 178 keys left as literal copy-pasted
   English (essentially the entire `options.step.*` reconfigure flow), and 7
   stale leftover keys from a removed feature. There was no German or
   Spanish translation at all.
2. **~26 diagnostic sensor entities never actually used the translation
   system**: they set their display name via a hardcoded `name` property
   override or a direct `_attr_name` assignment, which silently wins over
   `_attr_translation_key`-based resolution in Home Assistant's
   `Entity.name` — so their `entity.sensor.*` translations were dead code
   and non-English users always saw English sensor names, even where
   `_attr_translation_key` was also (uselessly) set.

## What changed

- Filled the 80 missing `da.json` keys, re-translated the 178
  copy-pasted-English entries, removed the 7 stale keys.
- Added full `de.json` and `es.json` translation files (886 keys each).
- Added `scripts/validate_translations.py` — diffs `da`/`de`/`es.json`
  against `en.json` for missing/stale keys and `{placeholder}` mismatches
  (hard errors), plus a warning for byte-identical untranslated values.
- Added `.claude/skills/hsem-translation-sync/SKILL.md` (glossary +
  workflow), wired into `hsem-pr-workflow`, `hsem-doc-sync`, and
  `CLAUDE.md`'s pre-commit checklist so this doesn't regress.
- Refactored the ~26 affected sensor classes (`working_mode_sensor.py`,
  `battery_soc_sensor.py`, `degraded_mode_sensor.py`,
  `force_mode_sensor.py`, `ev_charger_calculated_power_sensor.py`,
  `ev_charger_current_limit_sensor.py`, `ocpp_sensors.py` (4 classes),
  `financial_sensors.py` (3 classes), and others) to use
  `_attr_translation_key` + `_attr_has_entity_name` properly, matching the
  pattern already correct in `switch.py`/`number.py`/`select.py`/`time.py`.
- Added the ~15 `entity.sensor.*` keys these sensors were missing entirely
  (financial sensors, forecast/prediction accuracy, PV curtailment, solar
  confidence, savings tracker, second-EV OCPP sensors) to all four
  language files.
- Deleted ~35 now-dead `get_*_sensor_name()` helpers from
  `utils/sensornames/{diagnostics,ev,financial,ocpp}.py` and fixed the two
  tests that referenced them directly.
- Fixed one real text drift: `applier_status` displayed "Inverter Apply
  Status" but `en.json` said "Applier Status" — corrected the JSON to
  match current behavior, so nothing changes for English users.

**Intentionally out of scope**: `HSEMAvgSensor`
(`custom_sensors/avg_sensor.py`) and `HSEMHouseConsumptionPowerSensor`
(`custom_sensors/house_consumption_power_sensor.py`) are dynamically
parametrized per hour-block/day-window and need
`_attr_translation_placeholders` rather than a static
`_attr_translation_key` — flagged in the skill as a follow-up, not
attempted here.

## Test plan

- [x] `python3 scripts/validate_translations.py` — 0 missing/stale/placeholder-mismatch
      across `da`/`de`/`es.json`
- [x] `./scripts/quality.sh lint` — clean
- [x] `./scripts/quality.sh typing` — 0 mypy errors
- [x] `./scripts/quality.sh quality` — pyright 0 errors, vulture clean at min-confidence 80
- [x] `./scripts/quality.sh test` — 3067 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
