### PR TITLE
fix(tracking): credit avoided grid-import savings from battery discharge

### DIFF
--- a/custom_components/hsem/coordinator_tracking.py
+++ b/custom_components/hsem/coordinator_tracking.py
@@ -10,6 +10,7 @@ Extracted to keep :mod:`coordinator` under the 30 KB / 1000-line limit.
 from __future__ import annotations
 
 import asyncio
+import math
 from datetime import date, datetime
 from pathlib import Path
 
@@ -416,8 +417,9 @@ async def accumulate_savings(
 ) -> None:
     """Accumulate savings data for the current cycle.
 
-    Computes export revenue delta, charge savings delta, and baseline
-    cost delta from the daily tracker and planner output.
+    Computes export revenue delta, charge savings delta, discharge savings
+    delta, and baseline cost delta from the daily tracker, live battery
+    power, and planner output.
 
     Args:
         now: Current datetime (timezone-aware).
@@ -468,6 +470,28 @@ async def accumulate_savings(
         if abs(charge_kwh) > 1e-9:
             charge_savings_delta = charge_kwh * (avg_import_price - import_price)
 
+    # ---- Discharge savings: money saved by avoiding grid import now ----
+    # Battery energy discharged to serve house load avoids buying that
+    # energy from the grid at the current import price.  Without this term,
+    # installations that rely mainly on self-consumption (rather than
+    # export or below-average-price charging) are reported as saving
+    # nothing even while the battery is actively reducing grid import
+    # (issue #960).
+    discharge_savings_delta = 0.0
+    power_w = live.huawei_batteries_charge_discharge_power_w
+    if (
+        st._last_discharge_sample_at is not None
+        and power_w is not None
+        and math.isfinite(power_w)
+        and power_w < 0.0
+        and import_price > 0.0
+    ):
+        elapsed = (now - st._last_discharge_sample_at).total_seconds()
+        if elapsed > 0:
+            discharge_kwh = compute_accumulated_energy(-power_w, elapsed)
+            discharge_savings_delta = discharge_kwh * import_price
+    st._last_discharge_sample_at = now
+
     # ---- Baseline cost: what passive mode would cost this cycle ----
     baseline_cost_delta = import_cost_delta
 
@@ -479,6 +503,7 @@ async def accumulate_savings(
         charge_savings_delta=charge_savings_delta,
         baseline_cost_delta=baseline_cost_delta,
         switch_on=switch_on,
+        discharge_savings_delta=discharge_savings_delta,
     )
 
 

--- a/custom_components/hsem/models/savings_tracker.py
+++ b/custom_components/hsem/models/savings_tracker.py
@@ -36,6 +36,8 @@ class SavingsTracker:
         _switch_was_off: Whether the master switch was off this cycle.
         _last_export_rev: Snapshot of daily_tracker grid_export_rev for delta.
         _last_import_cost: Snapshot of daily_tracker grid_import_cost for delta.
+        _last_discharge_sample_at: Previous sample timestamp used to
+            integrate battery discharge power into discharge-savings energy.
     """
 
     max_history_days: int = 90
@@ -57,6 +59,9 @@ class SavingsTracker:
     _last_export_rev: float | None = field(default=None, repr=False)
     _last_import_cost: float | None = field(default=None, repr=False)
 
+    # Previous sample timestamp for discharge-savings elapsed-time integration.
+    _last_discharge_sample_at: datetime | None = field(default=None, repr=False)
+
     def __post_init__(self) -> None:
         """Set today's date if not already set."""
         if not self._today:
@@ -75,6 +80,7 @@ class SavingsTracker:
         charge_savings_delta: float,
         baseline_cost_delta: float,
         switch_on: bool,
+        discharge_savings_delta: float = 0.0,
     ) -> None:
         """Accumulate one cycle's worth of savings data.
 
@@ -87,8 +93,10 @@ class SavingsTracker:
             charge_savings_delta: Money saved by charging cheap now vs later.
             baseline_cost_delta: What passive mode would have cost this cycle.
             switch_on: ``True`` when the master switch is on (auto mode).
+            discharge_savings_delta: Money saved by battery discharge that
+                avoided grid import this cycle (currency).
         """
