### PR TITLE
fix(ocpp): gate charger from free-vending on plug-in before HSEM's plan can react

### DIFF
--- a/custom_components/hsem/custom_sensors/ocpp_anti_flap.py
+++ b/custom_components/hsem/custom_sensors/ocpp_anti_flap.py
@@ -17,6 +17,7 @@ the sibling mixins resolve there.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import Callable, Coroutine
 from datetime import UTC, datetime
@@ -26,6 +27,7 @@ from custom_components.hsem.custom_sensors.ocpp_commands import (
     CHARGER_STALL_THRESHOLD_S,
     charger_appears_stalled,
 )
+from custom_components.hsem.custom_sensors.ocpp_profiles import HSEM_PROFILE_IDS
 from custom_components.hsem.models.ocpp_session import ChargerSession
 
 _LOGGER = logging.getLogger(__name__)
@@ -59,6 +61,13 @@ class OCPPAntiFlapMixin:
     _remote_stop_due: Callable[[datetime], bool]
     _profile_retry_due: Callable[[datetime], bool]
 
+    # Declared (not assigned) so mypy resolves these against
+    # OCPPProfilesMixin / OCPPControlMixin, which compose into the same
+    # OCPPServer — used by the connect-time pending-plan gate (issue #969).
+    _send_zero_current_profile: Callable[[ChargerSession], Coroutine[Any, Any, bool]]
+    send_clear_charging_profile: Callable[[str, int], Coroutine[Any, Any, bool]]
+    _background_tasks: set[asyncio.Task[Any]]
+
     async def update_charge_target(
         self,
         cpid: str,
@@ -88,6 +97,27 @@ class OCPPAntiFlapMixin:
             now = datetime.now(UTC)
 
         target_w = target_power_kw * 1000.0
+
+        if session.gate_pending_plan:
+            # This call is itself the signal that the planner has now had
+            # its first real look at this connection — update_charge_target()
+            # runs once per full coordinator cycle, and the connect-time
+            # gate (issue #969) exists only to bridge the gap before that
+            # first cycle. It must not outlive this one decision either
+            # way, or a legitimate long-term zero allocation (smart
+            # charging disabled, feature off, ...) would land right back
+            # in the standing-block regression issue #920 fixed.
+            session.gate_pending_plan = False
+            if target_w <= _SLOT_EPSILON:
+                _LOGGER.info(
+                    "OCPP %s: planner's first cycle since connect allocated "
+                    "no charge — releasing the transient pending-plan gate",
+                    session.cpid,
+                )
+                await self._release_connect_gate(session)
+            # target_w > 0 needs no special handling here — the normal
+            # "starting" branch below installs the real profile, replacing
+            # the transient 0 A one.
 
         # Anti-flap state machine
         if target_w > _SLOT_EPSILON:
@@ -222,6 +252,97 @@ class OCPPAntiFlapMixin:
                     )
             self._target_entered_at = None
             self._target_power_w = 0.0
