### PR TITLE
fix(coordinator): defer first refresh until platforms are forwarded

### DIFF
--- a/custom_components/hsem/__init__.py
+++ b/custom_components/hsem/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Coroutine
 from dataclasses import dataclass
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any
@@ -157,26 +158,15 @@ async def async_setup(hass: HomeAssistant, _config: dict[str, Any]) -> bool:
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: HSEMConfigEntry) -> bool:
-    """Set up the HSEM integration from a config entry.
+async def _run_coordinator_setup_step(coro: Coroutine[Any, Any, None]) -> None:
+    """Run one coordinator setup step, translating failures for HA's config-entry lifecycle.
 
-    Creates the shared :class:`HSEMDataUpdateCoordinator`, runs the first
-    update cycle, forwards platform setups, and adds an options update
-    listener.  Services are registered once in ``async_setup``.
+    Shared by both ``coordinator.async_setup()`` and
+    ``coordinator.async_run_first_refresh()`` (issue #926) so a failure in
+    either phase is treated identically by Home Assistant.
     """
-    if not await check_huawei_solar_version(hass):
-        raise ConfigEntryError(
-            "Huawei Solar integration is not installed or version is too old"
-        )
-
-    # Initialise the HSEM dedicated log file (hsem.log in the config dir).
-    await async_init_hsem_logger(hass)
-
-    # Create the shared DataUpdateCoordinator and run the first update cycle.
-    coordinator = HSEMDataUpdateCoordinator(hass, entry)
-
     try:
-        await coordinator.async_setup()
+        await coro
     except ConfigEntryNotReady:
         raise
     except ConfigEntryAuthFailed:
@@ -190,9 +180,39 @@ async def async_setup_entry(hass: HomeAssistant, entry: HSEMConfigEntry) -> bool
     except Exception as exc:
         raise ConfigEntryError(f"Unexpected error during HSEM setup: {exc}") from exc
 
+
+async def async_setup_entry(hass: HomeAssistant, entry: HSEMConfigEntry) -> bool:
+    """Set up the HSEM integration from a config entry.
+
+    Creates the shared :class:`HSEMDataUpdateCoordinator`, forwards platform
+    setups, runs the first update cycle, and adds an options update
+    listener.  Services are registered once in ``async_setup``.
+
+    The first update cycle intentionally runs *after* platform setups are
+    forwarded: it reads HSEM's own select/number/switch/time entities back
+    via the live HA state machine, so those entities must already exist
+    (issue #926) — running it earlier raced the entity registry and logged
+    spurious "not found" warnings on every restart/reload.
+    """
+    if not await check_huawei_solar_version(hass):
+        raise ConfigEntryError(
+            "Huawei Solar integration is not installed or version is too old"
+        )
+
+    # Initialise the HSEM dedicated log file (hsem.log in the config dir).
+    await async_init_hsem_logger(hass)
+
+    # Create the shared DataUpdateCoordinator.
+    coordinator = HSEMDataUpdateCoordinator(hass, entry)
+
+    await _run_coordinator_setup_step(coordinator.async_setup())
+
     entry.runtime_data = HSEMRuntimeData(coordinator=coordinator)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Run the first update cycle now that HSEM's own entities exist.
+    await _run_coordinator_setup_step(coordinator.async_run_first_refresh())
 
     # Add update listener for options.
     entry.async_on_unload(entry.add_update_listener(async_update_options))

--- a/custom_components/hsem/coordinator_lifecycle.py
+++ b/custom_components/hsem/coordinator_lifecycle.py
@@ -50,10 +50,16 @@ class CoordinatorLifecycleMixin(CoordinatorSharedState):
     """Setup, teardown, options handling, timers, and plan persistence."""
 
     async def async_setup(self) -> None:
-        """Register timers and run the first update cycle.
+        """Initialise trackers, start the OCPP server(s), and register timers.
 
         Call this once after the coordinator is created (from
-        :func:`~custom_components.hsem.__init__.async_setup_entry`).
+        :func:`~custom_components.hsem.__init__.async_setup_entry`), **before**
+        platform setups are forwarded. This method must not read any
+        HSEM-owned entity (select/number/switch/time) via ``hass.states`` —
+        those platforms have not been set up yet at this point, so any such
+        read would race the entity registry (issue #926). Call
+        :meth:`async_run_first_refresh` once platform setups have been
+        forwarded instead.
         """
         # Restore prediction diagnostics before the first cycle so an options
         # reload does not restart the scorecard warm-up window.
@@ -111,9 +117,6 @@ class CoordinatorLifecycleMixin(CoordinatorSharedState):
                 async_log("error", "Failed to start second OCPP server: %s", e)
                 self._ocpp_second_server = None
 
-        # Run an immediate first cycle so entities have data before first render.
-        await self._async_handle_update(None)
-
         # Hourly tick — guarantees a refresh at the top of every hour.
         self._hourly_timer_unsub = async_track_time_change(
             self.hass,
@@ -135,6 +138,17 @@ class CoordinatorLifecycleMixin(CoordinatorSharedState):
             self.async_monitor_live_power,  # type: ignore[arg-type]  # HA stub expects Callable[[datetime], ...]
             timedelta(seconds=LIVE_POWER_MONITOR_INTERVAL_SECONDS),
         )
+
+    async def async_run_first_refresh(self) -> None:
+        """Run an immediate first cycle so entities have data before first render.
+
+        Call this once after platform setups have been forwarded (from
+        :func:`~custom_components.hsem.__init__.async_setup_entry`), so that
+        HSEM's own select/number/switch/time entities already exist in the
+        state machine before the cycle reads them back via
+        ``async_collect_live_state`` (issue #926).
+        """
+        await self._async_handle_update(None)
 
     async def async_teardown(self) -> None:
         """Cancel all registered timers and state-change listeners.

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -31,7 +31,7 @@ import asyncio
 import inspect
 from datetime import UTC, datetime, timedelta
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -201,6 +201,75 @@ class TestCoordinatorUpdateLock:
         await coord._async_handle_update()
         await coord._async_handle_update()
         assert coord._cycle_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Coordinator async_setup / async_run_first_refresh ordering (issue #926)
+# ---------------------------------------------------------------------------
+
+
+class TestCoordinatorFirstRefreshOrdering:
+    """async_setup must not read live entity state; only async_run_first_refresh may.
+
+    Regression for issue #926: HSEM's own select/number/switch/time entities
+    are not yet registered in ``hass.states`` while ``__init__.py`` is still
+    inside ``coordinator.async_setup()`` (platform setups are forwarded only
+    after that call returns). The mandatory first cycle — which reads those
+    entities back via ``async_collect_live_state`` — must therefore live in a
+    separate method that ``__init__.py`` calls *after* forwarding platform
+    setups, never inside ``async_setup()`` itself.
+    """
+
+    @pytest.mark.asyncio
+    async def test_async_setup_does_not_run_first_cycle(self) -> None:
+        """async_setup must not call _async_handle_update (the live-state read)."""
+        coord = _make_bare_coordinator()
+        coord.hass = MagicMock()
+        coord._config_entry = MagicMock()
+        coord._prediction_tracker = MagicMock()
+        coord._financial_tracker = MagicMock()
+        coord.async_monitor_live_power = MagicMock()  # type: ignore[method-assign]
+        coord._async_handle_update = AsyncMock()  # type: ignore[method-assign]
+
+        cfg = MagicMock()
+        cfg.ocpp_enabled = False
+        cfg.ev_second_planned_load_enabled = False
+
+        with (
+            patch(
+                "custom_components.hsem.coordinator_lifecycle.init_prediction_tracker",
+                new=AsyncMock(),
+            ),
+            patch(
+                "custom_components.hsem.coordinator_lifecycle.init_financial_tracker",
+                new=AsyncMock(),
+            ),
+            patch(
+                "custom_components.hsem.coordinator_lifecycle.build_sensor_config",
+                return_value=cfg,
+            ),
+            patch(
+                "custom_components.hsem.coordinator_lifecycle.async_track_time_change",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "custom_components.hsem.coordinator_lifecycle.async_track_time_interval",
+                return_value=MagicMock(),
+            ),
+        ):
+            await coord.async_setup()
+
+        coord._async_handle_update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_run_first_refresh_runs_first_cycle(self) -> None:
+        """async_run_first_refresh must call _async_handle_update(None)."""
+        coord = _make_bare_coordinator()
+        coord._async_handle_update = AsyncMock()  # type: ignore[method-assign]
+
+        await coord.async_run_first_refresh()
+
+        coord._async_handle_update.assert_awaited_once_with(None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_init_setup_order.py
+++ b/tests/test_init_setup_order.py
@@ -1,0 +1,87 @@
+"""Tests for HSEM's config-entry setup ordering (issue #926).
+
+Regression for the intermittent "select.hsem_force_working_mode not found in
+Home Assistant" warning: ``async_setup_entry`` used to run the coordinator's
+first update cycle (which reads HSEM's own select/number/switch/time entities
+back via ``hass.states``) *before* forwarding platform setups — so those
+entities did not exist yet in the state machine. The fix moves the first
+cycle to run only after platform setups are forwarded.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.hsem import HSEMRuntimeData, async_setup_entry
+
+
+@pytest.fixture
+def mock_hass() -> MagicMock:
+    """Return a mocked HomeAssistant with a recordable platform-forward call."""
+    hass = MagicMock()
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    return hass
+
+
+@pytest.mark.asyncio
+async def test_first_refresh_runs_after_platforms_are_forwarded(
+    mock_hass: MagicMock,
+) -> None:
+    """The coordinator's first cycle must run after platforms are forwarded.
+
+    Before the fix, ``coordinator.async_setup()`` itself ran the first cycle,
+    so it always preceded ``async_forward_entry_setups``. Now the first cycle
+    lives in ``coordinator.async_run_first_refresh()``, called only after
+    platforms are forwarded.
+    """
+    call_order: list[str] = []
+
+    mock_coordinator = MagicMock()
+
+    async def _record_setup() -> None:
+        call_order.append("coordinator.async_setup")
+
+    async def _record_forward(*_args: object, **_kwargs: object) -> bool:
+        call_order.append("async_forward_entry_setups")
+        return True
+
+    async def _record_first_refresh() -> None:
+        call_order.append("coordinator.async_run_first_refresh")
+
+    mock_coordinator.async_setup = AsyncMock(side_effect=_record_setup)
+    mock_coordinator.async_run_first_refresh = AsyncMock(
+        side_effect=_record_first_refresh
+    )
+    mock_hass.config_entries.async_forward_entry_setups = AsyncMock(
+        side_effect=_record_forward
+    )
+
+    entry = MagicMock()
+    entry.runtime_data = None
+
+    with (
+        patch(
+            "custom_components.hsem.check_huawei_solar_version",
+            new=AsyncMock(return_value=True),
+        ),
+        patch(
+            "custom_components.hsem.async_init_hsem_logger",
+            new=AsyncMock(),
+        ),
+        patch(
+            "custom_components.hsem.HSEMDataUpdateCoordinator",
+            return_value=mock_coordinator,
+        ),
+    ):
+        result = await async_setup_entry(mock_hass, entry)
+
+    assert result is True
+    assert call_order == [
+        "coordinator.async_setup",
+        "async_forward_entry_setups",
+        "coordinator.async_run_first_refresh",
+    ]
+    assert entry.runtime_data == HSEMRuntimeData(coordinator=mock_coordinator)


### PR DESCRIPTION
## Summary

- Fixes the intermittent `select.hsem_force_working_mode`
  `EntityNotFoundError` / TOU-periods "state unknown" warnings seen on
  restart/reload, root-caused from `logs/*/hsem.log`: every occurrence fell
  strictly between `OCPP server started on port %d` and
  `HSEM integration successfully set up`, i.e. it only ever happened during
  `async_setup_entry`.
- `async_setup_entry` (`custom_components/hsem/__init__.py`) called
  `coordinator.async_setup()` — which ran the coordinator's mandatory first
  update cycle — **before** `hass.config_entries.async_forward_entry_setups()`.
  That first cycle reads HSEM's own select/number/switch/time entities back
  via `hass.states.get()`, but those platforms hadn't been set up yet, so the
  read raced the entity registry.
- Split the first cycle out of `coordinator.async_setup()`
  (`custom_components/hsem/coordinator_lifecycle.py`) into a new
  `coordinator.async_run_first_refresh()`. `async_setup()` still starts the
  OCPP server(s) and registers timers at the same point as before;
  `async_run_first_refresh()` is now called from `__init__.py` only after
  `async_forward_entry_setups()` returns, so HSEM's own entities already
  exist by the time the cycle reads them.
- Added `_run_coordinator_setup_step()` in `__init__.py` so the existing
  `ConfigEntryNotReady` / `ConfigEntryAuthFailed` / `ConfigEntryError`
  translation is applied identically to both the setup phase and the
  (now-separate) first-refresh phase, instead of duplicating the
  try/except.

## Files changed

- `custom_components/hsem/__init__.py`
- `custom_components/hsem/coordinator_lifecycle.py`
- `tests/test_coordinator.py`
- `tests/test_init_setup_order.py` (new)

## Tests added

- `tests/test_coordinator.py::TestCoordinatorFirstRefreshOrdering` — asserts
  `async_setup()` never calls `_async_handle_update`, and
  `async_run_first_refresh()` does.
- `tests/test_init_setup_order.py` — asserts `async_setup_entry` calls
  `coordinator.async_setup()` → `async_forward_entry_setups` →
  `coordinator.async_run_first_refresh()`, in that order.

## Test and lint results

```
./scripts/quality.sh lint     — clean (ruff format + ruff check + prettier)
./scripts/quality.sh typing   — 0 errors
./scripts/quality.sh quality  — pyright 0 errors; vulture output unchanged
                                 from baseline (no new dead-code flags)
./scripts/quality.sh test     — 3103 passed
```

No user-facing strings changed, so no translation updates were needed.

## Known limitations

The sibling `sensor.batteries_tou_charging_and_discharging_periods` "state
unknown" warning (a Huawei Solar entity outside HSEM's control) is a
different race — Huawei Solar's own entity may exist by the time HSEM reads
it, but not yet have a populated value. Deferring HSEM's first refresh until
after platform forwarding likely reduces its frequency but can't fully
eliminate it, since HSEM doesn't control Huawei Solar's own setup timing.
Not addressed by this PR — tracked as an open question in #926 if it
resurfaces.

Fixes #926
