### PR TITLE
fix(planner): stop wait-mode reserve scan at next discharge, not just next charge

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -1308,6 +1308,20 @@ instead of keeping the battery strictly idle.
   means no reliable reserve could be derived; the applier then forces strict
   TOU wait instead of enabling self-consumption. See `docs/planner-spec.md`
   §"Wait-mode self-consumption reserve (issue #914)".
+- **Scan stops at the next discharge too, not just the next charge (issue
+  #942 follow-up, fixed 2026-09-08):** the scan originally broke only on a
+  genuine planned _charge_, so it accumulated through every future discharge
+  slot up to that charge — often the plan's whole overnight total — and
+  applied that sum as an immediate floor hours before it was needed. Since
+  Wait-mode slots never discharge in the simulation (`soc_simulation.py`
+  forces `discharge = 0.0` while `recommendation == BatteriesWaitMode`),
+  this silently starved the #942 SoC-floor gate of any surplus for the
+  entire Wait span (reserve ≈ current capacity), even though the fix had
+  just landed. The loop now also breaks on `batteries_discharged_kwh > 1e-9`:
+  the reserve protects only the plan's very next committed action (charge or
+  discharge), trusting the next replan (interval tick, event-triggered, or
+  the 10-second live-power monitor) to re-derive the reserve fresh from the
+  then-current capacity before any later slot arrives.
 
 Files involved: `flows/batteries_wait_mode.py`, `config_flow.py`,
 `options_flow.py`, `translations/en.json`, `const.py`,

--- a/custom_components/hsem/planner/discharge_scheduler.py
+++ b/custom_components/hsem/planner/discharge_scheduler.py
@@ -217,10 +217,20 @@ def calculate_required_battery_for_plan(
     :func:`~custom_components.hsem.planner.soc_simulation.simulate_soc` for
     the winning candidate) and returns how far that trajectory dips below
     ``current_capacity`` before the plan's next slot with an actual, solved
-    battery charge (grid or solar) — not just a forecast surplus. A small or
-    short-lived forecast surplus that the plan does not actually charge from
-    does not end the scan early, so the reserve still protects a later
-    planned discharge.
+    battery **action** — charge (grid or solar) or discharge — not just a
+    forecast surplus. A small or short-lived forecast surplus that the plan
+    does not actually charge from does not end the scan early, so the
+    reserve still protects the plan's very next committed discharge.
+
+    The scan stops at the first committed action rather than accumulating
+    through every future discharge slot up to the next charge (issue #942
+    follow-up): reactive replanning (interval tick, event-triggered, or the
+    10-second live-power monitor) re-derives this same reserve from the
+    then-current capacity before any later slot arrives, so protecting
+    slots beyond the very next one here would only lock up capacity for
+    house-load self-consumption hours before it's actually needed, without
+    adding real protection — the next replan supersedes this value long
+    before that later slot starts.
 
     Slots are sorted by start time before scanning, so calling code does not
     need to guarantee chronological order.
