### PR TITLE
fix(sensor): reject negative/non-finite utility-meter readings in avg sensor

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -1039,6 +1039,31 @@ Regression tests: `tests/test_avg_sensor_partial_day.py`.
 
 ---
 
+## Avg Sensor Must Reject Negative/Non-Finite Utility-Meter Readings (issue #938)
+
+`HSEMAvgSensor._async_store_utility_meter_value` and the `async_added_to_hass`
+restore path never validated the tracked utility-meter's value before writing
+it into `self._measurements`. A misconfigured net-consumption accounting mode
+produced one negative reading; once persisted it became the sole "1d" sample
+(the "1d" window holds only 1 entry) and kept `assess_load_forecast()`
+(`coordinator_helpers.py`, ~line 436) fail-closed with
+`reason="invalid_future_values"` — engaging `safety_hold` — even after the
+source misconfiguration was corrected, because the window would not refresh
+until that specific hour block completed again on a later day.
+
+Canonical rule: **reject non-finite/negative readings before they ever reach
+`self._measurements`**, both at write time (`_async_store_utility_meter_value`
+— log a warning and skip storing, leaving any existing sample for that date
+untouched) and at restore time (`async_added_to_hass` — drop bad entries out
+of the restored `measurements` dict so a value persisted by a pre-fix version
+is never replayed). A rejected sample leaves the sensor `unavailable` (never
+a negative published average), so the very next completed block produces a
+fresh valid sample instead of waiting out a multi-day window.
+
+Regression tests: `tests/test_avg_sensor_negative_guard.py`.
+
+---
+
 ## Solar-Charge Mislabel at Zero PV (issue #720 follow-up)
 
 `apply_optimization_strategy` used `NEAR_ZERO_CONSUMPTION_THRESHOLD_KWH`

--- a/custom_components/hsem/custom_sensors/avg_sensor.py
+++ b/custom_components/hsem/custom_sensors/avg_sensor.py
@@ -174,10 +174,24 @@ class HSEMAvgSensor(RestoreEntity, SensorEntity, HSEMEntity):
             restored_measurements = old_state.attributes.get("measurements", None)
 
             if restored_measurements is not None:
-                self._measurements = {
-                    self.parse_date(k): round(float(v), 2)
-                    for k, v in restored_measurements.items()
-                }
+                # A non-finite/negative value persisted by a pre-fix version
+                # (e.g. a misconfigured net-consumption utility meter) must
+                # not be replayed as a valid sample after an upgrade/restart
+                # — see issue #938.
+                parsed_measurements: dict[str, float] = {}
+                for raw_date, raw_value in restored_measurements.items():
+                    value = round(float(raw_value), 2)
+                    if not math.isfinite(value) or value < 0.0:
+                        _LOGGER.warning(
+                            "Discarding restored non-finite/negative measurement "
+                            "for entity_id=%s date=%s value=%s",
+                            self._tracked_entity,
+                            raw_date,
+                            value,
+                        )
+                        continue
+                    parsed_measurements[self.parse_date(raw_date)] = value
+                self._measurements = parsed_measurements
 
             self._last_updated = old_state.attributes.get("last_updated", None)
 
@@ -297,9 +311,22 @@ class HSEMAvgSensor(RestoreEntity, SensorEntity, HSEMEntity):
                 )
 
             if block_complete:
-                self._measurements[measurement_date.isoformat()] = round(
-                    float(utility_meter_value), 2
-                )
+                value = round(float(utility_meter_value), 2)
+                # A misconfigured tracked utility meter (e.g. net-consumption
+                # accounting) can report a negative or non-finite reading.
+                # Storing that as the day's sample would poison a rolling
+                # window that may not roll over for days — reject it instead
+                # (issue #938).
+                if math.isfinite(value) and value >= 0.0:
+                    self._measurements[measurement_date.isoformat()] = value
+                else:
+                    _LOGGER.warning(
+                        "Rejected non-finite/negative utility-meter reading for "
+                        "entity_id=%s on %s: %s",
+                        self._tracked_entity,
+                        measurement_date.isoformat(),
+                        value,
+                    )
 
         if self._measurements is not None and len(self._measurements) > self._average:
             await self._async_cleanup_old_measurements()

--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -101,6 +101,15 @@ zero-load forecast.
 - **Fix:** Wait for the next statistics cycle (usually 5 minutes), or repair an
   average sensor that remains unavailable. HSEM retries every minute and runs a
   fresh plan when the profile recovers.
+- **Misconfigured utility meter (e.g. net-consumption accounting) producing a
+  negative reading:** the rolling-average sensors
+  (`sensor.hsem_*_avg_energy_{1,3,7,14}d_*`) reject non-finite/negative
+  readings before storing them — a bad reading is logged and skipped rather
+  than persisted, so the sensor reports `unavailable` for that block instead
+  of a negative value. Once the source configuration is corrected, the next
+  completed hour block stores a valid sample and `load_forecast_ready`
+  recovers on the next cycle — it does not wait for a multi-day window to
+  age out the bad entry.
 
 ---
 

