### PR TITLE
fix(sensors): stop PV curtailment false positive at low positive export price

### DIFF
--- a/custom_components/hsem/custom_sensors/pv_curtailment_sensor.py
+++ b/custom_components/hsem/custom_sensors/pv_curtailment_sensor.py
@@ -2,7 +2,13 @@
 
 Curtailment occurs when the inverter throttles solar production because there
 is no place for the energy to go — the battery is full, house consumption is
-low, and grid export is blocked (export price below the configured minimum).
+low, and grid export is physically blocked. Since issue #767, HSEM only
+physically blocks the whole grid connection point when the export price is
+**negative** (exporting would cost money); a positive-but-low export price
+below ``export_electricity_min_price``/``batteries_export_min_price`` only
+gates intentional *battery*-to-grid export, PV surplus keeps exporting
+normally. Do not conflate "export price below the configured minimum" with
+"grid export is blocked" — see ``applier_power_control.py``.
 
 The sensor uses two complementary detection methods:
 
@@ -11,8 +17,8 @@ The sensor uses two complementary detection methods:
    ``"Limited to 100W"``) instead of ``"Unlimited"``, PV is being curtailed.
 
 2. **Derived**: When the battery SoC is high (≥ 95 %) AND the export price
-   is below the minimum threshold, curtailment is likely even if the direct
-   register has not yet updated.
+   is negative (the only case where HSEM itself blocks grid export),
+   curtailment is likely even if the direct register has not yet updated.
 
 The sensor state is either ``"curtailed"`` or ``"normal"``.
 """
@@ -54,9 +60,13 @@ _UNLIMITED_STATES: frozenset[str] = frozenset(
 # combined with export price blocking.
 _DERIVED_SOC_THRESHOLD: float = 95.0
 
-# Export price threshold (currency/kWh) below which export is considered
-# blocked for the derived detection method.
-_DERIVED_EXPORT_PRICE_THRESHOLD: float = 0.01
+# Export price (currency/kWh) at/above which the applier keeps the grid
+# connection point unlimited (issue #767) — PV surplus export is never
+# blocked by ``export_electricity_min_price``/``batteries_export_min_price``,
+# only intentional battery-to-grid export is gated. Only a strictly negative
+# export price causes the applier to physically block the whole connection
+# point, so that is the only price condition the derived heuristic may use.
+_DERIVED_EXPORT_PRICE_THRESHOLD: float = 0.0
 
 
 class HSEMPVTailedSensor(
@@ -183,7 +193,8 @@ def _is_derived_curtailment(live: Any) -> bool:
     Curtailment is likely when:
     - PV is actually producing (> 0 W)
     - Battery SoC is high (≥ ``_DERIVED_SOC_THRESHOLD``)
-    - Export price is below the minimum (effectively blocked)
+    - Export price is negative (the only case where HSEM's applier
+      physically blocks the whole grid connection point — issue #767)
     - The active power control register is unavailable (None)
 
     If the register is available and says "Unlimited", the inverter is
@@ -204,7 +215,9 @@ def _is_derived_curtailment(live: Any) -> bool:
     if soc is None or soc < _DERIVED_SOC_THRESHOLD:
         return False
 
-    # Export must be price-blocked.
+    # Export must be negative-price-blocked (issue #767 — a positive-but-low
+    # price below the configured minimum does NOT block PV export, only
+    # intentional battery-to-grid export).
     export_price = live.export_electricity_price
     if export_price >= _DERIVED_EXPORT_PRICE_THRESHOLD:
         return False

--- a/custom_components/hsem/translations/da.json
+++ b/custom_components/hsem/translations/da.json
@@ -136,7 +136,7 @@
           "hsem_export_electricity_price_sensor": "Vælg den sensor, der leverer eksport-elpriser.",
           "hsem_import_electricity_price_forecast_sensor": "Valgfrit: vælg en separat sensor til importprisprognoser (bruges af Amber Electric og lignende integrationer).",
           "hsem_export_electricity_price_forecast_sensor": "Valgfrit: vælg en separat sensor til eksportprisprognoser.",
-          "hsem_export_electricity_min_price": "Indstil minimumsprisen for eksport. Eksport under denne pris blokeres.",
+          "hsem_export_electricity_min_price": "Grænse pr. tidsrum for tvungen batteri-til-net-eksport. Under denne pris tvinger HSEM ikke batteriet til at aflade til nettet – batteriet dækker stadig husets forbrug som normalt, og at nå tærsklen udløser ikke automatisk eksport. Dette blokerer ikke PV-eksport: overskydende solenergi eksporteres fortsat ved enhver ikke-negativ pris. Kun en negativ eksportpris får HSEM til at blokere al net-eksport, da eksport så koster penge.",
           "hsem_electricity_price_update_interval": "Hvor ofte din prissensor giver nye data (15, 30 eller 60 minutter)."
         },
         "description": "Konfigurer dine elprissensorer til import- og eksportpriser.",
@@ -665,7 +665,7 @@
           "hsem_export_electricity_price_sensor": "Vælg den sensor, der leverer eksport-elpriser.",
           "hsem_import_electricity_price_forecast_sensor": "Valgfrit: vælg en separat sensor til importprisprognoser (bruges af Amber Electric og lignende integrationer).",
           "hsem_export_electricity_price_forecast_sensor": "Valgfrit: vælg en separat sensor til eksportprisprognoser.",
-          "hsem_export_electricity_min_price": "Indstil minimumsprisen for eksport. Eksport under denne pris blokeres.",
+          "hsem_export_electricity_min_price": "Grænse pr. tidsrum for tvungen batteri-til-net-eksport. Under denne pris tvinger HSEM ikke batteriet til at aflade til nettet – batteriet dækker stadig husets forbrug som normalt, og at nå tærsklen udløser ikke automatisk eksport. Dette blokerer ikke PV-eksport: overskydende solenergi eksporteres fortsat ved enhver ikke-negativ pris. Kun en negativ eksportpris får HSEM til at blokere al net-eksport, da eksport så koster penge.",
           "hsem_electricity_price_update_interval": "Hvor ofte din prissensor giver nye data (15, 30 eller 60 minutter)."
         },
         "description": "Konfigurer dine elprissensorer til import- og eksportpriser.",

--- a/custom_components/hsem/translations/de.json
+++ b/custom_components/hsem/translations/de.json
@@ -176,7 +176,7 @@
           "hsem_export_electricity_price_sensor": "Wähle den Sensor, der Stromexportpreise liefert.",
           "hsem_import_electricity_price_forecast_sensor": "Optional: Wähle einen separaten Sensor für Importpreis-Prognosen (verwendet von Amber Electric und ähnlichen Integrationen).",
           "hsem_export_electricity_price_forecast_sensor": "Optional: Wähle einen separaten Sensor für Exportpreis-Prognosen.",
-          "hsem_export_electricity_min_price": "Lege den Mindestexportpreis fest. Exporte unterhalb dieses Preises werden blockiert.",
+          "hsem_export_electricity_min_price": "Untergrenze pro Zeitfenster für erzwungenen Batterie-zu-Netz-Export. Unterhalb dieses Preises zwingt HSEM die Batterie nicht zur Einspeisung ins Netz – die Batterie versorgt weiterhin normal den Hausverbrauch, und das Erreichen der Schwelle löst keinen automatischen Export aus. Dies blockiert nicht den PV-Export: überschüssiger Solarstrom wird bei jedem nicht-negativen Preis weiterhin exportiert. Nur ein negativer Exportpreis veranlasst HSEM, den gesamten Netzexport zu blockieren, da der Export dann Geld kosten würde.",
           "hsem_electricity_price_update_interval": "Wie oft dein Preissensor neue Daten liefert (15, 30 oder 60 Minuten)."
         },
         "description": "Konfiguriere deine Strompreissensoren für Import- und Exportpreise.",
@@ -705,7 +705,7 @@
           "hsem_export_electricity_price_sensor": "Wähle den Sensor, der Stromexportpreise liefert.",
           "hsem_import_electricity_price_forecast_sensor": "Optional: Wähle einen separaten Sensor für Importpreis-Prognosen (verwendet von Amber Electric und ähnlichen Integrationen).",
           "hsem_export_electricity_price_forecast_sensor": "Optional: Wähle einen separaten Sensor für Exportpreis-Prognosen.",
-          "hsem_export_electricity_min_price": "Lege den Mindestexportpreis fest. Exporte unterhalb dieses Preises werden blockiert.",
+          "hsem_export_electricity_min_price": "Untergrenze pro Zeitfenster für erzwungenen Batterie-zu-Netz-Export. Unterhalb dieses Preises zwingt HSEM die Batterie nicht zur Einspeisung ins Netz – die Batterie versorgt weiterhin normal den Hausverbrauch, und das Erreichen der Schwelle löst keinen automatischen Export aus. Dies blockiert nicht den PV-Export: überschüssiger Solarstrom wird bei jedem nicht-negativen Preis weiterhin exportiert. Nur ein negativer Exportpreis veranlasst HSEM, den gesamten Netzexport zu blockieren, da der Export dann Geld kosten würde.",
           "hsem_electricity_price_update_interval": "Wie oft dein Preissensor neue Daten liefert (15, 30 oder 60 Minuten)."
         },
         "description": "Konfiguriere deine Strompreissensoren für Import- und Exportpreise.",

--- a/custom_components/hsem/translations/en.json
+++ b/custom_components/hsem/translations/en.json
@@ -176,7 +176,7 @@
           "hsem_export_electricity_price_sensor": "Select the sensor that provides export electricity prices.",
           "hsem_import_electricity_price_forecast_sensor": "Optional: select a separate sensor for import price forecasts (used by Amber Electric and similar integrations).",
           "hsem_export_electricity_price_forecast_sensor": "Optional: select a separate sensor for export price forecasts.",
-          "hsem_export_electricity_min_price": "Set the minimum export price. Exports below this price will be blocked.",
+          "hsem_export_electricity_min_price": "Per-slot floor for intentional battery-to-grid export. Below this price HSEM will not force the battery to discharge into the grid — the battery still serves house load normally, and reaching the threshold does not auto-trigger export. This does not block PV export: surplus solar continues to export at any non-negative price. Only a negative export price causes HSEM to block all grid export, since exporting would then cost money.",
           "hsem_electricity_price_update_interval": "How often your price sensor provides new data (15, 30, or 60 minutes)."
         },
         "description": "Configure your electricity price sensors for import and export pricing.",
@@ -705,7 +705,7 @@
           "hsem_export_electricity_price_sensor": "Select the sensor that provides export electricity prices.",
           "hsem_import_electricity_price_forecast_sensor": "Optional: select a separate sensor for import price forecasts (used by Amber Electric and similar integrations).",
           "hsem_export_electricity_price_forecast_sensor": "Optional: select a separate sensor for export price forecasts.",
-          "hsem_export_electricity_min_price": "Set the minimum export price. Exports below this price will be blocked.",
+          "hsem_export_electricity_min_price": "Per-slot floor for intentional battery-to-grid export. Below this price HSEM will not force the battery to discharge into the grid — the battery still serves house load normally, and reaching the threshold does not auto-trigger export. This does not block PV export: surplus solar continues to export at any non-negative price. Only a negative export price causes HSEM to block all grid export, since exporting would then cost money.",
           "hsem_electricity_price_update_interval": "How often your price sensor provides new data (15, 30, or 60 minutes)."
         },
         "description": "Configure your electricity price sensors for import and export pricing.",

--- a/custom_components/hsem/translations/es.json
+++ b/custom_components/hsem/translations/es.json
@@ -176,7 +176,7 @@
           "hsem_export_electricity_price_sensor": "Selecciona el sensor que proporciona los precios de electricidad de exportación.",
           "hsem_import_electricity_price_forecast_sensor": "Opcional: selecciona un sensor independiente para las previsiones de precio de importación (usado por Amber Electric e integraciones similares).",
           "hsem_export_electricity_price_forecast_sensor": "Opcional: selecciona un sensor independiente para las previsiones de precio de exportación.",
-          "hsem_export_electricity_min_price": "Define el precio mínimo de exportación. Las exportaciones por debajo de este precio se bloquearán.",
+          "hsem_export_electricity_min_price": "Límite por franja horaria para la exportación forzada de batería a la red. Por debajo de este precio, HSEM no obliga a la batería a descargarse hacia la red; la batería sigue cubriendo el consumo de la casa con normalidad, y alcanzar el umbral no activa la exportación automáticamente. Esto no bloquea la exportación fotovoltaica: el excedente solar sigue exportándose a cualquier precio no negativo. Solo un precio de exportación negativo hace que HSEM bloquee toda la exportación a la red, ya que entonces exportar costaría dinero.",
           "hsem_electricity_price_update_interval": "Con qué frecuencia proporciona nuevos datos tu sensor de precios (15, 30 o 60 minutos)."
         },
         "description": "Configura tus sensores de precio de electricidad para los precios de importación y exportación.",
@@ -705,7 +705,7 @@
           "hsem_export_electricity_price_sensor": "Selecciona el sensor que proporciona los precios de electricidad de exportación.",
           "hsem_import_electricity_price_forecast_sensor": "Opcional: selecciona un sensor independiente para las previsiones de precio de importación (usado por Amber Electric e integraciones similares).",
           "hsem_export_electricity_price_forecast_sensor": "Opcional: selecciona un sensor independiente para las previsiones de precio de exportación.",
-          "hsem_export_electricity_min_price": "Define el precio mínimo de exportación. Las exportaciones por debajo de este precio se bloquearán.",
+          "hsem_export_electricity_min_price": "Límite por franja horaria para la exportación forzada de batería a la red. Por debajo de este precio, HSEM no obliga a la batería a descargarse hacia la red; la batería sigue cubriendo el consumo de la casa con normalidad, y alcanzar el umbral no activa la exportación automáticamente. Esto no bloquea la exportación fotovoltaica: el excedente solar sigue exportándose a cualquier precio no negativo. Solo un precio de exportación negativo hace que HSEM bloquee toda la exportación a la red, ya que entonces exportar costaría dinero.",
           "hsem_electricity_price_update_interval": "Con qué frecuencia proporciona nuevos datos tu sensor de precios (15, 30 o 60 minutos)."
         },
         "description": "Configura tus sensores de precio de electricidad para los precios de importación y exportación.",

--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -140,15 +140,22 @@ cost function.
   and _Reduktion_. Verify against your electricity bill.
 - **Fix:** Correct any mismatched values.
 
-**2c. Export minimum price blocks all export**
+**2c. Export minimum price blocks battery-to-grid export only**
 
-The `export_min_price` setting prevents grid export when the export price
-is below that threshold. If set too high, HSEM never exports — the battery
-stays full and the inverter physically blocks export.
+The `export_min_price` setting (and the dedicated `battery_export_min_price`)
+only gate **intentional battery-to-grid export** — the battery keeps serving
+house load normally below the threshold, and the optimizer still decides
+whether exporting is worthwhile above it. It does **not** block PV surplus
+export: PV keeps exporting at any non-negative price (issue #767). Only a
+**negative** export price makes HSEM physically block the whole grid
+connection point, because exporting would then cost money. If PV export
+looks blocked at a positive-but-low price, look elsewhere (grid export power
+cap, inverter fault, `no_export` setting) — it is not this setting.
 
 - **Check:** HSEM → **Configure** → **Energi Data Service** step.
   _Export Minimum Price_. Compare against current export spot prices.
-- **Fix:** Lower or set to 0 if you want to export at all positive prices.
+- **Fix:** Lower or set to 0 if you want the battery to export at all
+  positive prices too.
 
 **2d. Negative prices trigger force-export**
 
@@ -494,16 +501,17 @@ end-of-discharge threshold, no discharge is scheduled.
 - **Fix:** Lower the `end_of_discharge_soc` if safe for your battery
   chemistry. Never set below the manufacturer's recommended minimum.
 
-**7c. Export minimum price blocks all export**
+**7c. Export minimum price blocks battery-to-grid export only**
 
-See [Section 2c](#2c-export-minimum-price-blocks-all-export). If
-`export_min_price` is set above current export prices, the inverter blocks
-grid export. The battery may still discharge to serve house load, but won't
-export.
+See [Section 2c](#2c-export-minimum-price-blocks-battery-to-grid-export-only).
+If `export_min_price` is set above current export prices, HSEM won't force
+the battery to discharge to the grid. The battery still discharges to serve
+house load, and PV surplus still exports normally — neither is blocked by
+this setting.
 
 - **Check:** Current export spot price vs the `export_min_price` setting.
-- **Fix:** Lower the threshold if you want to export during low-price
-  periods.
+- **Fix:** Lower the threshold if you want the battery to export during
+  low-price periods too.
 
 **7d. Discharge efficiency configured incorrectly**
 

--- a/tests/custom_sensors/test_pv_curtailment_sensor.py
+++ b/tests/custom_sensors/test_pv_curtailment_sensor.py
@@ -1,0 +1,98 @@
+"""Regression tests for the PV curtailment sensor's derived heuristic (issue #925).
+
+Since issue #767, ``export_electricity_min_price``/``batteries_export_min_price``
+only gate intentional battery-to-grid export — PV surplus export continues
+unrestricted at any non-negative export price. The applier only physically
+blocks the whole grid connection point when the export price is negative.
+
+The derived curtailment heuristic previously assumed "export price below the
+configured minimum" meant "grid export is blocked", which stopped being true
+once #767 shipped. That produced a false ``"curtailed"`` reading whenever the
+battery was full, PV was producing, the active-power-control register was
+unavailable, and the export price was merely low-but-positive — exactly the
+scenario reported in issue #925 (export price 0.004 with a 0.02 floor).
+"""
+
+from __future__ import annotations
+
+from custom_components.hsem.custom_sensors.pv_curtailment_sensor import (
+    _is_derived_curtailment,
+    _is_directly_limited,
+)
+from custom_components.hsem.models.live_state import LiveState
+
+
+def _live(
+    *,
+    solar_w: float = 2000.0,
+    soc_pct: float | None = 96.0,
+    export_price: float = 0.004,
+    power_control: str | None = None,
+) -> LiveState:
+    live = LiveState()
+    live.solar_production_power_w = solar_w
+    live.huawei_batteries_soc_pct = soc_pct
+    live.export_electricity_price = export_price
+    live.huawei_inverter_active_power_control = power_control
+    return live
+
+
+class TestDerivedCurtailmentPositivePriceNotBlocked:
+    """Issue #925: a low-but-non-negative export price must not read as curtailed."""
+
+    def test_low_positive_price_below_configured_floor_is_not_curtailed(self) -> None:
+        # Mirrors the issue report: export_electricity_min_price=0.02,
+        # live export price=0.004, battery near-full, PV producing, register
+        # unavailable. PV export is not blocked at this price (issue #767),
+        # so the sensor must not report "curtailed".
+        live = _live(export_price=0.004, soc_pct=96.0, power_control=None)
+
+        assert _is_derived_curtailment(live) is False
+
+    def test_zero_export_price_is_not_curtailed(self) -> None:
+        live = _live(export_price=0.0, soc_pct=100.0, power_control=None)
+
+        assert _is_derived_curtailment(live) is False
+
+
+class TestDerivedCurtailmentNegativePriceStillDetected:
+    """Negative export prices are the only case HSEM itself blocks export."""
+
+    def test_negative_price_with_full_battery_is_curtailed(self) -> None:
+        live = _live(export_price=-0.01, soc_pct=96.0, power_control=None)
+
+        assert _is_derived_curtailment(live) is True
+
+    def test_negative_price_with_low_soc_is_not_curtailed(self) -> None:
+        live = _live(export_price=-0.01, soc_pct=50.0, power_control=None)
+
+        assert _is_derived_curtailment(live) is False
+
+    def test_negative_price_with_no_pv_production_is_not_curtailed(self) -> None:
+        live = _live(export_price=-0.01, solar_w=0.0, soc_pct=96.0, power_control=None)
+
+        assert _is_derived_curtailment(live) is False
+
+    def test_negative_price_with_known_unlimited_register_is_not_curtailed(
+        self,
+    ) -> None:
+        # Direct register reading takes precedence over the derived heuristic.
+        live = _live(export_price=-0.01, soc_pct=96.0, power_control="Unlimited")
+
+        assert _is_derived_curtailment(live) is False
+
+
+class TestDirectCurtailmentDetection:
+    """Direct register reading is unaffected by this fix."""
+
+    def test_unlimited_is_not_curtailed(self) -> None:
+        assert _is_directly_limited("Unlimited") is False
+
+    def test_limited_percentage_is_curtailed(self) -> None:
+        assert _is_directly_limited("Limited to 80%") is True
+
+    def test_limited_watt_is_curtailed(self) -> None:
+        assert _is_directly_limited("Limited to 100W") is True
+
+    def test_none_is_not_curtailed(self) -> None:
+        assert _is_directly_limited(None) is False