@@ -245,7 +255,7 @@ def calculate_required_battery_for_plan(
     min_capacity = current_capacity
     for slot in future_slots:
         min_capacity = min(min_capacity, slot.estimated_battery_capacity_kwh)
-        if slot.batteries_charged_kwh > 1e-9:
+        if slot.batteries_charged_kwh > 1e-9 or slot.batteries_discharged_kwh > 1e-9:
             break
 
     result = round(max(current_capacity - min_capacity, 0.0), 3)

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -2136,19 +2136,37 @@ from the **selected** plan's own already-simulated SoC trajectory instead:
 ```text
 for each future slot (chronological order, end > now):
     min_capacity = min(min_capacity, slot.estimated_battery_capacity_kwh)
-    if slot.batteries_charged_kwh > 0:  # a genuine solved charge, not a
-        break                           # forecast surplus signal
+    if slot.batteries_charged_kwh > 0 or slot.batteries_discharged_kwh > 0:
+        break  # a genuine solved battery action, not a forecast signal
 reserve = max(current_capacity - min_capacity, 0)
 ```
 
 This protects the battery down to the deepest point the **winning
-candidate's** SoC simulation actually dips to before its own next solved
-charge (grid or solar) — a small forecast surplus slot that the plan does not
-actually charge from no longer truncates the reserve early. When the plan
-has no future charge anywhere in the horizon, the scan runs to the horizon
-end and the reserve naturally covers (up to) the full current capacity,
-which forces strict Wait behaviour via the normal `surplus <= 0` path — no
-special-cased fallback is needed for that case.
+candidate's** SoC simulation dips to by the end of its own next solved
+battery action (charge — grid or solar — **or** discharge) — a small
+forecast surplus slot that the plan does not actually charge from no longer
+truncates the reserve early. When the plan has no future charge or discharge
+anywhere in the horizon, the scan runs to the horizon end and the reserve
+naturally covers (up to) the full current capacity, which forces strict Wait
+behaviour via the normal `surplus <= 0` path — no special-cased fallback is
+needed for that case.
+
+**Scan stops at the first committed action, not the next charge (issue #942
+follow-up, fixed 2026-09-08):** the scan originally only broke on a genuine
+_charge_ event, so it accumulated through every discharge slot between now
+and the plan's next charge — often the plan's entire overnight consumption,
+even though that total would not be needed for hours. Applied as an
+immediate floor, this locked up nearly the whole battery for the length of
+the Wait span, silently reopening #942 (grid import on load spikes) even
+after the SoC-floor discharge-cap gate landed, because the "surplus above
+reserve" the gate checks was already ~0. The scan now also breaks on the
+plan's next **discharge** slot: the reserve protects only that one upcoming
+commitment. Anything beyond it is re-protected by the next replan (interval
+tick, event-triggered, or the 10-second live-power monitor), which
+re-derives this same reserve from the then-current capacity before that
+later slot arrives — so scanning past the next action adds no real
+protection, only unnecessary throttling of house-load self-consumption in
+the meantime.
 
 `wait_mode_reserve_kwh` is `None` when it cannot be derived (no future slots
 in the horizon). The applier treats `None` as "fall back to strict Wait":

--- a/tests/planner/test_wait_mode_reserve_from_plan.py
+++ b/tests/planner/test_wait_mode_reserve_from_plan.py
@@ -122,6 +122,77 @@ class TestReliableRechargeStopsTheScan:
         assert reserve == 0.5
 
 
+class TestReserveStopsAtFirstScheduledAction:
+    """The scan stops at the plan's next discharge, not just its next charge
+    (issue #942 follow-up).
+
+    Regression scenario reported against #949: a long run of Wait-mode slots
+    (flat ``estimated_battery_capacity_kwh``, no discharge modelled — see
+    ``soc_simulation.py``) precedes a small scheduled discharge, which is in
+    turn followed by further discharge slots before the next genuine charge.
+    Before this fix, the scan accumulated through *all* of those later
+    discharge slots, inflating the reserve computed right now to nearly the
+    full current capacity and starving the SoC-floor discharge-cap gate of
+    any surplus for the entire Wait span. The reserve must now protect only
+    the plan's very next committed action.
+    """
+
+    def test_reserve_does_not_accumulate_past_the_next_discharge(self) -> None:
+        slots = [
+            # Long Wait-mode run: capacity stays flat, nothing committed yet.
+            _slot(1, estimated_battery_capacity_kwh=9.5),
+            _slot(2, estimated_battery_capacity_kwh=9.5),
+            _slot(3, estimated_battery_capacity_kwh=9.5),
+            _slot(4, estimated_battery_capacity_kwh=9.5),
+            _slot(5, estimated_battery_capacity_kwh=9.5),
+            # First scheduled discharge — small, matches the issue's 0.139 kWh.
+            _slot(
+                5.25,
+                estimated_battery_capacity_kwh=9.361,
+                batteries_discharged_kwh=0.139,
+            ),
+            # Further overnight discharge slots before any recharge — must
+            # NOT inflate the reserve computed at hour 1 above.
+            _slot(
+                6,
+                estimated_battery_capacity_kwh=4.0,
+                batteries_discharged_kwh=5.361,
+            ),
+            _slot(
+                12,
+                estimated_battery_capacity_kwh=0.2,
+                batteries_discharged_kwh=3.8,
+            ),
+        ]
+
+        reserve = calculate_required_battery_for_plan(slots, _NOW, current_capacity=9.5)
+
+        # Only the dip through the first discharge slot (9.5 -> 9.361) is
+        # protected — not the cumulative overnight total down to 0.2 kWh.
+        assert reserve == 0.139
+
+    def test_reserve_still_stops_at_charge_when_charge_comes_first(self) -> None:
+        """A charge slot before any discharge still ends the scan (unchanged)."""
+        slots = [
+            _slot(1, estimated_battery_capacity_kwh=9.5),
+            _slot(
+                2,
+                estimated_battery_capacity_kwh=9.8,
+                batteries_charged_kwh=0.3,
+            ),
+            # Deep discharge after the recharge must not inflate "now"'s reserve.
+            _slot(
+                6,
+                estimated_battery_capacity_kwh=0.1,
+                batteries_discharged_kwh=9.7,
+            ),
+        ]
+
+        reserve = calculate_required_battery_for_plan(slots, _NOW, current_capacity=9.5)
+
+        assert reserve == 0.0
+
+
 class TestNoFutureRechargeInHorizon:
     """No planned charge anywhere in the horizon forces (near) full reserve."""
 


### PR DESCRIPTION
## Summary

- Follow-up to #949: after that PR shipped the SoC-floor discharge-cap gate,
  `tonnr` reported (https://github.com/woopstar/hsem/issues/942#issuecomment-5584381684)
  that the gate was still writing `0 W` for the entire `14:30`–`19:30` Wait
  span, even with the battery at 100 %.
- Root cause: `calculate_required_battery_for_plan()` (`discharge_scheduler.py`)
  only stopped its forward SoC-trajectory scan at the plan's next **charge**
  event. Since Wait-mode slots never discharge in the simulation
  (`soc_simulation.py` forces `discharge = 0.0` while
  `recommendation == BatteriesWaitMode`), the scan instead accumulated
  through *every* future discharge slot up to that charge — in this report,
  the plan's whole overnight total — and applied that sum as an immediate
  reserve floor hours before any of it was actually needed. That collapsed
  `battery_current_capacity_kwh - wait_mode_reserve_kwh` to ~0 for the whole
  afternoon, silently reopening #942 even though the #949 gate itself was
  working exactly as designed.
- Fix: the scan now also breaks on the plan's next **discharge**
  (`batteries_discharged_kwh > 1e-9`), so the reserve protects only the
  plan's very next committed battery action. Anything further out is
  re-derived fresh by the next replan (interval tick, event-triggered, or
  the 10-second live-power monitor) once it actually becomes relevant —
  matching the direction confirmed in the issue thread.
- `docs/planner-spec.md` §"Wait-mode self-consumption reserve (issue #914)"
  and `.github/memories.md` updated to document the new stop condition.

## Test plan

- [x] Added `TestReserveStopsAtFirstScheduledAction` to
      `tests/planner/test_wait_mode_reserve_from_plan.py`, reproducing the
      reported scenario (long flat Wait run → small first discharge →
      further overnight discharge slots) and asserting the reserve now
      equals only the first discharge's dip, not the cumulative overnight
      total. Also covers the unchanged "charge comes first" case.
- [x] `./scripts/quality.sh lint`
- [x] `./scripts/quality.sh typing`
- [x] `./scripts/quality.sh quality`
- [x] `./scripts/quality.sh test` (3306 passed)
- [x] `./scripts/quality.sh translations` (no user-facing strings changed)

Fixes #942