--- a/tests/test_avg_sensor_negative_guard.py
+++ b/tests/test_avg_sensor_negative_guard.py
@@ -1,0 +1,276 @@
+"""Regression tests for issue #938 — stale negative rolling-average sample.
+
+Bug
+---
+``HSEMAvgSensor._async_store_utility_meter_value`` never validated that the
+tracked utility meter's value was finite and non-negative before persisting
+it as a day's sample.  A misconfigured net-consumption accounting mode
+produced a negative reading for one hour block; once persisted it became the
+sole "1d" rolling-average sample (the "1d" window holds only 1 entry) and
+kept ``assess_load_forecast()`` (``coordinator_helpers.py``) failing closed
+with ``reason="invalid_future_values"`` — engaging ``safety_hold`` — even
+after the source misconfiguration was corrected, because the window would
+not refresh until that specific hour block completed again on a later day.
+
+Fix
+---
+Reject non-finite/negative readings both when storing a new sample
+(``_async_store_utility_meter_value``) and when replaying a persisted
+sample across restart (``async_added_to_hass``), so a bad reading is
+skipped (logged) rather than poisoning the window, and the average
+recovers on the very next completed block.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from homeassistant.helpers.restore_state import RestoreEntity
+
+from custom_components.hsem.coordinator_helpers import assess_load_forecast
+from custom_components.hsem.custom_sensors.avg_sensor import HSEMAvgSensor
+from custom_components.hsem.models.hourly_recommendation import HourlyRecommendation
+from custom_components.hsem.utils.recommendations import Recommendations
+
+
+def _make_sensor(
+    hour_start: int,
+    hour_end: int,
+    measurements: dict[str, float] | None = None,
+    average: int = 1,
+) -> MagicMock:
+    sensor = MagicMock(spec=HSEMAvgSensor)
+    sensor.hass = MagicMock()
+    sensor._tracked_entity = "sensor.daily_kwh"
+    sensor._measurements = measurements if measurements is not None else {}
+    sensor._average = average
+    sensor._hour_start = hour_start
+    sensor._hour_end = hour_end
+    sensor._async_cleanup_old_measurements = AsyncMock()
+    return sensor
+
+
+async def _store(sensor: MagicMock, now: datetime, meter_value: float) -> None:
+    with (
+        patch(
+            "custom_components.hsem.custom_sensors.avg_sensor.dt_util.now",
+            return_value=now,
+        ),
+        patch(
+            "custom_components.hsem.custom_sensors.avg_sensor"
+            ".ha_get_entity_state_and_convert",
+            return_value=meter_value,
+        ),
+    ):
+        await HSEMAvgSensor._async_store_utility_meter_value(sensor)
+
+
+def _avg_sensor(average: int = 1) -> HSEMAvgSensor:
+    """Return a real average sensor with its HA dependencies mocked."""
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    entry.options = {}
+    entry.data = {}
+    sensor = HSEMAvgSensor(
+        config_entry=entry,
+        hour_start=14,
+        hour_end=15,
+        avg=average,
+        tracked_entity="sensor.utility",
+        name="Test average",
+        unique_id="test_average",
+        entity_id="sensor.test_average",
+    )
+    sensor.hass = MagicMock()
+    return sensor
+
+
+class TestNegativeReadingRejectedAtWriteTime:
+    """A bad reading from a misconfigured utility meter must be skipped."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "bad_value", [-0.205, float("nan"), float("inf"), float("-inf")]
+    )
+    async def test_bad_reading_not_stored(self, bad_value: float) -> None:
+        sensor = _make_sensor(hour_start=14, hour_end=15)
+        await _store(sensor, datetime(2026, 8, 8, 15, 5, tzinfo=UTC), bad_value)
+        assert sensor._measurements == {}
+
+    @pytest.mark.asyncio
+    async def test_negative_reading_does_not_overwrite_existing_sample(self) -> None:
+        """A glitched reading must not clobber a previously valid sample."""
+        sensor = _make_sensor(
+            hour_start=14, hour_end=15, measurements={"2026-08-07": 0.42}
+        )
+        await _store(sensor, datetime(2026, 8, 8, 15, 5, tzinfo=UTC), -0.205)
+        assert sensor._measurements == {"2026-08-07": 0.42}
+
+    @pytest.mark.asyncio
+    async def test_valid_reading_after_rejected_negative_recovers(self) -> None:
+        """Once the source config is corrected, the next block stores fine."""
+        sensor = _make_sensor(hour_start=14, hour_end=15, average=1)
+        # Day 1: misconfigured net-consumption accounting — rejected.
+        await _store(sensor, datetime(2026, 8, 8, 15, 5, tzinfo=UTC), -0.205)
+        assert sensor._measurements == {}
+        # Day 2: source config corrected, a real positive reading is stored.
+        await _store(sensor, datetime(2026, 8, 9, 15, 5, tzinfo=UTC), 0.35)
+        assert sensor._measurements == {"2026-08-09": 0.35}
+
+
+class TestNegativeMeasurementRejectedAtRestoreTime:
+    """A negative value persisted by a pre-fix version must not be replayed."""
+
+    @pytest.mark.asyncio
+    async def test_negative_restored_measurement_is_discarded(self) -> None:
+        sensor = _avg_sensor()
+        sensor.async_get_last_state = AsyncMock(  # type: ignore[method-assign]
+            return_value=SimpleNamespace(
+                state="-0.21",
+                attributes={"measurements": {"2026-08-08": -0.205}},
+            )
+        )
+        sensor._async_handle_update = AsyncMock()  # type: ignore[method-assign]
+        with (
+            patch(
+                "custom_components.hsem.custom_sensors.avg_sensor"
+                ".async_track_time_interval",
+                return_value=MagicMock(),
+            ),
+            patch.object(RestoreEntity, "async_added_to_hass", new_callable=AsyncMock),
+        ):
+            await sensor.async_added_to_hass()
+        assert sensor._measurements == {}
+
+    @pytest.mark.asyncio
+    async def test_mixed_restored_measurements_only_valid_kept(self) -> None:
+        sensor = _avg_sensor(average=3)
+        sensor.async_get_last_state = AsyncMock(  # type: ignore[method-assign]
+            return_value=SimpleNamespace(
+                state="0.4",
+                attributes={
+                    "measurements": {
+                        "2026-08-06": 0.3,
+                        "2026-08-07": -0.205,
+                        "2026-08-08": float("nan"),
+                    }
+                },
+            )
+        )
+        sensor._async_handle_update = AsyncMock()  # type: ignore[method-assign]
+        with (
+            patch(
+                "custom_components.hsem.custom_sensors.avg_sensor"
+                ".async_track_time_interval",
+                return_value=MagicMock(),
+            ),
+            patch.object(RestoreEntity, "async_added_to_hass", new_callable=AsyncMock),
+        ):
+            await sensor.async_added_to_hass()
+        assert sensor._measurements == {"2026-08-06": 0.3}
+
+
+class TestRecoveryAfterCorrection:
+    """End-to-end: bad reading never reaches the load forecast; recovers."""
+
+    @pytest.mark.asyncio
+    async def test_negative_reading_leaves_sensor_unavailable_not_negative(
+        self,
+    ) -> None:
+        """The bad reading must never surface as the published average."""
+        sensor = _avg_sensor(average=1)
+        sensor._async_track_entities = AsyncMock()  # type: ignore[method-assign]
+        sensor.async_write_ha_state = MagicMock()  # type: ignore[method-assign,misc]
+        with (
+            patch(
+                "custom_components.hsem.custom_sensors.avg_sensor.dt_util.now",
+                return_value=datetime(2026, 8, 8, 15, 5, tzinfo=UTC),
+            ),
+            patch(
+                "custom_components.hsem.custom_sensors.avg_sensor"
+                ".ha_get_entity_state_and_convert",
+                return_value=-0.205,
+            ),
+        ):
+            await sensor._async_handle_update()
+        assert sensor._measurements == {}
+        assert sensor.state is None
+        assert sensor.available is False
+
+    @pytest.mark.asyncio
+    async def test_recovers_and_load_forecast_becomes_ready_on_next_valid_sample(
+        self,
+    ) -> None:
+        """After the source config is fixed, the next completed block
+        produces a valid sample and ``assess_load_forecast`` reports
+        ``ready=True`` again — ``safety_hold`` clears (issue #938)."""
+        sensor = _avg_sensor(average=1)
+        sensor._async_track_entities = AsyncMock()  # type: ignore[method-assign]
+        sensor.async_write_ha_state = MagicMock()  # type: ignore[method-assign,misc]
+
+        # Day 1 (misconfigured): negative reading rejected, stays unavailable.
+        with (
+            patch(
+                "custom_components.hsem.custom_sensors.avg_sensor.dt_util.now",
+                return_value=datetime(2026, 8, 8, 15, 5, tzinfo=UTC),
+            ),
+            patch(
+                "custom_components.hsem.custom_sensors.avg_sensor"
+                ".ha_get_entity_state_and_convert",
+                return_value=-0.205,
+            ),
+        ):
+            await sensor._async_handle_update()
+        assert sensor.state is None
+
+        # Day 2 (corrected): a valid positive reading replaces it.
+        with (
+            patch(
+                "custom_components.hsem.custom_sensors.avg_sensor.dt_util.now",
+                return_value=datetime(2026, 8, 9, 15, 5, tzinfo=UTC),
+            ),
+            patch(
+                "custom_components.hsem.custom_sensors.avg_sensor"
+                ".ha_get_entity_state_and_convert",
+                return_value=0.35,
+            ),
+        ):
+            await sensor._async_handle_update()
+        assert sensor.state == pytest.approx(0.35)
+        avg_value = sensor.state
+        assert avg_value is not None
+
+        now = datetime(2026, 8, 21, 12, 5, tzinfo=UTC)
+        rec = HourlyRecommendation(
+            start=now + timedelta(minutes=10),
+            end=now + timedelta(minutes=25),
+            recommendation=Recommendations.BatteriesWaitMode.value,
+            avg_house_consumption_kwh=avg_value,
+            avg_house_consumption_1d_kwh=avg_value,
+            avg_house_consumption_3d_kwh=avg_value,
+            avg_house_consumption_7d_kwh=avg_value,
+            avg_house_consumption_14d_kwh=avg_value,
+            batteries_charged_kwh=0.0,
+            batteries_discharged_kwh=0.0,
+            estimated_battery_capacity_kwh=0.0,
+            estimated_battery_soc_pct=0.0,
+            estimated_cost_currency=0.0,
+            estimated_net_consumption_kwh=0.0,
+            export_price=0.0,
+            grid_export_kwh=0.0,
+            grid_import_kwh=0.0,
+            import_price=0.0,
+            solcast_pv_estimate_kwh=0.0,
+        )
+        result = assess_load_forecast(
+            [rec],
+            now,
+            population_succeeded=True,
+            live_house_demand_w=0.0,
+        )
+        assert result.ready is True
+        assert result.reason is None


