### PR TITLE
fix(diagnostics): log which slot/field trips invalid_future_values

### DIFF
--- a/custom_components/hsem/coordinator_helpers.py
+++ b/custom_components/hsem/coordinator_helpers.py
@@ -421,19 +421,36 @@ def assess_load_forecast(
     signature_slots: list[_LoadSlotSignature] = []
     weighted_profile_is_zero = True
     for rec in future_slots:
-        raw_values = (
-            rec.avg_house_consumption_kwh,
-            rec.avg_house_consumption_1d_kwh,
-            rec.avg_house_consumption_3d_kwh,
-            rec.avg_house_consumption_7d_kwh,
-            rec.avg_house_consumption_14d_kwh,
+        named_raw_values = (
+            ("avg_house_consumption_kwh", rec.avg_house_consumption_kwh),
+            ("avg_house_consumption_1d_kwh", rec.avg_house_consumption_1d_kwh),
+            ("avg_house_consumption_3d_kwh", rec.avg_house_consumption_3d_kwh),
+            ("avg_house_consumption_7d_kwh", rec.avg_house_consumption_7d_kwh),
+            ("avg_house_consumption_14d_kwh", rec.avg_house_consumption_14d_kwh),
         )
         canonical_values: list[float] = []
-        for raw_value in raw_values:
+        for field_name, raw_value in named_raw_values:
             if isinstance(raw_value, bool) or not isinstance(raw_value, (int, float)):
+                async_log(
+                    "warning",
+                    "[load] Forecast slot %s has a non-numeric %s (%r, type=%s); "
+                    "holding as invalid_future_values.",
+                    utc_key(rec.start).isoformat(),
+                    field_name,
+                    raw_value,
+                    type(raw_value).__name__,
+                )
                 return LoadForecastReadiness(False, "invalid_future_values", None)
             number = float(raw_value)
             if not math.isfinite(number) or number < 0.0:
+                async_log(
+                    "warning",
+                    "[load] Forecast slot %s has an out-of-range %s (%s); "
+                    "holding as invalid_future_values.",
+                    utc_key(rec.start).isoformat(),
+                    field_name,
+                    number,
+                )
                 return LoadForecastReadiness(False, "invalid_future_values", None)
             canonical_values.append(round(number, 5))
 

--- a/tests/test_load_forecast_readiness.py
+++ b/tests/test_load_forecast_readiness.py
@@ -92,6 +92,52 @@ class TestLoadForecastAssessment:
         )
         assert result.ready is False
         assert result.reason == "invalid_future_values"
+
+    def test_invalid_value_is_logged_with_slot_and_field_name(self) -> None:
+        # Issue #925 follow-up: the generic "invalid_future_values" reason
+        # alone gives operators nothing to act on. Diagnostic logging must
+        # name the offending slot and field so a bad ML/legacy-avg output
+        # can actually be traced back to its source.
+        now = datetime(2026, 8, 21, 12, 5, tzinfo=UTC)
+        profile = _profile(now, 0.2)
+        profile[1].avg_house_consumption_7d_kwh = float("nan")
+
+        with patch("custom_components.hsem.coordinator_helpers.async_log") as mock_log:
+            result = assess_load_forecast(
+                profile,
+                now,
+                population_succeeded=True,
+                live_house_demand_w=0.0,
+            )
+
+        assert result.reason == "invalid_future_values"
+        mock_log.assert_called_once()
+        level, msg, *args = mock_log.call_args.args
+        assert level == "warning"
+        formatted = msg % tuple(args)
+        assert "avg_house_consumption_7d_kwh" in formatted
+        assert profile[1].start.isoformat() in formatted
+
+    def test_non_numeric_value_is_logged_with_type(self) -> None:
+        now = datetime(2026, 8, 21, 12, 5, tzinfo=UTC)
+        profile = _profile(now, 0.2)
+        profile[1].avg_house_consumption_1d_kwh = None  # type: ignore[assignment]
+
+        with patch("custom_components.hsem.coordinator_helpers.async_log") as mock_log:
+            result = assess_load_forecast(
+                profile,
+                now,
+                population_succeeded=True,
+                live_house_demand_w=0.0,
+            )
+
+        assert result.reason == "invalid_future_values"
+        mock_log.assert_called_once()
+        level, msg, *args = mock_log.call_args.args
+        assert level == "warning"
+        formatted = msg % tuple(args)
+        assert "avg_house_consumption_1d_kwh" in formatted
+        assert "NoneType" in formatted
         assert result.signature is None
 
     @pytest.mark.parametrize("live_w", [None, 0.0, 49.9, 50.0])


### PR DESCRIPTION
## Summary

Fixes #931 — follow-up from the second comment on #925 (191/192 `hourly_recommendations` slots had `recommendation=None` because `load_forecast_reason=invalid_future_values` engaged a `safety_hold`).

That fail-closed behaviour is correct by design — `assess_load_forecast()` deliberately holds the battery rather than plan on a broken future-load profile. The gap was purely diagnostic: the generic `"invalid_future_values"` reason gave no way to tell which of the 192 slots, or which of the 5 consumption fields, actually failed validation, so a genuine upstream ML/legacy-avg data bug would be invisible in the logs.

## Changes

- `custom_components/hsem/coordinator_helpers.py::assess_load_forecast()`: added a warning-level `async_log()` call at each existing fail-closed return, naming the slot's UTC timestamp and the specific field (`avg_house_consumption_kwh`/`_1d_kwh`/`_3d_kwh`/`_7d_kwh`/`_14d_kwh`). Non-numeric/bool failures log the raw value and its type; non-finite/negative failures log the numeric value. No change to the validation logic or return values — logging only.
- `tests/test_load_forecast_readiness.py`: two new tests asserting the log call fires with the correct field name, slot timestamp, and type/value detail for both failure branches.

## Test plan

- [x] `pytest tests/test_load_forecast_readiness.py` — 27 passed
- [x] `./scripts/quality.sh lint`
- [x] `./scripts/quality.sh typing`
- [x] `./scripts/quality.sh quality`
- [x] `./scripts/quality.sh test` — 3115 passed
