### PR TITLE
fix(planner): time-decay the wait-mode reserve so a far-future action doesn't lock up the battery now

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -1347,6 +1347,28 @@ wait_mode_reserve_kwh is not None`) and checking it _before_ the
   `tests/test_batteries_wait_mode.py::_wait_rec()` now builds a genuinely
   held slot by default — the realistic case — with a separate inline
   override for the rarer unheld edge case.
+- **Reserve must time-decay, not just stop at the next action (issue #956):**
+  limiting the scan to the very next committed action (#950, above) was not
+  enough — that one action can still be _far_ away and still lock up nearly
+  the whole battery immediately. Reproduced directly: battery at 6.4 kWh, a
+  discharge scheduled 5 hours away needing 5.9 kWh → reserve computed as
+  `5.9 kWh` right now, leaving only `0.5 kWh` surplus for self-consumption
+  for the entire 5-hour lead time — the exact symptom `tonnr` kept reporting
+  even after #955. Fixed in `calculate_required_battery_for_plan()`
+  (`planner/discharge_scheduler.py`) by tracking the `start` time of the
+  slot that ends the scan and multiplying the full computed reserve by
+  `max(0, min(1, 1 - hours_until_action / WAIT_MODE_RESERVE_DECAY_HOURS))`
+  (`WAIT_MODE_RESERVE_DECAY_HOURS = 2.0`, an internal tuning constant, not
+  user-configurable). At 0 hours away the action is fully protected; at or
+  beyond 2 hours the reserve is 0. Applies uniformly to charge- and
+  discharge-terminated scans; the "no action found anywhere in the horizon"
+  case is unaffected (already naturally correct from min-tracking alone).
+  `tests/planner/test_wait_mode_reserve_from_plan.py`'s existing scenarios
+  were re-timed to sit inside the decay window so their original regression
+  intent (no premature truncation at a small surplus; scan stops at the
+  next action, not the cumulative overnight total) stays visible against a
+  non-zero decayed value; `TestWaitModeReserveTimeDecay` covers the decay
+  curve itself.
 
 Files involved: `flows/batteries_wait_mode.py`, `config_flow.py`,
 `options_flow.py`, `translations/en.json`, `const.py`,

--- a/custom_components/hsem/planner/discharge_scheduler.py
+++ b/custom_components/hsem/planner/discharge_scheduler.py
@@ -203,6 +203,14 @@ def calculate_required_battery_until_solar(
     return result
 
 
+WAIT_MODE_RESERVE_DECAY_HOURS = 2.0
+"""Time window (hours) over which the wait-mode reserve ramps up to full
+strength as the plan's next committed battery action approaches.
+
+See :func:`calculate_required_battery_for_plan` (issue #954 follow-up).
+"""
+
+
 def calculate_required_battery_for_plan(
     slots: list[PlannedSlot],
     now: datetime,
@@ -232,6 +240,18 @@ def calculate_required_battery_for_plan(
     adding real protection — the next replan supersedes this value long
     before that later slot starts.
 
+    **Time-decayed reserve (issue #954 follow-up):** the full energy needed
+    for that next action is only protected in full once it's imminent. When
+    the next committed action is more than :data:`WAIT_MODE_RESERVE_DECAY_HOURS`
+    away, the reserve is 0 — self-consumption may use the entire current
+    surplus, trusting that one of the next several replans will re-derive a
+    tighter reserve long before the action actually starts. Inside that
+    window the reserve ramps up linearly to its full value exactly when the
+    action begins. Without this decay, a large discharge scheduled hours
+    away (e.g. an evening peak) would lock up nearly the whole battery for
+    self-consumption immediately, defeating the purpose of
+    ``self_consumption_with_reserve`` for the entire time in between.
+
     Slots are sorted by start time before scanning, so calling code does not
     need to guarantee chronological order.
 
@@ -253,18 +273,35 @@ def calculate_required_battery_for_plan(
         return None
 
     min_capacity = current_capacity
+    next_action_start: datetime | None = None
     for slot in future_slots:
         min_capacity = min(min_capacity, slot.estimated_battery_capacity_kwh)
         if slot.batteries_charged_kwh > 1e-9 or slot.batteries_discharged_kwh > 1e-9:
+            next_action_start = as_tz(slot.start, now.tzinfo)
             break
 
-    result = round(max(current_capacity - min_capacity, 0.0), 3)
+    full_reserve = max(current_capacity - min_capacity, 0.0)
+    time_factor = 1.0
+    hours_until_action = 0.0
+    if next_action_start is not None and full_reserve > 1e-9:
+        hours_until_action = max(
+            (next_action_start - now).total_seconds() / 3600.0, 0.0
+        )
+        time_factor = max(
+            0.0, min(1.0, 1.0 - hours_until_action / WAIT_MODE_RESERVE_DECAY_HOURS)
+        )
+
+    result = round(max(full_reserve * time_factor, 0.0), 3)
     log_planner(
         "debug",
         "[disch] calculate_required_battery_for_plan  current=%.3f  "
-        "min_planned=%.3f  result=%.3f",
+        "min_planned=%.3f  full_reserve=%.3f  hours_until_action=%.3f  "
+        "time_factor=%.3f  result=%.3f",
         current_capacity,
         min_capacity,
+        full_reserve,
+        hours_until_action,
+        time_factor,
         result,
     )
     return result

--- a/docs/planner-guide.md
+++ b/docs/planner-guide.md
@@ -505,7 +505,12 @@ recommendation it is not changed by later rules in the same layer.
 > PV-surplus scan, so a small or short-lived forecast surplus no longer lets the
 > battery discharge energy the plan needs for a later expensive period. If no
 > reliable reserve can be derived, the applier falls back to strict Wait for that
-> slot.
+> slot. The reserve also **decays with time** (issue #956): the plan's next
+> committed charge/discharge is only protected in full once it's imminent — a
+> large discharge scheduled hours away no longer locks up nearly the whole
+> battery for self-consumption right now; the reserve ramps up linearly over
+> the last two hours before that action, trusting the next replan to
+> re-tighten it as the action approaches.
 
 **Discharge concentration** (`concentrate_discharge_on_expensive_slots`) runs after the
 seasonal fill but before candidate generation. It re-evaluates all discharge-mode

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -2187,6 +2187,34 @@ later slot arrives — so scanning past the next action adds no real
 protection, only unnecessary throttling of house-load self-consumption in
 the meantime.
 
+**Time-decayed reserve (issue #954 follow-up, issue #956):** limiting the
+scan to the next committed action was not enough on its own — even a single
+upcoming action can be _far_ in the future and still lock up nearly the
+whole battery immediately. Confirmed by direct reproduction: a battery at
+6.4 kWh with a discharge scheduled 5 hours away that needs 5.9 kWh computed
+a reserve of `5.9 kWh` right now, leaving only `0.5 kWh` of surplus for
+self-consumption for the entire 5-hour lead time. The full reserve is now
+only protected once that action is imminent; `calculate_required_battery_for_plan()`
+tracks the `start` time of the slot that ends the scan and multiplies the
+full computed reserve by a linear decay factor:
+
+```text
+hours_until_action = max((next_action_start - now).total_seconds() / 3600, 0)
+time_factor = clamp(1 - hours_until_action / WAIT_MODE_RESERVE_DECAY_HOURS, 0, 1)
+reserve = full_reserve * time_factor
+```
+
+`WAIT_MODE_RESERVE_DECAY_HOURS = 2.0` is an internal tuning constant (not
+user-configurable, matching e.g. `LIVE_POWER_MONITOR_INTERVAL_SECONDS`). At 0
+hours away the action is fully protected; at or beyond the 2-hour window the
+reserve is 0 and self-consumption may use the full current surplus, trusting
+the next replan (interval tick, event-triggered, or the 10-second live-power
+monitor) to re-derive a tighter reserve well before the action actually
+starts. This applies uniformly whether the terminating action is a charge or
+a discharge. When no future action is found in the horizon at all (the scan
+reaches the end without a break), decay does not apply — that case already
+naturally yields the correct result from the min-tracking alone.
+
 `wait_mode_reserve_kwh` is `None` when it cannot be derived (no future slots
 in the horizon). The applier treats `None` as "fall back to strict Wait":
 `self_consumption_with_reserve` self-consumption is never enabled without a

--- a/tests/planner/test_wait_mode_reserve_from_plan.py
+++ b/tests/planner/test_wait_mode_reserve_from_plan.py
@@ -13,8 +13,11 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 
+import pytest
+
 from custom_components.hsem.models.planned_slot import PlannedSlot
 from custom_components.hsem.planner.discharge_scheduler import (
+    WAIT_MODE_RESERVE_DECAY_HOURS,
     calculate_required_battery_for_plan,
     calculate_required_battery_until_solar,
 )
@@ -54,7 +57,10 @@ class TestSmallForecastSurplusDoesNotEndReserveEarly:
     at the first forecast-surplus slot), the plan itself does not actually
     charge from that small surplus (``batteries_charged_kwh == 0``) and
     still expects a much larger discharge later during an expensive period.
-    The new reserve must protect the full later dip.
+    The new reserve must protect the full later dip. Both slots sit inside
+    the issue #954 time-decay window so the protected dip is still visible
+    (a scenario placed beyond the window would decay to 0 regardless of
+    depth — see ``TestWaitModeReserveTimeDecay``).
     """
 
     def test_reserve_protects_later_discharge_past_small_surplus(self) -> None:
@@ -63,14 +69,16 @@ class TestSmallForecastSurplusDoesNotEndReserveEarly:
             # plan does NOT actually charge from — old function would have
             # stopped scanning here.
             _slot(
-                1,
+                0.25,
                 estimated_net_consumption_kwh=-0.2,
                 estimated_battery_capacity_kwh=1.8,
                 batteries_charged_kwh=0.0,
             ),
-            # Later, deeper planned discharge during an expensive period.
+            # Later, deeper planned discharge during an expensive period —
+            # 1h away, inside the decay window, so ~half the full 1.7 kWh
+            # dip is protected right now (issue #954).
             _slot(
-                3,
+                1.0,
                 estimated_net_consumption_kwh=1.5,
                 estimated_battery_capacity_kwh=0.3,
                 batteries_discharged_kwh=1.5,
@@ -80,10 +88,8 @@ class TestSmallForecastSurplusDoesNotEndReserveEarly:
         reserve = calculate_required_battery_for_plan(slots, _NOW, current_capacity=2.0)
         assert reserve is not None
 
-        # Old function would only have reserved down to the first surplus
-        # slot (~0.2 kWh dip); the new one must protect the deeper 1.7 kWh
-        # dip the plan actually relies on before any real recharge.
-        assert reserve == 1.7
+        # full dip = 2.0 - 0.3 = 1.7 kWh; decayed by (1 - 1.0/2.0) = 0.5.
+        assert reserve == 0.85
 
         old_reserve = calculate_required_battery_until_solar(
             slots, _NOW, usable_capacity=2.0, discharge_buffer_pct=0.0
@@ -98,13 +104,14 @@ class TestReliableRechargeStopsTheScan:
         slots = [
             # Small dip before the plan actually recharges.
             _slot(
-                1,
+                0.5,
                 estimated_battery_capacity_kwh=1.5,
             ),
             # Genuine planned recharge — the plan relies on this, not on
             # today's stored energy, to cover anything past this point.
+            # 1h away, inside the issue #954 decay window.
             _slot(
-                2,
+                1.0,
                 estimated_battery_capacity_kwh=3.0,
                 batteries_charged_kwh=1.5,
             ),
@@ -119,14 +126,15 @@ class TestReliableRechargeStopsTheScan:
 
         reserve = calculate_required_battery_for_plan(slots, _NOW, current_capacity=2.0)
 
-        assert reserve == 0.5
+        # full dip = 2.0 - 1.5 = 0.5 kWh; decayed by (1 - 1.0/2.0) = 0.5.
+        assert reserve == 0.25
 
 
 class TestReserveStopsAtFirstScheduledAction:
     """The scan stops at the plan's next discharge, not just its next charge
     (issue #942 follow-up).
 
-    Regression scenario reported against #949: a long run of Wait-mode slots
+    Regression scenario reported against #949: a run of Wait-mode slots
     (flat ``estimated_battery_capacity_kwh``, no discharge modelled — see
     ``soc_simulation.py``) precedes a small scheduled discharge, which is in
     turn followed by further discharge slots before the next genuine charge.
@@ -134,32 +142,31 @@ class TestReserveStopsAtFirstScheduledAction:
     discharge slots, inflating the reserve computed right now to nearly the
     full current capacity and starving the SoC-floor discharge-cap gate of
     any surplus for the entire Wait span. The reserve must now protect only
-    the plan's very next committed action.
+    the plan's very next committed action — timed inside the issue #954
+    decay window here so the protected dip is still visible against the
+    (larger) cumulative overnight total a pre-#950 scan would have produced.
     """
 
     def test_reserve_does_not_accumulate_past_the_next_discharge(self) -> None:
         slots = [
-            # Long Wait-mode run: capacity stays flat, nothing committed yet.
-            _slot(1, estimated_battery_capacity_kwh=9.5),
-            _slot(2, estimated_battery_capacity_kwh=9.5),
-            _slot(3, estimated_battery_capacity_kwh=9.5),
-            _slot(4, estimated_battery_capacity_kwh=9.5),
-            _slot(5, estimated_battery_capacity_kwh=9.5),
+            # Short Wait-mode run: capacity stays flat, nothing committed yet.
+            _slot(0.25, estimated_battery_capacity_kwh=9.5),
+            _slot(0.5, estimated_battery_capacity_kwh=9.5),
             # First scheduled discharge — small, matches the issue's 0.139 kWh.
             _slot(
-                5.25,
+                0.75,
                 estimated_battery_capacity_kwh=9.361,
                 batteries_discharged_kwh=0.139,
             ),
             # Further overnight discharge slots before any recharge — must
-            # NOT inflate the reserve computed at hour 1 above.
+            # NOT inflate the reserve computed above.
             _slot(
-                6,
+                1.0,
                 estimated_battery_capacity_kwh=4.0,
                 batteries_discharged_kwh=5.361,
             ),
             _slot(
-                12,
+                2.0,
                 estimated_battery_capacity_kwh=0.2,
                 batteries_discharged_kwh=3.8,
             ),
@@ -167,9 +174,11 @@ class TestReserveStopsAtFirstScheduledAction:
 
         reserve = calculate_required_battery_for_plan(slots, _NOW, current_capacity=9.5)
 
-        # Only the dip through the first discharge slot (9.5 -> 9.361) is
-        # protected — not the cumulative overnight total down to 0.2 kWh.
-        assert reserve == 0.139
+        # Full dip through the first discharge slot only (9.5 -> 9.361 =
+        # 0.139 kWh), decayed by (1 - 0.75/2.0) = 0.625 -> 0.087. Far below
+        # what a pre-#950 cumulative-overnight-total scan would have given
+        # (9.5 - 0.2 = 9.3 kWh, i.e. nearly the entire current capacity).
+        assert reserve == 0.087
 
     def test_reserve_still_stops_at_charge_when_charge_comes_first(self) -> None:
         """A charge slot before any discharge still ends the scan (unchanged)."""
@@ -191,6 +200,101 @@ class TestReserveStopsAtFirstScheduledAction:
         reserve = calculate_required_battery_for_plan(slots, _NOW, current_capacity=9.5)
 
         assert reserve == 0.0
+
+
+class TestWaitModeReserveTimeDecay:
+    """The reserve ramps up as the next committed action approaches (issue #954).
+
+    Reported scenario: a large discharge scheduled hours away (e.g. an
+    evening peak) locked up nearly the entire current capacity for
+    self-consumption immediately, even though the battery wasn't needed for
+    hours — 100% SoC, reserve well below capacity, yet the applier still
+    wrote 0 W. Confirmed directly: a discharge 5h away consumed 5.9 of a
+    6.4 kWh capacity as "reserve" right away. The full energy needed for the
+    next action is now only protected once it's imminent; farther out, the
+    reserve decays linearly to 0 over ``WAIT_MODE_RESERVE_DECAY_HOURS``.
+    """
+
+    def test_action_beyond_decay_window_has_zero_reserve(self) -> None:
+        """A discharge needing most of the battery, 5h away, protects nothing yet."""
+        slots = [
+            _slot(1, estimated_battery_capacity_kwh=6.4),
+            _slot(3, estimated_battery_capacity_kwh=6.4),
+            _slot(
+                5,
+                estimated_battery_capacity_kwh=0.5,
+                batteries_discharged_kwh=5.9,
+            ),
+        ]
+
+        reserve = calculate_required_battery_for_plan(slots, _NOW, current_capacity=6.4)
+
+        assert reserve == 0.0
+
+    def test_action_at_decay_window_boundary_has_zero_reserve(self) -> None:
+        """Exactly at the decay window boundary, the reserve is still 0."""
+        slots = [
+            _slot(
+                WAIT_MODE_RESERVE_DECAY_HOURS,
+                estimated_battery_capacity_kwh=0.5,
+                batteries_discharged_kwh=5.9,
+            ),
+        ]
+
+        reserve = calculate_required_battery_for_plan(slots, _NOW, current_capacity=6.4)
+
+        assert reserve == 0.0
+
+    def test_imminent_action_has_full_reserve(self) -> None:
+        """An action starting now (or already in progress) is fully protected."""
+        slots = [
+            _slot(
+                0.0,
+                estimated_battery_capacity_kwh=0.5,
+                batteries_discharged_kwh=5.9,
+            ),
+        ]
+
+        reserve = calculate_required_battery_for_plan(slots, _NOW, current_capacity=6.4)
+
+        assert reserve == 5.9
+
+    def test_reserve_ramps_linearly_inside_the_decay_window(self) -> None:
+        """Halfway through the decay window, half the full reserve is protected."""
+        halfway = WAIT_MODE_RESERVE_DECAY_HOURS / 2
+        slots = [
+            _slot(
+                halfway,
+                estimated_battery_capacity_kwh=0.5,
+                batteries_discharged_kwh=5.9,
+            ),
+        ]
+
+        reserve = calculate_required_battery_for_plan(slots, _NOW, current_capacity=6.4)
+
+        assert reserve == pytest.approx(5.9 / 2, abs=0.01)
+
+    def test_decay_also_applies_to_a_far_future_charge(self) -> None:
+        """A far-future recharge decays the same way as a far-future discharge."""
+        slots = [
+            _slot(1, estimated_battery_capacity_kwh=1.0),
+            _slot(5, estimated_battery_capacity_kwh=6.4, batteries_charged_kwh=5.4),
+        ]
+
+        reserve = calculate_required_battery_for_plan(slots, _NOW, current_capacity=6.4)
+
+        assert reserve == 0.0
+
+    def test_no_future_action_in_horizon_is_unaffected_by_decay(self) -> None:
+        """No committed action anywhere -> decay never engages (unchanged)."""
+        slots = [
+            _slot(1, estimated_battery_capacity_kwh=1.0),
+            _slot(10, estimated_battery_capacity_kwh=0.4),
+        ]
+
+        reserve = calculate_required_battery_for_plan(slots, _NOW, current_capacity=2.0)
+
+        assert reserve == 1.6
 
 
 class TestNoFutureRechargeInHorizon:


### PR DESCRIPTION
## Summary

- Follow-up to #942 / #949 / #950 / #954. After #955 fixed the hold-vs-reserve precedence bug, `tonnr` re-tested on `v6.3.0-beta4` and reported the same practical symptom persisted: `Maximum discharging power` still `0 W` at 69% SoC (6.4 kWh current / 9.5 kWh usable) with the current Wait slot planning 0 kWh discharge and 0.192 kWh grid import (https://github.com/woopstar/hsem/pull/950 thread).
- Root cause, confirmed by direct reproduction: `calculate_required_battery_for_plan()` computes the wait-mode reserve as the full energy needed for the plan's *next* committed charge-or-discharge action, regardless of how far in the future that action is. A battery at 6.4 kWh with a discharge scheduled 5 hours away needing 5.9 kWh computed a reserve of `5.9 kWh` — leaving only `0.5 kWh` of surplus for self-consumption for the entire 5-hour lead time, even though the reactive replanning design (interval tick, event-triggered, 10-second live-power monitor) will re-derive that same reserve fresh well before the action actually starts.
- Discussed and confirmed with the maintainer: time-decay the reserve. Fixed by tracking the `start` time of the slot that ends the scan and multiplying the full computed reserve by a linear decay factor based on how far away that action is — full protection at 0 hours away, ramping to 0 protection at/beyond `WAIT_MODE_RESERVE_DECAY_HOURS = 2.0` (an internal tuning constant, not user-configurable).
- Applies uniformly to charge- and discharge-terminated scans. The "no committed action anywhere in the horizon" case is unaffected (already naturally correct from the min-tracking alone, since a fully idle horizon keeps `estimated_battery_capacity_kwh` flat).

## Branch

`fix/wait-mode-reserve-time-decay`

## Files changed

- `custom_components/hsem/planner/discharge_scheduler.py` — `calculate_required_battery_for_plan()` now tracks the next-action start time and applies the decay factor; new `WAIT_MODE_RESERVE_DECAY_HOURS` constant
- `docs/planner-spec.md` — "Wait-mode self-consumption reserve (issue #914)" section documents the decay and the reproduction numbers
- `docs/planner-guide.md` — wait-mode behaviour note updated
- `.github/memories.md` — "Wait Mode Self-Consumption with Reserve" entry updated
- `tests/planner/test_wait_mode_reserve_from_plan.py` — existing scenarios re-timed to sit inside the decay window (preserving their original regression intent with non-zero decayed values); new `TestWaitModeReserveTimeDecay` class covers the decay curve itself

## Tests added/updated

- `TestSmallForecastSurplusDoesNotEndReserveEarly`, `TestReliableRechargeStopsTheScan`, `TestReserveStopsAtFirstScheduledAction` — re-timed so their next action sits inside the 2h decay window; assertions updated to the decayed values with the arithmetic shown in comments.
- New `TestWaitModeReserveTimeDecay`:
  - `test_action_beyond_decay_window_has_zero_reserve` — the exact issue #956 reproduction (discharge 5h away, needs 5.9 of 6.4 kWh → reserve now `0.0`, not `5.9`).
  - `test_action_at_decay_window_boundary_has_zero_reserve` — boundary condition.
  - `test_imminent_action_has_full_reserve` — action starting now is fully protected.
  - `test_reserve_ramps_linearly_inside_the_decay_window` — midpoint gives half the full reserve.
  - `test_decay_also_applies_to_a_far_future_charge` — decay isn't discharge-specific.
  - `test_no_future_action_in_horizon_is_unaffected_by_decay` — existing full-horizon-Wait behavior preserved.

## Test and lint results

- `./scripts/quality.sh lint` — pass
- `./scripts/quality.sh typing` — pass (mypy, 0 errors)
- `./scripts/quality.sh quality` — pass (pyright + vulture, 0 errors)
- `./scripts/quality.sh test` — 3323 passed

## Known limitations / open questions

- `WAIT_MODE_RESERVE_DECAY_HOURS = 2.0` was chosen as a reasonable default balancing responsiveness against protection lead time; it's not user-configurable in this PR. If real-world testing shows it needs tuning, that can be a fast follow-up rather than a config option.

## Required configuration changes

None.

Fixes #956