### PR DESCRIPTION
## Summary

- `HSEMAvgSensor._async_store_utility_meter_value()` never validated that the
  tracked utility-meter's value was finite/non-negative before persisting it
  as a completed hour-block-day sample into `self._measurements`. A
  misconfigured net-consumption accounting mode produced a single negative
  reading for one hour block; once persisted it became the sole "1d" rolling
  sample (the "1d" window holds only 1 entry) and kept
  `assess_load_forecast()` (`coordinator_helpers.py`) fail-closed with
  `reason="invalid_future_values"` — engaging `safety_hold` — even after the
  reporter corrected the source configuration, because the 1-day window
  would not refresh until that specific hour block completed again on a
  later day.
- Fixed by rejecting non-finite/negative readings in two places:
  - `_async_store_utility_meter_value` — log a warning and skip storing
    (leaving any existing sample for that date untouched) instead of writing
    a physically-impossible value.
  - `async_added_to_hass` restore path — drop bad entries out of the
    restored `measurements` dict so a negative value persisted by a pre-fix
    version is never replayed as valid state after an upgrade/restart.
- A rejected reading leaves the sensor `unavailable` for that block (never a
  negative published average), so the very next completed block produces a
  fresh valid sample instead of waiting out a multi-day window.

## Branch

`fix/938-negative-avg-sensor-value`

