### PR TITLE
fix(applier): cap Huawei discharge to 0 W during batteries_charge_solar

### DIFF
--- a/custom_components/hsem/custom_sensors/applier.py
+++ b/custom_components/hsem/custom_sensors/applier.py
@@ -207,7 +207,17 @@ async def async_apply_battery_settings(
         )
         if _ev_is_active_or_planned(ev=ev, planned_power_w=planned_power_w)
     )
-    if (primary_battery_hold or relevant_evs) and recommendation not in (
+    # A genuine batteries_charge_solar slot is solar-charge-only: the MILP
+    # expects the grid to cover any house-load deficit, not the battery.
+    # Huawei's own MaximizeSelfConsumption firmware behaviour follows live
+    # house load vs. live PV, so without an explicit 0 W cap it discharges
+    # the battery whenever live load exceeds live PV (issue #922).
+    # `_primary_battery_hold()` never returns True here since a real
+    # solar-charge slot has material `batteries_charged_kwh`.
+    solar_charge_only = recommendation == Recommendations.BatteriesChargeSolar.value
+    if (
+        primary_battery_hold or relevant_evs or solar_charge_only
+    ) and recommendation not in (
         Recommendations.ForceBatteriesDischarge.value,
         Recommendations.ForceExport.value,
     ):
@@ -220,7 +230,7 @@ async def async_apply_battery_settings(
                 # already ~0 and would drive the same result below anyway.
                 cap_w = 0
                 cap_reason = "planned battery hold"
-            else:
+            elif relevant_evs:
                 blocked = tuple(
                     name
                     for name, ev, _ in relevant_evs
@@ -273,6 +283,11 @@ async def async_apply_battery_settings(
                                 total_reservation_w,
                             )
                             cap_w = reserved_cap_w
+            else:
+                # solar_charge_only with no active/planned EV: the grid
+                # covers any house-load deficit this slot, never the battery.
+                cap_w = 0
+                cap_reason = "planned solar-charge-only slot"
 
             # SoC guard (issue #592, v6.2.0-beta1): never let the EV cap
             # drain the battery below the energy the planner has reserved

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -2011,6 +2011,19 @@ applier (`applier._planned_ev_discharge_cap_w()` +
 scheduled neither charge nor discharge for the primary battery this slot
 (`primary_battery_hold` — see below), the cap is unconditionally 0 W.
 
+**Solar-charge-only slot (issue #922)**: when the recommendation is
+`batteries_charge_solar` and no EV is active/planned, the cap is
+unconditionally 0 W, mirroring the primary-battery-hold cap. A genuine
+solar-charge slot has a material `batteries_charged_kwh`, so
+`primary_battery_hold` is always `False` for it and would otherwise leave
+the discharge cap at its normal value. Huawei's `MaximizeSelfConsumption`
+firmware follows **live** house load vs. **live** PV, not the MILP's solved
+per-slot flow — without this cap the inverter discharges the battery
+whenever live load exceeds live PV, even though the MILP planned this slot
+as solar-charge-only with the grid covering any deficit. An active/planned
+EV takes precedence: when `relevant_evs` is non-empty the normal EV
+permission/rate-cap logic above governs instead of the blanket 0 W.
+
 **SoC guard:** when the battery's remaining usable energy is at or below
 the planner's required reserve (`current_required_battery_kwh` — energy
 needed until the next solar surplus), the cap is forced to 0 W so the

--- a/tests/test_safety_gates.py
+++ b/tests/test_safety_gates.py
@@ -1065,6 +1065,116 @@ class TestEvDischargePermissionAndHeldExport:
 
 
 # ---------------------------------------------------------------------------
+# BatteriesChargeSolar discharge cap (issue #922)
+# ---------------------------------------------------------------------------
+
+
+class TestSolarChargeDischargeCap:
+    """batteries_charge_solar must cap Huawei discharge to 0 W (issue #922).
+
+    Without this cap, Huawei's MaximizeSelfConsumption firmware discharges
+    the battery whenever live house load exceeds live PV, even though the
+    MILP solved this slot as solar-charge-only with the grid covering any
+    deficit.
+    """
+
+    @staticmethod
+    def _cfg_and_live() -> tuple[SensorConfig, LiveState]:
+        cfg = _make_cfg(read_only=False)
+        cfg.huawei_solar_batteries_maximum_discharging_power = "number.max_discharge"
+        cfg.huawei_solar_batteries_excess_pv_energy_use_in_tou = "select.excess_pv"
+        cfg.huawei_solar_batteries_tou_charging_and_discharging_periods = (
+            "sensor.tou_periods"
+        )
+        cfg.huawei_solar_device_id_batteries = "bat1"
+        live = _make_live(degraded_mode=DegradedMode.OK)
+        live.huawei_batteries_max_discharge_power_w = 5000
+        live.huawei_batteries_excess_pv_use_in_tou = "charge"
+        return cfg, live
+
+    @staticmethod
+    async def _run(cfg, live, rec):
+        written: dict[str, object] = {}
+
+        async def _record_desired(entity_id, desired, writer, reader, **kwargs):  # type: ignore[no-untyped-def]
+            written[entity_id] = desired
+            return ApplyResult(
+                entity_id=entity_id,
+                desired=desired,
+                actual=desired,
+                status=ApplyStatus.OK,
+                attempts=1,
+            )
+
+        with (
+            patch(_LOGGER_PATCH, new_callable=MagicMock),
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_write_and_verify",
+                side_effect=_record_desired,
+            ),
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_set_tou_periods",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await async_apply_battery_settings(_make_sensor(), cfg, live, rec, 0.0)
+        return written
+
+    @pytest.mark.asyncio
+    async def test_solar_charge_caps_discharge_to_zero(self):
+        """A genuine solar-charge-only slot forces max discharge power to 0 W."""
+        from custom_components.hsem.utils.recommendations import Recommendations
+
+        cfg, live = self._cfg_and_live()
+        rec = _make_rec_with_energy(
+            Recommendations.BatteriesChargeSolar.value,
+            batteries_charged_kwh=1.0,
+        )
+
+        written = await self._run(cfg, live, rec)
+
+        assert written["number.max_discharge"] == 0
+
+    @pytest.mark.asyncio
+    async def test_cap_lifts_on_recommendation_change(self):
+        """Once the recommendation permits discharge, the normal cap is restored."""
+        from custom_components.hsem.utils.recommendations import Recommendations
+
+        cfg, live = self._cfg_and_live()
+        # Simulate a prior cycle that left the cap at 0 W for a solar-charge
+        # slot; this cycle's recommendation now permits discharge.
+        live.huawei_batteries_max_discharge_power_w = 0
+        rec = _make_rec_with_energy(
+            Recommendations.BatteriesDischargeMode.value,
+            batteries_discharged_kwh=1.0,
+        )
+
+        written = await self._run(cfg, live, rec)
+
+        assert written["number.max_discharge"] == 2500
+
+    @pytest.mark.asyncio
+    async def test_ev_active_precedence_over_solar_charge_cap(self):
+        """An active, permitted EV's own planned rate governs, not a blanket 0."""
+        from custom_components.hsem.utils.recommendations import Recommendations
+
+        cfg, live = self._cfg_and_live()
+        live.ev.is_charging = True
+        live.ev.force_max_discharge_power = True
+        live.ev.max_discharge_power_w = 4000
+        rec = _make_rec_with_energy(
+            Recommendations.BatteriesChargeSolar.value,
+            batteries_charged_kwh=1.0,
+            batteries_discharged_kwh=0.5,  # 0.5 kWh over a 1 h slot = 500 W
+            ev_charger_calculated_power=3000.0,
+        )
+
+        written = await self._run(cfg, live, rec)
+
+        assert written["number.max_discharge"] == 500
+
+
+# ---------------------------------------------------------------------------
 # ForceBatteriesDischarge — excess PV routing regression (issue #819)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- During a `batteries_charge_solar` recommendation, the applier mapped the slot to Huawei working mode `MaximizeSelfConsumption` but never capped `maximum_discharging_power`. `_primary_battery_hold()` is always `False` for a genuine solar-charge slot (it has material `batteries_charged_kwh` by definition), so the existing discharge-cap block (gated on `primary_battery_hold or relevant_evs`) never triggered. Huawei's `MaximizeSelfConsumption` firmware follows **live** house load vs. **live** PV rather than the MILP's solved per-slot flow, so the battery discharged to cover any live deficit even though the MILP planned the slot as solar-charge-only with the grid covering the deficit.
- Extended the discharge-cap gate in `async_apply_battery_settings()` (`custom_components/hsem/custom_sensors/applier.py`) to also trigger for `batteries_charge_solar`, forcing the cap to 0 W. An active/planned EV takes precedence: when `relevant_evs` is non-empty, the existing EV permission/rate-cap logic governs instead of the blanket 0 W, preserving the reporter's noted precedence order.
- The cap lifts automatically once the recommendation changes to something that permits discharge, via the existing "restore normal max discharge power unless EV charging" block (`applier.py:165-189`) — no new restore logic was needed.
- Documented the new cap in `docs/planner-spec.md` under "EV discharge cap semantics" alongside the existing primary-battery-hold cap.

## Test plan

- [x] Added `TestSolarChargeDischargeCap` in `tests/test_safety_gates.py`:
  - `test_solar_charge_caps_discharge_to_zero` — a genuine solar-charge slot (material `batteries_charged_kwh`, no EV) writes `maximum_discharging_power = 0`.
  - `test_cap_lifts_on_recommendation_change` — once the recommendation changes to `batteries_discharge_mode`, the normal calculated max discharge power (2500 W) is restored.
  - `test_ev_active_precedence_over_solar_charge_cap` — with an active, permitted EV present, the EV's own planned discharge rate (500 W) governs instead of the blanket 0 W cap.
- [x] `./scripts/quality.sh all` passes (lint, typing, quality/vulture, translations, 3085 tests).

Fixes #922
