### PR TITLE
fix(planner): derive wait-mode reserve from selected plan's SoC trajectory

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -1131,20 +1131,31 @@ instead of keeping the battery strictly idle.
 - When set to `"self_consumption_with_reserve"`, the applier
   (`custom_components/hsem/custom_sensors/applier.py`) switches the inverter to
   `MaximizeSelfConsumption` and caps the discharge power so only surplus energy
-  above the planner's required reserve (`current_required_battery_kwh`) can be
-  used. Once the battery reaches the reserve, the applier falls back to strict
-  TOU wait mode.
+  above the reserve can be used. Once the battery reaches the reserve, the
+  applier falls back to strict TOU wait mode.
 - PV surplus during wait-mode self-consumption is directed to charge the battery
   (`desired_excess = "charge"`), not exported to grid.
 - The cap is computed from the surplus energy and the slot duration so the
   reserve is preserved even if the house load is high.
 - EV-active slots keep their existing EV discharge cap logic; the wait-mode cap
   is not applied while an EV is charging.
+- **Reserve source (issue #914):** the wait-mode reserve is `wait_mode_reserve_kwh`
+  (`PlannerOutput`/`CoordinatorData.current_wait_mode_reserve`), computed by
+  `calculate_required_battery_for_plan()` in `discharge_scheduler.py` from the
+  _selected_ plan's own simulated SoC trajectory — how far it dips before its
+  next actual solved charge — **not** `current_required_battery_kwh` (which
+  is `calculate_required_battery_until_solar()`, unchanged, and still used
+  for `apply_excess_export()` and the EV discharge-cap SoC guard). `None`
+  means no reliable reserve could be derived; the applier then forces strict
+  TOU wait instead of enabling self-consumption. See `docs/planner-spec.md`
+  §"Wait-mode self-consumption reserve (issue #914)".
 
 Files involved: `flows/batteries_wait_mode.py`, `config_flow.py`,
 `options_flow.py`, `translations/en.json`, `const.py`,
 `models/sensor_config.py`, `custom_sensors/config_reader.py`,
-`custom_sensors/applier.py`.
+`custom_sensors/applier.py`, `planner/discharge_scheduler.py`,
+`planner/engine_core.py`, `models/planner_output.py`,
+`coordinator_planner_phase.py`, `coordinator_data.py`.
 
 ## GitHub Operations — `gh` CLI Is Available (Corrected 2026-08-30)
 

--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -188,6 +188,7 @@ class HSEMDataUpdateCoordinator(
         self._batteries_schedules: list = []
         self._batteries_schedules_remaining_capacity_needed: float = 0.0
         self._current_required_battery: float = 0.0
+        self._current_wait_mode_reserve: float | None = None
         self._next_update: str | None = None
 
         # Entity resolution cache (persisted across cycles).

--- a/custom_components/hsem/coordinator_cycle.py
+++ b/custom_components/hsem/coordinator_cycle.py
@@ -416,6 +416,7 @@ class CoordinatorCycleMixin(CoordinatorSharedState):
             "_window_hys_previous_rec",
             "_window_hys_previous_slot_start",
             "_current_required_battery",
+            "_current_wait_mode_reserve",
             "_plan_explanation",
             "_data_quality",
             "_ev_charging_plan",
@@ -583,6 +584,7 @@ class CoordinatorCycleMixin(CoordinatorSharedState):
                 self._batteries_schedules_remaining_capacity_needed
             ),
             current_required_battery=self._current_required_battery,
+            current_wait_mode_reserve=self._current_wait_mode_reserve,
             state=state,
             last_updated=last_updated,
             next_update=self._next_update,

--- a/custom_components/hsem/coordinator_data.py
+++ b/custom_components/hsem/coordinator_data.py
@@ -37,7 +37,14 @@ class CoordinatorData:
         batteries_schedules: Parsed battery charge/discharge schedule windows.
         batteries_schedules_remaining_capacity_needed: Total remaining capacity
             needed across all enabled battery schedules (kWh).
-        current_required_battery: Required battery capacity from the planner (kWh).
+        current_required_battery: Required battery capacity from the planner (kWh),
+            derived from ``calculate_required_battery_until_solar``. Used for
+            excess-export scheduling and the EV discharge-cap SoC guard.
+        current_wait_mode_reserve: Wait-mode self-consumption reserve (kWh),
+            derived from the selected plan's own SoC trajectory
+            (``calculate_required_battery_for_plan``, issue #914). ``None``
+            when no reliable reserve could be derived — the applier falls
+            back to strict Wait behaviour in that case.
         state: Working-mode recommendation string for the current slot, or one
             of the :class:`~utils.recommendations.Recommendations` sentinel values.
         last_updated: ISO-format timestamp of the cycle that produced this data.
@@ -51,6 +58,7 @@ class CoordinatorData:
     batteries_schedules: list = field(default_factory=list)
     batteries_schedules_remaining_capacity_needed: float = 0.0
     current_required_battery: float = 0.0
+    current_wait_mode_reserve: float | None = None
     state: str | None = None
     last_updated: str | None = None
     next_update: str | None = None

--- a/custom_components/hsem/coordinator_planner_phase.py
+++ b/custom_components/hsem/coordinator_planner_phase.py
@@ -194,6 +194,7 @@ class CoordinatorPlannerPhaseMixin(CoordinatorSharedState):
                 async_log("debug", "[planner] %s", warning)
 
             self._current_required_battery = planner_output.required_capacity_kwh
+            self._current_wait_mode_reserve = planner_output.wait_mode_reserve_kwh
             self._data_quality = replace(
                 planner_output.data_quality,
                 load_forecast_ready=True,
@@ -223,6 +224,7 @@ class CoordinatorPlannerPhaseMixin(CoordinatorSharedState):
 
             planner_output = deepcopy(self._last_planner_output)
             self._current_required_battery = planner_output.required_capacity_kwh
+            self._current_wait_mode_reserve = planner_output.wait_mode_reserve_kwh
             self._data_quality = replace(
                 planner_output.data_quality,
                 load_forecast_ready=True,

--- a/custom_components/hsem/coordinator_state.py
+++ b/custom_components/hsem/coordinator_state.py
@@ -76,6 +76,7 @@ class CoordinatorSharedState(_Base):
     _config_entry: ConfigEntry
     _current_load_forecast_signature: LoadForecastSignature | None
     _current_required_battery: float
+    _current_wait_mode_reserve: float | None
     _daily_plan_last_accumulated: datetime | None
     _daily_tracker: DailyPlanVsActualTracker
     _data_quality: DataQuality

--- a/custom_components/hsem/custom_sensors/applier.py
+++ b/custom_components/hsem/custom_sensors/applier.py
@@ -100,6 +100,7 @@ async def async_apply_battery_settings(
     rec: HourlyRecommendation,
     current_required_battery_kwh: float,
     *,
+    wait_mode_reserve_kwh: float | None = None,
     primary_grid_charge_transition_reference_w: float | None = None,
     primary_grid_charge_transition_timed_out: bool = False,
 ) -> CycleApplySummary:
@@ -119,8 +120,16 @@ async def async_apply_battery_settings(
         cfg: Current sensor configuration.
         live: Live state snapshot.
         rec: The current-interval recommendation.
-        current_required_battery_kwh: Remaining energy required until end of day
-            (used when computing forcible-discharge target SoC).
+        current_required_battery_kwh: Energy required until the first forecast
+            solar-surplus slot (``calculate_required_battery_until_solar``).
+            Used for the EV discharge-cap SoC guard and forcible-discharge
+            gating — NOT for wait-mode self-consumption, which uses
+            ``wait_mode_reserve_kwh`` instead (issue #914).
+        wait_mode_reserve_kwh: Reserve derived from the selected plan's own
+            SoC trajectory (``calculate_required_battery_for_plan``). Gates
+            whether the battery may discharge during a ``batteries_wait_mode``
+            slot under ``self_consumption_with_reserve``. ``None`` means no
+            reliable reserve could be derived — falls back to strict Wait.
         primary_grid_charge_transition_reference_w: Passed through to
             :func:`~custom_sensors.phase_charge_limiter.build_phase_aware_charge_commands`
             (issue #831). See that function's docstring.
@@ -391,10 +400,11 @@ async def async_apply_battery_settings(
                     working_mode = WorkingModes.TimeOfUse.value
                 else:
                     working_mode = WorkingModes.MaximizeSelfConsumption.value
-            elif cfg.batteries_wait_mode_behavior == "self_consumption_with_reserve":
-                surplus = (
-                    live.battery_current_capacity_kwh - current_required_battery_kwh
-                )
+            elif (
+                cfg.batteries_wait_mode_behavior == "self_consumption_with_reserve"
+                and wait_mode_reserve_kwh is not None
+            ):
+                surplus = live.battery_current_capacity_kwh - wait_mode_reserve_kwh
                 if surplus > 1e-9:
                     working_mode = WorkingModes.MaximizeSelfConsumption.value
                 else:
@@ -471,15 +481,14 @@ async def async_apply_battery_settings(
         and cfg.batteries_wait_mode_behavior == "self_consumption_with_reserve"
         and working_mode == WorkingModes.MaximizeSelfConsumption.value
         and not relevant_evs
+        and wait_mode_reserve_kwh is not None
     )
-    if wait_mode_self_consumption:
+    if wait_mode_self_consumption and wait_mode_reserve_kwh is not None:
         slot_hours = slot_duration_hours(rec.start, rec.end)
-        surplus = max(
-            live.battery_current_capacity_kwh - current_required_battery_kwh, 0.0
-        )
+        surplus = max(live.battery_current_capacity_kwh - wait_mode_reserve_kwh, 0.0)
         cap_w = _wait_mode_self_consumption_cap_w(
             battery_capacity_kwh=live.battery_current_capacity_kwh,
-            required_capacity_kwh=current_required_battery_kwh,
+            required_capacity_kwh=wait_mode_reserve_kwh,
             slot_hours=slot_hours,
             max_discharge_power_w=max_discharge_power,
         )
@@ -506,7 +515,7 @@ async def async_apply_battery_settings(
                 "slot_hours=%.3f)",
                 cap_w,
                 live.battery_current_capacity_kwh,
-                current_required_battery_kwh,
+                wait_mode_reserve_kwh,
                 surplus,
                 slot_hours,
             )

--- a/custom_components/hsem/custom_sensors/working_mode_sensor.py
+++ b/custom_components/hsem/custom_sensors/working_mode_sensor.py
@@ -567,6 +567,7 @@ class HSEMWorkingModeSensor(
                     live,
                     hourly_rec,
                     data.current_required_battery,
+                    wait_mode_reserve_kwh=data.current_wait_mode_reserve,
                     primary_grid_charge_transition_reference_w=transition_reference_w,
                     primary_grid_charge_transition_timed_out=transition_timed_out,
                 )

--- a/custom_components/hsem/models/planner_output.py
+++ b/custom_components/hsem/models/planner_output.py
@@ -35,6 +35,21 @@ class PlannerOutput:
             slot is found.
         battery_soc_at_end:
             Estimated battery SoC (%) at the end of the planning horizon.
+        required_capacity_kwh:
+            Energy required until the first forecast solar-surplus slot
+            (``calculate_required_battery_until_solar``).  Used by the
+            excess-export scheduling pass and the applier's EV discharge-cap
+            SoC guard.  Not used to gate wait-mode self-consumption — see
+            ``wait_mode_reserve_kwh``.
+        wait_mode_reserve_kwh:
+            Reserve derived from the *selected* plan's own simulated SoC
+            trajectory (``calculate_required_battery_for_plan``): how far the
+            plan's battery capacity dips below its current level before the
+            plan's next slot with an actual solved charge.  Gates whether the
+            battery may discharge during a ``batteries_wait_mode`` slot under
+            ``self_consumption_with_reserve`` (issue #914).  ``None`` when no
+            reliable reserve could be derived — callers must fall back to
+            strict Wait behaviour in that case.
         missing_inputs:
             Names / identifiers of any inputs that were absent or invalid
             during planning.  An empty list means all inputs were present.
@@ -64,6 +79,7 @@ class PlannerOutput:
     current_recommendation: str | None = None
     battery_soc_at_end: float = 0.0
     required_capacity_kwh: float = 0.0
+    wait_mode_reserve_kwh: float | None = None
     missing_inputs: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
     time_series_index: TimeSeriesIndex | None = field(default=None, repr=False)

--- a/custom_components/hsem/planner/discharge_scheduler.py
+++ b/custom_components/hsem/planner/discharge_scheduler.py
@@ -203,6 +203,63 @@ def calculate_required_battery_until_solar(
     return result
 
 
+def calculate_required_battery_for_plan(
+    slots: list[PlannedSlot],
+    now: datetime,
+    current_capacity: float,
+) -> float | None:
+    """Derive the wait-mode reserve from the selected plan's SoC trajectory.
+
+    Unlike :func:`calculate_required_battery_until_solar`, which stops at the
+    first slot with *any* forecast PV surplus regardless of size, this reads
+    the already-simulated SoC trajectory of the *selected* plan
+    (``slot.estimated_battery_capacity_kwh``, populated by
+    :func:`~custom_components.hsem.planner.soc_simulation.simulate_soc` for
+    the winning candidate) and returns how far that trajectory dips below
+    ``current_capacity`` before the plan's next slot with an actual, solved
+    battery charge (grid or solar) — not just a forecast surplus. A small or
+    short-lived forecast surplus that the plan does not actually charge from
+    does not end the scan early, so the reserve still protects a later
+    planned discharge.
+
+    Slots are sorted by start time before scanning, so calling code does not
+    need to guarantee chronological order.
+
+    Args:
+        slots: The selected plan's slots (already SoC-simulated).
+        now: Timezone-aware current datetime.
+        current_capacity: Currently available battery energy in kWh.
+
+    Returns:
+        Required reserve in kWh, or ``None`` when no future slots exist and
+        the reserve cannot be derived — callers should fall back to strict
+        Wait behaviour in that case.
+    """
+    future_slots = sorted(
+        (s for s in slots if as_tz(s.end, now.tzinfo) > now),
+        key=lambda s: s.start,
+    )
+    if not future_slots:
+        return None
+
+    min_capacity = current_capacity
+    for slot in future_slots:
+        min_capacity = min(min_capacity, slot.estimated_battery_capacity_kwh)
+        if slot.batteries_charged_kwh > 1e-9:
+            break
+
+    result = round(max(current_capacity - min_capacity, 0.0), 3)
+    log_planner(
+        "debug",
+        "[disch] calculate_required_battery_for_plan  current=%.3f  "
+        "min_planned=%.3f  result=%.3f",
+        current_capacity,
+        min_capacity,
+        result,
+    )
+    return result
+
+
 def apply_excess_export(
     slots: list[PlannedSlot],
     now: datetime,

--- a/custom_components/hsem/planner/engine_core.py
+++ b/custom_components/hsem/planner/engine_core.py
@@ -36,6 +36,7 @@ from custom_components.hsem.planner.discharge_scheduler import (
     apply_discharge_schedules,
     apply_excess_export,
     apply_optimization_strategy,
+    calculate_required_battery_for_plan,
     calculate_required_battery_until_solar,
 )
 from custom_components.hsem.planner.engine_ev import (
@@ -660,6 +661,11 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
     # drift and to ensure the final score matches the selector's score.
     slots = winner.slots
 
+    # Wait-mode self-consumption reserve (issue #914): derived from the
+    # *selected* plan's own simulated SoC trajectory, not the raw forecast
+    # scan used by ``rc``/``calculate_required_battery_until_solar`` above.
+    wait_mode_reserve_kwh = calculate_required_battery_for_plan(slots, now, current_kwh)
+
     _label_commanded_ev_slots(slots)
     cur_rec: str | None = None
     for s in slots:
@@ -688,14 +694,15 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
     log_planner(
         "debug",
         "[core] run_planner DONE  winner=%s  cost=%.4f  score=%.4f  "
-        "cur_rec=%s  bsoc_end=%.1f%%  rc=%.3f  warnings=%d  missing=%d  "
-        "cw=%d  dw=%d",
+        "cur_rec=%s  bsoc_end=%.1f%%  rc=%.3f  wait_reserve=%s  warnings=%d  "
+        "missing=%d  cw=%d  dw=%d",
         winner.name,
         pc.total_cost,
         pc.score,
         cur_rec if cur_rec is not None else "(none)",
         bsoc_end,
         rc,
+        f"{wait_mode_reserve_kwh:.3f}" if wait_mode_reserve_kwh is not None else "None",
         len(warnings),
         len(missing_inputs),
         len(cw_out),
@@ -753,6 +760,7 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
         current_recommendation=cur_rec,
         battery_soc_at_end=bsoc_end,
         required_capacity_kwh=rc,
+        wait_mode_reserve_kwh=wait_mode_reserve_kwh,
         missing_inputs=missing_inputs,
         warnings=warnings,
         time_series_index=tsi,

--- a/docs/planner-guide.md
+++ b/docs/planner-guide.md
@@ -489,8 +489,13 @@ recommendation it is not changed by later rules in the same layer.
 > battery idle. When `hsem_batteries_wait_mode_behavior` is set to
 > `self_consumption_with_reserve`, the applier switches the inverter to
 > `MaximizeSelfConsumption` and caps discharge power so only surplus energy above
-> the planner's required reserve is used. This reduces unnecessary grid import
-> while still preserving capacity for future scheduled discharge windows.
+> the reserve is used. This reduces unnecessary grid import while still preserving
+> capacity for future scheduled discharge windows. The reserve is derived from the
+> **selected plan's own simulated SoC trajectory** (issue #914) — how far it dips
+> before its next actual solved charge — not from a raw forecast PV-surplus scan,
+> so a small or short-lived forecast surplus no longer lets the battery discharge
+> energy the plan needs for a later expensive period. If no reliable reserve can
+> be derived, the applier falls back to strict Wait for that slot.
 
 **Discharge concentration** (`concentrate_discharge_on_expensive_slots`) runs after the
 seasonal fill but before candidate generation. It re-evaluates all discharge-mode

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -2041,6 +2041,48 @@ TOU; self-consumption-with-reserve still applies when unheld) and
 `ev_smart_charging` (which otherwise always executes as MSC to retain
 unexpected solar).
 
+### Wait-mode self-consumption reserve (issue #914)
+
+The **EV discharge-cap SoC guard** above and `apply_excess_export()` both use
+`current_required_battery_kwh`, derived from
+`calculate_required_battery_until_solar()` (`planner/discharge_scheduler.py`):
+it scans forward from `now` and accumulates positive net consumption **until
+the first slot with any forecast PV surplus** (`estimated_net_consumption_kwh
+< 0`), regardless of how small or short-lived that surplus is, or whether the
+selected plan can actually rely on it.
+
+The `batteries_wait_mode` self-consumption gate (the two usages described
+under "Wait Mode Self-Consumption with Reserve" — the MSC-vs-TOU decision and
+the discharge-cap computation) uses a **separate** reserve,
+`wait_mode_reserve_kwh`, computed by `calculate_required_battery_for_plan()`
+from the **selected** plan's own already-simulated SoC trajectory instead:
+
+```text
+for each future slot (chronological order, end > now):
+    min_capacity = min(min_capacity, slot.estimated_battery_capacity_kwh)
+    if slot.batteries_charged_kwh > 0:  # a genuine solved charge, not a
+        break                           # forecast surplus signal
+reserve = max(current_capacity - min_capacity, 0)
+```
+
+This protects the battery down to the deepest point the **winning
+candidate's** SoC simulation actually dips to before its own next solved
+charge (grid or solar) — a small forecast surplus slot that the plan does not
+actually charge from no longer truncates the reserve early. When the plan
+has no future charge anywhere in the horizon, the scan runs to the horizon
+end and the reserve naturally covers (up to) the full current capacity,
+which forces strict Wait behaviour via the normal `surplus <= 0` path — no
+special-cased fallback is needed for that case.
+
+`wait_mode_reserve_kwh` is `None` when it cannot be derived (no future slots
+in the horizon). The applier treats `None` as "fall back to strict Wait":
+`self_consumption_with_reserve` self-consumption is never enabled without a
+reliable reserve value.
+
+`calculate_required_battery_until_solar()` and `current_required_battery_kwh`
+are otherwise **unchanged** — they continue to gate the EV discharge-cap SoC
+guard and `apply_excess_export()` exactly as before.
+
 ### Live phase-aware grid-charge safety limiter (issue #831)
 
 `custom_sensors/phase_charge_limiter.py::build_phase_aware_charge_commands()`

--- a/tests/planner/test_wait_mode_reserve_from_plan.py
+++ b/tests/planner/test_wait_mode_reserve_from_plan.py
@@ -1,0 +1,174 @@
+"""Tests for the wait-mode self-consumption reserve (issue #914).
+
+``calculate_required_battery_for_plan()`` derives the reserve used to gate
+``batteries_wait_mode`` self-consumption from the *selected* plan's own
+simulated SoC trajectory (``slot.estimated_battery_capacity_kwh`` /
+``slot.batteries_charged_kwh``), instead of scanning raw forecast net
+consumption until the first slot with *any* PV surplus
+(``calculate_required_battery_until_solar``, unaffected by this change and
+covered by a regression test below).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from custom_components.hsem.models.planned_slot import PlannedSlot
+from custom_components.hsem.planner.discharge_scheduler import (
+    calculate_required_battery_for_plan,
+    calculate_required_battery_until_solar,
+)
+from custom_components.hsem.utils.prices import SlotPrice
+
+_NOW = datetime(2024, 6, 15, 12, 0, tzinfo=UTC)
+
+
+def _slot(
+    offset_hours: float,
+    *,
+    estimated_net_consumption_kwh: float = 0.0,
+    estimated_battery_capacity_kwh: float = 0.0,
+    batteries_charged_kwh: float = 0.0,
+    batteries_discharged_kwh: float = 0.0,
+) -> PlannedSlot:
+    """Build a minimal already-simulated PlannedSlot anchored at NOW + offset."""
+    start = _NOW + timedelta(hours=offset_hours)
+    return PlannedSlot(
+        start=start,
+        end=start + timedelta(hours=1),
+        price=SlotPrice(import_price=0.20, export_price=0.05),
+        solcast_pv_estimate_kwh=0.0,
+        avg_house_consumption_kwh=0.5,
+        estimated_net_consumption_kwh=estimated_net_consumption_kwh,
+        estimated_battery_capacity_kwh=estimated_battery_capacity_kwh,
+        batteries_charged_kwh=batteries_charged_kwh,
+        batteries_discharged_kwh=batteries_discharged_kwh,
+    )
+
+
+class TestSmallForecastSurplusDoesNotEndReserveEarly:
+    """A short/small forecast PV-surplus slot must not truncate the reserve.
+
+    Regression scenario from issue #914: at ~0.5 kWh reserve remaining
+    (as ``calculate_required_battery_until_solar`` would compute, stopping
+    at the first forecast-surplus slot), the plan itself does not actually
+    charge from that small surplus (``batteries_charged_kwh == 0``) and
+    still expects a much larger discharge later during an expensive period.
+    The new reserve must protect the full later dip.
+    """
+
+    def test_reserve_protects_later_discharge_past_small_surplus(self) -> None:
+        slots = [
+            # Small forecast PV surplus (negative net consumption) that the
+            # plan does NOT actually charge from — old function would have
+            # stopped scanning here.
+            _slot(
+                1,
+                estimated_net_consumption_kwh=-0.2,
+                estimated_battery_capacity_kwh=1.8,
+                batteries_charged_kwh=0.0,
+            ),
+            # Later, deeper planned discharge during an expensive period.
+            _slot(
+                3,
+                estimated_net_consumption_kwh=1.5,
+                estimated_battery_capacity_kwh=0.3,
+                batteries_discharged_kwh=1.5,
+            ),
+        ]
+
+        reserve = calculate_required_battery_for_plan(slots, _NOW, current_capacity=2.0)
+        assert reserve is not None
+
+        # Old function would only have reserved down to the first surplus
+        # slot (~0.2 kWh dip); the new one must protect the deeper 1.7 kWh
+        # dip the plan actually relies on before any real recharge.
+        assert reserve == 1.7
+
+        old_reserve = calculate_required_battery_until_solar(
+            slots, _NOW, usable_capacity=2.0, discharge_buffer_pct=0.0
+        )
+        assert reserve > old_reserve
+
+
+class TestReliableRechargeStopsTheScan:
+    """A genuine planned charge (grid/solar) ends the reserve requirement."""
+
+    def test_reserve_stops_at_first_actual_planned_charge(self) -> None:
+        slots = [
+            # Small dip before the plan actually recharges.
+            _slot(
+                1,
+                estimated_battery_capacity_kwh=1.5,
+            ),
+            # Genuine planned recharge — the plan relies on this, not on
+            # today's stored energy, to cover anything past this point.
+            _slot(
+                2,
+                estimated_battery_capacity_kwh=3.0,
+                batteries_charged_kwh=1.5,
+            ),
+            # Deep dip AFTER the recharge — must not inflate the reserve
+            # computed for "now", since it will be served by the recharge.
+            _slot(
+                5,
+                estimated_battery_capacity_kwh=0.1,
+                batteries_discharged_kwh=2.9,
+            ),
+        ]
+
+        reserve = calculate_required_battery_for_plan(slots, _NOW, current_capacity=2.0)
+
+        assert reserve == 0.5
+
+
+class TestNoFutureRechargeInHorizon:
+    """No planned charge anywhere in the horizon forces (near) full reserve."""
+
+    def test_reserve_covers_entire_horizon_when_no_recharge_planned(self) -> None:
+        slots = [
+            _slot(1, estimated_battery_capacity_kwh=1.0),
+            _slot(2, estimated_battery_capacity_kwh=0.4),
+            _slot(3, estimated_battery_capacity_kwh=0.0),
+        ]
+
+        reserve = calculate_required_battery_for_plan(slots, _NOW, current_capacity=2.0)
+
+        # The whole current capacity must be protected — this naturally
+        # forces strict Wait behaviour downstream (surplus <= 0), without
+        # needing a special-cased fallback for this scenario.
+        assert reserve == 2.0
+
+    def test_none_returned_when_no_future_slots_exist(self) -> None:
+        """No future slots at all -> undefined reserve -> fall back to strict Wait."""
+        # offset=-2 -> start = now-2h, end = now-1h, i.e. entirely in the past.
+        past_slot = _slot(-2, estimated_battery_capacity_kwh=1.0)
+
+        reserve = calculate_required_battery_for_plan(
+            [past_slot], _NOW, current_capacity=2.0
+        )
+
+        assert reserve is None
+
+
+class TestApplyExcessExportRegressionUnaffected:
+    """calculate_required_battery_until_solar() behaviour must be unchanged."""
+
+    def test_until_solar_still_stops_at_first_surplus_slot(self) -> None:
+        """The original until-solar scan still stops at the first surplus slot,
+        regardless of what the plan actually schedules there — this is the
+        exact (unchanged) behaviour ``apply_excess_export`` continues to rely
+        on."""
+        slots = [
+            _slot(1, estimated_net_consumption_kwh=0.6),
+            _slot(2, estimated_net_consumption_kwh=-0.1),
+            _slot(3, estimated_net_consumption_kwh=1.5),
+        ]
+
+        result = calculate_required_battery_until_solar(
+            slots, _NOW, usable_capacity=5.0, discharge_buffer_pct=0.0
+        )
+
+        # Only the first (pre-surplus) slot's positive net consumption is
+        # accumulated; the later 1.5 kWh slot past the surplus is ignored.
+        assert result == 0.6

--- a/tests/test_batteries_wait_mode.py
+++ b/tests/test_batteries_wait_mode.py
@@ -4,17 +4,39 @@ Covers:
 - Default constant value for wait-mode behaviour in ``const.py``
 - Input validation in ``flows/batteries_wait_mode.py``
 - Discharge cap helper in ``custom_sensors/applier.py``
+- The ``wait_mode_reserve_kwh`` fallback-to-strict-Wait and
+  reserve-gated self-consumption integration in ``async_apply_battery_settings``
+  (issue #914)
 """
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from custom_components.hsem.const import DEFAULT_CONFIG_VALUES
+from custom_components.hsem.const import (
+    DEFAULT_CONFIG_VALUES,
+    DEFAULT_HSEM_BATTERIES_WAIT_MODE,
+)
 from custom_components.hsem.custom_sensors.applier import (
     _wait_mode_self_consumption_cap_w,
+    async_apply_battery_settings,
 )
 from custom_components.hsem.flows.batteries_wait_mode import (
     validate_batteries_wait_mode_input,
 )
+from custom_components.hsem.models.hourly_recommendation import HourlyRecommendation
+from custom_components.hsem.models.live_state import LiveState
+from custom_components.hsem.models.sensor_config import SensorConfig
+from custom_components.hsem.utils.degraded_mode import DegradedMode
+from custom_components.hsem.utils.inverter_verify import ApplyResult, ApplyStatus
+from custom_components.hsem.utils.recommendations import Recommendations
+from custom_components.hsem.utils.workingmodes import WorkingModes
+
+_LOGGER_PATCH = "custom_components.hsem.utils.logger.HSEM_LOGGER.debug"
+_NOW = datetime(2026, 8, 27, 12, 0, tzinfo=UTC)
 
 # ---------------------------------------------------------------------------
 # Default constant value tests
@@ -127,3 +149,183 @@ class TestValidateBatteriesWaitModeInput:
     async def test_missing_field_is_rejected(self):
         errors = await validate_batteries_wait_mode_input({})
         assert "hsem_batteries_wait_mode_behavior" in errors
+
+
+# ---------------------------------------------------------------------------
+# async_apply_battery_settings — wait_mode_reserve_kwh integration (issue #914)
+# ---------------------------------------------------------------------------
+
+
+def _sensor() -> MagicMock:
+    sensor = MagicMock()
+    sensor.hass = MagicMock()
+    return sensor
+
+
+def _cfg() -> SensorConfig:
+    cfg = SensorConfig()
+    cfg.read_only = False
+    cfg.batteries_wait_mode_behavior = "self_consumption_with_reserve"
+    cfg.huawei_solar_batteries_working_mode = "select.wm"
+    cfg.huawei_solar_batteries_maximum_discharging_power = "number.maxdis"
+    cfg.huawei_solar_batteries_excess_pv_energy_use_in_tou = "select.excess"
+    cfg.huawei_solar_batteries_tou_charging_and_discharging_periods = "sensor.tou"
+    cfg.huawei_solar_device_id_batteries = "bat1"
+    return cfg
+
+
+def _live(*, working_mode: str) -> LiveState:
+    live = LiveState()
+    live._degraded_mode = DegradedMode.OK
+    live.battery_current_capacity_kwh = 2.0
+    live.huawei_batteries_rated_capacity_wh = 5000
+    # Matches get_max_discharge_power(5000) so the unconditional first write
+    # (independent of wait-mode) is a no-op and doesn't interfere.
+    live.huawei_batteries_max_discharge_power_w = 2500
+    live.huawei_batteries_working_mode = working_mode
+    live.huawei_batteries_excess_pv_use_in_tou = "charge"
+    live.tou_periods.periods = list(DEFAULT_HSEM_BATTERIES_WAIT_MODE)
+    return live
+
+
+def _wait_rec() -> HourlyRecommendation:
+    """A non-held BatteriesWaitMode slot (material planned discharge)."""
+    return HourlyRecommendation(
+        start=_NOW,
+        end=_NOW + timedelta(hours=1),
+        recommendation=Recommendations.BatteriesWaitMode.value,
+        avg_house_consumption_kwh=0.5,
+        avg_house_consumption_1d_kwh=0.0,
+        avg_house_consumption_3d_kwh=0.0,
+        avg_house_consumption_7d_kwh=0.0,
+        avg_house_consumption_14d_kwh=0.0,
+        batteries_charged_kwh=0.0,
+        # Material (non-near-zero) so _primary_battery_hold() is False and
+        # the self_consumption_with_reserve branch is actually reached.
+        batteries_discharged_kwh=0.05,
+        estimated_battery_capacity_kwh=1.0,
+        estimated_battery_soc_pct=50.0,
+        estimated_cost_currency=0.0,
+        estimated_net_consumption_kwh=0.5,
+        export_price=0.05,
+        grid_export_kwh=0.0,
+        grid_import_kwh=0.0,
+        import_price=0.20,
+        solcast_pv_estimate_kwh=0.0,
+    )
+
+
+async def _write_and_verify_ok(entity_id, desired, writer, reader, **kwargs):  # type: ignore[no-untyped-def]  # local test shim mirrors async_write_and_verify signature
+    await writer()
+    return ApplyResult(
+        entity_id=entity_id,
+        desired=desired,
+        actual=desired,
+        status=ApplyStatus.OK,
+        attempts=1,
+    )
+
+
+class TestWaitModeReserveNoneFallsBackToStrictWait:
+    """``wait_mode_reserve_kwh=None`` must force strict TOU wait (issue #914).
+
+    Even with ``self_consumption_with_reserve`` configured, a reserve that
+    could not be reliably derived must never be treated as "no reserve
+    needed" (which would let the battery discharge freely) — the applier
+    must fall back to the same strict TOU wait behaviour as
+    ``batteries_wait_mode_behavior == "strict"``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_none_reserve_writes_strict_tou_wait(self):
+        sensor = _sensor()
+        cfg = _cfg()
+        live = _live(working_mode=WorkingModes.MaximizeSelfConsumption.value)
+        rec = _wait_rec()
+
+        with (
+            patch(_LOGGER_PATCH, new_callable=MagicMock),
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_write_and_verify",
+                side_effect=_write_and_verify_ok,
+            ),
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_set_select_option",
+                new_callable=AsyncMock,
+            ) as mock_select,
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_set_number_value",
+                new_callable=AsyncMock,
+            ) as mock_number,
+        ):
+            await async_apply_battery_settings(
+                sensor, cfg, live, rec, 5.0, wait_mode_reserve_kwh=None
+            )
+
+        mock_select.assert_any_await(sensor, "select.wm", WorkingModes.TimeOfUse.value)
+        # No wait-mode self-consumption discharge cap write — the max
+        # discharge power number entity is never touched (the unconditional
+        # first write is a no-op because live already matches).
+        mock_number.assert_not_awaited()
+
+
+class TestWaitModeReserveGatesSelfConsumption:
+    """A valid ``wait_mode_reserve_kwh`` gates MSC + the reserve-preserving cap."""
+
+    @pytest.mark.asyncio
+    async def test_surplus_above_reserve_enables_msc_with_capped_discharge(self):
+        sensor = _sensor()
+        cfg = _cfg()
+        live = _live(working_mode=WorkingModes.TimeOfUse.value)
+        rec = _wait_rec()
+
+        with (
+            patch(_LOGGER_PATCH, new_callable=MagicMock),
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_write_and_verify",
+                side_effect=_write_and_verify_ok,
+            ),
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_set_select_option",
+                new_callable=AsyncMock,
+            ) as mock_select,
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_set_number_value",
+                new_callable=AsyncMock,
+            ) as mock_number,
+        ):
+            await async_apply_battery_settings(
+                sensor, cfg, live, rec, 5.0, wait_mode_reserve_kwh=1.0
+            )
+
+        mock_select.assert_any_await(
+            sensor, "select.wm", WorkingModes.MaximizeSelfConsumption.value
+        )
+        # capacity=2.0, reserve=1.0 -> surplus=1.0 kWh over a 1h slot -> 1000 W.
+        mock_number.assert_any_await(sensor, "number.maxdis", 1000)
+
+    @pytest.mark.asyncio
+    async def test_capacity_at_reserve_falls_back_to_strict_wait(self):
+        """No surplus above the reserve -> strict TOU wait, same as ``strict`` mode."""
+        sensor = _sensor()
+        cfg = _cfg()
+        live = _live(working_mode=WorkingModes.MaximizeSelfConsumption.value)
+        live.battery_current_capacity_kwh = 1.0  # equals the reserve -> no surplus
+        rec = _wait_rec()
+
+        with (
+            patch(_LOGGER_PATCH, new_callable=MagicMock),
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_write_and_verify",
+                side_effect=_write_and_verify_ok,
+            ),
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_set_select_option",
+                new_callable=AsyncMock,
+            ) as mock_select,
+        ):
+            await async_apply_battery_settings(
+                sensor, cfg, live, rec, 5.0, wait_mode_reserve_kwh=1.0
+            )
+
+        mock_select.assert_any_await(sensor, "select.wm", WorkingModes.TimeOfUse.value)

--- a/tests/test_ha_mock_integration.py
+++ b/tests/test_ha_mock_integration.py
@@ -223,6 +223,7 @@ def make_bare_coordinator(
     coord._batteries_schedules = []
     coord._batteries_schedules_remaining_capacity_needed = 0.0
     coord._current_required_battery = 0.0
+    coord._current_wait_mode_reserve = None
     coord._live = None
     coord._snapshot = None
     coord._net_consumption_ema = None


### PR DESCRIPTION
## Summary

- `self_consumption_with_reserve` wait-mode discharge gating previously reused
  `calculate_required_battery_until_solar()`, which stops accumulating required
  energy at the **first** slot with any forecast PV surplus
  (`estimated_net_consumption_kwh < 0`), no matter how small or short-lived. A
  small/short forecast surplus could therefore make the wait-mode reserve far
  too low, letting the battery discharge energy the selected MILP plan needed
  for a later expensive period (regression on #742/#743, reported in
  #732#issuecomment-5527513303).
- Added `calculate_required_battery_for_plan()`
  (`planner/discharge_scheduler.py`), which derives the wait-mode reserve from
  the **selected plan's own already-simulated SoC trajectory**
  (`estimated_battery_capacity_kwh`), stopping only at the plan's next actual
  **solved** charge (`batteries_charged_kwh > 0`) instead of a raw forecast
  signal. Returns `None` when no reliable reserve can be derived (no future
  slots) — the applier then falls back to strict Wait.
- `calculate_required_battery_until_solar()` is **unchanged** and continues to
  gate `apply_excess_export()` and the EV discharge-cap SoC guard in
  `custom_sensors/applier.py`.

## Branch

`fix/914-wait-mode-reserve-plan-trajectory`

## Files changed

- `custom_components/hsem/planner/discharge_scheduler.py` — new
  `calculate_required_battery_for_plan()`
- `custom_components/hsem/planner/engine_core.py` — computes
  `wait_mode_reserve_kwh` from the winning candidate's slots after selection
- `custom_components/hsem/models/planner_output.py` — new
  `wait_mode_reserve_kwh: float | None` field
- `custom_components/hsem/coordinator.py`,
  `coordinator_state.py`, `coordinator_planner_phase.py`,
  `coordinator_cycle.py`, `coordinator_data.py` — plumb
  `wait_mode_reserve_kwh` through to `CoordinatorData.current_wait_mode_reserve`
- `custom_components/hsem/custom_sensors/working_mode_sensor.py` — passes the
  new value into the applier
- `custom_components/hsem/custom_sensors/applier.py` — new keyword-only
  `wait_mode_reserve_kwh` param on `async_apply_battery_settings()`; the two
  wait-mode-specific usages (MSC-vs-TOU decision, discharge-cap computation)
  now use it instead of `current_required_battery_kwh`, falling back to
  strict Wait when it's `None`. The EV discharge-cap SoC guard and
  `_async_apply_forcible_discharge()` are untouched.
- `docs/planner-spec.md`, `docs/planner-guide.md`, `.github/memories.md` —
  document the new reserve derivation and its `None` fallback
- Tests: `tests/planner/test_wait_mode_reserve_from_plan.py` (new),
  `tests/test_batteries_wait_mode.py` (extended),
  `tests/test_ha_mock_integration.py` (fixture update for the new coordinator
  attribute)

## Tests added/updated

- `tests/planner/test_wait_mode_reserve_from_plan.py`:
  - a short/small forecast PV-surplus slot that the plan does not actually
    charge from no longer truncates the reserve — a later planned discharge
    is still protected
  - a genuine planned charge stops the scan (reserve doesn't over-protect past
    a real recharge point)
  - no future charging opportunity in the horizon → reserve covers (up to)
    full current capacity, naturally forcing strict Wait
  - no future slots at all → `None` (fallback signal)
  - regression: `calculate_required_battery_until_solar()` behaviour is
    unchanged (still stops at the first forecast-surplus slot)
- `tests/test_batteries_wait_mode.py` (new integration tests against
  `async_apply_battery_settings`):
  - `wait_mode_reserve_kwh=None` → strict TOU wait is written, no
    self-consumption discharge-cap write happens
  - a valid reserve with surplus above it → MSC + correctly capped discharge
    power write
  - capacity at/below the reserve → strict TOU wait (same as before)

## Test and lint results

```
./scripts/quality.sh lint     → 0 issues
./scripts/quality.sh typing   → 0 errors
./scripts/quality.sh quality  → 0 errors (pyright + vulture)
./scripts/quality.sh test     → 3075 passed
```

## Known limitations / open questions

None. `calculate_required_battery_until_solar()` and its existing consumers
(`apply_excess_export()`, EV discharge-cap SoC guard) are intentionally
unchanged, per the issue's request to keep those semantics separate.

## Required configuration changes

None — no new config keys; `hsem_batteries_wait_mode_behavior` semantics are
unchanged from the user's perspective (only the internal reserve computation
changed).

Fixes #914