### PR DESCRIPTION
## Summary

Fixes #925 — "MILP plans PV export below configured minimum export price while PV Curtailment reports curtailed".

- The reporter's scenario (`export_electricity_min_price = 0.02`, live export price `0.004`, `Applier status = pending`, `Total writes = 0`) is actually **correct behaviour**: since issue #767, `export_electricity_min_price`/`batteries_export_min_price` only gate *intentional battery-to-grid export*. PV surplus export is never blocked at a non-negative price — only a **negative** export price makes the applier physically block the whole grid connection point. The MILP/applier code already implements this correctly (`planner/milp/_price_sanitise.py`, `custom_sensors/applier_power_control.py`).
- The real bug: `custom_sensors/pv_curtailment_sensor.py`'s derived-detection heuristic still used the **pre-#767** assumption — it flagged `"curtailed"` whenever the export price was below a fixed `0.01` threshold, the battery SoC was ≥ 95 %, PV was producing, and the inverter's active-power-control register was unavailable. That's exactly the reporter's scenario, and it produced a false `"curtailed"` reading even though the planner/applier were correctly continuing to export the PV surplus.
- Also corrected `hsem_export_electricity_min_price` translation copy (en/da/de/es) and two `docs/troubleshooting-guide.md` sections, which still described the old "blocks all export" behaviour and were the likely source of the reporter's expectation.

## Changes

- `custom_components/hsem/custom_sensors/pv_curtailment_sensor.py`: derived heuristic now keys off a **negative** export price (matching `applier_power_control.py`'s real gating boundary) instead of a fixed low-price threshold. Updated module/function docstrings accordingly.
- `custom_components/hsem/translations/{en,da,de,es}.json`: rewrote the `hsem_export_electricity_min_price` description to state it only gates intentional battery-to-grid export and does not block PV surplus export.
- `docs/troubleshooting-guide.md`: sections 2c/7c corrected to describe the current (post-#767) behaviour.
- `tests/custom_sensors/test_pv_curtailment_sensor.py` (new): regression coverage for the exact issue-925 scenario, plus negative-price detection and direct-register-override cases.

## Test plan

- [x] `pytest tests/custom_sensors/test_pv_curtailment_sensor.py` — 10 passed
- [x] `./scripts/quality.sh lint`
- [x] `./scripts/quality.sh typing`
- [x] `./scripts/quality.sh quality`
- [x] `./scripts/quality.sh test` — 3113 passed
- [x] `python3 scripts/validate_translations.py` — 0 errors (pre-existing unrelated warnings only)
