### PR TITLE
fix(applier): wait-mode self-consumption reserve floor now overrides plain hold, not the other way around

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -1322,6 +1322,31 @@ instead of keeping the battery strictly idle.
   discharge), trusting the next replan (interval tick, event-triggered, or
   the 10-second live-power monitor) to re-derive the reserve fresh from the
   then-current capacity before any later slot arrives.
+- **Reserve-floor decision must run ahead of the plain hold check, not
+  behind it (issue #954, fixed 2026-09-09):** a genuine `BatteriesWaitMode`
+  slot always satisfies `_primary_battery_hold()` — `soc_simulation.py`
+  forces `discharge = 0.0` for this recommendation, the same near-zero
+  condition the hold check tests for. #949's reserve-floor gate was gated
+  behind `not primary_battery_hold`, so it never actually overrode the
+  hold's unconditional `0 W` default for a real Wait slot — it only ever
+  ran in the test suite's synthetic non-held fixture (`_wait_rec()` used to
+  set a material `batteries_discharged_kwh` specifically to dodge the hold
+  check). Reproduced directly: battery at 100% SoC, reserve well below
+  capacity, genuine held Wait slot → the applier still wrote `0 W`. Fixed
+  by computing `wait_mode_reserve_active` (`recommendation ==
+BatteriesWaitMode and not relevant_evs and not held_planned_export and
+batteries_wait_mode_behavior == "self_consumption_with_reserve" and
+wait_mode_reserve_kwh is not None`) and checking it _before_ the
+  hold/EV/solar-charge-only branch in both the single cap-decision block
+  and the `BatteriesWaitMode` match-statement case — so it applies
+  regardless of hold status. `held_planned_export` and an active/planned EV
+  still take priority, unchanged. This also removed the former second,
+  independently-gated discharge-cap write block entirely (folded into the
+  single cap decision), so the entity is now written at most once per apply
+  cycle for every path, not just the hold/EV/solar-charge-only ones.
+  `tests/test_batteries_wait_mode.py::_wait_rec()` now builds a genuinely
+  held slot by default — the realistic case — with a separate inline
+  override for the rarer unheld edge case.
 
 Files involved: `flows/batteries_wait_mode.py`, `config_flow.py`,
 `options_flow.py`, `translations/en.json`, `const.py`,