+
+    # ------------------------------------------------------------------
+    # Connect-time "pending plan" gate (issue #969)
+    # ------------------------------------------------------------------
+
+    def _spawn_gate_task(self, coro: Coroutine[Any, Any, Any]) -> None:
+        """Fire-and-forget a gate-related OCPP call.
+
+        Mirrors the detached-task pattern already used for the
+        post-``StartTransaction`` profile resend (issue #920 follow-up):
+        never awaited inline, so a caller invoked synchronously from a
+        message handler (e.g. :meth:`~ocpp_message_handlers.
+        OCPPMessageHandlersMixin._handle_status_notification`) doesn't risk
+        putting an extra unsolicited ``CALL`` on the wire before that
+        handler's own CALLRESULT is returned.
+
+        Args:
+            coro: The coroutine to run detached.
+        """
+        task = asyncio.create_task(coro)
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+
+    def _arm_connect_gate(self, session: ChargerSession) -> None:
+        """Arm the transient pending-plan gate for a freshly connected EV.
+
+        Called from :meth:`~ocpp_message_handlers.OCPPMessageHandlersMixin.
+        _handle_status_notification` the moment a charger's own status
+        leaves ``"Available"`` while HSEM's anti-flap state is still
+        ``"idle"`` — the earliest signal available that a car has just been
+        plugged in, ahead of some chargers' own ``StartTransaction``, which
+        they send without ever asking HSEM (issue #969). Installs a 0 A
+        block immediately so the charger cannot free-vend at its default
+        rate before the planner's next cycle decides a real target.
+
+        Reuses :meth:`~ocpp_profiles.OCPPProfilesMixin._send_zero_current_profile`
+        — the same generic mechanism :meth:`~ocpp_commands.OCPPCommandsMixin.
+        _send_remote_stop` uses — rather than a second code path. Unlike
+        that stop path, this fires unconditionally on the transition since
+        the whole point is to get ahead of a charger that hasn't opened a
+        transaction yet.
+
+        Args:
+            session: The charger session that just left ``"Available"``.
+        """
+        session.gate_pending_plan = True
+        _LOGGER.info(
+            "OCPP %s: status left 'Available' with no plan yet — gating at "
+            "0 A pending the planner's next decision",
+            session.cpid,
+        )
+        self._spawn_gate_task(self._send_zero_current_profile(session))
+
+    def _schedule_release_connect_gate(self, session: ChargerSession) -> None:
+        """Release the pending-plan gate from a message-handler context.
+
+        Called when the car disconnects (status returns to ``"Available"``)
+        while the gate is still armed — the planner never got a chance to
+        decide anything for this connection, so there is nothing left to
+        gate (issue #969). Scheduled as a detached task for the same
+        ordering reason as :meth:`_arm_connect_gate`.
+
+        Args:
+            session: The charger session that returned to ``"Available"``.
+        """
+        session.gate_pending_plan = False
+        _LOGGER.info(
+            "OCPP %s: disconnected before the planner decided — releasing "
+            "the transient pending-plan gate",
+            session.cpid,
+        )
+        self._spawn_gate_task(self._release_connect_gate(session))
+
+    async def _release_connect_gate(self, session: ChargerSession) -> None:
+        """Clear HSEM's own charging profiles, giving control back.
+
+        Removes exactly the two profile IDs HSEM owns
+        (:data:`~ocpp_profiles.HSEM_PROFILE_IDS`) via ``ClearChargingProfile``
+        — never a blanket clear — so a profile another system installed is
+        never touched (same scoping as :meth:`~ocpp_control.
+        OCPPControlMixin.release_charging_profiles`, but for one charger
+        instead of every connected one). Without this, the transient 0 A
+        block installed by :meth:`_arm_connect_gate` would linger as a
+        standing limit once the gate lifts with nothing to replace it —
+        exactly the issue #920 regression this gate must not reintroduce.
+
+        Args:
+            session: The charger session to release.
+        """
+        for profile_id in HSEM_PROFILE_IDS:
+            await self.send_clear_charging_profile(session.cpid, profile_id)
 
 
 __all__ = ["OCPPAntiFlapMixin"]

--- a/custom_components/hsem/custom_sensors/ocpp_message_handlers.py
+++ b/custom_components/hsem/custom_sensors/ocpp_message_handlers.py
@@ -23,6 +23,12 @@ only *after* the handler coroutine returns, so awaiting extra
 wire before the charger receives the response to its own still-pending
 StartTransaction request. Some charger firmware handles messages strictly
 request/response and can misbehave when that ordering is violated.