-        savings = export_revenue_delta + charge_savings_delta
+        savings = export_revenue_delta + charge_savings_delta + discharge_savings_delta
 
         if switch_on:
             self.actual_savings += savings

--- a/tests/models/test_savings_tracker.py
+++ b/tests/models/test_savings_tracker.py
@@ -115,6 +115,39 @@ class TestSavingsTracker:
         assert st.missed_savings == pytest.approx(0.20)
         assert st.baseline_cost == pytest.approx(1.00 + 0.50 + 0.30)  # 1.80
 
+    def test_accumulate_with_discharge_savings(self) -> None:
+        """discharge_savings_delta should be included in the savings sum."""
+        st = SavingsTracker()
+        st.accumulate(
+            export_revenue_delta=0.50,
+            charge_savings_delta=0.30,
+            baseline_cost_delta=2.00,
+            switch_on=True,
+            discharge_savings_delta=0.40,
+        )
+        assert st.actual_savings == pytest.approx(1.20)  # 0.50 + 0.30 + 0.40
+        assert st.missed_savings == 0.0
+        assert st.today_actual == pytest.approx(1.20)
+
+    def test_accumulate_discharge_savings_when_switch_off(self) -> None:
+        """discharge_savings_delta should accumulate as missed when switch is off."""
+        st = SavingsTracker()
+        st.accumulate(
+            export_revenue_delta=0.0,
+            charge_savings_delta=0.0,
+            baseline_cost_delta=1.00,
+            switch_on=False,
+            discharge_savings_delta=0.40,
+        )
+        assert st.actual_savings == 0.0
+        assert st.missed_savings == pytest.approx(0.40)
+
+    def test_accumulate_discharge_savings_defaults_to_zero(self) -> None:
+        """Omitting discharge_savings_delta must not change prior behaviour."""
+        st = SavingsTracker()
+        st.accumulate(0.50, 0.30, 2.00, True)
+        assert st.actual_savings == pytest.approx(0.80)  # 0.50 + 0.30
+
     def test_zero_savings(self) -> None:
         """Zero deltas should not affect totals."""
         st = SavingsTracker()

