### PR TITLE
fix(ev-charging): floor EV minimum-power-to-current conversion at 6A

### DIFF
--- a/custom_components/hsem/coordinator_ev_command_stability.py
+++ b/custom_components/hsem/coordinator_ev_command_stability.py
@@ -61,8 +61,8 @@ from custom_components.hsem.utils.misc import get_config_value
 from custom_components.hsem.utils.phase_power import (
     charger_current_to_power_w,
     charger_max_power_to_current_a,
-    charger_min_power_to_current_a,
     charger_power_to_current_a,
+    ev_min_start_current_a,
 )
 from custom_components.hsem.utils.units import slot_duration_hours
 
@@ -167,7 +167,7 @@ class CoordinatorEvCommandStabilityMixin(CoordinatorSharedState):
                         max(float(charger_power_kw or 0.0), 0.0) * 1000.0,
                         topology,
                     ),
-                    min_current_a=charger_min_power_to_current_a(
+                    min_current_a=ev_min_start_current_a(
                         max(float(min_power_w or 0.0), 0.0), topology
                     ),
                     managed=bool(enabled) and bool(connected) and bool(smart_charging),

--- a/custom_components/hsem/flows/ev_planned_load_helpers.py
+++ b/custom_components/hsem/flows/ev_planned_load_helpers.py
@@ -35,6 +35,7 @@ from homeassistant.helpers.selector import selector
 from custom_components.hsem.utils.config_validator import (
     merge_errors,
     validate_energy_limits,
+    validate_ev_min_power_topology,
     validate_power_limits,
 )
 from custom_components.hsem.utils.misc import get_config_value
@@ -245,5 +246,10 @@ async def validate_ev_planned_load_schema_input(
         min_watts=0.0,
         max_watts=22_000.0,
     )
+    min_power_topology_errors = validate_ev_min_power_topology(
+        user_input,
+        f"{prefix}_charger_min_power_w",
+        f"{prefix}_charger_phase_topology",
+    )
 
-    return merge_errors(capacity_errors, min_power_errors)
+    return merge_errors(capacity_errors, min_power_errors, min_power_topology_errors)

--- a/custom_components/hsem/models/ev_config.py
+++ b/custom_components/hsem/models/ev_config.py
@@ -33,7 +33,11 @@ class EVConfig:
         charger_min_power_w: Minimum AC power (W) the charger needs to start.
             When the per-slot AC power falls below this threshold the
             charger will not operate — zero out those allocations.
-            Default 1380 W (230 V × 6 A single-phase).
+            Default 1380 W (230 V × 6 A single-phase). Every site that
+            converts this to an executable amp floor
+            (``utils.phase_power.ev_min_start_current_a``) enforces a hard
+            6 A minimum regardless of the computed value or phase topology,
+            since no real EVSE starts below 6 A (IEC 61851, issue #968).
         deadline_slot: Index into the LP's future-slot list (0..m-1) of the
             last slot that can be used to meet the target.  Slots beyond this
             index may still charge but the target must be met by this slot.

--- a/custom_components/hsem/planner/engine_ev_milp.py
+++ b/custom_components/hsem/planner/engine_ev_milp.py
@@ -19,7 +19,7 @@ from custom_components.hsem.utils.misc import clamp_efficiency
 from custom_components.hsem.utils.phase_power import (
     charger_current_to_power_w,
     charger_max_power_to_current_a,
-    charger_min_power_to_current_a,
+    ev_min_start_current_a,
     normalize_ev_phase_topology,
 )
 
@@ -180,7 +180,7 @@ def _build_ev_configs_for_milp(
             phase_topology,
         )
         effective_min_power_w = charger_current_to_power_w(
-            charger_min_power_to_current_a(min_pwr_w, phase_topology),
+            ev_min_start_current_a(min_pwr_w, phase_topology),
             phase_topology,
         )
         effective_capacity = float(cap)

--- a/custom_components/hsem/planner/milp/_ev_amp_lattice.py
+++ b/custom_components/hsem/planner/milp/_ev_amp_lattice.py
@@ -24,8 +24,8 @@ import numpy as np
 from custom_components.hsem.planner.milp._layout import Bound, MilpBoundsBuilder
 from custom_components.hsem.utils.phase_power import (
     charger_current_to_power_w,
-    charger_min_power_to_current_a,
     charger_power_to_current_a,
+    ev_min_start_current_a,
 )
 
 if TYPE_CHECKING:
@@ -131,11 +131,8 @@ def resolve_ev_amp_plan(
         rated_current_a = charger_power_to_current_a(
             ev_bound_ac_power_w, ev.charger_phase_topology
         )
-        minimum_current_a = max(
-            charger_min_power_to_current_a(
-                ev.charger_min_power_w, ev.charger_phase_topology
-            ),
-            1,
+        minimum_current_a = ev_min_start_current_a(
+            ev.charger_min_power_w, ev.charger_phase_topology
         )
         runnable = rated_current_a >= minimum_current_a
         # A conditional discharge-permission binary is only useful when this
@@ -322,11 +319,8 @@ def target_cap_activation_quantum_dc(
     point exactly at the remaining need, and a strict cap would report an
     avoidable deadline miss (issue #797).
     """
-    activation_current_a = max(
-        charger_min_power_to_current_a(
-            ev.charger_min_power_w, ev.charger_phase_topology
-        ),
-        1,
+    activation_current_a = ev_min_start_current_a(
+        ev.charger_min_power_w, ev.charger_phase_topology
     )
     activation_power_w = charger_current_to_power_w(
         activation_current_a, ev.charger_phase_topology

--- a/custom_components/hsem/planner/milp/_ev_quantize.py
+++ b/custom_components/hsem/planner/milp/_ev_quantize.py
@@ -13,8 +13,8 @@ from typing import TYPE_CHECKING
 from custom_components.hsem.utils.phase_power import (
     charger_current_to_power_w,
     charger_max_power_to_current_a,
-    charger_min_power_to_current_a,
     charger_power_to_current_a,
+    ev_min_start_current_a,
 )
 from custom_components.hsem.utils.units import ev_dc_to_ac_kwh
 
@@ -129,11 +129,10 @@ def _quantize_ev_allocation_to_whole_amps(
         rated_ac_power_w,
         charger_phase_topology,
     )
-    configured_min_current_a = charger_min_power_to_current_a(
+    activation_min_current_a = ev_min_start_current_a(
         charger_min_power_w,
         charger_phase_topology,
     )
-    activation_min_current_a = max(configured_min_current_a, 1)
     if rated_current_a < activation_min_current_a:
         return {}, target_dc
 
@@ -280,9 +279,7 @@ def _quantize_one_ev_allocation(
         ev.charger_phase_topology,
     )
     effective_min_power_w = charger_current_to_power_w(
-        charger_min_power_to_current_a(
-            ev.charger_min_power_w, ev.charger_phase_topology
-        ),
+        ev_min_start_current_a(ev.charger_min_power_w, ev.charger_phase_topology),
         ev.charger_phase_topology,
     )
 
@@ -291,11 +288,8 @@ def _quantize_one_ev_allocation(
     # whole-amp command that will be published; the fractional residue is
     # handed to the flexible slots below to recover.
     session_quantization_residue_dc = 0.0
-    min_current_a = max(
-        charger_min_power_to_current_a(
-            effective_min_power_w, ev.charger_phase_topology
-        ),
-        1,
+    min_current_a = ev_min_start_current_a(
+        effective_min_power_w, ev.charger_phase_topology
     )
     for t in range(m):
         if t not in ev_session_slots:

--- a/custom_components/hsem/translations/da.json
+++ b/custom_components/hsem/translations/da.json
@@ -25,7 +25,8 @@
       "start_time_after_end_time": "Starttidspunkt skal være før sluttidspunkt.",
       "start_time_equals_end_time": "Starttidspunkt og sluttidspunkt kan ikke være ens - dette skaber et nul-længdevindue. Deaktiver tidsplanen i stedet.",
       "invalid_wait_mode_behavior": "Ugyldig ventetilstand. Vælg Streng ventetilstand eller Selvforbrug med reserve.",
-      "port_conflict": "Den anden OCPP-port skal være forskellig fra den første OCPP-port."
+      "port_conflict": "Den anden OCPP-port skal være forskellig fra den første OCPP-port.",
+      "ev_min_power_below_start_current": "Den konfigurerede minimumseffekt er for lav til den valgte fasetopologi — en rigtig lader kan ikke starte under 6 A. Øg minimumseffekten, eller skift fasetopologi."
     },
     "step": {
       "batteries_excess_export": {
@@ -562,7 +563,8 @@
       "start_time_after_end_time": "Starttidspunkt skal være før sluttidspunkt.",
       "start_time_equals_end_time": "Starttidspunkt og sluttidspunkt kan ikke være ens - dette skaber et nul-længdevindue. Deaktiver tidsplanen i stedet.",
       "invalid_wait_mode_behavior": "Ugyldig ventetilstand. Vælg Streng ventetilstand eller Selvforbrug med reserve.",
-      "port_conflict": "Den anden OCPP-port skal være forskellig fra den første OCPP-port."
+      "port_conflict": "Den anden OCPP-port skal være forskellig fra den første OCPP-port.",
+      "ev_min_power_below_start_current": "Den konfigurerede minimumseffekt er for lav til den valgte fasetopologi — en rigtig lader kan ikke starte under 6 A. Øg minimumseffekten, eller skift fasetopologi."
     },
     "step": {
       "batteries_excess_export": {

--- a/custom_components/hsem/translations/de.json
+++ b/custom_components/hsem/translations/de.json
@@ -25,7 +25,8 @@
       "start_time_after_end_time": "Die Startzeit muss vor der Endzeit liegen.",
       "start_time_equals_end_time": "Start- und Endzeit dürfen nicht identisch sein — das ergibt ein Zeitfenster der Länge null. Deaktiviere stattdessen den Zeitplan.",
       "invalid_wait_mode_behavior": "Ungültiges Wartemodus-Verhalten. Wähle Strenges Warten oder Eigenverbrauch mit Reserve.",
-      "port_conflict": "Der zweite OCPP-Port muss sich vom ersten OCPP-Port unterscheiden."
+      "port_conflict": "Der zweite OCPP-Port muss sich vom ersten OCPP-Port unterscheiden.",
+      "ev_min_power_below_start_current": "Die konfigurierte Mindestleistung ist für die gewählte Phasentopologie zu niedrig — ein echtes Ladegerät kann nicht unter 6 A starten. Erhöhe die Mindestleistung oder ändere die Phasentopologie."
     },
     "step": {
       "batteries_excess_export": {
@@ -562,7 +563,8 @@
       "start_time_after_end_time": "Die Startzeit muss vor der Endzeit liegen.",
       "start_time_equals_end_time": "Start- und Endzeit dürfen nicht identisch sein — das ergibt ein Zeitfenster der Länge null. Deaktiviere stattdessen den Zeitplan.",
       "invalid_wait_mode_behavior": "Ungültiges Wartemodus-Verhalten. Wähle Strenges Warten oder Eigenverbrauch mit Reserve.",
-      "port_conflict": "Der zweite OCPP-Port muss sich vom ersten OCPP-Port unterscheiden."
+      "port_conflict": "Der zweite OCPP-Port muss sich vom ersten OCPP-Port unterscheiden.",
+      "ev_min_power_below_start_current": "Die konfigurierte Mindestleistung ist für die gewählte Phasentopologie zu niedrig — ein echtes Ladegerät kann nicht unter 6 A starten. Erhöhe die Mindestleistung oder ändere die Phasentopologie."
     },
     "step": {
       "batteries_excess_export": {

--- a/custom_components/hsem/translations/en.json
+++ b/custom_components/hsem/translations/en.json
@@ -25,7 +25,8 @@
       "start_time_after_end_time": "Start time must be before end time.",
       "start_time_equals_end_time": "Start time and end time cannot be the same — this creates a zero-length window. Disable the schedule instead.",
       "invalid_wait_mode_behavior": "Invalid wait mode behaviour. Choose Strict wait or Self-consumption with reserve.",
-      "port_conflict": "The second OCPP port must differ from the first OCPP port."
+      "port_conflict": "The second OCPP port must differ from the first OCPP port.",
+      "ev_min_power_below_start_current": "The configured minimum power is too low for the selected phase topology — a real charger cannot start below 6 A. Increase the minimum power or switch phase topology."
     },
     "step": {
       "batteries_excess_export": {
@@ -562,7 +563,8 @@
       "start_time_after_end_time": "Start time must be before end time.",
       "start_time_equals_end_time": "Start time and end time cannot be the same — this creates a zero-length window. Disable the schedule instead.",
       "invalid_wait_mode_behavior": "Invalid wait mode behaviour. Choose Strict wait or Self-consumption with reserve.",
-      "port_conflict": "The second OCPP port must differ from the first OCPP port."
+      "port_conflict": "The second OCPP port must differ from the first OCPP port.",
+      "ev_min_power_below_start_current": "The configured minimum power is too low for the selected phase topology — a real charger cannot start below 6 A. Increase the minimum power or switch phase topology."
     },
     "step": {
       "batteries_excess_export": {

--- a/custom_components/hsem/translations/es.json
+++ b/custom_components/hsem/translations/es.json
@@ -25,7 +25,8 @@
       "start_time_after_end_time": "La hora de inicio debe ser anterior a la hora de fin.",
       "start_time_equals_end_time": "La hora de inicio y la hora de fin no pueden ser iguales, ya que esto crea una ventana de duración cero. Desactiva la programación en su lugar.",
       "invalid_wait_mode_behavior": "Comportamiento de modo de espera no válido. Elige Espera estricta o Autoconsumo con reserva.",
-      "port_conflict": "El segundo puerto OCPP debe ser diferente del primer puerto OCPP."
+      "port_conflict": "El segundo puerto OCPP debe ser diferente del primer puerto OCPP.",
+      "ev_min_power_below_start_current": "La potencia mínima configurada es demasiado baja para la topología de fases seleccionada — un cargador real no puede arrancar por debajo de 6 A. Aumenta la potencia mínima o cambia la topología de fases."
     },
     "step": {
       "batteries_excess_export": {
@@ -562,7 +563,8 @@
       "start_time_after_end_time": "La hora de inicio debe ser anterior a la hora de fin.",
       "start_time_equals_end_time": "La hora de inicio y la hora de fin no pueden ser iguales, ya que esto crea una ventana de duración cero. Desactiva la programación en su lugar.",
       "invalid_wait_mode_behavior": "Comportamiento de modo de espera no válido. Elige Espera estricta o Autoconsumo con reserva.",
-      "port_conflict": "El segundo puerto OCPP debe ser diferente del primer puerto OCPP."
+      "port_conflict": "El segundo puerto OCPP debe ser diferente del primer puerto OCPP.",
+      "ev_min_power_below_start_current": "La potencia mínima configurada es demasiado baja para la topología de fases seleccionada — un cargador real no puede arrancar por debajo de 6 A. Aumenta la potencia mínima o cambia la topología de fases."
     },
     "step": {
       "batteries_excess_export": {

--- a/custom_components/hsem/utils/config_validator.py
+++ b/custom_components/hsem/utils/config_validator.py
@@ -26,6 +26,11 @@ from custom_components.hsem.utils.ha_helpers import (
     async_device_exists,
     async_entity_exists,
 )
+from custom_components.hsem.utils.phase_power import (
+    EV_MIN_START_CURRENT_A,
+    charger_min_power_to_current_a,
+    normalize_ev_phase_topology,
+)
 
 # ---------------------------------------------------------------------------
 # Compiled patterns
@@ -362,6 +367,56 @@ def validate_energy_limits(
 
     if kwh < min_kwh or kwh > max_kwh:
         errors[field] = "energy_out_of_range"
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# EV charger minimum-power / phase-topology cross-field validation
+# ---------------------------------------------------------------------------
+
+
+def validate_ev_min_power_topology(
+    user_input: dict,
+    min_power_field: str,
+    topology_field: str,
+) -> dict[str, str]:
+    """Validate that a charger's minimum power clears the real EVSE floor.
+
+    ``charger_min_power_w`` is documented and defaulted as a single-phase
+    watt figure, but the conversion to an executable current is
+    phase-topology-aware: the same watt value spread across a
+    ``three_phase_balanced`` charger's phases can compute a current below
+    any real EVSE's minimum start current (6 A per IEC 61851). Saving such a
+    value lets the planner command an unusable sub-6A charge that the
+    charger will refuse (issue #968), so this is rejected at the config
+    flow rather than left to fail at runtime.
+
+    Args:
+        user_input: Dict from the config/options form.
+        min_power_field: Field name of the minimum-power (W) value, e.g.
+            ``"hsem_ev_planned_load_charger_min_power_w"``.
+        topology_field: Field name of the phase-topology selector, e.g.
+            ``"hsem_ev_planned_load_charger_phase_topology"``.
+
+    Returns:
+        Dict mapping ``min_power_field`` to ``"ev_min_power_below_start_current"``
+        when the configured value computes below the real-world EVSE
+        minimum for the selected topology, otherwise empty.
+    """
+    errors: dict[str, str] = {}
+    value = user_input.get(min_power_field)
+    if value is None:
+        return errors
+
+    try:
+        power_w = float(value)
+    except ValueError, TypeError:
+        return errors  # invalid_power_value is reported by validate_power_limits
+
+    topology = normalize_ev_phase_topology(user_input.get(topology_field))
+    if charger_min_power_to_current_a(power_w, topology) < EV_MIN_START_CURRENT_A:
+        errors[min_power_field] = "ev_min_power_below_start_current"
 
     return errors
 

--- a/custom_components/hsem/utils/phase_power.py
+++ b/custom_components/hsem/utils/phase_power.py
@@ -25,6 +25,17 @@ if TYPE_CHECKING:
 #: Nominal number of mains phases used by the per-phase fuse model.
 PHASE_COUNT = 3
 
+#: No real EVSE starts a charging session below this current, per IEC 61851
+#: (also the practical floor for go-e and most other charger vendors).  A
+#: configured ``charger_min_power_w`` is a single-phase watt figure by
+#: convention (see ``EVConfig.charger_min_power_w``); dividing it across a
+#: ``three_phase_balanced`` charger's phases can compute a lower current that
+#: no EVSE will actually accept, so every site that turns a configured
+#: minimum-power threshold into an executable amp floor must go through
+#: :func:`ev_min_start_current_a`, never :func:`charger_min_power_to_current_a`
+#: directly (issue #968).
+EV_MIN_START_CURRENT_A = 6
+
 #: Signed live per-phase grid power in Watts, ``(phase_a, phase_b, phase_c)``.
 PhasePowers = tuple[float, float, float]
 
@@ -132,6 +143,23 @@ def charger_min_power_to_current_a(
     if not math.isfinite(power_w) or power_w <= 0.0 or step_power_w <= 0.0:
         return 0
     return int(math.ceil((power_w - 1e-9) / step_power_w))
+
+
+def ev_min_start_current_a(power_w: float, topology: str | None) -> int:
+    """Return the executable minimum start current for a configured threshold.
+
+    Wraps :func:`charger_min_power_to_current_a` with a hard floor at
+    :data:`EV_MIN_START_CURRENT_A`: no real EVSE starts below 6 A, so a
+    low, zero, or phase-naive configured ``charger_min_power_w`` can never
+    compute an unusable sub-6A minimum, regardless of the charger's phase
+    topology (issue #968). Every site that turns a configured minimum-power
+    threshold into an executable amp floor must call this, not
+    :func:`charger_min_power_to_current_a` directly.
+    """
+    return max(
+        charger_min_power_to_current_a(power_w, topology),
+        EV_MIN_START_CURRENT_A,
+    )
 
 
 def normalize_ev_phase_topology(value: object) -> str:

--- a/docs/planner-spec.md
+++ b/docs/planner-spec.md
@@ -804,6 +804,19 @@ opt-in for the primary battery to discharge while a specific EV charges.
 `planner/milp/_ev_amp_lattice.py::resolve_ev_amp_plan` computes each
 managed EV's:
 
+- `minimum_current_a` — the configured `charger_min_power_w` converted to
+  amps via `utils.phase_power.ev_min_start_current_a`, which applies a hard
+  floor at `EV_MIN_START_CURRENT_A` (6 A). `charger_min_power_w` is
+  documented and defaulted as a single-phase watt figure (1380 W = 230 V ×
+  6 A); dividing it across a `three_phase_balanced` charger's phases can
+  compute a current below any real EVSE's minimum start current (6 A per
+  IEC 61851), so the floor is applied regardless of the computed value or
+  topology (issue #968). Every site that converts a configured
+  `charger_min_power_w` into an executable amp floor — the amp lattice
+  here, the target-cap activation quantum below, `engine_ev_milp.py`'s
+  `effective_min_power_w`, and the command-stability layer
+  (`coordinator_ev_command_stability.py`) — goes through this same helper,
+  never the raw `charger_min_power_to_current_a` conversion.
 - `discharge_cap_kwh` — `0` unless `force_max_discharge_power` is `True`
   with a finite, positive `max_discharge_power_w` (fail-closed).
 - Whether it `needs_on`: a conditional `ev_on[t]` binary is created only
@@ -923,6 +936,11 @@ revenue the optimiser forbade.
   first redistributed forward onto a later pre-deadline slot with
   headroom (`planner/milp/_ev_power_writeout.py`, issue #845); only the
   portion that cannot be placed anywhere is discarded.
+- `resolve_ev_amp_plan`'s `minimum_current_a` is never below
+  `EV_MIN_START_CURRENT_A` (6 A), for every phase topology and every
+  configured `charger_min_power_w` value, including `0` or a value that
+  would compute below 6 A when divided across a three-phase charger's
+  phases (issue #968).
 
 ### MILP decision priority
 

--- a/tests/planner/test_ev_min_start_current_floor.py
+++ b/tests/planner/test_ev_min_start_current_floor.py
@@ -1,0 +1,146 @@
+"""EV minimum-power-to-current floor: no command below 6 A (issue #968).
+
+``charger_min_power_w`` is documented and defaulted as a single-phase watt
+figure (1380 W = 230 V x 6 A), but the conversion to an amp command is
+phase-topology-aware. On a ``three_phase_balanced`` charger the same 1380 W
+value divides across 3 phases and computes to 2 A -- below any real EVSE's
+minimum start current (6 A per IEC 61851). Reproduced live against a
+go-eCharger V4: HSEM published ``SetChargingProfile limit: 2``, and the
+charger flipped to ``SuspendedEVSE``.
+
+Every site that turns a configured minimum-power threshold into an
+executable amp floor must go through
+``utils.phase_power.ev_min_start_current_a``, which applies a hard 6 A
+floor on top of the raw (unfloored) conversion.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from custom_components.hsem.models.ev_config import EVConfig
+from custom_components.hsem.planner.milp._ev_amp_lattice import (
+    resolve_ev_amp_plan,
+    target_cap_activation_quantum_dc,
+)
+from custom_components.hsem.utils.phase_power import (
+    EV_MIN_START_CURRENT_A,
+    EV_TOPOLOGY_SINGLE_PHASE,
+    EV_TOPOLOGY_THREE_PHASE_BALANCED,
+    charger_min_power_to_current_a,
+    ev_min_start_current_a,
+)
+
+# HSEM's documented default -- correct for single-phase (230 V x 6 A) but
+# silently wrong once spread across a three-phase charger's 3 phases.
+_DEFAULT_MIN_POWER_W = 1380.0
+
+
+def test_default_min_power_raw_conversion_is_2a_on_three_phase() -> None:
+    """Pin the underlying bug in the raw (unfloored) conversion.
+
+    ``charger_min_power_to_current_a`` stays a pure conversion primitive --
+    it is ``ev_min_start_current_a`` that must apply the real-world floor,
+    so callers that only need the raw arithmetic (whole-amp bookkeeping,
+    diagnostics) keep an unmodified building block.
+    """
+    assert (
+        charger_min_power_to_current_a(
+            _DEFAULT_MIN_POWER_W, EV_TOPOLOGY_THREE_PHASE_BALANCED
+        )
+        == 2
+    )
+
+
+def test_ev_min_start_current_floors_three_phase_default_to_6a() -> None:
+    """The default 1380 W min-power never computes below 6 A on 3-phase."""
+    assert (
+        ev_min_start_current_a(_DEFAULT_MIN_POWER_W, EV_TOPOLOGY_THREE_PHASE_BALANCED)
+        == EV_MIN_START_CURRENT_A
+        == 6
+    )
+
+
+def test_ev_min_start_current_leaves_correct_single_phase_default_unchanged() -> None:
+    """The single-phase default already computes exactly 6 A -- no change."""
+    assert ev_min_start_current_a(_DEFAULT_MIN_POWER_W, EV_TOPOLOGY_SINGLE_PHASE) == 6
+
+
+def test_ev_min_start_current_floors_zero_configured_power() -> None:
+    """A misconfigured 0 W threshold still floors to the real EVSE minimum."""
+    assert (
+        ev_min_start_current_a(0.0, EV_TOPOLOGY_THREE_PHASE_BALANCED)
+        == EV_MIN_START_CURRENT_A
+    )
+
+
+@pytest.mark.parametrize(
+    "topology", [EV_TOPOLOGY_SINGLE_PHASE, EV_TOPOLOGY_THREE_PHASE_BALANCED]
+)
+def test_ev_min_start_current_never_lowers_an_already_adequate_floor(
+    topology: str,
+) -> None:
+    """A generously configured minimum is never dragged down to 6 A."""
+    assert ev_min_start_current_a(11_000.0, topology) > EV_MIN_START_CURRENT_A
+
+
+def _ev(topology: str, **overrides: object) -> EVConfig:
+    base: dict[str, object] = {
+        "enabled": True,
+        "initial_soc_kwh": 0.0,
+        "target_kwh": 10.0,
+        "capacity_kwh": 40.0,
+        "max_charge_per_slot": 11.0,
+        "charger_efficiency": 1.0,
+        "charger_min_power_w": _DEFAULT_MIN_POWER_W,
+        "charger_phase_topology": topology,
+        "deadline_slot": 3,
+    }
+    base.update(overrides)
+    return EVConfig(**base)  # type: ignore[arg-type]
+
+
+def test_resolve_ev_amp_plan_floors_three_phase_default_minimum_to_6a() -> None:
+    """The MILP amp lattice's bound is the real-world floor, not raw math.
+
+    Reproduces the go-eCharger V4 field failure (issue #968): a
+    ``three_phase_balanced`` charger left at the default 1380 W minimum used
+    to bound the amp lattice at 2 A, which HSEM then published as
+    ``SetChargingProfile limit: 2`` -- below any real EVSE's start current,
+    so the charger flipped to ``SuspendedEVSE``.
+    """
+    ev = _ev(EV_TOPOLOGY_THREE_PHASE_BALANCED)
+    plan = resolve_ev_amp_plan([ev], max_dis=0.0, slot_hours=1.0)
+
+    assert len(plan.specs) == 1
+    spec = plan.specs[0]
+    assert spec.managed is True
+    assert spec.minimum_current_a == EV_MIN_START_CURRENT_A == 6
+    # The charger can still run: its rated current is well above the floor.
+    assert spec.runnable is True
+
+
+def test_resolve_ev_amp_plan_single_phase_default_is_unaffected() -> None:
+    """The correct single-phase default (6 A exactly) is unchanged."""
+    ev = _ev(EV_TOPOLOGY_SINGLE_PHASE)
+    plan = resolve_ev_amp_plan([ev], max_dis=0.0, slot_hours=1.0)
+
+    assert plan.specs[0].minimum_current_a == 6
+
+
+def test_target_cap_activation_quantum_uses_the_floored_minimum() -> None:
+    """The target-cap slack quantum must match the lattice's real floor.
+
+    If this used the raw (un-floored) 2 A conversion while the lattice
+    itself floors to 6 A, the quantum would under-estimate the largest
+    single-slot jump the solver can actually take, reopening the
+    under-budgeted-slack class of bug issue #797 fixed.
+    """
+    ev = _ev(EV_TOPOLOGY_THREE_PHASE_BALANCED)
+    available_slot_hours = np.array([1.0, 1.0, 1.0, 1.0])
+    quantum = target_cap_activation_quantum_dc(
+        ev, d=0, available_slot_hours=available_slot_hours
+    )
+    # 6 A * 230 V * 3 phases * 1 h / 1000 = 4.14 kWh at 100% efficiency.
+    assert quantum == pytest.approx(4.14)

--- a/tests/planner/test_session_ev.py
+++ b/tests/planner/test_session_ev.py
@@ -587,15 +587,16 @@ def test_managed_session_reaches_target_with_bounded_amp_overshoot() -> None:
 
     assert result is not None
     out, diagnostics = result
-    # One executable single-phase amp is 0.23 kWh in an hourly slot. The
-    # target-cap constraint now permits one activation quantum (the
-    # charger's startup minimum) above the exact 1.0 kWh target, so the
-    # nearest reachable whole-amp point (5 A / 1.15 kWh) is used instead of
-    # rounding down to an avoidable shortfall (issue #797).
+    # The amp lattice is zero-or-an-integer-in-[min_amp, rated_amp], never a
+    # fractional amp below the real-world EVSE minimum of 6 A (issue #968).
+    # A configured charger_min_power_w of 0.0 no longer relaxes that floor,
+    # so the smallest command that clears the 1.0 kWh target is exactly
+    # 6 A / 1.38 kWh, not a partial amp rounded up from the old (incorrect)
+    # 1 A floor.
     total_dc = sum(slot.ev_total_planned_load_kwh for slot in out)
-    assert 1.0 <= total_dc <= 1.23 + 1e-9
+    assert total_dc == pytest.approx(1.38)
     assert max(slot.ev_charger_calculated_power for slot in out) == pytest.approx(
-        1_150.0
+        1_380.0
     )
     assert diagnostics["ev"]["ev0"]["deadline_penalty_kwh"] == pytest.approx(0.0)
     assert diagnostics["ev"]["ev0"]["deadline_met"] is True
@@ -679,12 +680,14 @@ def test_mixed_managed_and_unmanaged_sessions_keep_distinct_windows() -> None:
 
     assert result is not None
     out, _diagnostics = result
-    # The unmanaged EV remains fixed in slot 1. At most one executable amp of
-    # managed energy may supplement it to close the target lattice; the live
-    # 6 kW observation never freezes the managed slot (issue #797).
+    # The unmanaged EV remains fixed in slot 1. The managed EV's amp lattice
+    # floors at the real-world EVSE minimum of 6 A (issue #968), so it
+    # either contributes nothing or exactly one 6 A / 1.38 kWh command to
+    # supplement it; the live 6 kW observation never freezes the managed
+    # slot (issue #797).
     managed_slot_1_kwh = out[1].ev_charger_calculated_power / 1000.0
     assert out[1].ev_total_planned_load_kwh == pytest.approx(3.0 + managed_slot_1_kwh)
-    assert managed_slot_1_kwh <= 0.23 + 1e-9
+    assert managed_slot_1_kwh == pytest.approx(1.38)
     assert out[1].ev_second_charger_calculated_power == pytest.approx(0.0)
     assert out[2].ev_charger_calculated_power == pytest.approx(5980.0)
 

--- a/tests/test_ev_planned_load_flow_validation.py
+++ b/tests/test_ev_planned_load_flow_validation.py
@@ -85,3 +85,53 @@ async def test_both_fields_out_of_range_reports_both_errors(prefix: str) -> None
     errors = await validate_ev_planned_load_schema_input(user_input, prefix)
     assert errors[f"{prefix}_battery_capacity_kwh"] == "energy_out_of_range"
     assert errors[f"{prefix}_charger_min_power_w"] == "power_out_of_range"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prefix", _PREFIXES)
+async def test_default_min_power_on_three_phase_topology_is_rejected(
+    prefix: str,
+) -> None:
+    """The documented 1380 W single-phase default computes to 2A on 3-phase.
+
+    Reproduces issue #968: a user who switches ``charger_phase_topology`` to
+    ``three_phase_balanced`` without also raising ``charger_min_power_w``
+    would previously save a config that silently commands 2 A -- below any
+    real EVSE's minimum start current -- and the charger refuses to charge.
+    """
+    user_input = {
+        f"{prefix}_enabled": True,
+        f"{prefix}_battery_capacity_kwh": 75.0,
+        f"{prefix}_charger_min_power_w": 1380.0,
+        f"{prefix}_charger_phase_topology": "three_phase_balanced",
+    }
+    errors = await validate_ev_planned_load_schema_input(user_input, prefix)
+    assert errors[f"{prefix}_charger_min_power_w"] == "ev_min_power_below_start_current"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prefix", _PREFIXES)
+async def test_min_power_raised_for_three_phase_topology_passes(prefix: str) -> None:
+    """4140 W (6 A x 230 V x 3 phases) is the correct three-phase minimum."""
+    user_input = {
+        f"{prefix}_enabled": True,
+        f"{prefix}_battery_capacity_kwh": 75.0,
+        f"{prefix}_charger_min_power_w": 4140.0,
+        f"{prefix}_charger_phase_topology": "three_phase_balanced",
+    }
+    errors = await validate_ev_planned_load_schema_input(user_input, prefix)
+    assert errors == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prefix", _PREFIXES)
+async def test_default_min_power_on_single_phase_topology_passes(prefix: str) -> None:
+    """The documented default is correct for the (default) single-phase case."""
+    user_input = {
+        f"{prefix}_enabled": True,
+        f"{prefix}_battery_capacity_kwh": 75.0,
+        f"{prefix}_charger_min_power_w": 1380.0,
+        f"{prefix}_charger_phase_topology": "single_phase",
+    }
+    errors = await validate_ev_planned_load_schema_input(user_input, prefix)
+    assert errors == {}


### PR DESCRIPTION
## Summary

- `charger_min_power_w` is documented and defaulted as a **single-phase** watt figure
  (1380 W = 230 V × 6 A), but the conversion to an executable amp command is
  phase-topology-aware. On a `three_phase_balanced` charger the same default divides
  across 3 phases and computed to **2 A** — below any real EVSE's minimum start current
  (6 A per IEC 61851). Reproduced live against a go-eCharger V4: HSEM sent
  `SetChargingProfile limit: 2`, and the charger flipped to `SuspendedEVSE`.
- Adds `utils/phase_power.py::ev_min_start_current_a()`, a single source of truth
  wrapping `charger_min_power_to_current_a()` with a hard 6 A floor
  (`EV_MIN_START_CURRENT_A`), and routes every site that turns a configured
  minimum-power threshold into an executable amp floor through it instead of the raw
  conversion: the MILP amp lattice (`resolve_ev_amp_plan`,
  `target_cap_activation_quantum_dc`), the EV config builder (`engine_ev_milp.py`), the
  portioned-charging quantizer (`_ev_quantize.py`, both call sites), and the
  command-stability layer (`coordinator_ev_command_stability.py`).
- Adds cross-field config-flow validation
  (`utils/config_validator.py::validate_ev_min_power_topology`) rejecting a
  `charger_min_power_w` that computes below 6 A for the selected `charger_phase_topology`,
  wired into both the primary and second EV planned-load steps, with a new translated
  error string (`ev_min_power_below_start_current`) in all four locales.
- `docs/planner-spec.md` updated: documents the floor in the whole-amp lattice section
  and adds the invariant to the EV co-optimisation "Invariants" list.

Fixes #968

## Test plan

- [x] New unit tests (`tests/planner/test_ev_min_start_current_floor.py`) pin the bug
      (`charger_min_power_to_current_a(1380, three_phase_balanced) == 2`) and the fix
      (`ev_min_start_current_a(...) == 6`, `resolve_ev_amp_plan(...)` never below 6 A,
      `target_cap_activation_quantum_dc` uses the floored minimum).
- [x] New config-flow validation tests
      (`tests/test_ev_planned_load_flow_validation.py`) cover the default-1380W +
      `three_phase_balanced` rejection, the correct 4140 W three-phase minimum passing,
      and the correct single-phase default passing — parametrized over both the
      primary and second EV config blocks.
- [x] Two existing MILP tests (`tests/planner/test_session_ev.py`) that used
      `charger_min_power_w=0.0` as an "any positive amp" test convenience were updated:
      the amp lattice now floors at 6 A (1.38 kWh/slot) instead of the old, also-incorrect
      1 A floor — new expected values were derived by running the solver directly and
      confirmed against the updated invariant.
- [x] `./scripts/quality.sh lint` — pass
- [x] `./scripts/quality.sh typing` — pass
- [x] `./scripts/quality.sh quality` (pyright + vulture) — pass
- [x] `./scripts/quality.sh test` — 3366 passed
- [x] `./scripts/quality.sh translations` — 0 missing/stale/placeholder-mismatch keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

