### PR TITLE
fix(planner): hold current-slot EV charger power at its slot-entry rate

### DIFF
--- a/.github/memories.md
+++ b/.github/memories.md
@@ -683,10 +683,73 @@ is `sum(1 for ev in active_evs if ev.charge_past_target) * m` and is included
 in `ev_total_rows`.
 
 EV charger watts must remain coherent with the accepted slot's EV energy,
-grid flow, net load, and cost fields. Production no longer invokes the old
-per-slot power freeze because restoring stale watts after replanning can revive
-a command whose energy is no longer reserved. Runtime overrides update the
-complete current-slot accounting and respect aggregate fuse headroom.
+grid flow, net load, and cost fields. PR #783 removed the old
+`coordinator.py::_freeze_ev_charger_power_for_current_slot` mechanism because
+it restored stale watts **in isolation**, after replanning, independent of
+whatever the freshly accepted plan's energy/grid-flow/cost fields said —
+a command could get resurrected for a charge whose energy was no longer
+reserved. **Issue #957 reintroduced a current-slot hold in a different,
+narrower form that does not repeat that mistake** — see
+"Current-Slot EV Power Hold (Issue #957)" below. The key difference: the
+new hold runs **once, after candidate selection**, mutates only the
+display/command wattage field (never energy, grid-flow, or cost), and
+clears itself immediately the instant the accepted plan retracts the
+charge — it never restores a value the current plan has disowned. If
+touching either mechanism again, read both write-ups before assuming one
+supersedes or duplicates the other.
+
+## Current-Slot EV Power Hold (Issue #957)
+
+`_compute_ev_charger_power` (baseline path, `planner/engine_ev.py`) and the
+MILP write-out (`planner/milp/_ev_power_writeout.py`) both derive the
+_current_ slot's target power as allocated-energy ÷ remaining-slot-time,
+re-derived from the live clock on every solve. In the steady, capacity-bound
+case both terms shrink together and the ratio is a stable constant — but
+because the coordinator re-solves far more often than once per slot
+(sometimes under a second apart), rounding on an already-small energy
+numerator dominates as remaining time collapses toward its floor, and the
+ratio degenerates into "run at rated power to deliver a trickle in a
+fraction of a second". That degenerate value can then stay published past
+the slot's actual end, spiking to rated power then dropping straight to 0 W
+at the next boundary and stopping the charger mid-session. Confirmed against
+`logs/20260909_133056` where the **MILP write-out** (not the baseline path)
+was the winning candidate producing exactly this pattern — the bug is not
+baseline-only, so the fix must not be either.
+
+`_hold_current_slot_ev_power()` (`planner/engine_ev.py`) fixes this by
+running **once, after candidate selection**, directly on `winner.slots` —
+agnostic to which internal path produced the raw value, since it operates
+on whichever candidate actually won. It only mutates the display/command
+wattage field, never energy, grid-flow, or cost, so `winner.cost ==
+final_output.cost` is untouched. Semantics: the first time the current slot
+is seen as current, or the first time its allocation goes from zero to
+non-zero (a session starting mid-slot, or a genuine re-rank that newly
+selects it), the freshly computed rate is captured once and held; every
+subsequent solve within the same slot republishes that held rate verbatim,
+discarding whatever the fresh (potentially degenerate) recomputation
+produced. The instant the current slot's allocation is retracted to zero,
+the hold clears and zero publishes immediately — never a stale non-zero
+value.
+
+The hold state (`ev_held_slot_start` / `ev_held_power_w`, plus
+`ev_second_*`) is threaded through `PlannerInput` → `PlannerOutput` and
+persisted by the coordinator (`coordinator_planner_phase.py`) across solves,
+mirroring the existing `_last_plan_ev_*` cross-cycle state pattern — the
+engine itself stays a pure function of its input. It must also be added to
+`coordinator_cycle.py::_capture_accepted_plan_state`'s snapshot/restore list
+alongside `_ev_charging_plan`, or a stale/cancelled cycle can roll back the
+EV plan while leaving the hold pointing at energy that plan no longer
+reserves — the exact class of bug PR #783 fixed, reintroduced through a
+different door.
+
+This is orthogonal to the amp deadband / slot-tail stop suppression in
+`coordinator_ev_command_stability.py` — that layer still runs afterward as a
+defense-in-depth execution-layer smoother (see "EV charger command
+stability" in `docs/planner-spec.md`), but with the current slot's rate now
+stable by construction it typically has nothing left to damp for this class
+of churn. Do not fix this class of bug there — see that section's own
+docstring for why a deadband structurally cannot catch a spike-to-max or a
+same-cycle large drop.
 
 ## EV Pre-Deadline Target Cap (Issue #636 — Overcharge Fix)
 

--- a/custom_components/hsem/coordinator.py
+++ b/custom_components/hsem/coordinator.py
@@ -205,6 +205,15 @@ class HSEMDataUpdateCoordinator(
         # Most recent EV charging plans from the planner engine.
         self._ev_charging_plan: EVChargingPlan | None = None
         self._ev_second_charging_plan: EVChargingPlan | None = None
+
+        # Current-slot EV charger power hold (issue #957). The rate the
+        # planner froze for the current slot at slot-entry, fed back into the
+        # next solve's PlannerInput so it can hold the rate for the rest of
+        # the slot instead of re-deriving it from the live clock.
+        self._ev_held_slot_start: datetime | None = None
+        self._ev_held_power_w: float = 0.0
+        self._ev_second_held_slot_start: datetime | None = None
+        self._ev_second_held_power_w: float = 0.0
         # Most recent planner input/output retained for diagnostics dumps.
         self._last_planner_input: PlannerInput | None = None
         self._last_planner_output: PlannerOutput | None = None

--- a/custom_components/hsem/coordinator_builder.py
+++ b/custom_components/hsem/coordinator_builder.py
@@ -17,7 +17,7 @@ directly.
 from __future__ import annotations
 
 import math
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from custom_components.hsem.models.battery_schedule_input import BatteryScheduleInput
 from custom_components.hsem.models.hourly_consumption_average import (
@@ -136,6 +136,10 @@ def build_planner_input(
     capacity_learner: CapacityLearner | None = None,
     dynamic_discharge_floor_pct: float | None = None,
     live_power_estimate: LivePowerEstimate | None = None,
+    ev_held_slot_start: datetime | None = None,
+    ev_held_power_w: float = 0.0,
+    ev_second_held_slot_start: datetime | None = None,
+    ev_second_held_power_w: float = 0.0,
 ) -> PlannerInput:
     """Assemble a :class:`PlannerInput` from the coordinator's current pipeline state.
 
@@ -468,6 +472,10 @@ def build_planner_input(
             ev_session_kw.get("ev_second") if ev_session_kw else None
         ),
         dynamic_discharge_floor_pct=dynamic_discharge_floor_pct,
+        ev_held_slot_start=ev_held_slot_start,
+        ev_held_power_w=ev_held_power_w,
+        ev_second_held_slot_start=ev_second_held_slot_start,
+        ev_second_held_power_w=ev_second_held_power_w,
     )
 
 

--- a/custom_components/hsem/coordinator_cycle.py
+++ b/custom_components/hsem/coordinator_cycle.py
@@ -442,6 +442,10 @@ class CoordinatorCycleMixin(CoordinatorSharedState):
             "_data_quality",
             "_ev_charging_plan",
             "_ev_second_charging_plan",
+            "_ev_held_slot_start",
+            "_ev_held_power_w",
+            "_ev_second_held_slot_start",
+            "_ev_second_held_power_w",
             "_hourly_recommendation",
             "_hourly_recommendations",
         )

--- a/custom_components/hsem/coordinator_planner_phase.py
+++ b/custom_components/hsem/coordinator_planner_phase.py
@@ -168,6 +168,10 @@ class CoordinatorPlannerPhaseMixin(CoordinatorSharedState):
                 dynamic_discharge_floor_pct=_dynamic_floor_pct,
                 capacity_learner=getattr(self, "_capacity_learner", CapacityLearner()),
                 live_power_estimate=live_power_estimate,
+                ev_held_slot_start=self._ev_held_slot_start,
+                ev_held_power_w=self._ev_held_power_w,
+                ev_second_held_slot_start=self._ev_second_held_slot_start,
+                ev_second_held_power_w=self._ev_second_held_power_w,
             )
             planner_input.solar_corrector = self._solar_corrector
             self._last_planner_input = planner_input
@@ -202,6 +206,10 @@ class CoordinatorPlannerPhaseMixin(CoordinatorSharedState):
             )
             self._ev_charging_plan = planner_output.ev_charging_plan
             self._ev_second_charging_plan = planner_output.ev_second_charging_plan
+            self._ev_held_slot_start = planner_output.ev_held_slot_start
+            self._ev_held_power_w = planner_output.ev_held_power_w
+            self._ev_second_held_slot_start = planner_output.ev_second_held_slot_start
+            self._ev_second_held_power_w = planner_output.ev_second_held_power_w
 
             if live.any_ev_charging:
                 has_planned = any(
@@ -232,6 +240,10 @@ class CoordinatorPlannerPhaseMixin(CoordinatorSharedState):
             )
             self._ev_charging_plan = planner_output.ev_charging_plan
             self._ev_second_charging_plan = planner_output.ev_second_charging_plan
+            self._ev_held_slot_start = planner_output.ev_held_slot_start
+            self._ev_held_power_w = planner_output.ev_held_power_w
+            self._ev_second_held_slot_start = planner_output.ev_second_held_slot_start
+            self._ev_second_held_power_w = planner_output.ev_second_held_power_w
             async_log(
                 "debug",
                 "[replan] Skipping planner — no material changes detected."

--- a/custom_components/hsem/coordinator_state.py
+++ b/custom_components/hsem/coordinator_state.py
@@ -85,9 +85,13 @@ class CoordinatorSharedState(_Base):
     _effective_discharge_floor_pct: float | None
     _ev_charging_plan: EVChargingPlan | None
     _ev_delivered_energy_tracker: EVDeliveredEnergyTracker
+    _ev_held_power_w: float
+    _ev_held_slot_start: datetime | None
     _ev_last_command_w: dict[str, float]
     _ev_second_charging_plan: EVChargingPlan | None
     _ev_second_delivered_energy_tracker: EVDeliveredEnergyTracker
+    _ev_second_held_power_w: float
+    _ev_second_held_slot_start: datetime | None
     _event_update_pending: bool
     _financial_tracker: FinancialTracker
     _force_working_mode_entity: str | None

--- a/custom_components/hsem/models/planner_input.py
+++ b/custom_components/hsem/models/planner_input.py
@@ -311,6 +311,17 @@ class PlannerInput:
     #: Same as ev_planned_load_deadline_safety_margin_pct, for the second EV.
     ev_second_planned_load_deadline_safety_margin_pct: float = 0.0
 
+    # --- Current-slot EV charger power hold (issue #957) — the rate held
+    # for the current slot from the previous solve's ``PlannerOutput``, fed
+    # back in so the engine can tell "still the same current slot" from "a
+    # new current slot" without recomputing the rate from the live clock.
+    # ``None`` slot_start means nothing is currently held. ---
+    ev_held_slot_start: datetime | None = None
+    ev_held_power_w: float = 0.0
+    #: Same as ev_held_slot_start/ev_held_power_w, for the second EV.
+    ev_second_held_slot_start: datetime | None = None
+    ev_second_held_power_w: float = 0.0
+
     # --- planner hysteresis — keep the active plan unless the new plan
     # is materially better (anti-flapping, issue #372). ---
     #: When True, hysteresis is active.  The previous winner's strategy

--- a/custom_components/hsem/models/planner_output.py
+++ b/custom_components/hsem/models/planner_output.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from custom_components.hsem.models.charge_window import ChargeWindow
@@ -106,6 +107,17 @@ class PlannerOutput:
     #: ``"aggressive"``).  Used by the coordinator to persist the active plan
     #: name across cycles for hysteresis (issue #372).
     winner_name: str = ""
+    #: Current-slot EV charger power hold state (issue #957): the rate held
+    #: for the current slot after this solve, to be persisted by the
+    #: coordinator and fed back into the next solve's ``PlannerInput`` so the
+    #: engine can hold the rate for the rest of the slot instead of
+    #: re-deriving it from the live clock on every re-solve. ``None`` means
+    #: nothing is held (no charge planned for the current slot).
+    ev_held_slot_start: datetime | None = None
+    ev_held_power_w: float = 0.0
+    #: Same as ev_held_slot_start/ev_held_power_w, for the second EV.
+    ev_second_held_slot_start: datetime | None = None
+    ev_second_held_power_w: float = 0.0
 
     # ------------------------------------------------------------------
     # Convenience helpers used by tests

--- a/custom_components/hsem/planner/engine_core.py
+++ b/custom_components/hsem/planner/engine_core.py
@@ -42,6 +42,7 @@ from custom_components.hsem.planner.discharge_scheduler import (
 from custom_components.hsem.planner.engine_ev import (
     _build_and_inject_for_ev,
     _compute_ev_charger_power,
+    _hold_current_slot_ev_power,
 )
 from custom_components.hsem.planner.engine_ev_milp import (
     _build_ev_configs_for_milp,
@@ -662,6 +663,22 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
     # drift and to ensure the final score matches the selector's score.
     slots = winner.slots
 
+    # Freeze the current slot's EV charger command at its slot-entry rate
+    # (issue #957). Runs once, on the winning candidate's slots, so it is
+    # agnostic to whether the baseline EV planner or the MILP produced the
+    # raw value, and only mutates the display/command wattage field — never
+    # energy, grid-flow, or cost — so it cannot move `winner.cost`.
+    ev_held_slot_start, ev_held_power_w = _hold_current_slot_ev_power(
+        slots, now, inp.ev_held_slot_start, inp.ev_held_power_w, second=False
+    )
+    ev_second_held_slot_start, ev_second_held_power_w = _hold_current_slot_ev_power(
+        slots,
+        now,
+        inp.ev_second_held_slot_start,
+        inp.ev_second_held_power_w,
+        second=True,
+    )
+
     # Wait-mode self-consumption reserve (issue #914): derived from the
     # *selected* plan's own simulated SoC trajectory, not the raw forecast
     # scan used by ``rc``/``calculate_required_battery_until_solar`` above.
@@ -772,4 +789,8 @@ def run_planner(inp: PlannerInput) -> PlannerOutput:
         winner_name=winner.name,
         ev_charging_plan=ev_cp,
         ev_second_charging_plan=ev2_cp,
+        ev_held_slot_start=ev_held_slot_start,
+        ev_held_power_w=ev_held_power_w,
+        ev_second_held_slot_start=ev_second_held_slot_start,
+        ev_second_held_power_w=ev_second_held_power_w,
     )

--- a/custom_components/hsem/planner/engine_ev.py
+++ b/custom_components/hsem/planner/engine_ev.py
@@ -10,6 +10,7 @@ from custom_components.hsem.planner.ev_planner import (
     apply_ev_planned_load_to_slots,
     build_ev_charging_plan,
 )
+from custom_components.hsem.utils.datetime_utils import as_tz, utc_key
 from custom_components.hsem.utils.logger import log_planner
 
 
@@ -97,6 +98,101 @@ def _compute_ev_charger_power(
             else "ev_charger_calculated_power"
         )
         setattr(slots[idx], attr, ac_power_w)
+
+
+def _hold_current_slot_ev_power(
+    slots: list,
+    now: datetime,
+    held_slot_start: datetime | None,
+    held_power_w: float,
+    *,
+    second: bool = False,
+) -> tuple[datetime | None, float]:
+    """Freeze the current slot's EV charger command at its slot-entry rate.
+
+    Both the baseline EV planner path (:func:`_compute_ev_charger_power`) and
+    the MILP write-out (``milp/_ev_power_writeout.py``) derive the *current*
+    slot's target power as allocated energy ÷ remaining slot time, re-derived
+    from the live clock on every solve. Numerator and denominator shrink
+    together, so in the steady case the ratio is a stable constant — but as
+    the remaining time collapses toward its floor, rounding on the
+    (already-small) energy numerator dominates and the ratio degenerates
+    into "run at rated power to deliver a trickle in a fraction of a
+    second". Because the coordinator re-solves far more often than once per
+    slot, that degenerate value can stay published past the slot's actual
+    end (issue #957).
+
+    This runs once, on the *winning* candidate's slots, after candidate
+    selection — so it is agnostic to which internal path (baseline or MILP)
+    produced the raw value, and it never affects ``winner.cost`` since it
+    only touches the display/command wattage field, not energy, grid-flow,
+    or cost fields.
+
+    The fix: capture the rate the first time this slot is seen as current —
+    using whatever time genuinely remains at that instant, full width for a
+    freshly entered slot, less for a session starting mid-slot — and hold
+    it for the rest of the slot. Only a genuine plan change (a new current
+    slot, or this slot's allocation being retracted to zero) moves the
+    published value; the wall clock ticking down within the same slot does
+    not.
+
+    Args:
+        slots: The winning candidate's slot list, mutated in place.
+        now: Timezone-aware current datetime.
+        held_slot_start: Start of the slot the previous solve held a rate
+            for, or ``None`` if nothing is currently held.
+        held_power_w: The rate held for ``held_slot_start``, in watts.
+        second: If ``True``, operate on
+            ``ev_second_charger_calculated_power``; otherwise
+            ``ev_charger_calculated_power``.
+
+    Returns:
+        The ``(slot_start, power_w)`` to persist and pass back in on the
+        next solve.
+    """
+    attr = (
+        "ev_second_charger_calculated_power"
+        if second
+        else "ev_charger_calculated_power"
+    )
+    current = next(
+        (
+            s
+            for s in slots
+            if as_tz(s.start, now.tzinfo) <= now < as_tz(s.end, now.tzinfo)
+        ),
+        None,
+    )
+    if current is None:
+        return None, 0.0
+
+    fresh_w = max(float(getattr(current, attr)), 0.0)
+    if fresh_w < 1e-9:
+        # The plan has no (or no longer has) a charge for this slot — publish
+        # zero immediately.  A stale non-zero hold must never be resurrected
+        # once the plan has retracted the charge (see PR #783's lesson on
+        # coherent EV command accounting).
+        return None, 0.0
+
+    same_held_slot = held_slot_start is not None and utc_key(
+        held_slot_start
+    ) == utc_key(current.start)
+    if same_held_slot:
+        setattr(current, attr, held_power_w)
+        return held_slot_start, held_power_w
+
+    # New current slot, or this slot just transitioned from zero to
+    # non-zero (a session starting mid-slot, or a genuine re-rank that
+    # newly selects this slot) — capture the freshly computed rate once,
+    # using the actual remaining time right now, and hold it going forward.
+    log_planner(
+        "debug",
+        "[core] ev_power_hold  attr=%s  slot=%s  rate_w=%.0f  (new hold)",
+        attr,
+        current.start.isoformat(),
+        fresh_w,
+    )
+    return current.start, fresh_w
 
 
 def _build_and_inject_for_ev(

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -2819,13 +2819,13 @@ There is no separate user-facing configuration for this field.
 
 Three per-slot fields capture EV load intent precisely:
 
-| Field                                | Meaning                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ev_planned_load_kwh`                | Extra EV AC load **added to net consumption** — only the portion not already in `avg_house_consumption`. Zero when `base_load_includes_ev = True`.                                                                                                                                                                                                                                                                                                  |
-| `ev_accounted_load_kwh`              | EV AC load **already included** in the house consumption sensor. Non-zero when `base_load_includes_ev = True`. Must not be added to net consumption again.                                                                                                                                                                                                                                                                                          |
-| `ev_total_planned_load_kwh`          | Total planned EV AC load regardless of accounting mode: `ev_planned_load_kwh + ev_accounted_load_kwh`. Always non-zero when any EV charging is planned.                                                                                                                                                                                                                                                                                             |
-| `ev_charger_calculated_power`        | Target AC power (W) for the primary EV charger during this slot. Computed from the EV planner's per-slot energy target: `round((ac_load_kwh / slot_duration_hours) × 1000)`. For the **current** (partially elapsed) slot, `slot_duration_hours` is the remaining time (minimum 1 s), because the EV planner already scales `ac_load_kwh` to the remaining minutes. For future slots the full slot width is used. Zero when no charging is planned. |
-| `ev_second_charger_calculated_power` | Same as above, for the second EV.                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| Field                                | Meaning                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ev_planned_load_kwh`                | Extra EV AC load **added to net consumption** — only the portion not already in `avg_house_consumption`. Zero when `base_load_includes_ev = True`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `ev_accounted_load_kwh`              | EV AC load **already included** in the house consumption sensor. Non-zero when `base_load_includes_ev = True`. Must not be added to net consumption again.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `ev_total_planned_load_kwh`          | Total planned EV AC load regardless of accounting mode: `ev_planned_load_kwh + ev_accounted_load_kwh`. Always non-zero when any EV charging is planned.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `ev_charger_calculated_power`        | Target AC power (W) for the primary EV charger during this slot. For **future** slots: `round((ac_load_kwh / slot_duration_hours) × 1000)` using the full slot width, re-derived every solve. For the **current** slot: the rate is decided **once**, the first time the slot is seen as current (or the first time its allocation goes from zero to non-zero), using whatever time genuinely remains at that instant — then **held** for the rest of the slot regardless of how the live clock or a re-solve's raw energy÷time ratio would otherwise move it (issue #957; see "Current-slot EV power hold" below). Zero when no charging is planned. |
+| `ev_second_charger_calculated_power` | Same as above, for the second EV.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 
 When `base_load_includes_ev = False`:
 
@@ -2970,7 +2970,9 @@ The EV planner (`planner/ev_planner.py`) MUST satisfy these invariants:
     and `ev_second_charger_calculated_power` (second EV) are each computed
     **per-EV** from that EV's own charging plan (`EVChargingPlan.charging_slots`)
     by `_compute_ev_charger_power()` (for non-MILP candidates) or directly by
-    the MILP's EV power computation (for MILP candidates).
+    the MILP's EV power computation (for MILP candidates). This raw,
+    per-candidate value is a plain energy÷time ratio; see invariant 14 for how
+    the **current** slot's published value is derived from it.
 
     The per-EV power fields are set **before** candidate selection and
     correctly adjusted by the main-fuse throttling block (per-field loop).
@@ -2993,10 +2995,64 @@ The EV planner (`planner/ev_planner.py`) MUST satisfy these invariants:
 
 13. **Executable EV command coherence**: Charger watts, EV energy, grid flow,
     net consumption, estimated cost, and the EV plan sensor must come from the
-    same accepted snapshot. The coordinator must not restore an older frozen
-    watt command after replanning. Runtime force-charge and negative-price
-    overrides must update all related current-slot fields together, respect
-    aggregate fuse headroom, and never energize an explicitly disconnected EV.
+    same accepted snapshot. The coordinator must not restore a watt command
+    left over from a _different_ accepted plan after replanning (e.g. a value
+    computed for a slot the current plan no longer selects). Runtime
+    force-charge and negative-price overrides must update all related
+    current-slot fields together, respect aggregate fuse headroom, and never
+    energize an explicitly disconnected EV. This does not conflict with
+    invariant 14's slot-entry hold: the hold only ever republishes a rate
+    computed _for this same slot, from this same accepted plan_ — it is
+    cleared immediately, not restored, the instant the plan retracts the
+    charge (see below).
+
+14. **Current-slot EV power hold** (issue #957): the raw per-slot power from
+    invariant 12 is an energy÷time ratio re-derived on every solve. For a
+    **future** slot both terms come from the full slot width, so the ratio is
+    stable. For the **current** slot, the time term is the _remaining_ slot
+    duration (invariant 6's partial-slot scaling propagated through to the
+    power field) — a term that shrinks toward zero as the slot elapses. In
+    the steady, capacity-bound case numerator and denominator shrink together
+    and the ratio stays a constant equal to the achievable rate. But because
+    the coordinator re-solves far more often than once per slot (sometimes
+    under a second apart), rounding on an already-small energy numerator
+    dominates as the remaining time collapses toward its floor, and the
+    ratio degenerates into "run at rated power to deliver a trickle of
+    energy in a fraction of a second" — a value that can then stay published
+    past the slot's actual end.
+
+    `_hold_current_slot_ev_power()` (`planner/engine_ev.py`) fixes this by
+    running **once, after candidate selection**, on the winning candidate's
+    slots — so it is agnostic to whether the baseline EV planner or the MILP
+    produced the raw value, and it mutates only the display/command wattage
+    field, never energy, grid-flow, or cost, so it cannot move `winner.cost`
+    (invariant "Cost identity" in `docs/planner-spec.md`'s top-level
+    invariants). For the current slot:
+
+    - The first time the slot is seen as current, or the first time its
+      allocation goes from zero to non-zero (a session starting mid-slot, or
+      a genuine re-rank that newly selects the slot), the freshly computed
+      rate is captured **once** — using whatever time genuinely remains at
+      that instant — and held.
+    - On every subsequent solve within the _same_ current slot, the held
+      rate is republished verbatim; the freshly (and potentially
+      degenerate) recomputed value is discarded.
+    - The instant the current slot's allocation is retracted to zero (the
+      plan no longer wants to charge it), the held state is cleared and zero
+      is published immediately — never a stale non-zero hold.
+    - Crossing into a new current slot always re-evaluates from scratch.
+
+    The hold state (`ev_held_slot_start` / `ev_held_power_w`, and the
+    `ev_second_*` equivalents) is threaded through `PlannerInput` →
+    `PlannerOutput` and persisted by the coordinator across solves — the
+    engine itself stays a pure function of its input, including this state.
+
+    This is orthogonal to the amp deadband and slot-tail stop suppression in
+    `coordinator_ev_command_stability.py` (see "EV charger command
+    stability" below): that layer still runs afterward as a defense-in-depth
+    execution-layer smoother, but because the current slot's rate is now
+    stable by construction, it will typically see nothing to damp for the
+    class of churn this invariant addresses.
 
 ### Invariants for tests
 
@@ -3028,24 +3084,47 @@ The EV planner (`planner/ev_planner.py`) MUST satisfy these invariants:
 - One EV with zero load does not clear the other EV's load.
 - `ev_smart_charging` label is applied when `ev_total_planned_load_kwh > 0`, even when
   `ev_planned_load_kwh == 0` (i.e. `base_load_includes_ev = True`).
+- Current-slot EV power hold (issue #957):
+  - A slot with only seconds remaining, re-solved after a rate is already
+    held for it, republishes the held rate — never a spike toward rated
+    power.
+  - A slot boundary where the current slot's allocation goes from positive
+    to zero clears the hold and publishes zero immediately; one where it
+    goes from zero to positive captures a fresh rate for the new slot.
+  - A session starting mid-slot (nothing held yet, partially elapsed slot)
+    captures the rate for the time that genuinely remains, not the full
+    slot width.
+  - A slot re-solved multiple times mid-duration returns the identical held
+    rate on every solve, regardless of what a fresh energy÷time
+    recomputation would have produced.
+  - `winner.cost == final_output.cost` still holds — the hold only mutates
+    the display/command wattage field.
 
 ### EV charger command stability (post-plan command layer)
 
-The planner re-solves on every cycle and re-derives the **live** slot's charger
-command from scratch:
+Before the slot-entry hold (issue #957, invariant 14 above), the planner
+re-solved on every cycle and re-derived the **live** slot's charger command
+from scratch on _every_ solve:
 
 ```text
 command_W = energy allocated to the remainder of this slot
             ÷ time remaining in this slot
 ```
 
-Both terms move every solve. The amp lattice is integer, the target-cap pins
-total pre-deadline energy to the remaining need, and the live slot's amp step
-shrinks continuously as the slot elapses — so the live slot's amps is a
-_residual_ on a lattice that is itself moving. Competing integer splits are
-routinely within a rounding error of each other on cost: on one observed
-2.5 h session the two best splits for a slot differed by **0.01 %**, yet a
-0.3 % SoC update flipped the published command by 2–3 A.
+with both terms moving every solve. The hold now pins this ratio once, the
+first time the current slot is captured, and republishes that same value on
+every subsequent solve within the slot — so the residual churn this layer
+damps is narrower than it used to be: it no longer sees the raw energy÷time
+ratio move every cycle, only the single fresh value computed when a slot is
+first captured (or re-captured after a genuine retraction). That first
+capture is still exactly the scenario described below: the amp lattice is
+integer, the target-cap pins total pre-deadline energy to the remaining
+need, and competing integer splits are routinely within a rounding error of
+each other on cost — on one observed 2.5 h session the two best splits for a
+slot differed by **0.01 %**, yet a 0.3 % SoC update flipped the published
+command by 2–3 A. This layer remains a necessary defense-in-depth smoother
+for that first-capture jitter and for any command movement introduced by
+runtime overrides (force-charge-now, auto-full-EV) applied after the hold.
 
 Two corrections are applied in
 `coordinator_ev_command_stability.py`, invoked from

--- a/tests/planner/test_ev_charger_power_hold.py
+++ b/tests/planner/test_ev_charger_power_hold.py
@@ -1,0 +1,365 @@
+"""Tests for the current-slot EV charger power hold (issue #957).
+
+Both the baseline EV planner path and the MILP write-out derive the
+*current* slot's target power as allocated energy ÷ remaining slot time,
+re-derived from the live clock on every solve. As the remaining time
+collapses toward its floor near a slot's end, the ratio degenerates into
+"run at rated power to deliver a trickle of energy in a fraction of a
+second" — a value that can then stay published past the slot's actual end,
+because the coordinator re-solves far more often than once per slot.
+
+``_hold_current_slot_ev_power`` fixes this by capturing the current slot's
+rate once — the first time the slot is seen as current, or the first time
+its allocation goes from zero to non-zero (a session starting mid-slot) —
+and holding it for the rest of the slot. Only a genuine plan change (a new
+current slot, or the slot's allocation being retracted to zero) moves the
+published value.
+
+Test classes
+------------
+TestHoldCapturesOnce       — a slot re-solved multiple times mid-duration
+                              keeps returning the same held rate
+TestHoldDoesNotSpike       — a slot with only seconds remaining must not
+                              spike, once a rate is already held
+TestHoldSlotBoundary       — allocation transitions from positive to zero
+                              (and vice versa) across a slot boundary
+TestHoldSessionStartsMidSlot — a session starting mid-slot captures the
+                              correct one-time rate for the time that
+                              genuinely remains
+TestHoldWiringThroughPlanner — PlannerInput/PlannerOutput round trip
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from custom_components.hsem.models.hourly_consumption_average import (
+    HourlyConsumptionAverage,
+)
+from custom_components.hsem.models.planned_slot import PlannedSlot
+from custom_components.hsem.models.planner_input import PlannerInput
+from custom_components.hsem.models.price_point import PricePoint
+from custom_components.hsem.models.solcast_slot import SolcastSlot
+from custom_components.hsem.planner import run_planner
+from custom_components.hsem.planner.engine_ev import _hold_current_slot_ev_power
+
+_TZ = UTC
+_SLOT_START = datetime(2024, 6, 15, 12, 30, tzinfo=_TZ)
+_SLOT_END = datetime(2024, 6, 15, 12, 45, tzinfo=_TZ)
+_NEXT_SLOT_END = datetime(2024, 6, 15, 13, 0, tzinfo=_TZ)
+
+
+def _slots(*, current_power_w: float, next_power_w: float = 0.0) -> list[PlannedSlot]:
+    """Return a two-slot list: the 12:30-12:45 slot and the 12:45-13:00 slot."""
+    return [
+        PlannedSlot(
+            start=_SLOT_START,
+            end=_SLOT_END,
+            ev_charger_calculated_power=current_power_w,
+        ),
+        PlannedSlot(
+            start=_SLOT_END,
+            end=_NEXT_SLOT_END,
+            ev_charger_calculated_power=next_power_w,
+        ),
+    ]
+
+
+class TestHoldCapturesOnce:
+    """A slot re-solved multiple times mid-duration returns the same held rate."""
+
+    def test_repeated_resolve_holds_first_captured_rate(self):
+        """Three re-solves within the same slot all return the first rate.
+
+        The first solve (15 min left) is a fresh capture at ~730 W. Later
+        re-solves recompute a wildly different "fresh" value (simulating
+        the degenerate tail-of-slot blowup) — the hold must ignore it.
+        """
+        now1 = _SLOT_START  # slot just became current, full 15 min left
+        slots1 = _slots(current_power_w=730.0)
+        held_start, held_w = _hold_current_slot_ev_power(
+            slots1, now1, None, 0.0, second=False
+        )
+        assert held_start == _SLOT_START
+        assert held_w == 730.0
+        assert slots1[0].ev_charger_calculated_power == 730.0
+
+        # Second re-solve, 10 minutes later, same slot. The "fresh" value
+        # this solve produced (as if freshly recomputed from a shrinking
+        # clock) is wildly different — must be ignored in favour of the hold.
+        now2 = _SLOT_START + timedelta(minutes=10)
+        slots2 = _slots(current_power_w=9999.0)
+        held_start2, held_w2 = _hold_current_slot_ev_power(
+            slots2, now2, held_start, held_w, second=False
+        )
+        assert held_start2 == _SLOT_START
+        assert held_w2 == 730.0
+        assert slots2[0].ev_charger_calculated_power == 730.0
+
+        # Third re-solve, seconds before the slot ends.
+        now3 = _SLOT_END - timedelta(seconds=2)
+        slots3 = _slots(current_power_w=11040.0)
+        held_start3, held_w3 = _hold_current_slot_ev_power(
+            slots3, now3, held_start2, held_w2, second=False
+        )
+        assert held_start3 == _SLOT_START
+        assert held_w3 == 730.0
+        assert slots3[0].ev_charger_calculated_power == 730.0
+
+
+class TestHoldDoesNotSpike:
+    """A slot with only seconds remaining must not spike once already held."""
+
+    def test_seconds_remaining_does_not_republish_spike(self):
+        """Held at 730 W early in the slot; a few seconds before the slot
+        ends the raw (pre-hold) value has degenerated to rated max — the
+        published value must stay at the held rate, not the spike."""
+        held_start, held_w = _hold_current_slot_ev_power(
+            _slots(current_power_w=730.0), _SLOT_START, None, 0.0, second=False
+        )
+        assert held_w == 730.0
+
+        now_tail = _SLOT_END - timedelta(seconds=4)
+        slots_tail = _slots(current_power_w=11040.0)  # degenerate rated-max spike
+        _, tail_w = _hold_current_slot_ev_power(
+            slots_tail, now_tail, held_start, held_w, second=False
+        )
+        assert tail_w == 730.0
+        assert slots_tail[0].ev_charger_calculated_power == 730.0
+
+    def test_fresh_capture_with_seconds_remaining_uses_the_fresh_value_once(self):
+        """If nothing was held yet and only seconds remain, the first
+        capture takes whatever was already (safely) computed upstream —
+        this function does not itself compute a rate, it only decides
+        whether to hold or accept the fresh one."""
+        now_tail = _SLOT_END - timedelta(seconds=4)
+        slots_tail = _slots(current_power_w=250.0)
+        held_start, held_w = _hold_current_slot_ev_power(
+            slots_tail, now_tail, None, 0.0, second=False
+        )
+        assert held_start == _SLOT_START
+        assert held_w == 250.0
+
+
+class TestHoldSlotBoundary:
+    """Allocation transitions from positive to zero (and vice versa)."""
+
+    def test_new_slot_with_zero_allocation_clears_the_hold(self):
+        """Crossing into a new slot the plan does not want to charge:
+        the held state must reset to (None, 0.0), not carry the old rate."""
+        now_new_slot = _SLOT_END + timedelta(seconds=3)
+        current_slots = [
+            PlannedSlot(
+                start=_SLOT_END, end=_NEXT_SLOT_END, ev_charger_calculated_power=0.0
+            )
+        ]
+        held_start, held_w = _hold_current_slot_ev_power(
+            current_slots, now_new_slot, _SLOT_START, 730.0, second=False
+        )
+        assert held_start is None
+        assert held_w == 0.0
+        assert current_slots[0].ev_charger_calculated_power == 0.0
+
+    def test_new_slot_with_nonzero_allocation_captures_fresh(self):
+        """Crossing into a new slot the plan DOES want to charge: a fresh
+        rate is captured for the new slot, not the old held rate."""
+        now_new_slot = _SLOT_END + timedelta(seconds=3)
+        current_slots = [
+            PlannedSlot(
+                start=_SLOT_END, end=_NEXT_SLOT_END, ev_charger_calculated_power=2747.0
+            )
+        ]
+        held_start, held_w = _hold_current_slot_ev_power(
+            current_slots, now_new_slot, _SLOT_START, 730.0, second=False
+        )
+        assert held_start == _SLOT_END
+        assert held_w == 2747.0
+
+    def test_retraction_mid_slot_zeroes_immediately(self):
+        """The plan retracts the current slot's charge mid-slot (e.g. the
+        MILP re-ranks battery ahead of the EV) — must publish zero right
+        away, never resurrect the previously held non-zero command."""
+        now_mid = _SLOT_START + timedelta(minutes=7)
+        slots = _slots(current_power_w=0.0)
+        held_start, held_w = _hold_current_slot_ev_power(
+            slots, now_mid, _SLOT_START, 730.0, second=False
+        )
+        assert held_start is None
+        assert held_w == 0.0
+        assert slots[0].ev_charger_calculated_power == 0.0
+
+    def test_reselection_after_retraction_captures_fresh(self):
+        """After a retraction cleared the hold, the slot becomes selected
+        again later in the same slot — must capture fresh, not silently
+        stay at zero and not resurrect the pre-retraction rate."""
+        now_later = _SLOT_START + timedelta(minutes=12)
+        slots = _slots(current_power_w=500.0)
+        held_start, held_w = _hold_current_slot_ev_power(
+            slots, now_later, None, 0.0, second=False
+        )
+        assert held_start == _SLOT_START
+        assert held_w == 500.0
+
+
+class TestHoldSessionStartsMidSlot:
+    """A session starting mid-slot captures the correct one-time rate."""
+
+    def test_mid_slot_session_start_uses_actual_remaining_time_rate(self):
+        """Smart charging enabled 10 minutes into a 15-min slot: nothing
+        was held before, so the fresh value computed for the remaining 5
+        minutes is captured as-is (not the full-slot-width value)."""
+        now_mid_start = _SLOT_START + timedelta(minutes=10)
+        slots = _slots(current_power_w=9360.0)  # sized for 5 min remaining
+        held_start, held_w = _hold_current_slot_ev_power(
+            slots, now_mid_start, None, 0.0, second=False
+        )
+        assert held_start == _SLOT_START
+        assert held_w == 9360.0
+
+        # A later re-solve in the same slot must hold that captured rate.
+        now_later = _SLOT_START + timedelta(minutes=13)
+        slots_later = _slots(current_power_w=99999.0)
+        _, later_w = _hold_current_slot_ev_power(
+            slots_later, now_later, held_start, held_w, second=False
+        )
+        assert later_w == 9360.0
+
+
+class TestHoldSecondEv:
+    """The second EV's hold state is tracked independently of the primary."""
+
+    def test_second_ev_uses_its_own_attribute_and_state(self):
+        slots = [
+            PlannedSlot(
+                start=_SLOT_START,
+                end=_SLOT_END,
+                ev_charger_calculated_power=730.0,
+                ev_second_charger_calculated_power=1500.0,
+            )
+        ]
+        held_start, held_w = _hold_current_slot_ev_power(
+            slots, _SLOT_START, None, 0.0, second=True
+        )
+        assert held_start == _SLOT_START
+        assert held_w == 1500.0
+        # Primary field is untouched by the second-EV call.
+        assert slots[0].ev_charger_calculated_power == 730.0
+
+
+class TestHoldNoCurrentSlot:
+    """No matching current slot returns a cleared hold without raising."""
+
+    def test_now_outside_all_slots_returns_none(self):
+        slots = _slots(current_power_w=730.0)
+        held_start, held_w = _hold_current_slot_ev_power(
+            slots, _SLOT_START - timedelta(hours=1), _SLOT_START, 730.0, second=False
+        )
+        assert held_start is None
+        assert held_w == 0.0
+
+
+# ---------------------------------------------------------------------------
+# TestHoldWiringThroughPlanner — PlannerInput/PlannerOutput round trip
+# ---------------------------------------------------------------------------
+
+
+def _make_planner_input(
+    now_iso: str,
+    *,
+    ev_held_slot_start: datetime | None = None,
+    ev_held_power_w: float = 0.0,
+) -> PlannerInput:
+    """Build a minimal PlannerInput with EV planned load enabled."""
+    now = datetime.fromisoformat(now_iso)
+    deadline = now + timedelta(hours=8)
+
+    prices = [
+        PricePoint(hour=h, import_price=0.10, export_price=0.05) for h in range(24)
+    ]
+    pv = [SolcastSlot(hour=h, pv_estimate=0.0) for h in range(24)]
+    averages = [
+        HourlyConsumptionAverage(
+            hour=h, avg_1d=1.0, avg_3d=1.0, avg_7d=1.0, avg_14d=1.0
+        )
+        for h in range(24)
+    ]
+
+    return PlannerInput(
+        now_iso=now_iso,
+        interval_minutes=60,
+        interval_length_hours=24,
+        battery_soc_pct=50.0,
+        battery_rated_capacity_kwh=10.0,
+        battery_end_of_discharge_soc_pct=10.0,
+        battery_max_soc_pct=90.0,
+        battery_max_charge_power_w=5000.0,
+        battery_max_discharge_power_w=5000.0,
+        battery_charge_efficiency_pct=95.0,
+        battery_discharge_efficiency_pct=95.0,
+        weight_1d=25,
+        weight_3d=30,
+        weight_7d=30,
+        weight_14d=15,
+        consumption_averages=averages,
+        price_points=prices,
+        solcast_slots=pv,
+        ev_planned_load_enabled=True,
+        ev_planned_load_connected=True,
+        ev_planned_load_smart_charging_enabled=True,
+        ev_planned_load_current_soc_pct=50.0,
+        ev_planned_load_target_soc_pct=80.0,
+        ev_planned_load_battery_capacity_kwh=77.0,
+        ev_planned_load_charger_power_kw=11.0,
+        ev_planned_load_charger_efficiency_pct=100.0,
+        ev_planned_load_deadline=deadline,
+        ev_held_slot_start=ev_held_slot_start,
+        ev_held_power_w=ev_held_power_w,
+    )
+
+
+class TestHoldWiringThroughPlanner:
+    """PlannerInput → run_planner → PlannerOutput carries the hold state."""
+
+    def test_output_reports_held_state_for_the_current_slot(self):
+        """A fresh solve with nothing held returns held state that matches
+        the current slot's published command."""
+        now_iso = "2024-06-15T06:05:00+00:00"
+        now = datetime.fromisoformat(now_iso)
+        out = run_planner(_make_planner_input(now_iso))
+
+        current = next((s for s in out.slots if s.start <= now < s.end), None)
+        assert current is not None
+        if current.ev_charger_calculated_power > 1e-9:
+            assert out.ev_held_slot_start == current.start
+            assert out.ev_held_power_w == current.ev_charger_calculated_power
+        else:
+            assert out.ev_held_slot_start is None
+            assert out.ev_held_power_w == 0.0
+
+    def test_held_input_overrides_freshly_computed_value(self):
+        """Feeding back a synthetic held rate for the still-current slot
+        makes the planner publish that exact rate, not a freshly derived
+        one — proving the coordinator → PlannerInput → engine wiring is
+        live, not just the output side."""
+        now_iso = "2024-06-15T06:05:00+00:00"
+        now = datetime.fromisoformat(now_iso)
+        baseline_out = run_planner(_make_planner_input(now_iso))
+        current = next((s for s in baseline_out.slots if s.start <= now < s.end), None)
+        assert current is not None
+        assert current.ev_charger_calculated_power > 1e-9, (
+            "Test setup expects the current slot to be charging the EV; "
+            "adjust the fixture if this assumption changes."
+        )
+
+        synthetic_w = current.ev_charger_calculated_power + 1234.0
+        held_out = run_planner(
+            _make_planner_input(
+                now_iso,
+                ev_held_slot_start=current.start,
+                ev_held_power_w=synthetic_w,
+            )
+        )
+        held_current = next((s for s in held_out.slots if s.start <= now < s.end), None)
+        assert held_current is not None
+        assert held_current.ev_charger_calculated_power == synthetic_w
+        assert held_out.ev_held_power_w == synthetic_w

--- a/tests/test_ha_mock_integration.py
+++ b/tests/test_ha_mock_integration.py
@@ -236,6 +236,10 @@ def make_bare_coordinator(
     coord._data_quality = DataQuality()
     coord._ev_charging_plan = None
     coord._ev_second_charging_plan = None
+    coord._ev_held_slot_start = None
+    coord._ev_held_power_w = 0.0
+    coord._ev_second_held_slot_start = None
+    coord._ev_second_held_power_w = 0.0
 
     from custom_components.hsem.custom_sensors.config_reader import build_sensor_config
 


### PR DESCRIPTION
## Summary

Fixes #957 — the EV charger command (`ev_charger_calculated_power`) spikes
to the charger's rated max power in a slot's dying seconds, then drops
straight to 0 W after the slot boundary, stopping the charger mid-session.

**Root cause:** both `_compute_ev_charger_power` (baseline EV planner path,
`planner/engine_ev.py`) and the MILP write-out
(`planner/milp/_ev_power_writeout.py`) derive the *current* slot's target
power as `allocated_energy ÷ remaining_slot_time`, re-derived from the live
clock on every solve. In the steady, capacity-bound case both terms shrink
together and the ratio is a stable constant — but because the coordinator
re-solves far more often than once per slot (sometimes under a second
apart, via the 10 s live-power monitor plus other triggers), rounding on an
already-small energy numerator dominates as remaining time collapses toward
its floor, and the ratio degenerates into "run at rated power to deliver a
trickle of energy in a fraction of a second". That degenerate value then
stays published past the slot's actual end.

Confirmed against `logs/20260909_133056/hsem.log`: the 12:44:56.365 spike to
11040 W and the 12:45:03.075 drop to 0 W both came from the **MILP
write-out** path (`winner=milp` in both surrounding `run_planner DONE`
lines), not the baseline path the issue's code excerpt named — the bug
pattern is identical in both files, so the fix covers both.

## What changed

A naive fix of swapping the divisor to the full slot width would break the
numerator/denominator relationship and understate the ceiling for most of a
slot (explicitly ruled out by the issue). Instead:

- **`_hold_current_slot_ev_power()`** (new, `planner/engine_ev.py`) runs
  **once, after candidate selection**, directly on `winner.slots` — so it is
  agnostic to whether the baseline path or the MILP produced the raw value,
  and it only mutates the display/command wattage field (never energy,
  grid-flow, or cost), so `winner.cost == final_output.cost` is untouched.
- The first time the current slot is seen as current, or the first time its
  allocation goes from zero to non-zero (a session starting mid-slot, or a
  genuine re-rank that newly selects it), the freshly computed rate is
  captured **once** and held. Every subsequent solve within the same slot
  republishes that held rate verbatim, discarding whatever the fresh
  (potentially degenerate) recomputation produced.
- The instant the current slot's allocation is retracted to zero, the hold
  clears and zero publishes immediately — never a stale non-zero value
  (this mirrors the lesson from PR #783, which removed an earlier
  coordinator-level freeze precisely because it could restore watts for
  energy the plan no longer reserved; see below for how this one avoids
  that trap).
- The hold state (`ev_held_slot_start` / `ev_held_power_w`, and
  `ev_second_*`) threads through `PlannerInput` → `PlannerOutput` and is
  persisted by the coordinator across solves (`coordinator_planner_phase.py`),
  mirroring the existing `_last_plan_ev_*` cross-cycle state pattern — the
  engine itself stays a pure function of its input.
- Also wired into `coordinator_cycle.py`'s `_capture_accepted_plan_state` /
  `_restore_accepted_plan_state` snapshot list, alongside `_ev_charging_plan`
  — otherwise a stale/cancelled cycle could roll back the accepted EV plan
  while leaving the new hold state pointing at energy that plan no longer
  reserves, reintroducing the exact PR #783 class of bug through a
  different door.
- Slot **selection** (`build_ev_charging_plan` in `ev_planner.py`) is
  untouched — it already lives correctly, per the issue.
- The command-stability deadband (`coordinator_ev_command_stability.py`) is
  untouched — it remains a defense-in-depth execution-layer smoother for
  whatever first-capture jitter and runtime-override movement remains, but
  with the current slot's rate now stable by construction it typically has
  nothing left to damp for this specific class of churn.

## Files changed

- `custom_components/hsem/planner/engine_ev.py` — new
  `_hold_current_slot_ev_power()`.
- `custom_components/hsem/planner/engine_core.py` — calls the hold right
  after `slots = winner.slots` (before `_label_commanded_ev_slots` and
  `rebuild_ev_plan_from_slots`, so the EV label and the EV plan sensor both
  reflect the held value), and returns the new held state on `PlannerOutput`.
- `custom_components/hsem/models/planner_input.py` /
  `planner_output.py` — new `ev_held_slot_start` / `ev_held_power_w` (+
  `ev_second_*`) fields.
- `custom_components/hsem/coordinator_builder.py` — `build_planner_input()`
  accepts and forwards the held state.
- `custom_components/hsem/coordinator_planner_phase.py` — passes the
  coordinator's persisted held state into `build_planner_input()`, and
  persists `planner_output`'s held state back after every solve (both the
  fresh-replan and the reused-plan branch).
- `custom_components/hsem/coordinator_state.py` /
  `custom_components/hsem/coordinator.py` — new instance attributes.
- `custom_components/hsem/coordinator_cycle.py` — added to the
  accepted-plan-state snapshot/restore list.
- `docs/planner-spec.md` — documents the new invariant 14 ("Current-slot EV
  power hold"), updates invariant 12/13 and the field table, adds an
  "Invariants for tests" bullet list, and clarifies the interplay with the
  existing command-stability deadband section.
- `.github/memories.md` — records why this hold is a different, narrower
  mechanism than the one PR #783 removed.

## Tests

New `tests/planner/test_ev_charger_power_hold.py` (12 tests), covering all
four scenarios called out in the issue:

- A slot re-solved multiple times mid-duration returns the identical held
  rate every time, ignoring wildly different "fresh" values on later solves.
- A slot with only seconds remaining does not spike, once a rate is already
  held for it.
- A slot boundary where allocation goes from positive → zero (hold clears,
  zero published immediately) and zero → positive (fresh capture for the
  new slot) in both directions, plus mid-slot retraction and reselection.
- A session starting mid-slot captures the rate for the time that genuinely
  remains, not the full slot width.
- Second-EV independence, no-current-slot safety, and an end-to-end
  `PlannerInput` → `run_planner` → `PlannerOutput` wiring round trip proving
  the coordinator-persisted state is actually read back by the engine.

`tests/test_ha_mock_integration.py`'s hand-built fake coordinator fixture
needed the four new attributes added (it bypasses `__init__` via
`object.__new__`); without this, `TestDryRunCycle` failed with
`AttributeError: 'HSEMDataUpdateCoordinator' object has no attribute
'_ev_held_slot_start'` — caught by running the full suite before opening
this PR.

## Test plan

- [x] `./scripts/quality.sh lint` — 0 errors
- [x] `./scripts/quality.sh typing` — 0 errors
- [x] `./scripts/quality.sh quality` — 0 errors (pyright + vulture)
- [x] `./scripts/quality.sh test` — 3335 passed
- [x] `python3 scripts/validate_translations.py` — 0 errors (no user-facing
      strings changed)
- [x] File size check — `engine_ev.py` 10.5 KB, `engine_core.py` 28.9 KB
      (both under the 30 KB limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
