### PR TITLE
fix(sensors): stop PV Curtailment sensor false-positive at configured export cap

### DIFF
--- a/custom_components/hsem/custom_sensors/pv_curtailment_sensor.py
+++ b/custom_components/hsem/custom_sensors/pv_curtailment_sensor.py
@@ -8,7 +8,12 @@ The sensor uses two complementary detection methods:
 
 1. **Direct**: Reads ``live.huawei_inverter_active_power_control``.
    If the inverter reports a limit (e.g. ``"Limited to 80%"`` or
-   ``"Limited to 100W"``) instead of ``"Unlimited"``, PV is being curtailed.
+   ``"Limited to 100W"``) that sits *below* the routine, always-applied
+   ``max_grid_export_power_kw`` DNO/grid cap (or below ``"Unlimited"`` when no
+   cap is configured), PV is being actively curtailed. A limit that merely
+   matches the configured cap is normal steady-state operation, not
+   curtailment (issue #924) — the applier writes that cap for every
+   non-negative export price regardless of price-based curtailment.
 
 2. **Derived**: When the battery SoC is high (≥ 95 %) AND the export price
    is below the minimum threshold, curtailment is likely even if the direct
@@ -30,7 +35,12 @@ from custom_components.hsem.coordinator import (
     CoordinatorData,
     HSEMDataUpdateCoordinator,
 )
+from custom_components.hsem.custom_sensors.applier_state_readers import (
+    _is_watt_limit,
+    _parse_power_control_pct,
+)
 from custom_components.hsem.entity import HSEMCoordinatorEntity, HSEMEntity
+from custom_components.hsem.models.sensor_config import SensorConfig
 from custom_components.hsem.utils.sensornames.diagnostics import (
     get_pv_curtailment_sensor_entity_id,
     get_pv_curtailment_sensor_unique_id,
@@ -57,6 +67,10 @@ _DERIVED_SOC_THRESHOLD: float = 95.0
 # Export price threshold (currency/kWh) below which export is considered
 # blocked for the derived detection method.
 _DERIVED_EXPORT_PRICE_THRESHOLD: float = 0.01
+
+# Tolerance (W) when comparing the inverter's reported watt limit against the
+# expected routine grid-export cap, to absorb minor Modbus read-back rounding.
+_CURTAILMENT_TOLERANCE_WATT: float = 5.0
 
 
 class HSEMPVTailedSensor(
@@ -135,7 +149,7 @@ class HSEMPVTailedSensor(
         live = data.live
 
         # --- Method 1: Direct active power control reading ---
-        if _is_directly_limited(live.huawei_inverter_active_power_control):
+        if _is_directly_limited(live.huawei_inverter_active_power_control, data.cfg):
             return "curtailed"
 
         # --- Method 2: Derived detection ---
@@ -162,19 +176,57 @@ class HSEMPVTailedSensor(
 # ------------------------------------------------------------------
 
 
-def _is_directly_limited(power_control_state: str | None) -> bool:
-    """Return True if the active power control state indicates a limit.
+def _is_directly_limited(
+    power_control_state: str | None, cfg: SensorConfig | None
+) -> bool:
+    """Return True if the active power control state indicates real curtailment.
+
+    A reported limit is only genuine curtailment when it sits *below* the
+    routine, always-applied baseline for the current configuration:
+
+    - No ``max_grid_export_power_kw`` cap configured → baseline is
+      ``"Unlimited"``; any reported limit is curtailment.
+    - A cap is configured → the applier writes that cap in watts for every
+      non-negative export price (issue #767), so the register normally reads
+      a matching watt limit even with no price-based curtailment in effect.
+      Only a watt limit *below* the configured cap indicates the applier
+      actively curtailed further (e.g. the negative-price export block).
 
     Args:
         power_control_state: Raw string from the inverter entity
-            (e.g. ``"Unlimited"``, ``"Limited to 80%"``).
+            (e.g. ``"Unlimited"``, ``"Limited to 80%"``, ``"Limited to 100W"``).
+        cfg: Current sensor configuration, used to resolve the routine
+            grid-export cap baseline. ``None`` falls back to the legacy
+            any-limit-is-curtailment behaviour.
 
     Returns:
-        ``True`` if the inverter is actively limiting output.
+        ``True`` if the inverter is actively curtailing output beyond the
+        routine configured cap.
     """
     if not isinstance(power_control_state, str):
         return False
-    return power_control_state.strip().lower() not in _UNLIMITED_STATES
+    normalized = power_control_state.strip().lower()
+    if normalized in _UNLIMITED_STATES:
+        return False
+
+    cap_kw = cfg.max_grid_export_power_kw if cfg is not None else 0.0
+    if cap_kw <= 1e-9:
+        # No routine cap configured — any reported limit is curtailment.
+        return True
+
+    if not _is_watt_limit(power_control_state):
+        # A percentage-based limit while a watt-based cap is configured is
+        # not the applier's routine steady state.
+        return True
+
+    parsed_watts = _parse_power_control_pct(power_control_state)
+    if parsed_watts is None:
+        # Unparseable limit string — cannot confirm it matches the routine
+        # cap, so report it for visibility rather than hide a real problem.
+        return True
+
+    baseline_watts = cap_kw * 1000.0
+    return parsed_watts < baseline_watts - _CURTAILMENT_TOLERANCE_WATT
 
 
 def _is_derived_curtailment(live: Any) -> bool:

--- a/tests/sensors/test_pv_curtailment_sensor.py
+++ b/tests/sensors/test_pv_curtailment_sensor.py
@@ -1,0 +1,210 @@
+"""Tests for the HSEMPVTailedSensor ("PV Curtailment") diagnostic sensor.
+
+Regression coverage for issue #924: the sensor previously reported
+``"curtailed"`` any time the inverter's active-power-control register showed
+*any* limit — including the routine, always-applied
+``max_grid_export_power_kw`` DNO/grid cap that the applier writes for every
+non-negative export price (issue #767). That made the sensor report
+``"curtailed"`` permanently for any installation with a configured grid
+export cap, regardless of whether real price/SoC-driven curtailment was
+happening.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.hsem.coordinator import CoordinatorData
+from custom_components.hsem.custom_sensors.pv_curtailment_sensor import (
+    HSEMPVTailedSensor,
+    _is_derived_curtailment,
+    _is_directly_limited,
+)
+from custom_components.hsem.models.live_state import LiveState
+from custom_components.hsem.models.sensor_config import SensorConfig
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_sensor(data: CoordinatorData | None = None) -> HSEMPVTailedSensor:
+    """Return a bare HSEMPVTailedSensor wired to a mock coordinator."""
+    coordinator = MagicMock()
+    coordinator.data = data
+    coordinator.last_update_success = data is not None
+
+    sensor = object.__new__(HSEMPVTailedSensor)
+    sensor.coordinator = coordinator
+    sensor._config_entry = MagicMock()
+    sensor._attr_unique_id = "hsem_pv_curtailment_sensor"
+    sensor.entity_id = "sensor.hsem_pv_curtailment_sensor"
+    sensor._restored_state = None
+    return sensor
+
+
+def _make_data(cfg: SensorConfig, live: LiveState) -> CoordinatorData:
+    data = CoordinatorData()
+    data.cfg = cfg
+    data.live = live
+    return data
+
+
+# ===========================================================================
+# _is_directly_limited — pure helper
+# ===========================================================================
+
+
+class TestIsDirectlyLimited:
+    """Unit tests for the direct active-power-control detection method."""
+
+    def test_none_state_is_not_limited(self):
+        assert _is_directly_limited(None, None) is False
+
+    def test_unlimited_is_not_limited(self):
+        cfg = SensorConfig()
+        cfg.max_grid_export_power_kw = 10.0
+        assert _is_directly_limited("Unlimited", cfg) is False
+
+    def test_unlimited_localized(self):
+        cfg = SensorConfig()
+        assert _is_directly_limited("Unbegrenzt", cfg) is False
+
+    def test_no_cap_configured_any_limit_is_curtailment(self):
+        """Legacy behaviour preserved when no grid export cap is configured."""
+        cfg = SensorConfig()
+        cfg.max_grid_export_power_kw = 0.0
+        assert _is_directly_limited("Limited to 80%", cfg) is True
+
+    def test_none_cfg_falls_back_to_legacy_behaviour(self):
+        assert _is_directly_limited("Limited to 80%", None) is True
+
+    def test_limit_matching_configured_cap_is_not_curtailment(self):
+        """Regression test for issue #924.
+
+        The applier always writes the configured grid-export cap in watts
+        for any non-negative export price. Reading that same cap back must
+        NOT be reported as curtailment — it is the routine steady state.
+        """
+        cfg = SensorConfig()
+        cfg.max_grid_export_power_kw = 10.0
+        assert _is_directly_limited("Limited to 10000W", cfg) is False
+
+    def test_limit_matching_cap_within_tolerance_is_not_curtailment(self):
+        cfg = SensorConfig()
+        cfg.max_grid_export_power_kw = 10.0
+        assert _is_directly_limited("Limited to 9998W", cfg) is False
+
+    def test_limit_below_configured_cap_is_curtailment(self):
+        """A watt limit meaningfully below the configured cap is real
+        curtailment (e.g. the negative-export-price 100 W block)."""
+        cfg = SensorConfig()
+        cfg.max_grid_export_power_kw = 10.0
+        assert _is_directly_limited("Limited to 100W", cfg) is True
+
+    def test_percentage_limit_with_watt_cap_configured_is_curtailment(self):
+        cfg = SensorConfig()
+        cfg.max_grid_export_power_kw = 10.0
+        assert _is_directly_limited("Limited to 50%", cfg) is True
+
+    def test_unparseable_limit_is_reported_as_curtailment(self):
+        cfg = SensorConfig()
+        cfg.max_grid_export_power_kw = 10.0
+        assert _is_directly_limited("some other value", cfg) is True
+
+
+# ===========================================================================
+# _is_derived_curtailment — unchanged fallback heuristic
+# ===========================================================================
+
+
+class TestIsDerivedCurtailment:
+    def test_no_pv_production_is_not_curtailed(self):
+        live = LiveState()
+        live.solar_production_power_w = 0.0
+        assert _is_derived_curtailment(live) is False
+
+    def test_low_soc_is_not_curtailed(self):
+        live = LiveState()
+        live.solar_production_power_w = 500.0
+        live.huawei_batteries_soc_pct = 50.0
+        live.export_electricity_price = 0.0
+        live.huawei_inverter_active_power_control = None
+        assert _is_derived_curtailment(live) is False
+
+    def test_export_price_above_threshold_is_not_curtailed(self):
+        live = LiveState()
+        live.solar_production_power_w = 500.0
+        live.huawei_batteries_soc_pct = 99.0
+        live.export_electricity_price = 0.5
+        live.huawei_inverter_active_power_control = None
+        assert _is_derived_curtailment(live) is False
+
+    def test_known_register_overrides_derived_heuristic(self):
+        live = LiveState()
+        live.solar_production_power_w = 500.0
+        live.huawei_batteries_soc_pct = 99.0
+        live.export_electricity_price = 0.0
+        live.huawei_inverter_active_power_control = "Unlimited"
+        assert _is_derived_curtailment(live) is False
+
+    def test_full_battery_blocked_export_unknown_register_is_curtailed(self):
+        live = LiveState()
+        live.solar_production_power_w = 500.0
+        live.huawei_batteries_soc_pct = 99.0
+        live.export_electricity_price = 0.0
+        live.huawei_inverter_active_power_control = None
+        assert _is_derived_curtailment(live) is True
+
+
+# ===========================================================================
+# HSEMPVTailedSensor.state — end-to-end
+# ===========================================================================
+
+
+class TestState:
+    def test_no_coordinator_data_defaults_to_normal(self):
+        sensor = _make_sensor(None)
+        assert sensor.state == "normal"
+
+    def test_issue_924_configured_cap_at_steady_state_is_normal(self):
+        """Reproduces the exact issue #924 report: a 10 kW configured grid
+        export cap, non-negative export price, register reading the cap
+        back verbatim — must be "normal", not "curtailed"."""
+        cfg = SensorConfig()
+        cfg.max_grid_export_power_kw = 10.0
+
+        live = LiveState()
+        live.solar_production_power_w = 6000.0
+        live.huawei_batteries_soc_pct = 100.0
+        live.export_electricity_price = 0.0
+        live.huawei_inverter_active_power_control = "Limited to 10000W"
+
+        sensor = _make_sensor(_make_data(cfg, live))
+        assert sensor.state == "normal"
+
+    def test_negative_price_block_below_cap_is_curtailed(self):
+        cfg = SensorConfig()
+        cfg.max_grid_export_power_kw = 10.0
+
+        live = LiveState()
+        live.solar_production_power_w = 6000.0
+        live.huawei_batteries_soc_pct = 100.0
+        live.export_electricity_price = -0.05
+        live.huawei_inverter_active_power_control = "Limited to 100W"
+
+        sensor = _make_sensor(_make_data(cfg, live))
+        assert sensor.state == "curtailed"
+
+    def test_no_cap_configured_any_limit_is_curtailed(self):
+        cfg = SensorConfig()
+        cfg.max_grid_export_power_kw = 0.0
+
+        live = LiveState()
+        live.solar_production_power_w = 6000.0
+        live.huawei_batteries_soc_pct = 100.0
+        live.export_electricity_price = 0.0
+        live.huawei_inverter_active_power_control = "Limited to 50%"
+
+        sensor = _make_sensor(_make_data(cfg, live))
+        assert sensor.state == "curtailed"


### PR DESCRIPTION
## Summary

- Fixes a false-positive in the **PV Curtailment** diagnostic sensor
  (`sensor.hsem_pv_curtailment_sensor`) reported in #924: it showed
  `curtailed` permanently on any installation with a configured
  `max_grid_export_power_kw` (DNO/grid export cap), even though the inverter
  was simply sitting at its routine, always-applied cap — not being
  actively throttled for price/SoC reasons.

## Root cause

Per issue #767's design (documented in `.github/memories.md`), the applier
(`async_apply_inverter_power_control`) writes the configured grid-export cap
in watts to the inverter for **every non-negative export price** — it only
drops to a hard near-zero block when the export price is genuinely
negative. This is intentional: surplus PV export should continue up to the
DNO cap even at low positive prices, since curtailing free PV production
wastes it for no benefit.

`HSEMPVTailedSensor._is_directly_limited()` treated *any* register reading
other than `"Unlimited"` as `curtailed`. With a configured export cap, the
register legitimately reads a watt limit (e.g. `"Limited to 10000W"` for a
10 kW cap) in normal, healthy steady-state operation — so the sensor
reported `curtailed` continuously, regardless of whether real curtailment
was happening. This matches the reporter's exact scenario: a 10 kW grid
export limit, `Hardware Writes = Allowed`, `Plan Strategy = milp`, and the
inverter register unchanged at 10 kW while the sensor claims `curtailed`.

(The applier's own behavior of not curtailing below the DNO cap for
low-but-positive prices is correct per #767 and is unchanged by this PR —
only the diagnostic sensor's interpretation of the register was wrong.)

## Fix

`_is_directly_limited()` now resolves the expected routine baseline from
`cfg.max_grid_export_power_kw`:

- No cap configured → baseline is `"Unlimited"`; any limit is curtailment
  (unchanged legacy behaviour).
- A cap is configured → baseline is that cap in watts. Only a reported watt
  limit **below** the configured cap (with a small tolerance for Modbus
  read-back rounding) is reported as `curtailed` — e.g. the genuine
  negative-export-price 100 W block. A limit matching the cap is `normal`.
- A percentage-based limit or an unparseable limit string while a watt cap
  is configured is still reported as `curtailed` (unexpected/non-routine
  state, surfaced for visibility).

The derived (fallback, SoC + price heuristic) detection method is
unchanged.

## Files changed

- `custom_components/hsem/custom_sensors/pv_curtailment_sensor.py` — fixed
  `_is_directly_limited()`, now takes `cfg: SensorConfig | None` and reuses
  the existing `_parse_power_control_pct` / `_is_watt_limit` helpers from
  `applier_state_readers.py`.
- `tests/sensors/test_pv_curtailment_sensor.py` — new test file (none
  existed before): unit tests for `_is_directly_limited` and
  `_is_derived_curtailment`, plus end-to-end `state` tests including a
  direct regression reproduction of the issue #924 scenario.

## Tests

- `./scripts/quality.sh lint` — pass
- `./scripts/quality.sh typing` — pass (0 errors)
- `./scripts/quality.sh quality` — pass (0 pyright errors; vulture output
  unchanged baseline)
- `./scripts/quality.sh test` — pass (3122 passed, including 19 new tests)
- `python3 scripts/validate_translations.py` — 0 errors (no user-facing
  strings changed)

## Known limitations

- This PR only fixes the diagnostic sensor's misreporting. It does not
  change the applier's export behaviour — PV export below the configured
  `export_electricity_min_price` but at a non-negative price is still
  allowed up to the DNO cap by design (#767). If the reporter's actual goal
  is to have HSEM physically curtail PV production for low-but-positive
  export prices (not just report on it), that would be a separate,
  intentional policy change and should be tracked as its own issue.

Fixes #924
