### PR TITLE
ci: wire translation validation into the quality gate

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Validate JSON/JSONC
         run: python3 scripts/validate-json.py
 
+      - name: Validate translations
+        run: python3 scripts/validate_translations.py
+
       - name: Lint shell scripts
         uses: ludeeus/action-shellcheck@2.0.0
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,7 @@ If credentials, API keys, or tokens are required:
 - Run `./scripts/quality.sh lint` locally before committing.
 - Run `./scripts/quality.sh typing` after lint — mypy type checking.
 - Run `./scripts/quality.sh quality` after typing (pyright + vulture static checks).
+- Run `./scripts/quality.sh translations` if any user-facing string changed (en/da/de/es sync).
 - Run `./scripts/quality.sh test` to run the full test suite with coverage before opening a PR.
 - See `CODE_QUALITY_STANDARDS.md` for full quality rules and conventions.
 - **Never use `==` or `!=` to compare floating-point values.** In production code use an epsilon

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,8 +123,9 @@ HSEM ships English, Danish, German, and Spanish
 source of truth. Any new or changed user-facing string (entity name,
 config/options flow label, selector option, error, service) must be added to
 **all four** files in the same PR — activate the `hsem-translation-sync` skill
-and run `python3 scripts/validate_translations.py` before opening the PR; it
-must report 0 missing/stale/placeholder-mismatch keys.
+and run `./scripts/quality.sh translations` (or `python3 scripts/validate_translations.py`
+directly) before opening the PR; it must report 0 missing/stale/placeholder-mismatch
+keys. This check is also enforced by CI (`lint-and-test.yml`) and by `./scripts/quality.sh all`.
 
 ## Development Workflow
 
@@ -210,7 +211,7 @@ See `AGENTS.md` → **Home Assistant Compliance** section for detailed requireme
 ./scripts/quality.sh test
 
 # Step 5: Translations — if any user-facing string changed
-python3 scripts/validate_translations.py
+./scripts/quality.sh translations
 
 # Step 6: Verify no unintended changes
 git status

--- a/CODE_QUALITY_STANDARDS.md
+++ b/CODE_QUALITY_STANDARDS.md
@@ -188,14 +188,15 @@ If any step fails, fix the issues before committing.
 
 The following checks run on every PR:
 
-| Check         | Tool          | Command                       | Purpose                        |
-| ------------- | ------------- | ----------------------------- | ------------------------------ |
-| Formatting    | `ruff format` | `./scripts/quality.sh lint`   | Consistent Python code style   |
-| Doc format    | `prettier`    | `./scripts/quality.sh lint`   | Markdown / YAML / JSON style   |
-| Linting       | `ruff check`  | `./scripts/quality.sh lint`   | Bugs, style issues, complexity |
-| Type Checking | `mypy`        | `./scripts/quality.sh typing` | Type errors and unsafe code    |
-| Tests         | `pytest`      | `./scripts/quality.sh test`   | Verifies functionality         |
-| Coverage      | `coverage`    | `--cov` flag                  | Ensures new code is tested     |
+| Check         | Tool                       | Command                             | Purpose                        |
+| ------------- | -------------------------- | ----------------------------------- | ------------------------------ |
+| Formatting    | `ruff format`              | `./scripts/quality.sh lint`         | Consistent Python code style   |
+| Doc format    | `prettier`                 | `./scripts/quality.sh lint`         | Markdown / YAML / JSON style   |
+| Linting       | `ruff check`               | `./scripts/quality.sh lint`         | Bugs, style issues, complexity |
+| Type Checking | `mypy`                     | `./scripts/quality.sh typing`       | Type errors and unsafe code    |
+| Translations  | `validate_translations.py` | `./scripts/quality.sh translations` | en/da/de/es keys stay in sync  |
+| Tests         | `pytest`                   | `./scripts/quality.sh test`         | Verifies functionality         |
+| Coverage      | `coverage`                 | `--cov` flag                        | Ensures new code is tested     |
 
 **All checks must pass before merge.**
 

--- a/scripts/quality.sh
+++ b/scripts/quality.sh
@@ -67,9 +67,10 @@ Commands:
   typing    Type check with mypy
   quality   Static quality checks (pyright + vulture)
   format-check  Verify prettier formatting without writing (used by CI)
+  translations  Validate en/da/de/es translation files stay in sync
   skylos    Run Skylos static analysis (experimental, not in 'all')
   test      Run tests with pytest and coverage
-  all       Run lint, typing, quality, and test in sequence
+  all       Run lint, typing, quality, translations, and test in sequence
 EOF
     exit 1
 }
@@ -94,6 +95,9 @@ case "${1:-}" in
         ;;
     format-check)
         prettier_run --check
+        ;;
+    translations)
+        run python3 scripts/validate_translations.py
         ;;
     skylos)
         SKYLOS_GREP_BUDGET=120 run skylos custom_components -a
@@ -123,6 +127,9 @@ case "${1:-}" in
         echo "[info] excluded, --min-confidence 0). Informational only -- same-named"
         echo "[info] methods across classes still won't be flagged (issue #890)."
         run python -m vulture custom_components/hsem vulture_whitelist.py --min-confidence 0 || true
+        echo ""
+        echo "=== Translations ==="
+        run python3 scripts/validate_translations.py
         echo ""
         echo "=== Tests ==="
         run python -m pytest tests/ \


### PR DESCRIPTION
## Summary

- `scripts/validate_translations.py` (missing/stale/placeholder-mismatch keys across en/da/de/es) was never wired into automated checks — it only ran when a human or the `hsem-translation-sync` skill remembered to invoke it manually before opening a PR. A PR could merge with broken translations undetected.
- Add a `translations` subcommand to `scripts/quality.sh`, include it in the `all` sequence, and run it as a step in the CI `validate` job (`.github/workflows/lint-and-test.yml`), alongside the existing YAML/JSON validators.
- Verified current translation state is clean (0 missing/stale/placeholder-mismatch keys; only cognate warnings like `Auto`/`Name`/`Server` which are expected and non-blocking) before wiring this in as a hard gate, so it won't break on existing content.
- Updated `CLAUDE.md`, `AGENTS.md`, and `CODE_QUALITY_STANDARDS.md` to point at the new automated command instead of only the manual one.

## Test plan

- [x] `./scripts/quality.sh translations` — 0 errors
- [x] `./scripts/quality.sh lint` — passes
- [x] `./scripts/quality.sh typing` — passes
- [x] `./scripts/quality.sh quality` — passes (pyright + vulture)
- [x] `./scripts/quality.sh test` — 3082 passed
- [x] `bash -n scripts/quality.sh` — syntax check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
