### PR TITLE
fix(applier): wait-mode self-consumption discharge cap as SoC-floor gate, not a slot-averaged rate

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -1279,8 +1279,23 @@ instead of keeping the battery strictly idle.
   applier falls back to strict TOU wait mode.
 - PV surplus during wait-mode self-consumption is directed to charge the battery
   (`desired_excess = "charge"`), not exported to grid.
-- The cap is computed from the surplus energy and the slot duration so the
-  reserve is preserved even if the house load is high.
+- **Discharge cap is an SoC-floor gate, not a rate cap (issue #942, fixed
+  2026-09-08):** the original formula was `surplus_kwh / slot_hours`, spreading
+  the reserved surplus evenly across the whole slot — this produced low,
+  load-averaged wattages (e.g. 264–380 W) that ignored actual instantaneous
+  house load, so a real load spike above that average pulled the extra power
+  from the grid even though the battery still held usable surplus.
+  `applier_caps._wait_mode_self_consumption_cap_w()` now returns the full
+  rated/configured `max_discharge_power_w` whenever
+  `battery_capacity_kwh > required_capacity_kwh` (material surplus), and `0`
+  otherwise — a stop-discharge gate re-evaluated every apply cycle, not a
+  slow-drain rate. Reserve protection and house-load support are thereby
+  decoupled: the reserve stops discharge once reached, but never throttles
+  discharge power while surplus remains. The EV-active cap
+  (`_planned_ev_discharge_cap_w`) was deliberately left unchanged — it is a
+  materially different formula (the planner's own solved per-slot discharge
+  rate, clamped to per-EV ceilings) and reworking it to the same floor-gate
+  model is tracked as a separate follow-up, not bundled into #942.
 - EV-active slots keep their existing EV discharge cap logic; the wait-mode cap
   is not applied while an EV is charging.
 - **Reserve source (issue #914):** the wait-mode reserve is `wait_mode_reserve_kwh`

--- a/custom_components/hsem/custom_sensors/applier.py
+++ b/custom_components/hsem/custom_sensors/applier.py
@@ -480,10 +480,13 @@ async def async_apply_battery_settings(
                 )
                 return summary
 
-    # Wait mode self-consumption: cap discharge power so only surplus energy
-    # above the planner's required reserve can be used.  This preserves the
-    # reserve for future scheduled discharge windows while still allowing the
-    # house to cover normal self-consumption from the surplus.
+    # Wait mode self-consumption: an SoC-floor stop-discharge gate, not a rate
+    # spread over the slot (issue #942).  While the battery holds any surplus
+    # above the planner's required reserve, the house may draw at the full
+    # rated/configured discharge rate, so a real load spike is served from the
+    # battery instead of the grid; once capacity reaches the reserve floor,
+    # discharge stops so the reserve is protected for future scheduled
+    # discharge windows.
     wait_mode_self_consumption = (
         recommendation == Recommendations.BatteriesWaitMode.value
         and not primary_battery_hold
@@ -493,12 +496,10 @@ async def async_apply_battery_settings(
         and wait_mode_reserve_kwh is not None
     )
     if wait_mode_self_consumption and wait_mode_reserve_kwh is not None:
-        slot_hours = slot_duration_hours(rec.start, rec.end)
         surplus = max(live.battery_current_capacity_kwh - wait_mode_reserve_kwh, 0.0)
         cap_w = _wait_mode_self_consumption_cap_w(
             battery_capacity_kwh=live.battery_current_capacity_kwh,
             required_capacity_kwh=wait_mode_reserve_kwh,
-            slot_hours=slot_hours,
             max_discharge_power_w=max_discharge_power,
         )
         if live.huawei_batteries_max_discharge_power_w != cap_w:
@@ -520,13 +521,11 @@ async def async_apply_battery_settings(
             summary.results.append(wait_cap_result)
             _LOGGER.debug(
                 "Wait mode self-consumption — capped max discharge power to %d W "
-                "(capacity=%.2f kWh, required=%.2f kWh, surplus=%.2f kWh, "
-                "slot_hours=%.3f)",
+                "(capacity=%.2f kWh, required=%.2f kWh, surplus=%.2f kWh)",
                 cap_w,
                 live.battery_current_capacity_kwh,
                 wait_mode_reserve_kwh,
                 surplus,
-                slot_hours,
             )
             if wait_cap_result.status == ApplyStatus.FAILED:
                 _LOGGER.debug(

--- a/custom_components/hsem/custom_sensors/applier_caps.py
+++ b/custom_components/hsem/custom_sensors/applier_caps.py
@@ -41,36 +41,39 @@ def _configured_battery_device_ids(cfg: SensorConfig) -> list[str]:
 def _wait_mode_self_consumption_cap_w(
     battery_capacity_kwh: float,
     required_capacity_kwh: float,
-    slot_hours: float,
     max_discharge_power_w: int,
 ) -> int:
     """Return the discharge power cap for wait-mode self-consumption.
 
-    When the battery holds more energy than the planner has reserved for future
-    expensive periods, the surplus may be used for normal household
-    self-consumption.  The cap is the power required to consume exactly that
-    surplus over the slot duration; the inverter will only draw what the house
-    actually needs, so the battery will not discharge faster than the surplus
-    allows.
+    This is an SoC-floor stop-discharge gate, not a rate spread over the slot
+    (issue #942): while the battery holds more energy than the planner has
+    reserved for future expensive periods, the house may draw at the full
+    rated/configured discharge rate, so a real load spike is served from the
+    battery instead of the grid. Once capacity reaches the reserve floor,
+    discharge is stopped so the reserve is protected.
+
+    The previous formula (``surplus_kwh / slot_hours``) spread the surplus
+    evenly across the whole slot, producing low average wattages that could
+    not track actual instantaneous load — a stove switching on above that
+    average cap pulled the extra power from the grid even though the battery
+    still had usable surplus. This gate is re-evaluated every apply cycle, so
+    the discharge stops as soon as live capacity reaches the reserve.
 
     Args:
         battery_capacity_kwh: Current usable battery energy above the discharge
             floor (kWh).
         required_capacity_kwh: Energy the planner has reserved for future use
             (kWh).
-        slot_hours: Duration of the current recommendation slot in hours.
         max_discharge_power_w: Maximum discharge power supported by the battery
             pack (W).
 
     Returns:
-        Discharge power cap in watts.  ``0`` when there is no surplus above the
-        reserve or the slot duration is invalid.
+        ``max_discharge_power_w`` when there is any surplus above the reserve,
+        ``0`` otherwise.
     """
-    surplus_kwh = max(battery_capacity_kwh - required_capacity_kwh, 0.0)
-    if surplus_kwh <= 1e-9 or slot_hours <= 1e-9:
+    if battery_capacity_kwh - required_capacity_kwh <= 1e-9:
         return 0
-    cap_w = int(surplus_kwh / slot_hours * 1000.0)
-    return min(cap_w, max_discharge_power_w)
+    return max_discharge_power_w
 
 
 def _is_positive_finite_number(value: object) -> bool:

--- a/docs/planner-guide.md
+++ b/docs/planner-guide.md
@@ -490,14 +490,18 @@ recommendation it is not changed by later rules in the same layer.
 > **Wait mode behaviour:** the `batteries_wait_mode` recommendation normally keeps the
 > battery idle. When `hsem_batteries_wait_mode_behavior` is set to
 > `self_consumption_with_reserve`, the applier switches the inverter to
-> `MaximizeSelfConsumption` and caps discharge power so only surplus energy above
-> the reserve is used. This reduces unnecessary grid import while still preserving
-> capacity for future scheduled discharge windows. The reserve is derived from the
-> **selected plan's own simulated SoC trajectory** (issue #914) — how far it dips
-> before its next actual solved charge — not from a raw forecast PV-surplus scan,
-> so a small or short-lived forecast surplus no longer lets the battery discharge
-> energy the plan needs for a later expensive period. If no reliable reserve can
-> be derived, the applier falls back to strict Wait for that slot.
+> `MaximizeSelfConsumption`. Discharge is gated by an SoC floor, not a rate cap
+> (issue #942): while the battery holds any surplus above the reserve, the house
+> may draw at the full rated/configured discharge rate — so a real load spike is
+> served from the battery instead of the grid — and once capacity reaches the
+> reserve floor, discharge stops. This reduces unnecessary grid import while still
+> preserving capacity for future scheduled discharge windows. The reserve is
+> derived from the **selected plan's own simulated SoC trajectory** (issue #914) —
+> how far it dips before its next actual solved charge — not from a raw forecast
+> PV-surplus scan, so a small or short-lived forecast surplus no longer lets the
+> battery discharge energy the plan needs for a later expensive period. If no
+> reliable reserve can be derived, the applier falls back to strict Wait for that
+> slot.
 
 **Discharge concentration** (`concentrate_discharge_on_expensive_slots`) runs after the
 seasonal fill but before candidate generation. It re-evaluates all discharge-mode

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -2101,6 +2101,24 @@ unexpected solar).
 
 ### Wait-mode self-consumption reserve (issue #914)
 
+**Discharge cap is an SoC-floor stop-discharge gate, not a rate spread over
+the slot (issue #942):** `applier_caps._wait_mode_self_consumption_cap_w()`
+originally computed `surplus_kwh / slot_hours`, spreading the reserved
+surplus evenly across the whole slot. This produced low, load-averaged
+wattages (e.g. 264–380 W) with no relationship to actual instantaneous house
+load — a real load spike above that average cap pulled the extra power from
+the grid even though the battery still held usable surplus, causing
+unnecessary grid import. The fix replaces the rate formula with a floor gate:
+while `battery_current_capacity_kwh` is above `wait_mode_reserve_kwh` by any
+material amount, the cap is the full rated/configured discharge maximum, so
+normal house-load support (including spikes) is served from the battery;
+once capacity reaches the reserve floor, the cap drops to 0 W so the reserve
+is protected. The gate is re-evaluated every apply cycle (interval tick,
+event-triggered replan, or the 10-second live-power monitor's reactive
+replan), so discharge stops as soon as live capacity reaches the reserve —
+battery-to-grid export remains governed separately by export-price/
+curtailment logic, never by this cap.
+
 The **EV discharge-cap SoC guard** above and `apply_excess_export()` both use
 `current_required_battery_kwh`, derived from
 `calculate_required_battery_until_solar()` (`planner/discharge_scheduler.py`):

--- a/tests/sensors/test_applier.py
+++ b/tests/sensors/test_applier.py
@@ -128,7 +128,13 @@ class TestPlannedEvDischargeCapW:
 
 
 class TestWaitModeSelfConsumptionCapW:
-    """Unit tests for the wait-mode self-consumption discharge cap."""
+    """Unit tests for the wait-mode self-consumption discharge cap (issue #942).
+
+    The cap is an SoC-floor stop-discharge gate, not a rate spread over the
+    slot: any surplus above the reserve unlocks the full rated/configured
+    discharge rate, so a real load spike is served from the battery instead
+    of the grid; at or below the reserve, discharge is 0.
+    """
 
     @staticmethod
     def _cap(**kwargs):
@@ -142,7 +148,6 @@ class TestWaitModeSelfConsumptionCapW:
         cap = self._cap(
             battery_capacity_kwh=2.0,
             required_capacity_kwh=2.0,
-            slot_hours=0.25,
             max_discharge_power_w=5000,
         )
         assert cap == 0
@@ -151,48 +156,26 @@ class TestWaitModeSelfConsumptionCapW:
         cap = self._cap(
             battery_capacity_kwh=1.5,
             required_capacity_kwh=2.0,
-            slot_hours=0.25,
             max_discharge_power_w=5000,
         )
         assert cap == 0
 
-    def test_surplus_converted_to_power(self):
-        """1 kWh surplus over a 1-hour slot → 1000 W cap."""
+    def test_small_surplus_unlocks_full_rated_max(self):
+        """A small surplus still unlocks the full rate, not a scaled-down value."""
         cap = self._cap(
-            battery_capacity_kwh=3.0,
+            battery_capacity_kwh=2.01,
             required_capacity_kwh=2.0,
-            slot_hours=1.0,
             max_discharge_power_w=5000,
         )
-        assert cap == 1000
+        assert cap == 5000
 
-    def test_surplus_over_short_slot(self):
-        """1 kWh surplus over a 15-minute slot → 4000 W cap."""
-        cap = self._cap(
-            battery_capacity_kwh=3.0,
-            required_capacity_kwh=2.0,
-            slot_hours=0.25,
-            max_discharge_power_w=5000,
-        )
-        assert cap == 4000
-
-    def test_cap_limited_by_max_discharge_power(self):
+    def test_large_surplus_still_capped_at_rated_max(self):
         cap = self._cap(
             battery_capacity_kwh=10.0,
             required_capacity_kwh=0.0,
-            slot_hours=0.25,
             max_discharge_power_w=2500,
         )
         assert cap == 2500
-
-    def test_zero_slot_hours_returns_zero(self):
-        cap = self._cap(
-            battery_capacity_kwh=5.0,
-            required_capacity_kwh=0.0,
-            slot_hours=0.0,
-            max_discharge_power_w=5000,
-        )
-        assert cap == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_batteries_wait_mode.py
+++ b/tests/test_batteries_wait_mode.py
@@ -57,13 +57,18 @@ class TestWaitModeDefaults:
 
 
 class TestWaitModeSelfConsumptionCapW:
-    """Unit tests for the reserve-preserving discharge cap helper."""
+    """Unit tests for the reserve-preserving discharge cap helper (issue #942).
+
+    The cap is an SoC-floor stop-discharge gate, not a rate spread over the
+    slot: any surplus above the reserve unlocks the full rated/configured
+    discharge rate, so a real load spike is served from the battery instead
+    of the grid; at or below the reserve, discharge is 0.
+    """
 
     def test_no_surplus_returns_zero(self):
         cap = _wait_mode_self_consumption_cap_w(
             battery_capacity_kwh=2.0,
             required_capacity_kwh=2.0,
-            slot_hours=0.25,
             max_discharge_power_w=5000,
         )
         assert cap == 0
@@ -72,48 +77,26 @@ class TestWaitModeSelfConsumptionCapW:
         cap = _wait_mode_self_consumption_cap_w(
             battery_capacity_kwh=1.5,
             required_capacity_kwh=2.0,
-            slot_hours=0.25,
             max_discharge_power_w=5000,
         )
         assert cap == 0
 
-    def test_surplus_converted_to_power(self):
-        """1 kWh surplus over a 1-hour slot -> 1000 W cap."""
+    def test_small_surplus_unlocks_full_rated_max(self):
+        """A small surplus still unlocks the full rate, not a scaled-down value."""
         cap = _wait_mode_self_consumption_cap_w(
-            battery_capacity_kwh=3.0,
+            battery_capacity_kwh=2.01,
             required_capacity_kwh=2.0,
-            slot_hours=1.0,
             max_discharge_power_w=5000,
         )
-        assert cap == 1000
+        assert cap == 5000
 
-    def test_surplus_over_short_slot(self):
-        """1 kWh surplus over a 15-minute slot -> 4000 W cap."""
-        cap = _wait_mode_self_consumption_cap_w(
-            battery_capacity_kwh=3.0,
-            required_capacity_kwh=2.0,
-            slot_hours=0.25,
-            max_discharge_power_w=5000,
-        )
-        assert cap == 4000
-
-    def test_cap_limited_by_max_discharge_power(self):
+    def test_large_surplus_still_capped_at_rated_max(self):
         cap = _wait_mode_self_consumption_cap_w(
             battery_capacity_kwh=10.0,
             required_capacity_kwh=0.0,
-            slot_hours=0.25,
             max_discharge_power_w=2500,
         )
         assert cap == 2500
-
-    def test_zero_slot_hours_returns_zero(self):
-        cap = _wait_mode_self_consumption_cap_w(
-            battery_capacity_kwh=5.0,
-            required_capacity_kwh=0.0,
-            slot_hours=0.0,
-            max_discharge_power_w=5000,
-        )
-        assert cap == 0
 
 
 # ---------------------------------------------------------------------------
@@ -273,10 +256,19 @@ class TestWaitModeReserveGatesSelfConsumption:
     """A valid ``wait_mode_reserve_kwh`` gates MSC + the reserve-preserving cap."""
 
     @pytest.mark.asyncio
-    async def test_surplus_above_reserve_enables_msc_with_capped_discharge(self):
+    async def test_surplus_above_reserve_enables_msc_at_full_rate(self):
+        """Any surplus above the reserve restores the full rated rate (issue #942).
+
+        Regression guard: the old formula computed ``surplus_kwh / slot_hours``,
+        producing a low, load-averaged wattage (e.g. 1000 W here) that could not
+        track a real household load spike. Starting from a stale low cap (as the
+        old formula would have written) proves the fix actively restores the
+        full rated/configured discharge rate instead.
+        """
         sensor = _sensor()
         cfg = _cfg()
         live = _live(working_mode=WorkingModes.TimeOfUse.value)
+        live.huawei_batteries_max_discharge_power_w = 380
         rec = _wait_rec()
 
         with (
@@ -301,8 +293,9 @@ class TestWaitModeReserveGatesSelfConsumption:
         mock_select.assert_any_await(
             sensor, "select.wm", WorkingModes.MaximizeSelfConsumption.value
         )
-        # capacity=2.0, reserve=1.0 -> surplus=1.0 kWh over a 1h slot -> 1000 W.
-        mock_number.assert_any_await(sensor, "number.maxdis", 1000)
+        # capacity=2.0 kWh > reserve=1.0 kWh -> full rated max for a 5000 Wh
+        # pack (2500 W), not surplus/slot_hours (which would have been 1000 W).
+        mock_number.assert_any_await(sensor, "number.maxdis", 2500)
 
     @pytest.mark.asyncio
     async def test_capacity_at_reserve_falls_back_to_strict_wait(self):


### PR DESCRIPTION
## Summary

- `applier_caps._wait_mode_self_consumption_cap_w()` computed the Huawei "Maximum discharging power" register as `surplus_kwh / slot_hours` — the planner's reserved surplus spread evenly across the whole slot. This produced low, load-averaged wattages (e.g. 264–380 W) with no relationship to actual instantaneous house load, so a real load spike (e.g. switching on a stove) above that average cap was served from the grid instead of the battery, even though usable surplus remained.
- Replaces the rate formula with an **SoC-floor stop-discharge gate**: while `battery_current_capacity_kwh` holds any material surplus above `wait_mode_reserve_kwh`, the cap is the full rated/configured discharge maximum, so normal house load (including spikes) is served from the battery; once capacity reaches the reserve floor, the cap drops to 0 W so the reserve is protected. The gate is re-evaluated every apply cycle (interval tick, event-triggered replan, or the reactive 10-second live-power monitor), so discharge stops as soon as live capacity actually reaches the reserve.
- Reserve protection and house-load support are thereby decoupled: the reserve stops discharge once reached, but never throttles discharge power while surplus remains. Battery-to-grid export continues to be governed separately by export-price/curtailment logic, untouched by this change.
- The EV-active discharge cap (`_planned_ev_discharge_cap_w`) is deliberately left unchanged in this PR — it's a materially different formula (the planner's own solved per-slot discharge rate, clamped to per-EV configured ceilings), and reworking it to the same floor-gate model is a separate design effort, not bundled into this fix.

## Branch

`fix/942-discharge-cap-house-load`

## Files changed

- `custom_components/hsem/custom_sensors/applier_caps.py` — `_wait_mode_self_consumption_cap_w()` rewritten as an SoC-floor gate (drops the `slot_hours` parameter entirely)
- `custom_components/hsem/custom_sensors/applier.py` — call site and log line updated to match
- `docs/planner-spec.md` — "Wait-mode self-consumption reserve (issue #914)" section documents the new gate and the issue #942 root cause
- `docs/planner-guide.md` — wait-mode behaviour note updated
- `.github/memories.md` — "Wait Mode Self-Consumption with Reserve" entry updated with the fix and rationale
- `tests/test_batteries_wait_mode.py`, `tests/sensors/test_applier.py` — unit tests updated for the new gate semantics; integration test rewritten as an explicit issue #942 regression guard (starts from a stale low cap and asserts the fix restores the full rated max, not a value scaled by `surplus/slot_hours`)

## What changed and why

Root cause investigation (see issue discussion): the update-interval timing was **not** the problem — a reactive live-power monitor already triggers replans within ~30–40s of a real load change. The actual defect was architectural: the cap formula itself had no house-load term at all, only a flat average spread over the whole slot, so even an instantaneous recompute wouldn't have helped. The fix (confirmed with the reporter) replaces the rate formula with a binary floor gate matching the same pattern already used by the existing EV discharge-cap SoC guard.

## Tests added/updated

- `tests/test_batteries_wait_mode.py::TestWaitModeSelfConsumptionCapW` — unit tests for the new gate: no/below-reserve surplus → 0; any material surplus (however small) → full rated max; large surplus still capped at rated max.
- `tests/test_batteries_wait_mode.py::TestWaitModeReserveGatesSelfConsumption::test_surplus_above_reserve_enables_msc_at_full_rate` — regression guard for issue #942: starts from a stale low cap (380 W, as the old formula would have written) and asserts the fix restores the full rated max (2500 W) rather than a value scaled by `surplus/slot_hours` (which would have been 1000 W).
- `tests/sensors/test_applier.py::TestWaitModeSelfConsumptionCapW` — mirrors the unit tests in the other file (existing duplicate test suite for the same helper).

## Test and lint results

- `./scripts/quality.sh lint` — pass
- `./scripts/quality.sh typing` — pass (mypy, 0 errors)
- `./scripts/quality.sh quality` — pass (pyright + vulture, 0 errors)
- `./scripts/quality.sh test` — 3304 passed

## Known limitations / open questions

- The EV-active discharge cap (`_planned_ev_discharge_cap_w`) still uses the planner's solved per-slot discharge rate rather than a reserve-floor gate. The reporter suggested aligning it to the same model (EV commitments raising the reserved SoC floor rather than imposing a flat rate cap) — that's a bigger, separate design change and is being tracked as a follow-up rather than bundled here.

## Required configuration changes

None — `hsem_batteries_wait_mode_behavior` config key and default (`strict`) are unchanged; this only changes the cap computation when a user has opted into `self_consumption_with_reserve`.

Fixes #942