--- a/tests/test_coordinator_tracking_savings_discharge.py
+++ b/tests/test_coordinator_tracking_savings_discharge.py
@@ -1,0 +1,182 @@
+"""Tests for savings tracker avoided-grid-import discharge credit (issue #960).
+
+Battery energy discharged to serve house load avoids buying that energy from
+the grid at the current import price.  Before this fix, ``accumulate_savings``
+only credited export revenue and below-average-price charging, so
+self-consumption-heavy installations were reported as saving nothing even
+while the battery was actively reducing grid import.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.hsem.coordinator_tracking import accumulate_savings
+from custom_components.hsem.models.daily_plan_vs_actual_tracker import (
+    DailyPlanVsActualTracker,
+)
+from custom_components.hsem.models.live_state import LiveState
+from custom_components.hsem.models.planner_output import PlannerOutput
+from custom_components.hsem.models.savings_tracker import SavingsTracker
+
+
+def _make_hass(config_dir: Path) -> HomeAssistant:
+    """Build a minimal fake HomeAssistant with just a config_dir."""
+    return cast(
+        HomeAssistant,
+        SimpleNamespace(config=SimpleNamespace(config_dir=str(config_dir))),
+    )
+
+
+async def _run_two_cycles(
+    hass: HomeAssistant,
+    live: LiveState,
+    savings_tracker: SavingsTracker,
+    daily_tracker: DailyPlanVsActualTracker,
+) -> None:
+    """Run two accumulate_savings cycles 15 minutes apart.
+
+    The first call only establishes the discharge-sample baseline timestamp
+    (no previous sample exists yet, so no delta can be computed). The second
+    call is where any discharge-savings delta is actually credited.
+    """
+    output = PlannerOutput()
+    t0 = datetime(2026, 6, 26, 12, 0, tzinfo=UTC)
+    await accumulate_savings(
+        now=t0,
+        live=live,
+        output=output,
+        savings_tracker=savings_tracker,
+        daily_tracker=daily_tracker,
+        hourly_recommendation=None,
+        hass=hass,
+    )
+    t1 = datetime(2026, 6, 26, 12, 15, tzinfo=UTC)  # 900s later
+    await accumulate_savings(
+        now=t1,
+        live=live,
+        output=output,
+        savings_tracker=savings_tracker,
+        daily_tracker=daily_tracker,
+        hourly_recommendation=None,
+        hass=hass,
+    )
+
+
+@pytest.mark.asyncio
+async def test_discharge_credits_savings_at_import_price(tmp_path: Path) -> None:
+    """Battery discharge to the house is credited at the live import price."""
+    hass = _make_hass(tmp_path)
+    savings_tracker = SavingsTracker()
+    daily_tracker = DailyPlanVsActualTracker()
+
+    live = LiveState()
+    live.import_electricity_price = 2.0
+    live.huawei_batteries_charge_discharge_power_w = -1000.0  # 1 kW discharging
+
+    await _run_two_cycles(hass, live, savings_tracker, daily_tracker)
+
+    # 1 kW for 900s = 0.25 kWh, valued at 2.0/kWh = 0.50.
+    assert savings_tracker.actual_savings == pytest.approx(0.50, rel=1e-6)
+
+
+@pytest.mark.asyncio
+async def test_first_cycle_credits_no_discharge_savings(tmp_path: Path) -> None:
+    """The very first cycle has no previous sample, so it credits zero."""
+    hass = _make_hass(tmp_path)
+    savings_tracker = SavingsTracker()
+    daily_tracker = DailyPlanVsActualTracker()
+    output = PlannerOutput()
+
+    live = LiveState()
+    live.import_electricity_price = 2.0
+    live.huawei_batteries_charge_discharge_power_w = -1000.0
+
+    await accumulate_savings(
+        now=datetime(2026, 6, 26, 12, 0, tzinfo=UTC),
+        live=live,
+        output=output,
+        savings_tracker=savings_tracker,
+        daily_tracker=daily_tracker,
+        hourly_recommendation=None,
+        hass=hass,
+    )
+
+    assert savings_tracker.actual_savings == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_charging_power_credits_no_discharge_savings(tmp_path: Path) -> None:
+    """Positive (charging) power must not be credited as discharge savings."""
+    hass = _make_hass(tmp_path)
+    savings_tracker = SavingsTracker()
+    daily_tracker = DailyPlanVsActualTracker()
+
+    live = LiveState()
+    live.import_electricity_price = 2.0
+    live.huawei_batteries_charge_discharge_power_w = 1000.0  # charging
+
+    await _run_two_cycles(hass, live, savings_tracker, daily_tracker)
+
+    assert savings_tracker.actual_savings == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_missing_power_reading_credits_no_discharge_savings(
+    tmp_path: Path,
+) -> None:
+    """A ``None`` power reading must not crash and must credit zero."""
+    hass = _make_hass(tmp_path)
+    savings_tracker = SavingsTracker()
+    daily_tracker = DailyPlanVsActualTracker()
+
+    live = LiveState()
+    live.import_electricity_price = 2.0
+    live.huawei_batteries_charge_discharge_power_w = None
+
+    await _run_two_cycles(hass, live, savings_tracker, daily_tracker)
+
+    assert savings_tracker.actual_savings == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_nan_power_reading_credits_no_discharge_savings(
+    tmp_path: Path,
+) -> None:
+    """A non-finite power reading must not crash and must credit zero."""
+    hass = _make_hass(tmp_path)
+    savings_tracker = SavingsTracker()
+    daily_tracker = DailyPlanVsActualTracker()
+
+    live = LiveState()
+    live.import_electricity_price = 2.0
+    live.huawei_batteries_charge_discharge_power_w = float("nan")
+
+    await _run_two_cycles(hass, live, savings_tracker, daily_tracker)
+
+    assert savings_tracker.actual_savings == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_zero_import_price_credits_no_discharge_savings(
+    tmp_path: Path,
+) -> None:
+    """A non-positive import price must not credit discharge savings."""
+    hass = _make_hass(tmp_path)
+    savings_tracker = SavingsTracker()
+    daily_tracker = DailyPlanVsActualTracker()
+
+    live = LiveState()
+    live.import_electricity_price = 0.0
+    live.huawei_batteries_charge_discharge_power_w = -1000.0
+
+    await _run_two_cycles(hass, live, savings_tracker, daily_tracker)
+
+    assert savings_tracker.actual_savings == pytest.approx(0.0)


### PR DESCRIPTION
## Summary

- The savings tracker (`sensor.hsem_savings_tracker_sensor`) only credited
  export revenue and below-average-price charging into `actual_savings` /
  `missed_savings`. Battery energy discharged to serve house load — the most
  common source of value for self-consumption-heavy installations — was
  silently valued at zero, so the sensor under-reported savings whenever a
  system relied mainly on discharge rather than export.
- `accumulate_savings()` (`custom_components/hsem/coordinator_tracking.py`)
  now computes a `discharge_savings_delta`: it reads the live signed battery
  power (`live.huawei_batteries_charge_discharge_power_w`; positive =
  charging, negative = discharging), integrates it into kWh over the elapsed
  cycle time when discharging, and values it at the live import price (the
  price that avoided import would otherwise have cost).
- `SavingsTracker.accumulate()` (`custom_components/hsem/models/savings_tracker.py`)
  gains a new trailing `discharge_savings_delta: float = 0.0` parameter,
  included in the `savings` sum, so existing 4-positional-argument call sites
  are unaffected.
- Out of scope (flagged in the tracking issue but not fixed here): the
  `baseline_cost_delta` term is still the actual grid-import cost, not an
  independently computed passive/no-battery counterfactual. A full
  counterfactual redesign is a larger change than this "credit the missing
  discharge value" fix.

## Branch

`fix/960-savings-discharge-credit`

## Files changed

- `custom_components/hsem/coordinator_tracking.py` — compute
  `discharge_savings_delta` from live battery power and elapsed cycle time.
- `custom_components/hsem/models/savings_tracker.py` — new
  `_last_discharge_sample_at` field and `discharge_savings_delta` parameter
  on `accumulate()`.
- `tests/models/test_savings_tracker.py` — unit tests for the new
  `accumulate()` parameter (switch on/off, default backward compatibility).
- `tests/test_coordinator_tracking_savings_discharge.py` (new) — tests for
  `accumulate_savings()`: discharge credited at import price, first-cycle
  no-op, charging (positive power) not credited, missing/NaN power reading
  not credited and does not crash, zero import price not credited.

## Why

Reported by @AndersN76 on issue #732:
https://github.com/woopstar/hsem/issues/732#issuecomment-5603558034, tracked
as #960. Evidence: a day with 5.50 kWh battery cycled and 6.23 kWh actual
grid import (cost 14.278) still showed `today_actual: 0.000`, while a
different day with only export activity showed `today_actual` exactly
matching export revenue — confirming discharge-to-house was the missing term.

## Test plan

- [x] `./scripts/quality.sh lint` — pass
- [x] `./scripts/quality.sh typing` — pass (0 errors)
- [x] `./scripts/quality.sh quality` — pass (0 errors; pre-existing vulture
      notes unrelated to this change)
- [x] `./scripts/quality.sh test` — full suite: 3332 passed, including 6 new
      discharge-credit tests and 3 new `SavingsTracker.accumulate()` tests
- [x] No user-facing strings changed — translation sync is a no-op

Fixes #960