--- a/custom_components/hsem/custom_sensors/applier.py
+++ b/custom_components/hsem/custom_sensors/applier.py
@@ -190,6 +190,23 @@ async def async_apply_battery_settings(
     # solar-charge slot has material `batteries_charged_kwh`.
     solar_charge_only = recommendation == Recommendations.BatteriesChargeSolar.value
 
+    # Wait-mode self-consumption reserve floor (issue #954, follow-up to
+    # #942/#949/#950): a genuine BatteriesWaitMode slot always satisfies
+    # primary_battery_hold — soc_simulation.py forces discharge=0 for this
+    # recommendation, the same near-zero condition the hold check tests —
+    # so this decision must run *ahead of* the hold check below, not gated
+    # behind `not primary_battery_hold`. Gating it behind the hold check
+    # made the opt-in self_consumption_with_reserve behaviour effectively
+    # dead code for its primary use case. EV-active slots and a held slot
+    # with an authoritative solved export keep their existing precedence.
+    wait_mode_reserve_active = (
+        recommendation == Recommendations.BatteriesWaitMode.value
+        and not relevant_evs
+        and not held_planned_export
+        and cfg.batteries_wait_mode_behavior == "self_consumption_with_reserve"
+        and wait_mode_reserve_kwh is not None
+    )
+
     # Compute the single intended max-discharge-power value for this cycle
     # before issuing any write. The rated max is only the *starting* value
     # fed into the same hold/EV/solar-charge-only cap computation below —
@@ -198,7 +215,20 @@ async def async_apply_battery_settings(
     # real (lower) cap in the same cycle (issue #939).
     cap_w = max_discharge_power
     cap_reason: str | None = None
-    if (
+    if wait_mode_reserve_active and wait_mode_reserve_kwh is not None:
+        reserve_kwh = wait_mode_reserve_kwh
+        surplus = max(live.battery_current_capacity_kwh - reserve_kwh, 0.0)
+        cap_w = _wait_mode_self_consumption_cap_w(
+            battery_capacity_kwh=live.battery_current_capacity_kwh,
+            required_capacity_kwh=reserve_kwh,
+            max_discharge_power_w=max_discharge_power,
+        )
+        cap_reason = (
+            "wait-mode self-consumption reserve "
+            f"(capacity={live.battery_current_capacity_kwh:.2f} kWh, "
+            f"required={reserve_kwh:.2f} kWh, surplus={surplus:.2f} kWh)"
+        )
+    elif (
         primary_battery_hold or relevant_evs or solar_charge_only
     ) and recommendation not in (
         Recommendations.ForceBatteriesDischarge.value,
@@ -398,27 +428,28 @@ async def async_apply_battery_settings(
         case Recommendations.BatteriesWaitMode.value:
             # A held idle MILP slot normally uses MSC with a verified 0 W
             # discharge cap so unexpected PV may still charge the battery. A
-            # material, authoritative solved export is different: keep that
-            # slot in TOU wait so its planned PV sale is executable. An
-            # unheld strict wait remains in TOU; self-consumption with
-            # reserve switches to MSC so the house can use surplus battery
-            # energy above the planner's required reserve (issue #797).
-            if primary_battery_hold:
-                if held_planned_export:
-                    tou_modes = DEFAULT_HSEM_BATTERIES_WAIT_MODE
-                    working_mode = WorkingModes.TimeOfUse.value
-                else:
-                    working_mode = WorkingModes.MaximizeSelfConsumption.value
-            elif (
-                cfg.batteries_wait_mode_behavior == "self_consumption_with_reserve"
-                and wait_mode_reserve_kwh is not None
-            ):
+            # material, authoritative solved export takes top priority
+            # regardless of hold/reserve state: keep that slot in TOU wait
+            # so its planned PV sale is executable (issue #797).
+            # Self-consumption-with-reserve is evaluated *ahead of* the
+            # plain hold check (issue #954): a genuine Wait slot always
+            # satisfies primary_battery_hold, so checking hold first would
+            # make the opt-in reserve behaviour never take effect. It
+            # switches to MSC so the house can use surplus battery energy
+            # above the planner's required reserve, holding a genuinely
+            # unheld slot in TOU only when no reserve behaviour applies.
+            if held_planned_export:
+                tou_modes = DEFAULT_HSEM_BATTERIES_WAIT_MODE
+                working_mode = WorkingModes.TimeOfUse.value
+            elif wait_mode_reserve_active and wait_mode_reserve_kwh is not None:
                 surplus = live.battery_current_capacity_kwh - wait_mode_reserve_kwh
                 if surplus > 1e-9:
                     working_mode = WorkingModes.MaximizeSelfConsumption.value
                 else:
                     tou_modes = DEFAULT_HSEM_BATTERIES_WAIT_MODE
                     working_mode = WorkingModes.TimeOfUse.value
+            elif primary_battery_hold:
+                working_mode = WorkingModes.MaximizeSelfConsumption.value
             else:
                 tou_modes = DEFAULT_HSEM_BATTERIES_WAIT_MODE
                 working_mode = WorkingModes.TimeOfUse.value
@@ -480,61 +511,15 @@ async def async_apply_battery_settings(
                 )
                 return summary
 
-    # Wait mode self-consumption: an SoC-floor stop-discharge gate, not a rate
-    # spread over the slot (issue #942).  While the battery holds any surplus
-    # above the planner's required reserve, the house may draw at the full
-    # rated/configured discharge rate, so a real load spike is served from the
-    # battery instead of the grid; once capacity reaches the reserve floor,
-    # discharge stops so the reserve is protected for future scheduled
-    # discharge windows.
+    # Wait-mode self-consumption reserve: the discharge cap for this case was
+    # already computed and written in the single cap_w decision above
+    # (issue #954) — this is only the flag `desired_excess` below needs to
+    # know whether the reserve-floor gate actually landed us in MSC (surplus
+    # above the reserve), as opposed to falling back to strict TOU wait.
     wait_mode_self_consumption = (
-        recommendation == Recommendations.BatteriesWaitMode.value
-        and not primary_battery_hold
-        and cfg.batteries_wait_mode_behavior == "self_consumption_with_reserve"
+        wait_mode_reserve_active
         and working_mode == WorkingModes.MaximizeSelfConsumption.value
-        and not relevant_evs
-        and wait_mode_reserve_kwh is not None
     )
-    if wait_mode_self_consumption and wait_mode_reserve_kwh is not None:
-        surplus = max(live.battery_current_capacity_kwh - wait_mode_reserve_kwh, 0.0)
-        cap_w = _wait_mode_self_consumption_cap_w(
-            battery_capacity_kwh=live.battery_current_capacity_kwh,
-            required_capacity_kwh=wait_mode_reserve_kwh,
-            max_discharge_power_w=max_discharge_power,
-        )
-        if live.huawei_batteries_max_discharge_power_w != cap_w:
-            discharge_entity = cfg.huawei_solar_batteries_maximum_discharging_power
-            if discharge_entity is None:
-                _LOGGER.debug(
-                    "Wait mode self-consumption discharge power entity not configured; "
-                    "skipping write.",
-                    "warning",
-                )
-                return summary
-            _de_wait: str = discharge_entity  # narrowed for closure
-            wait_cap_result = await async_write_and_verify(
-                entity_id=_de_wait,
-                desired=cap_w,
-                writer=lambda: async_set_number_value(sensor, _de_wait, cap_w),
-                reader=lambda: _read_number_state(sensor, _de_wait),
-            )
-            summary.results.append(wait_cap_result)
-            _LOGGER.debug(
-                "Wait mode self-consumption — capped max discharge power to %d W "
-                "(capacity=%.2f kWh, required=%.2f kWh, surplus=%.2f kWh)",
-                cap_w,
-                live.battery_current_capacity_kwh,
-                wait_mode_reserve_kwh,
-                surplus,
-            )
-            if wait_cap_result.status == ApplyStatus.FAILED:
-                _LOGGER.debug(
-                    "Wait mode self-consumption discharge cap write FAILED for %s. "
-                    "Blocking further battery writes this cycle.",
-                    discharge_entity,
-                    "error",
-                )
-                return summary
 
     # Excess PV use in TOU — fed_to_grid for the two explicit export modes and
     # when a held idle slot carries a material, authoritative solved export
@@ -544,7 +529,8 @@ async def async_apply_battery_settings(
     # (which already requires primary_battery_hold) grants that for
     # BatteriesWaitMode/EVSmartCharging.  Wait-mode self-consumption keeps
     # excess PV in the battery so the surplus above the reserve can be used
-    # for household self-consumption; it never overlaps with a held slot.
+    # for household self-consumption; it takes priority over a plain hold
+    # (issue #954), so it may now apply to a held slot too.
     export_is_intended = (
         recommendation
         in (

--- a/docs/planner-guide.md
+++ b/docs/planner-guide.md
@@ -494,8 +494,12 @@ recommendation it is not changed by later rules in the same layer.
 > (issue #942): while the battery holds any surplus above the reserve, the house
 > may draw at the full rated/configured discharge rate — so a real load spike is
 > served from the battery instead of the grid — and once capacity reaches the
-> reserve floor, discharge stops. This reduces unnecessary grid import while still
-> preserving capacity for future scheduled discharge windows. The reserve is
+> reserve floor, discharge stops. This applies to the normal case where the plan
+> held the battery fully idle for this slot, not just an edge case (issue #954) —
+> a genuine "Wait" slot always meets that hold condition, so the reserve-floor
+> decision must run instead of the hold default, not only when unheld. This
+> reduces unnecessary grid import while still preserving capacity for future
+> scheduled discharge windows. The reserve is
 > derived from the **selected plan's own simulated SoC trajectory** (issue #914) —
 > how far it dips before its next actual solved charge — not from a raw forecast
 > PV-surplus scan, so a small or short-lived forecast surplus no longer lets the

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -2095,9 +2095,9 @@ with the 0 W discharge cap above, so unexpected PV may still charge the
 battery.
 
 This applies to both `batteries_wait_mode` (an unheld strict wait stays in
-TOU; self-consumption-with-reserve still applies when unheld) and
-`ev_smart_charging` (which otherwise always executes as MSC to retain
-unexpected solar).
+TOU) and `ev_smart_charging` (which otherwise always executes as MSC to
+retain unexpected solar). `held_planned_export` takes priority over
+self-consumption-with-reserve too — see issue #954 below.
 
 ### Wait-mode self-consumption reserve (issue #914)
 
@@ -2118,6 +2118,25 @@ event-triggered replan, or the 10-second live-power monitor's reactive
 replan), so discharge stops as soon as live capacity reaches the reserve —
 battery-to-grid export remains governed separately by export-price/
 curtailment logic, never by this cap.
+
+**Self-consumption-with-reserve overrides the plain hold default, not the
+other way around (issue #954):** a genuine `BatteriesWaitMode` slot always
+satisfies `_primary_battery_hold()` — `soc_simulation.py` forces
+`discharge = 0.0` for this recommendation, the same near-zero condition the
+hold check tests for. #949 originally gated the reserve-floor decision
+behind `not primary_battery_hold`, which meant it never actually overrode
+the hold's `0 W` default for a real Wait slot — the reserve-floor logic only
+ever ran in a synthetic non-held test fixture. The fix evaluates
+`wait_mode_reserve_active` (`recommendation == BatteriesWaitMode and not
+relevant_evs and not held_planned_export and
+batteries_wait_mode_behavior == "self_consumption_with_reserve" and
+wait_mode_reserve_kwh is not None`) _ahead of_ the hold/EV/solar-charge-only
+branch in both the single cap-decision block and the working-mode match
+statement, so it applies regardless of hold status. `held_planned_export`
+(an authoritative solved export) and an active/planned EV both still take
+priority over it, unchanged. The former second, independently-gated
+discharge-cap write (from #949) was folded into the single cap decision and
+removed — the entity is written at most once per apply cycle.
 
 The **EV discharge-cap SoC guard** above and `apply_excess_export()` both use
 `current_required_battery_kwh`, derived from

--- a/tests/test_batteries_wait_mode.py
+++ b/tests/test_batteries_wait_mode.py
@@ -172,7 +172,15 @@ def _live(*, working_mode: str) -> LiveState:
 
 
 def _wait_rec() -> HourlyRecommendation:
-    """A non-held BatteriesWaitMode slot (material planned discharge)."""
+    """A genuine (held) BatteriesWaitMode slot — the realistic case (issue #954).
+
+    ``batteries_charged_kwh``/``batteries_discharged_kwh`` are both near-zero,
+    matching what ``planner/soc_simulation.py`` actually produces for a "Wait"
+    slot, so ``_primary_battery_hold()`` is ``True`` here — exactly the
+    real-world case the #954 fix targets (the reserve-floor decision must run
+    regardless of hold status, not only for the synthetic non-held slot the
+    tests used to construct).
+    """
     return HourlyRecommendation(
         start=_NOW,
         end=_NOW + timedelta(hours=1),
@@ -183,9 +191,7 @@ def _wait_rec() -> HourlyRecommendation:
         avg_house_consumption_7d_kwh=0.0,
         avg_house_consumption_14d_kwh=0.0,
         batteries_charged_kwh=0.0,
-        # Material (non-near-zero) so _primary_battery_hold() is False and
-        # the self_consumption_with_reserve branch is actually reached.
-        batteries_discharged_kwh=0.05,
+        batteries_discharged_kwh=0.0,
         estimated_battery_capacity_kwh=1.0,
         estimated_battery_soc_pct=50.0,
         estimated_cost_currency=0.0,
@@ -210,21 +216,61 @@ async def _write_and_verify_ok(entity_id, desired, writer, reader, **kwargs):  #
 
 
 class TestWaitModeReserveNoneFallsBackToStrictWait:
-    """``wait_mode_reserve_kwh=None`` must force strict TOU wait (issue #914).
+    """``wait_mode_reserve_kwh=None`` must fall back to the same behaviour
+    ``batteries_wait_mode_behavior == "strict"`` would produce for this slot
+    (issue #914) — a reserve that could not be reliably derived must never be
+    treated as "no reserve needed" (which would let the battery discharge
+    freely).
 
-    Even with ``self_consumption_with_reserve`` configured, a reserve that
-    could not be reliably derived must never be treated as "no reserve
-    needed" (which would let the battery discharge freely) — the applier
-    must fall back to the same strict TOU wait behaviour as
-    ``batteries_wait_mode_behavior == "strict"``.
+    For a genuine held Wait slot, "strict" behaviour is ``MaximizeSelfConsumption``
+    with the discharge cap held at 0 W (issue #797/#922) — not literal
+    ``TimeOfUse`` wait, which only applies to the rarer unheld case (issue #954).
     """
 
     @pytest.mark.asyncio
-    async def test_none_reserve_writes_strict_tou_wait(self):
+    async def test_none_reserve_on_held_slot_falls_back_to_msc_with_zero_cap(self):
+        """Genuine held slot + reserve=None -> same as strict mode: MSC, 0 W cap."""
+        sensor = _sensor()
+        cfg = _cfg()
+        live = _live(working_mode=WorkingModes.TimeOfUse.value)
+        rec = (
+            _wait_rec()
+        )  # held: batteries_charged_kwh == batteries_discharged_kwh == 0
+
+        with (
+            patch(_LOGGER_PATCH, new_callable=MagicMock),
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_write_and_verify",
+                side_effect=_write_and_verify_ok,
+            ),
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_set_select_option",
+                new_callable=AsyncMock,
+            ) as mock_select,
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_set_number_value",
+                new_callable=AsyncMock,
+            ) as mock_number,
+        ):
+            await async_apply_battery_settings(
+                sensor, cfg, live, rec, 5.0, wait_mode_reserve_kwh=None
+            )
+
+        mock_select.assert_any_await(
+            sensor, "select.wm", WorkingModes.MaximizeSelfConsumption.value
+        )
+        mock_number.assert_any_await(sensor, "number.maxdis", 0)
+
+    @pytest.mark.asyncio
+    async def test_none_reserve_on_unheld_slot_falls_back_to_strict_tou_wait(self):
+        """Rarer unheld slot + reserve=None -> strict TOU wait (issue #914)."""
         sensor = _sensor()
         cfg = _cfg()
         live = _live(working_mode=WorkingModes.MaximizeSelfConsumption.value)
         rec = _wait_rec()
+        # Material (non-near-zero) so _primary_battery_hold() is False —
+        # the rarer unheld-slot edge case.
+        rec.batteries_discharged_kwh = 0.05
 
         with (
             patch(_LOGGER_PATCH, new_callable=MagicMock),
@@ -264,6 +310,12 @@ class TestWaitModeReserveGatesSelfConsumption:
         track a real household load spike. Starting from a stale low cap (as the
         old formula would have written) proves the fix actively restores the
         full rated/configured discharge rate instead.
+
+        Also the issue #954 regression guard: ``rec`` here is a *genuine held*
+        Wait slot (``_primary_battery_hold()`` is ``True``) — the realistic
+        production case. Before #954, the hold check ran first and forced the
+        cap to 0 W unconditionally, so this reserve-floor branch never actually
+        overrode it for a real Wait slot at all.
         """
         sensor = _sensor()
         cfg = _cfg()
@@ -299,7 +351,12 @@ class TestWaitModeReserveGatesSelfConsumption:
 
     @pytest.mark.asyncio
     async def test_capacity_at_reserve_falls_back_to_strict_wait(self):
-        """No surplus above the reserve -> strict TOU wait, same as ``strict`` mode."""
+        """No surplus above the reserve -> strict TOU wait, same as ``strict`` mode.
+
+        Also asserts the discharge cap is explicitly written to 0 W (issue #954):
+        the reserve-floor decision now runs ahead of the hold check, so this is a
+        real hardware write, not just an implicit side effect of the mode switch.
+        """
         sensor = _sensor()
         cfg = _cfg()
         live = _live(working_mode=WorkingModes.MaximizeSelfConsumption.value)
@@ -316,9 +373,60 @@ class TestWaitModeReserveGatesSelfConsumption:
                 "custom_components.hsem.custom_sensors.applier.async_set_select_option",
                 new_callable=AsyncMock,
             ) as mock_select,
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_set_number_value",
+                new_callable=AsyncMock,
+            ) as mock_number,
         ):
             await async_apply_battery_settings(
                 sensor, cfg, live, rec, 5.0, wait_mode_reserve_kwh=1.0
             )
 
         mock_select.assert_any_await(sensor, "select.wm", WorkingModes.TimeOfUse.value)
+        mock_number.assert_any_await(sensor, "number.maxdis", 0)
+
+    @pytest.mark.asyncio
+    async def test_full_soc_held_slot_uses_full_rate_not_zero(self):
+        """Exact issue #954 reproduction: 100% SoC, held Wait slot, reserve well
+        below capacity -> full rated max, not 0 W.
+
+        Before this fix, ``_primary_battery_hold()`` was ``True`` for this
+        genuine Wait slot and forced the cap to 0 W before the
+        ``self_consumption_with_reserve`` reserve-floor logic ever ran, even
+        though the battery held 4x the reserve in usable surplus.
+        """
+        sensor = _sensor()
+        cfg = _cfg()
+        live = _live(working_mode=WorkingModes.TimeOfUse.value)
+        live.battery_current_capacity_kwh = 5.0  # 100% of a 5000 Wh pack
+        # Simulate the stale 0 W cap the pre-fix hold check would have forced.
+        live.huawei_batteries_max_discharge_power_w = 0
+        rec = (
+            _wait_rec()
+        )  # held: batteries_charged_kwh == batteries_discharged_kwh == 0
+        assert rec.batteries_charged_kwh == 0.0
+        assert rec.batteries_discharged_kwh == 0.0
+
+        with (
+            patch(_LOGGER_PATCH, new_callable=MagicMock),
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_write_and_verify",
+                side_effect=_write_and_verify_ok,
+            ),
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_set_select_option",
+                new_callable=AsyncMock,
+            ) as mock_select,
+            patch(
+                "custom_components.hsem.custom_sensors.applier.async_set_number_value",
+                new_callable=AsyncMock,
+            ) as mock_number,
+        ):
+            await async_apply_battery_settings(
+                sensor, cfg, live, rec, 0.0, wait_mode_reserve_kwh=1.0
+            )
+
+        mock_select.assert_any_await(
+            sensor, "select.wm", WorkingModes.MaximizeSelfConsumption.value
+        )
+        mock_number.assert_any_await(sensor, "number.maxdis", 2500)


### PR DESCRIPTION
## Summary

- Follow-up to #942 / #949 / #950, prompted by `tonnr`'s report on PR #950 (https://github.com/woopstar/hsem/pull/950#issuecomment-5598900740) that the Huawei "Maximum discharging power" register was still being written to `0 W` during Wait-mode slots even at 100% SoC.
- Root cause: `_primary_battery_hold(rec)` returns `True` for essentially every genuine `BatteriesWaitMode` slot (`planner/soc_simulation.py` forces `discharge = 0.0` for that recommendation — the same near-zero condition the hold check tests for). In `applier.py`, the cap-decision block checked `primary_battery_hold` *first* and unconditionally forced `cap_w = 0`, before the `self_consumption_with_reserve` reserve-floor logic (added in #949, gated on `not primary_battery_hold`) ever ran. So the #949/#950 fixes never actually took effect for a real Wait slot — only for the test suite's synthetic non-held fixture.
- Reproduced directly against `main`: battery at 5.0/5.0 kWh (100%), `wait_mode_reserve_kwh=1.0` (4 kWh surplus), genuine held Wait slot → `async_apply_battery_settings` still wrote `number.maxdis = 0`.
- Fix: compute `wait_mode_reserve_active` (`recommendation == BatteriesWaitMode and not relevant_evs and not held_planned_export and batteries_wait_mode_behavior == "self_consumption_with_reserve" and wait_mode_reserve_kwh is not None`) and check it *ahead of* the hold/EV/solar-charge-only branch in both the single cap-decision block and the `BatteriesWaitMode` match-statement case, so it applies regardless of hold status. `held_planned_export` (an authoritative solved export) and an active/planned EV still take priority, unchanged — this is a precedence reordering, not a new condition.
- This also removes the former second, independently-gated discharge-cap write block (from #949) entirely — its logic is folded into the single cap decision, so the entity is now written at most once per apply cycle for every path, closing the same class of double-write risk #941 fixed for a different pair of writers.

## Branch

`fix/954-wait-mode-reserve-hold-precedence`

## Files changed

- `custom_components/hsem/custom_sensors/applier.py` — `wait_mode_reserve_active` computed once, checked ahead of the hold/EV/solar-charge-only branch in the cap decision and the `BatteriesWaitMode` match case; the old second write block removed
- `docs/planner-spec.md` — "Wait-mode self-consumption reserve (issue #914)" section documents the corrected precedence; the stale "self-consumption-with-reserve still applies when unheld" line corrected
- `docs/planner-guide.md` — wait-mode behaviour note clarified: applies to the normal held case, not just an unheld edge case
- `.github/memories.md` — "Wait Mode Self-Consumption with Reserve" entry updated with the root cause and fix
- `tests/test_batteries_wait_mode.py` — `_wait_rec()` now builds a genuinely held slot by default (the realistic case; previously it hand-crafted a non-zero `batteries_discharged_kwh` specifically to dodge the hold check); tests updated/added accordingly

## Tests added/updated

- `_wait_rec()` now returns a genuine held Wait slot (`batteries_charged_kwh == batteries_discharged_kwh == 0`) — the realistic production case.
- `TestWaitModeReserveNoneFallsBackToStrictWait` split into two cases: the realistic held-slot case (`reserve=None` → same as strict mode for a held slot, which is `MaximizeSelfConsumption` + `0 W`, not literal TOU) and the rarer unheld edge case (`reserve=None` → strict TOU wait), since these differ.
- `test_capacity_at_reserve_falls_back_to_strict_wait` now also asserts the explicit `0 W` hardware write (previously only reachable as a side effect of the mode switch; now a real write from the unified cap decision).
- New `test_full_soc_held_slot_uses_full_rate_not_zero` — the exact issue #954 reproduction: 100% SoC, held Wait slot, reserve well below capacity → full rated max (2500 W), not 0 W.
- `test_surplus_above_reserve_enables_msc_at_full_rate` docstring updated — it now also exercises the #954 regression (a genuinely held rec) since `_wait_rec()` changed.

## Test and lint results

- `./scripts/quality.sh lint` — pass
- `./scripts/quality.sh typing` — pass (mypy, 0 errors)
- `./scripts/quality.sh quality` — pass (pyright + vulture, 0 errors)
- `./scripts/quality.sh test` — 3317 passed

## Known limitations / open questions

- The EV-active discharge cap (`_planned_ev_discharge_cap_w`) still uses the planner's solved per-slot discharge rate rather than a reserve-floor gate — unchanged in this PR, tracked separately per #942's discussion.

## Required configuration changes

None — `hsem_batteries_wait_mode_behavior` config key and default (`strict`) are unchanged; this only corrects the precedence when a user has opted into `self_consumption_with_reserve`.

Fixes #954