+
+:meth:`_handle_status_notification` also arms/releases the connect-time
+"pending plan" gate (issue #969, :mod:`~ocpp_anti_flap`) on a status
+transition into/out of ``"Available"`` — the earliest available signal
+that a car was plugged in or unplugged, ahead of a self-authorizing
+charger's own ``StartTransaction``.
 """
 
 from __future__ import annotations
@@ -71,6 +77,13 @@ class OCPPMessageHandlersMixin:
     # Declared (not assigned) so mypy resolves this against
     # OCPPControlMixin, which composes into the same OCPPServer.
     send_get_configuration: Callable[[str], Coroutine[Any, Any, bool]]
+
+    # Declared (not assigned) so mypy resolves these against
+    # OCPPAntiFlapMixin, which composes into the same OCPPServer — the
+    # connect-time pending-plan gate (issue #969).
+    _flap_state: str
+    _arm_connect_gate: Callable[[ChargerSession], None]
+    _schedule_release_connect_gate: Callable[[ChargerSession], None]
 
     async def _handle_boot_notification(
         self, session: ChargerSession, payload: dict
@@ -167,6 +180,7 @@ class OCPPMessageHandlersMixin:
         new_status = payload.get("status", "")
         if new_status:
             if new_status != session.status:
+                old_status = session.status
                 session.status_changed_at = datetime.now(UTC)
                 session.status = new_status
                 _LOGGER.debug(
@@ -176,6 +190,28 @@ class OCPPMessageHandlersMixin:
                 # not a repeated StatusNotification carrying the same
                 # status.
                 await self._notify_significant_event()
+
+                # Gate a fresh connection against free-vending before the
+                # planner has had a chance to decide anything for it yet
+                # (issue #969). The charger's own status leaving
+                # "Available" is the earliest signal HSEM has that a car
+                # was just plugged in — some chargers free-vend without
+                # ever sending StartTransaction through HSEM first. Only
+                # armed while HSEM's own anti-flap state is still "idle":
+                # a transition HSEM itself caused (e.g. its own remote
+                # start moving status to "Charging") is not a free-vend
+                # risk and must not re-arm the gate.
+                if (
+                    old_status == "Available"
+                    and new_status != "Available"
+                    and self._flap_state == "idle"
+                ):
+                    self._arm_connect_gate(session)
+                elif new_status == "Available" and session.gate_pending_plan:
+                    # The car was unplugged before the planner ever
+                    # decided anything for it — release the transient
+                    # block instead of leaving it stuck.
+                    self._schedule_release_connect_gate(session)
             else:
                 session.status = new_status
         return {}

--- a/custom_components/hsem/custom_sensors/ocpp_sensors.py
+++ b/custom_components/hsem/custom_sensors/ocpp_sensors.py
@@ -364,13 +364,21 @@ class HSEMOCPPChargerPowerSensor(
     @property  # type: ignore[misc]  # HA stub declares state as @final
     @override
     def state(self) -> float | str:
-        """Return the current charging power in kW."""
+        """Return the current charging power in kW.
+
+        Zeroed once the connector status leaves ``"Charging"`` (issue
+        #969) — the last ``MeterValues`` reading otherwise lingers, e.g.
+        still reporting several kW after the connector transitions to
+        ``SuspendedEVSE``, with no fresh MeterValues to overwrite it.
+        """
         data: CoordinatorData | None = self.coordinator.data
         chargers = _chargers_for(data, self._charger_index)
         if not chargers:
             return self._restored_state or "0.0"
 
         first = next(iter(chargers.values()))
+        if first.status != "Charging":
+            return 0.0
         return float(round(first.current_power_w / 1000.0, 2))  # type: ignore[no-any-return]
 
     @property

--- a/custom_components/hsem/models/ocpp_session.py
+++ b/custom_components/hsem/models/ocpp_session.py
@@ -54,6 +54,14 @@ class ChargerSession:
             (``ChargeProfileMaxStackLevel``), the current it is physically
             capped at (``Station-MaxCurrent``), and any vendor key that
             governs whether it will charge at all (go-e's ``ForceState``).
+        gate_pending_plan: ``True`` while HSEM is holding this connector at
+            a transient 0 A block because the charger's own status just
+            left ``"Available"`` (a car connected, or free-vended locally)
+            before the planner has had its first chance to decide a
+            target for it (issue #969). Cleared the moment either the
+            planner's next decision arrives (``update_charge_target()``,
+            whatever it decides) or the car disconnects — never a
+            standing idle-time block, which would regress issue #920.
     """
 
     cpid: str = ""
@@ -72,3 +80,4 @@ class ChargerSession:
     pending_calls: dict[str, str] = field(default_factory=dict)
     last_call_status: dict[str, str] = field(default_factory=dict)
     configuration_keys: dict[str, str] = field(default_factory=dict)
+    gate_pending_plan: bool = False

--- a/docs/ev-charge-plan-setup.md
+++ b/docs/ev-charge-plan-setup.md
@@ -672,6 +672,50 @@ has elapsed, HSEM retries `RemoteStopTransaction` roughly once a minute
 instead of assuming a single attempt worked — a charger that silently
 ignores or rejects the first stop request no longer gets stuck charging.
 
+### Preventing free-vend on fresh connect (issue #969)
+
+Some OCPP chargers (confirmed: go-e Charger V4) authorize and start a
+transaction **locally**, on cable insert, without ever waiting for HSEM's
+`RemoteStartTransaction` — the charger's own `StatusNotification`/
+`StartTransaction` arrive with no preceding command from HSEM at all. Since
+HSEM deliberately does **not** maintain a standing 0 A block while idle (see
+above — that was removed as part of the issue #920 follow-up, because it
+could silently prevent a user's manual/local charging whenever HSEM has no
+plan at all, e.g. smart charging disabled), a car plugged into a
+free-vending charger would draw power at the charger's own default rate for
+however long it takes the planner's next cycle to catch up and compute a
+real target.
+
+HSEM closes that gap with a **transient** gate, scoped to exactly this
+narrow window rather than reintroducing a general idle-time block:
+
+- **Armed** the instant a charger's own `StatusNotification` reports its
+  status leaving `"Available"` (cable/car connected) while HSEM's anti-flap
+  state is still `"idle"` — i.e. HSEM has not itself already started this
+  charge. This is the earliest signal available, ahead of a self-authorizing
+  charger's own `StartTransaction`. Arming immediately installs a 0 A
+  `SetChargingProfile`, reusing the same generic zero-current mechanism the
+  stop path uses.
+- **Released** the moment `update_charge_target()` is next called for this
+  connector — which happens on the very next coordinator cycle, itself
+  triggered promptly by the same debounced out-of-cycle refresh issue #908
+  wired for OCPP events (typically within a couple of seconds of the
+  connect, not the full ~5 minute polling interval). If the planner's first
+  decision allocates real power, the normal start path installs it,
+  replacing the transient 0 A profile. If the first decision is still zero
+  (smart charging disabled, feature off, or a legitimate zero-allocation
+  slot), HSEM actively clears its own 0 A profile via
+  `ClearChargingProfile` rather than leaving it standing — otherwise the
+  gate itself would become the exact issue #920 regression it exists to
+  prevent.
+- **Released** immediately if the car is unplugged (status returns to
+  `"Available"`) before the planner ever gets a chance to decide — nothing
+  is left gated with no connection behind it.
+
+The gate is per-connection state on `ChargerSession.gate_pending_plan`, so a
+disconnect (which recreates the session) always starts the next connection
+ungated until it is next armed.
+
 **Charger-stall diagnostics (issue #894):** an open transaction and a valid
 `SetChargingProfile` do not guarantee current is actually flowing — the
 charger can report `StatusNotification` status `"SuspendedEVSE"`,

--- a/docs/sensors-reference.md
+++ b/docs/sensors-reference.md
@@ -529,6 +529,12 @@ Sensors providing live status and diagnostics for an OCPP-compliant EV charger c
 | **Device class** | `power`                  |
 | **Unit**         | kW                       |
 
+Reports `0` whenever the connector's status is anything other than
+`"Charging"` (issue #969) — previously it kept showing the last
+`MeterValues` reading verbatim, so e.g. a connector that had just
+transitioned to `SuspendedEVSE` could still display several kW with no
+fresh meter data to explain why.
+
 ### `sensor.hsem_ocpp_charger_info`
 
 | Property       | Value                                                  |

--- a/tests/custom_sensors/test_ocpp_sensors.py
+++ b/tests/custom_sensors/test_ocpp_sensors.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 
 from custom_components.hsem.coordinator_data import CoordinatorData
 from custom_components.hsem.custom_sensors.ocpp_sensors import (
+    HSEMOCPPChargerPowerSensor,
     HSEMOCPPChargerStatusSensor,
 )
 from custom_components.hsem.models.ocpp_session import ChargerSession
@@ -349,3 +350,58 @@ def test_second_charger_url_uses_second_cpid() -> None:
     ):
         attrs = sensor.extra_state_attributes
     assert attrs["url"] == "ws://192.168.123.9:9001/ev2"
+
+
+# ---------------------------------------------------------------------------
+# HSEMOCPPChargerPowerSensor (issue #969)
+# ---------------------------------------------------------------------------
+
+
+def test_power_sensor_reports_live_power_while_charging() -> None:
+    """The normal case: a "Charging" connector reports its live MeterValues power."""
+    data = CoordinatorData(
+        cfg=SensorConfig(ocpp_enabled=True),
+        ocpp_chargers={
+            "CP1": ChargerSession(cpid="CP1", status="Charging", current_power_w=6010.0)
+        },
+    )
+    sensor = HSEMOCPPChargerPowerSensor(_make_config_entry(), _make_coordinator(data))
+    assert sensor.state == 6.01
+
+
+def test_power_sensor_zeroed_when_suspended() -> None:
+    """A stale non-zero MeterValues reading must not survive a suspend (issue #969).
+
+    Reproduces the reported case: the connector transitions to
+    "SuspendedEVSE" with no fresh MeterValues yet, so the last reading
+    (6.01 kW) would otherwise linger and misleadingly show alongside a
+    "suspended" status elsewhere in HA.
+    """
+    data = CoordinatorData(
+        cfg=SensorConfig(ocpp_enabled=True),
+        ocpp_chargers={
+            "CP1": ChargerSession(
+                cpid="CP1", status="SuspendedEVSE", current_power_w=6010.0
+            )
+        },
+    )
+    sensor = HSEMOCPPChargerPowerSensor(_make_config_entry(), _make_coordinator(data))
+    assert sensor.state == 0.0
+
+
+def test_power_sensor_zeroed_when_available() -> None:
+    """An idle, never-charged connector reports 0, not a stale reading."""
+    data = CoordinatorData(
+        cfg=SensorConfig(ocpp_enabled=True),
+        ocpp_chargers={"CP1": ChargerSession(cpid="CP1", status="Available")},
+    )
+    sensor = HSEMOCPPChargerPowerSensor(_make_config_entry(), _make_coordinator(data))
+    assert sensor.state == 0.0
+
+
+def test_power_sensor_falls_back_to_restored_state_when_no_charger() -> None:
+    """No connected charger falls back to the restored state, unaffected by the fix."""
+    data = CoordinatorData(cfg=SensorConfig(ocpp_enabled=True), ocpp_chargers={})
+    sensor = HSEMOCPPChargerPowerSensor(_make_config_entry(), _make_coordinator(data))
+    sensor._restored_state = "3.5"
+    assert sensor.state == "3.5"

--- a/tests/custom_sensors/test_ocpp_server.py
+++ b/tests/custom_sensors/test_ocpp_server.py
@@ -28,6 +28,7 @@ import aiohttp
 import pytest
 from aiohttp import web
 
+from custom_components.hsem.custom_sensors.ocpp_profiles import HSEM_PROFILE_IDS
 from custom_components.hsem.custom_sensors.ocpp_server import (
     _WS_HEARTBEAT_INTERVAL_S,
     CHARGER_STALL_THRESHOLD_S,
@@ -1520,6 +1521,154 @@ class TestAntiFlap:
             "test-cpid", target_power_kw=7.2, now=now + timedelta(seconds=60)
         )
         assert server._flap_state == "charging"
+
+
+# ---------------------------------------------------------------------------
+# Connect-time "pending plan" gate (issue #969)
+# ---------------------------------------------------------------------------
+
+
+class TestConnectPendingPlanGate:
+    """Tests for the transient gate against free-vending on fresh connect.
+
+    Covers: a car connecting before the planner has decided anything for
+    it gets an immediate 0 A block; the block lifts (and, if the plan's
+    first decision is still zero, is actively released) the moment the
+    planner has had its first real chance to look at the connection; and
+    a disconnect before that ever happens also releases it. Must never
+    become a general idle-time block — that's the issue #920 regression
+    this gate is explicitly designed not to reintroduce.
+    """
+
+    @pytest.mark.asyncio
+    async def test_fresh_connect_sends_immediate_zero_profile(
+        self, ocpp_server, charger_session
+    ):
+        """Status leaving 'Available' with no plan yet gates at 0 A right away."""
+        assert charger_session.status == "Available"
+        assert ocpp_server._flap_state == "idle"
+
+        await ocpp_server._handle_status_notification(
+            charger_session, {"status": "Preparing"}
+        )
+        await asyncio.sleep(0)  # let the detached gate task run
+
+        assert charger_session.gate_pending_plan is True
+        msg = _sent_message(charger_session, "SetChargingProfile")
+        assert msg is not None
+        schedule = msg[3]["csChargingProfiles"]["chargingSchedule"]
+        assert schedule["chargingSchedulePeriod"][0]["limit"] == 0
+
+    @pytest.mark.asyncio
+    async def test_gate_not_armed_when_hsem_already_controls_charger(
+        self, ocpp_server, charger_session
+    ):
+        """An HSEM-driven status change (already starting/charging) is not gated.
+
+        Only a transition HSEM did not itself cause is a free-vend risk.
+        """
+        ocpp_server._flap_state = "charging"
+
+        await ocpp_server._handle_status_notification(
+            charger_session, {"status": "Charging"}
+        )
+        await asyncio.sleep(0)
+
+        assert charger_session.gate_pending_plan is False
+        charger_session.websocket.send_str.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_gate_lifts_and_starts_on_real_allocation(
+        self, ocpp_server, charger_session
+    ):
+        """The planner allocating real power lifts the gate via the normal start path."""
+        ocpp_server._chargers["test-cpid"] = charger_session
+        charger_session.gate_pending_plan = True
+        now = datetime.now(UTC)
+
+        await ocpp_server.update_charge_target(
+            "test-cpid", target_power_kw=7.2, now=now
+        )
+
+        assert charger_session.gate_pending_plan is False
+        assert ocpp_server._flap_state == "charging"
+        assert "ClearChargingProfile" not in _sent_actions(charger_session)
+        msg = _sent_message(charger_session, "SetChargingProfile")
+        assert msg is not None
+        schedule = msg[3]["csChargingProfiles"]["chargingSchedule"]
+        assert schedule["chargingSchedulePeriod"][0]["limit"] == 16
+
+    @pytest.mark.asyncio
+    async def test_gate_releases_profile_on_zero_plan_decision(
+        self, ocpp_server, charger_session
+    ):
+        """A first decision of zero actively releases the gate, not just clears it.
+
+        Otherwise the transient 0 A block installed on connect would
+        linger as a standing limit with nothing to replace it — exactly
+        the issue #920 regression this gate must not reintroduce.
+        """
+        ocpp_server._chargers["test-cpid"] = charger_session
+        charger_session.gate_pending_plan = True
+        now = datetime.now(UTC)
+
+        await ocpp_server.update_charge_target(
+            "test-cpid", target_power_kw=0.0, now=now
+        )
+
+        assert charger_session.gate_pending_plan is False
+        assert ocpp_server._flap_state == "idle"
+        cleared_ids = {
+            json.loads(call.args[0])[3]["id"]
+            for call in charger_session.websocket.send_str.call_args_list
+            if json.loads(call.args[0])[2] == "ClearChargingProfile"
+        }
+        assert cleared_ids == set(HSEM_PROFILE_IDS)
+
+    @pytest.mark.asyncio
+    async def test_gate_releases_on_disconnect_before_plan_decides(
+        self, ocpp_server, charger_session
+    ):
+        """The car unplugging before the planner ever ran also releases the gate."""
+        ocpp_server._chargers["test-cpid"] = charger_session
+
+        await ocpp_server._handle_status_notification(
+            charger_session, {"status": "Preparing"}
+        )
+        await asyncio.sleep(0)
+        assert charger_session.gate_pending_plan is True
+
+        await ocpp_server._handle_status_notification(
+            charger_session, {"status": "Available"}
+        )
+        await asyncio.sleep(0)
+
+        assert charger_session.gate_pending_plan is False
+        cleared_ids = {
+            json.loads(call.args[0])[3]["id"]
+            for call in charger_session.websocket.send_str.call_args_list
+            if json.loads(call.args[0])[2] == "ClearChargingProfile"
+        }
+        assert cleared_ids == set(HSEM_PROFILE_IDS)
+
+    @pytest.mark.asyncio
+    async def test_no_gate_when_charger_never_leaves_available(
+        self, ocpp_server, charger_session
+    ):
+        """Issue #920 invariant preserved: no status change, no profile ever sent.
+
+        A charger that never reports leaving "Available" (e.g. no car ever
+        connects) must never see a 0 A profile from a repeatedly-zero
+        target — the standing idle-time block issue #920 removed.
+        """
+        ocpp_server._chargers["test-cpid"] = charger_session
+        now = datetime.now(UTC)
+        for _ in range(3):
+            await ocpp_server.update_charge_target(
+                "test-cpid", target_power_kw=0.0, now=now
+            )
+        assert charger_session.gate_pending_plan is False
+        charger_session.websocket.send_str.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Some OCPP chargers (confirmed: go-eCharger V4) authorize and start a transaction
  **locally** on cable insert, without ever waiting for HSEM's `RemoteStartTransaction`.
  Since HSEM deliberately has no standing 0 A block while idle (removed in the issue
  #920 follow-up, to avoid silently blocking manual/local charging), a freshly-connected
  car could free-vend at the charger's default rate for several minutes before the
  planner's next cycle caught up (reproduced in the linked log: charger self-issued
  `StatusNotification(Charging)` + `StartTransaction` at 08:02:49-50, HSEM's first
  `SetChargingProfile` not until 08:07:01).
- Add a **transient** "pending plan" gate on `ChargerSession` (`gate_pending_plan`):
  - **Armed** the instant a charger's own `StatusNotification` leaves `"Available"`
    while HSEM's anti-flap state is still `"idle"` (HSEM hasn't itself started this
    charge) — installs an immediate 0 A `SetChargingProfile`, reusing the existing
    `_send_zero_current_profile()` mechanism.
  - **Released** the moment `update_charge_target()` is next called for this connector —
    itself proof the planner has now had a real look at the connection, which happens
    within seconds via the existing issue #908 debounced out-of-cycle refresh (already
    wired to `StatusNotification` changes), not the full ~5 minute polling interval. If
    the plan allocates real power, the normal start path installs it. If the first
    decision is still zero (feature/smart-charging disabled, or a legitimate
    zero-allocation slot), the gate is actively released via `ClearChargingProfile`
    rather than left standing — this is the part that keeps the fix from reintroducing
    the issue #920 regression.
  - **Released** immediately if the car disconnects (status returns to `"Available"`)
    before the planner ever decides.
- Secondary fix: `sensor.hsem_ocpp_charger_power` now reports `0` whenever the
  connector's status is anything other than `"Charging"`, instead of showing the last
  `MeterValues` reading verbatim (e.g. still "6.01 kW" after the connector suspends).
- Documented in `docs/ev-charge-plan-setup.md` (new "Preventing free-vend on fresh
  connect" section) and `docs/sensors-reference.md`.

## Test plan

- [x] `./scripts/quality.sh lint`
- [x] `./scripts/quality.sh typing`
- [x] `./scripts/quality.sh quality`
- [x] `./scripts/quality.sh test` (3361 passed)
- [x] `./scripts/quality.sh translations` (0 errors; no new user-facing strings added)
- [x] New tests: connect-with-no-plan gating (immediate 0 A profile), gate not armed
      when HSEM already controls the charger, gate lift + normal start on real
      allocation, gate actively released on a zero first decision, gate release on
      disconnect before the planner decides, and a regression test confirming the
      issue #920 invariant (no status transition ⇒ no profile ever sent, even across
      repeated zero-target cycles) — `tests/custom_sensors/test_ocpp_server.py`.
- [x] New tests for the power sensor zeroing — `tests/custom_sensors/test_ocpp_sensors.py`.

Fixes #969

🤖 Generated with [Claude Code](https://claude.com/claude-code)