## Files changed

- `custom_components/hsem/custom_sensors/avg_sensor.py` — guard both the
  write path and the restore path against non-finite/negative readings.
- `tests/test_avg_sensor_negative_guard.py` (new) — regression tests.
- `.github/memories.md` — canonical-pattern entry documenting the guard,
  alongside the existing #720 partial-day entry for the same sensor.
- `docs/troubleshooting-guide.md` — note in the "Consumption energy sensors
  not ready after restart" section explaining the new guard and recovery
  behaviour.

## Tests added

`tests/test_avg_sensor_negative_guard.py`:

- Negative/NaN/±inf readings rejected at write time and don't overwrite an
  existing valid sample.
- A valid reading on the next completed block is stored normally after a
  rejected reading (recovery).
- Negative and NaN restored measurements are discarded on
  `async_added_to_hass`, while valid entries in the same restored dict are
  kept.
- A rejected reading leaves the sensor `unavailable` rather than publishing
  a negative average.
- End-to-end: after a rejected negative reading followed by a valid one,
  `assess_load_forecast()` returns `ready=True` (`safety_hold` clears) using
  the recovered average.

## Test & lint results

```
./scripts/quality.sh all
```

- lint (ruff format + ruff check + prettier): pass
- typing (mypy): 0 errors
- quality (pyright + vulture): 0 errors
- test (pytest + coverage): 3113 passed

## Known limitations / open questions

None. This is a targeted, backward-compatible fix — behaviour for valid
(finite, non-negative) readings is unchanged.

Fixes #938
