### PR TITLE
chore(tracking): wire in ForecastTracker's boundary-aware, layout-reconciling, and progressive-freeze methods

### DIFF
--- a/custom_components/hsem/coordinator_cycle.py
+++ b/custom_components/hsem/coordinator_cycle.py
@@ -508,6 +508,7 @@ class CoordinatorCycleMixin(CoordinatorSharedState):
                     self, "_prediction_tracker", PredictionTracker(max_records=2880)
                 ),
                 last_planner_output=getattr(self, "_last_planner_output", None),
+                update_interval_minutes=cfg.update_interval,
             )
             if prediction_record_added:
                 await persist_all_trackers(self, only=["_prediction_tracker"])

--- a/custom_components/hsem/coordinator_planner_phase.py
+++ b/custom_components/hsem/coordinator_planner_phase.py
@@ -371,7 +371,7 @@ class CoordinatorPlannerPhaseMixin(CoordinatorSharedState):
             state = hourly_rec.recommendation
 
         # Register forecasts in the forecast tracker.
-        register_forecasts_from_planner(planner_output, self._forecast_tracker)
+        register_forecasts_from_planner(planner_output, self._forecast_tracker, now=now)
 
         # Daily plan-vs-actual accumulation.
         try:

--- a/custom_components/hsem/coordinator_tracking.py
+++ b/custom_components/hsem/coordinator_tracking.py
@@ -55,12 +55,16 @@ def accumulate_forecast_actuals(
     solar_corrector_processed: set[datetime],
     prediction_tracker: PredictionTracker,
     last_planner_output: PlannerOutput | None,
+    update_interval_minutes: int,
 ) -> tuple[datetime | None, bool]:
-    """Accumulate actual PV and load energy into the current slot.
+    """Accumulate actual PV and load energy into the current slot(s).
 
     Called every coordinator cycle to accumulate energy from instantaneous
     power readings.  Uses the elapsed time since the last accumulation to
-    convert power (W) to energy (kWh).
+    convert power (W) to energy (kWh), splitting it by physical overlap
+    across slot boundaries so a delayed cycle does not attribute an entire
+    elapsed interval to whichever single slot merely contains ``now``
+    (issue #972).
 
     Args:
         now: Current time (timezone-aware).
@@ -73,10 +77,22 @@ def accumulate_forecast_actuals(
             solar corrector.
         prediction_tracker: Prediction accuracy tracker.
         last_planner_output: Most recent planner output, or None.
+        update_interval_minutes: Configured coordinator polling interval, used
+            to size the gap tolerance for the physical-overlap accumulation.
 
     Returns:
         The new ``last_accumulation_ts`` value (``now``).
     """
+    # Discard unfinalised records that no longer match the layout the
+    # previous cycle committed (interval reconfiguration, DST transition,
+    # horizon change) before accumulating anything into them (issue #972).
+    if hourly_recommendations:
+        expected_slots = [
+            (as_tz(rec.start, now.tzinfo), as_tz(rec.end, now.tzinfo))
+            for rec in hourly_recommendations
+        ]
+        forecast_tracker.reconcile_unfinalised_layout(expected_slots, now=now)
+
     # Compute elapsed seconds since last accumulation.
     if last_accumulation_ts is not None:
         elapsed = (now - last_accumulation_ts).total_seconds()
@@ -86,37 +102,36 @@ def accumulate_forecast_actuals(
     new_last_ts = now
     prediction_record_added = False
 
-    if elapsed <= 0:
+    if elapsed <= 0 or not hourly_recommendations:
         return new_last_ts, prediction_record_added
 
-    # Find the current slot's record.
-    if not hourly_recommendations:
-        return new_last_ts, prediction_record_added
+    interval_start = last_accumulation_ts
+    assert interval_start is not None  # elapsed > 0 implies a prior timestamp
 
-    # Find the slot whose time range contains 'now'.
-    current_slot = None
+    # Freeze pre-slot-start baselines for slots that have physically started
+    # so accumulate_power_interval below has a stable target to attribute
+    # actual energy into (issue #972).
+    forecast_tracker.freeze_forecasts(now)
+
+    # Ensure a record exists for every slot the elapsed interval could have
+    # touched — it may span more than one slot after a delayed cycle.
     for rec in hourly_recommendations:
-        if as_tz(rec.start, now.tzinfo) <= now < as_tz(rec.end, now.tzinfo):
-            current_slot = rec
-            break
+        slot_start = as_tz(rec.start, now.tzinfo)
+        slot_end = as_tz(rec.end, now.tzinfo)
+        if slot_end > interval_start and slot_start < now:
+            forecast_tracker.get_or_create_record(slot_start, slot_end)
 
-    if current_slot is None:
-        return new_last_ts, prediction_record_added
-
-    # Get or create the tracker record for this slot.
-    tracker_rec = forecast_tracker.get_or_create_record(
-        current_slot.start, current_slot.end
-    )
-
-    # Accumulate PV energy.
+    # Attribute the elapsed interval's PV/load energy by physical overlap.
     pv_power_w = live.solar_production_power_w or 0.0
-    pv_energy = compute_accumulated_energy(pv_power_w, elapsed)
-    tracker_rec.accumulate_pv(pv_energy)
-
-    # Accumulate load energy.
     load_power_w = live.house_consumption_power_w or 0.0
-    load_energy = compute_accumulated_energy(load_power_w, elapsed)
-    tracker_rec.accumulate_load(load_energy)
+    max_gap_seconds = 2.0 * max(float(update_interval_minutes) * 60.0, 60.0)
+    forecast_tracker.accumulate_power_interval(
+        interval_start,
+        now,
+        pv_power_w=pv_power_w,
+        load_power_w=load_power_w,
+        max_gap_seconds=max_gap_seconds,
+    )
 
     # Finalise any slots whose end time has passed.
     forecast_tracker.finalise_past_records(now)
@@ -186,25 +201,41 @@ async def init_prediction_tracker(
 def register_forecasts_from_planner(
     output: PlannerOutput,
     forecast_tracker: ForecastTracker,
+    *,
+    now: datetime,
 ) -> None:
     """Register PV and load forecasts from planner output into the tracker.
 
-    This is called after the planner runs successfully.  Forecast values
-    are only set if the tracker record exists and is not yet finalised.
+    Called after the planner runs successfully.  Creates a tracker record
+    for every slot in the horizon (if one does not already exist yet) and
+    progressively refines its forecast baseline via ``observed_at=now`` on
+    every subsequent cycle until the slot physically starts, at which point
+    ``accumulate_forecast_actuals``'s call to
+    :meth:`~custom_components.hsem.utils.forecast_tracker.ForecastTracker.freeze_forecasts`
+    locks in the freshest pre-start estimate — rather than whatever was known
+    up to the full planning horizon (e.g. 48h) ahead of the slot (issue #972).
 
     Args:
         output: The :class:`~planner.engine.PlannerOutput` returned by the
             planner engine.
         forecast_tracker: The forecast-vs-actual tracker instance.
+        now: Current time — the observation timestamp for this planner run.
     """
+    # Discard unfinalised records that no longer match the layout this
+    # cycle's planner run just produced (issue #972).
+    expected_slots = [(slot.start, slot.end) for slot in output.slots]
+    forecast_tracker.reconcile_unfinalised_layout(expected_slots, now=now)
+
     for slot in output.slots:
         pv_forecast = getattr(slot, "solcast_pv_estimate_kwh", 0.0)
         load_forecast = getattr(slot, "avg_house_consumption_kwh", 0.0)
 
+        forecast_tracker.get_or_create_record(slot.start, slot.end)
         forecast_tracker.set_forecasts(
             start=slot.start,
             pv_kwh=pv_forecast,
             load_kwh=load_forecast,
+            observed_at=now,
         )
 
 

--- a/custom_components/hsem/utils/forecast_tracker.py
+++ b/custom_components/hsem/utils/forecast_tracker.py
@@ -266,12 +266,19 @@ class ForecastTracker:
 
     Usage
     -----
-    1. Each coordinator cycle, call :meth:`get_or_create_record` for the
-       current slot, then :meth:`accumulate_actuals` with the instantaneous
-       power readings and elapsed time since the last cycle.
-    2. After a slot's end time has passed, call :meth:`finalise_record` to
-       lock the comparison and compute error metrics.
-    3. Read :attr:`summary` for the aggregated error snapshot.
+    1. Each planner cycle, call :meth:`get_or_create_record` for every slot
+       in the horizon, then :meth:`set_forecasts` with ``observed_at=now``
+       to progressively refine each slot's forecast baseline until it
+       physically starts.
+    2. Each coordinator cycle, call :meth:`reconcile_unfinalised_layout` to
+       discard any unfinalised record the current slot layout no longer
+       matches, then :meth:`freeze_forecasts` to lock in the freshest
+       pre-start baseline, then :meth:`accumulate_power_interval` to
+       attribute the elapsed interval's actual PV/load energy by physical
+       overlap.
+    3. Call :meth:`finalise_past_records` once a slot's end time has passed
+       to lock the comparison and compute error metrics.
+    4. Read :attr:`summary` for the aggregated error snapshot.
     """
 
     def __init__(self, max_slots: int = 96) -> None:
@@ -414,10 +421,15 @@ class ForecastTracker:
     ) -> bool:
         """Discard an incompatible live layout while keeping finalised history.
 
-        Not currently called by ``coordinator_tracking.py`` — see issue #972
-        for the forgotten-wiring gap this leaves (a slot-layout change can
-        make ``get_or_create_record()`` silently reuse a stale record, since
-        it matches by ``start`` only).
+        Called by ``coordinator_tracking.py`` in both
+        ``accumulate_forecast_actuals`` (guarding elapsed-interval
+        accumulation against the layout the previous cycle committed) and
+        ``register_forecasts_from_planner`` (guarding forecast registration
+        against the layout this cycle's planner run just produced) — see
+        issue #972.  Without this, a slot-layout change (interval
+        reconfiguration, DST transition, horizon change) would let
+        ``get_or_create_record()`` silently reuse a stale record, since it
+        matches by ``start`` only.
 
         Returns ``True`` when active/future records did not match the current
         recommendation starts and ends.  Callers use that signal to reset
@@ -441,8 +453,11 @@ class ForecastTracker:
     def finalise_record(self, start: datetime) -> bool:
         """Finalise the record at *start* if it exists and is not yet finalised.
 
-        Not called in production — ``finalise_past_records`` (below) has its
-        own loop instead of delegating here (issue #972).
+        Intentionally not called in production: ``finalise_past_records``
+        (below) bulk-finalises every due record per cycle, which is what the
+        coordinator needs.  This single-record variant is kept as public API
+        surface for direct/test callers (issue #972 Gap 4 — see the note in
+        ``vulture_whitelist.py``).
 
         Args:
             start: Slot start time.
@@ -478,10 +493,14 @@ class ForecastTracker:
     def freeze_forecasts(self, now: datetime) -> int:
         """Freeze baselines for slots that have physically started.
 
-        Not called in production: the only caller of ``set_forecasts``
-        (``coordinator_tracking.py::register_forecasts_from_planner``)
-        always omits ``observed_at``, so baselines freeze immediately at
-        first sight instead of progressively via this method. See issue #972.
+        Called every cycle by
+        ``coordinator_tracking.py::accumulate_forecast_actuals``, right
+        before it attributes elapsed-interval energy via
+        :meth:`accumulate_power_interval`.  ``register_forecasts_from_planner``
+        passes ``observed_at=now``, so a slot's baseline is progressively
+        refined by every planner cycle until this method locks in the
+        freshest pre-start estimate, instead of whatever was known when the
+        record was first created (issue #972).
         """
         count = 0
         now_key = _utc_key(now)
@@ -556,10 +575,12 @@ class ForecastTracker:
         Long gaps are rejected rather than treating a stale power sample as
         representative.  The return value is the allocated number of seconds.
 
-        Not called in production: ``coordinator_tracking.py`` attributes an
-        entire elapsed interval to whichever single slot contains ``now``
-        instead of splitting it by overlap across slot boundaries. See
-        issue #972.
+        Called every cycle by
+        ``coordinator_tracking.py::accumulate_forecast_actuals`` so a
+        delayed cycle (HA restart, long-running cycle, missed tick) that
+        spans a slot boundary splits its energy proportionally instead of
+        crediting 100% of it to whichever slot merely contains ``now``
+        (issue #972).
         """
         start_key = _utc_key(start)
         end_key = _utc_key(end)

--- a/docs/forecast-accuracy-tracking.md
+++ b/docs/forecast-accuracy-tracking.md
@@ -56,22 +56,23 @@ perfect. The forecast accuracy tracking system:
 flowchart TD
     A[async_collect_all_states]
     B[LiveState with instantaneous power readings]
+    E[accumulate_forecast_actuals now, live]
+    E1[reconcile_unfinalised_layout against hourly_recommendations]
+    E2[freeze_forecasts now — lock in the freshest pre-start baseline]
+    E3[accumulate_power_interval — split elapsed energy by physical overlap]
+    I[finalise_past_records for slots whose end time is before now]
     C[Planner runs]
     D[PlannerOutput with slot forecasts]
-    E[_accumulate_forecast_actuals now, live]
-    F[Read elapsed time and power from LiveState]
-    G[compute_accumulated_energy power, elapsed]
-    H[Accumulate kWh into current slot record]
-    I[finalise_past_records for slots whose end time is before now]
-    J[_register_forecasts_from_planner planner_output]
-    K[Copy solcast_pv_estimate_kwh and avg_house_consumption_kwh]
+    J[register_forecasts_from_planner output, now]
+    J1[reconcile_unfinalised_layout against output.slots]
+    K[get_or_create_record + set_forecasts observed_at=now, per slot]
     L[CoordinatorData packaged and pushed to subscribers]
     M[HSEMForecastAccuracySensor reads tracker]
     N[native_value is PV MAE in kWh]
     O[extra_state_attributes include error metrics and latest slot]
     P[_forecast_tracker_data serialized into attributes]
 
-    A --> B --> C --> D --> E --> F --> G --> H --> I --> J --> K --> L --> M --> N --> O --> P
+    A --> B --> E --> E1 --> E2 --> E3 --> I --> C --> D --> J --> J1 --> K --> L --> M --> N --> O --> P
 ```
 
 ### File layout
@@ -122,17 +123,20 @@ Key methods:
 
 ### ForecastTracker
 
-| Property / Method                        | Description                                                          |
-| ---------------------------------------- | -------------------------------------------------------------------- |
-| `records`                                | Copy of all slot records, oldest first                               |
-| `summary`                                | Computes and returns a `ForecastErrorSummary` from finalised records |
-| `get_or_create_record(start, end)`       | Returns existing record or creates a new one                         |
-| `find_record(start)`                     | Look up a record by slot start time                                  |
-| `finalise_record(start)`                 | Finalise a specific record                                           |
-| `finalise_past_records(now)`             | Finalise all records whose `end <= now`                              |
-| `set_forecasts(start, pv_kwh, load_kwh)` | Set forecast values (only if not finalised)                          |
-| `to_persistence_dict(now, max_records)`  | Serialize the bounded records that matter across a restart           |
-| `load_from_dict(data)`                   | Deserialize records produced by `to_persistence_dict()`              |
+| Property / Method                                                                     | Description                                                                                          |
+| ------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `records`                                                                             | Copy of all slot records, oldest first                                                               |
+| `summary`                                                                             | Computes and returns a `ForecastErrorSummary` from finalised records                                 |
+| `get_or_create_record(start, end)`                                                    | Returns existing record or creates a new one                                                         |
+| `find_record(start)`                                                                  | Look up a record by slot start time                                                                  |
+| `reconcile_unfinalised_layout(expected_slots, *, now)`                                | Discards unfinalised records whose `end` no longer matches the current slot layout (issue #972)      |
+| `finalise_record(start)`                                                              | Finalise a specific record (public API surface — production uses `finalise_past_records`, see below) |
+| `finalise_past_records(now)`                                                          | Finalise all records whose `end <= now`                                                              |
+| `freeze_forecasts(now)`                                                               | Lock in the baseline for every started, not-yet-frozen record (issue #972)                           |
+| `set_forecasts(start, pv_kwh, load_kwh, *, observed_at=None)`                         | Set forecast values; with `observed_at` it refines a future slot progressively until it starts       |
+| `accumulate_power_interval(start, end, *, pv_power_w, load_power_w, max_gap_seconds)` | Allocate an elapsed interval's energy across every record it physically overlaps (issue #972)        |
+| `to_persistence_dict(now, max_records)`                                               | Serialize the bounded records that matter across a restart                                           |
+| `load_from_dict(data)`                                                                | Deserialize records produced by `to_persistence_dict()`                                              |
 
 The default maximum is 2880 records, which covers approximately 30 days
 of 15-minute slots. Older records are automatically pruned.
@@ -149,6 +153,17 @@ The helper function `compute_accumulated_energy(power_w, elapsed_seconds)`
 handles this conversion. Elapsed time is computed as the difference between
 the current coordinator cycle timestamp and the previous cycle's timestamp,
 so the accuracy depends on the coordinator update interval (default 5 minutes).
+
+`ForecastTracker.accumulate_power_interval()` allocates that elapsed
+`[previous_ts, now)` interval across **every** record it physically
+overlaps in UTC, rather than crediting the whole sample to whichever single
+slot contains `now`. This matters when a coordinator cycle is delayed (HA
+restart, a long-running cycle, a missed tick) long enough for the elapsed
+interval to straddle a slot boundary — without splitting by overlap, the
+mis-attributed slot and its neighbour would both get a corrupted MAE.
+Intervals longer than `max_gap_seconds` (twice the configured update
+interval, floored at 60s — the same tolerance `accumulate_financials` uses)
+are rejected outright rather than treated as a representative sample.
 
 ---
 
@@ -208,27 +223,51 @@ The coordinator owns the single `_forecast_tracker: ForecastTracker`
 instance, created in `__init__` with `max_slots=192`. Two private methods
 are called during each update cycle:
 
-### `_accumulate_forecast_actuals(now, live)`
+### `accumulate_forecast_actuals(now, live, ...)`
 
-Called every cycle **after** state collection. Steps:
+Called every cycle **after** state collection, **before** the planner runs.
+Steps:
 
-1. Compute elapsed seconds since the last accumulation.
-2. Find the current recommendation slot (the one whose time range contains `now`).
-3. Get or create a tracker record for that slot.
-4. Convert instantaneous PV and load power to energy using `compute_accumulated_energy()`.
-5. Accumulate the energy into the tracker record.
+1. Call `reconcile_unfinalised_layout()` against the current
+   `hourly_recommendations` layout, discarding any unfinalised record whose
+   `end` no longer matches (interval reconfiguration, DST transition,
+   horizon change — issue #972). Finalised history is always kept.
+2. Compute elapsed seconds since the last accumulation; bail out if this is
+   the first cycle or there are no recommendations yet.
+3. Call `freeze_forecasts(now)` to lock in the baseline for every slot that
+   has physically started but is not yet frozen, using the freshest
+   pre-start estimate `register_forecasts_from_planner` registered on a
+   previous cycle.
+4. Ensure a tracker record exists for every recommendation slot the elapsed
+   interval could have touched (it may span more than one slot after a
+   delayed cycle).
+5. Call `accumulate_power_interval()` to convert instantaneous PV and load
+   power to energy and split it across every slot the interval physically
+   overlaps.
 6. Call `finalise_past_records(now)` to finalise any slots that have ended.
 7. Feed every newly-finalised record into the `SolarForecastCorrector` (issue #602)
    so it can learn per-hour accuracy factors from actual-vs-forecast PV ratios.
 
-### `_register_forecasts_from_planner(output)`
+### `register_forecasts_from_planner(output, tracker, *, now)`
 
 Called **after** the planner runs, before the current slot is resolved.
-Iterates over every slot in the `PlannerOutput` and calls
-`tracker.set_forecasts(start, pv_kwh=slot.solcast_pv_estimate_kwh, load_kwh=slot.avg_house_consumption_kwh)`.
+First calls `reconcile_unfinalised_layout()` against `output.slots` — the
+layout this cycle's planner run just produced — so a mid-cycle layout
+change cannot leave a stale unfinalised record behind. Then, for every slot
+in the `PlannerOutput`, creates the tracker record if it does not exist yet
+(`get_or_create_record`) and calls
+`tracker.set_forecasts(start, pv_kwh=slot.solcast_pv_estimate_kwh, load_kwh=slot.avg_house_consumption_kwh, observed_at=now)`.
 
-This means forecasts are only registered when the planner successfully runs.
-If the planner is skipped (missing entities, force mode, consumption data not
+Passing `observed_at=now` means a future slot's forecast is progressively
+refined by every planner cycle between when it first enters the horizon and
+when it physically starts — at which point `accumulate_forecast_actuals`'s
+`freeze_forecasts(now)` call (above) locks in whichever estimate was
+freshest at that moment, rather than whatever the planner predicted when the
+slot first entered the horizon (up to the full planning horizon ahead,
+e.g. 48h — issue #972).
+
+Forecasts are only registered when the planner successfully runs. If the
+planner is skipped (missing entities, force mode, consumption data not
 ready), forecasts are not updated but accumulation still happens.
 
 ---
@@ -310,26 +349,39 @@ any custom storage, file I/O, or database schema.
 
 ## Tests
 
-All tests are in `tests/test_forecast_tracker.py`. They use the real
-`ForecastTracker` class **without** Home Assistant — plain `pytest`
-against pure Python code.
+Tracker-level tests are in `tests/test_forecast_tracker.py`; they use the
+real `ForecastTracker` class **without** Home Assistant — plain `pytest`
+against pure Python code. Coordinator-wiring tests are in
+`tests/test_coordinator_tracking_forecast.py`, exercising
+`accumulate_forecast_actuals()` and `register_forecasts_from_planner()`
+directly (also without Home Assistant — both are free functions).
 
-### Test coverage (31 tests)
+### Tracker test coverage (`test_forecast_tracker.py`)
 
-| Category                           | Tests | What's covered                                                                                 |
-| ---------------------------------- | ----- | ---------------------------------------------------------------------------------------------- |
-| `TestComputeAccumulatedEnergy`     | 5     | 1000W/1h, 500W/30m, zero power, zero elapsed, negative power                                   |
-| `TestForecastSlotRecord`           | 5     | Finalise metrics, exact match, accumulate, idempotent finalise                                 |
-| `TestForecastTrackerLifecycle`     | 10    | Create/find records, finalise, prune, set forecasts, finalise past                             |
-| `TestForecastTrackerSummary`       | 9     | Empty, exact, over, under, mixed, MAPE div-by-zero, MAPE values, as_dict                       |
-| `TestForecastTrackerIntegration`   | 3     | Full cycle single slot, over+under pair, finalise past + summary                               |
-| `TestForecastTrackerSerialization` | 5     | Record to_dict empty, record to_dict finalised, tracker empty, round trip, unfinalised restore |
+| Category                           | What's covered                                                                                                                           |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `TestComputeAccumulatedEnergy`     | 1000W/1h, 500W/30m, zero power, zero elapsed, negative power                                                                             |
+| `TestForecastSlotRecord`           | Finalise metrics, exact match, accumulate, idempotent finalise                                                                           |
+| `TestForecastTrackerLifecycle`     | Create/find records, finalise, prune, set forecasts, finalise past                                                                       |
+| `TestForecastTrackerSummary`       | Empty, exact, over, under, mixed, MAPE div-by-zero, MAPE values, as_dict                                                                 |
+| `TestForecastTrackerIntegration`   | Full cycle single slot, over+under pair, finalise past + summary                                                                         |
+| `TestForecastTrackerSerialization` | Record to_dict empty, record to_dict finalised, tracker empty, round trip, unfinalised restore                                           |
+| `TestForecastLayoutReconciliation` | Layout change discards only unfinalised records; DST fold/spring-skip layouts don't false-trigger                                        |
+| `TestPhysicalIntervalAccumulation` | Boundary-crossing split, multi-slot gap distribution, over-long-gap rejection, progressive-refine-then-freeze, DST fold energy isolation |
+
+### Coordinator-wiring test coverage (`test_coordinator_tracking_forecast.py`, issue #972)
+
+| Category                                | What's covered                                                                                                                                                                          |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Cross-slot-boundary energy accumulation | A delayed cycle whose elapsed interval spans two slots splits PV/load energy proportionally instead of dumping it all on the slot containing `now`                                      |
+| Mid-cycle slot-layout change            | An interval-length change between cycles discards the stale unfinalised record instead of `get_or_create_record()` silently reusing it                                                  |
+| Stale vs. fresh forecast baseline       | `register_forecasts_from_planner()` progressively refines a future slot's forecast across cycles; `freeze_forecasts()` locks in the freshest pre-start value, not the first-sighted one |
 
 ### Running the tests
 
 ```bash
 # Requires the venv with HA dependencies:
-pytest tests/test_forecast_tracker.py
+pytest tests/test_forecast_tracker.py tests/test_coordinator_tracking_forecast.py
 ```
 
 Or run the standalone tests that inline the tracker logic (no HA imports):

--- a/tests/test_coordinator_tracking_forecast.py
+++ b/tests/test_coordinator_tracking_forecast.py
@@ -1,0 +1,332 @@
+"""Regression tests for the ForecastTracker coordinator wiring (issue #972).
+
+``ForecastTracker`` (``utils/forecast_tracker.py``) already had three
+methods — ``reconcile_unfinalised_layout``, ``accumulate_power_interval``,
+and the ``observed_at`` pathway of ``set_forecasts`` / ``freeze_forecasts``
+— that were more correct than what ``coordinator_tracking.py`` actually
+called, but nothing wired them in. This module exercises the coordinator
+free functions directly (``accumulate_forecast_actuals`` and
+``register_forecasts_from_planner``) against the three concrete failure
+modes the issue described:
+
+1. Cross-slot-boundary energy accumulation — a delayed cycle whose elapsed
+   interval spans two slots must split the energy proportionally instead of
+   crediting all of it to whichever slot merely contains ``now``.
+2. Mid-cycle slot-layout change — an interval reconfiguration must discard
+   the stale unfinalised record instead of ``get_or_create_record()``
+   silently reusing it with the wrong ``end``.
+3. Stale vs. fresh forecast baseline — the frozen baseline must reflect the
+   freshest pre-start planner estimate, not the first one ever seen, and
+   must not be overwritten once the slot has started.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from custom_components.hsem.coordinator_tracking import (
+    accumulate_forecast_actuals,
+    register_forecasts_from_planner,
+)
+from custom_components.hsem.models.hourly_recommendation import HourlyRecommendation
+from custom_components.hsem.models.live_state import LiveState
+from custom_components.hsem.models.planned_slot import PlannedSlot
+from custom_components.hsem.models.planner_output import PlannerOutput
+from custom_components.hsem.utils.forecast_tracker import ForecastTracker
+from custom_components.hsem.utils.prediction_tracker import PredictionTracker
+from custom_components.hsem.utils.solar_corrector import SolarForecastCorrector
+
+
+def _rec(start: datetime, end: datetime, **kwargs: float) -> HourlyRecommendation:
+    """Build a minimal hourly recommendation for the given slot bounds."""
+    defaults: dict = {
+        "avg_house_consumption_kwh": 0.0,
+        "avg_house_consumption_1d_kwh": 0.0,
+        "avg_house_consumption_3d_kwh": 0.0,
+        "avg_house_consumption_7d_kwh": 0.0,
+        "avg_house_consumption_14d_kwh": 0.0,
+        "batteries_charged_kwh": 0.0,
+        "batteries_discharged_kwh": 0.0,
+        "estimated_battery_capacity_kwh": 0.0,
+        "estimated_battery_soc_pct": 50.0,
+        "estimated_cost_currency": 0.0,
+        "estimated_net_consumption_kwh": 0.0,
+        "export_price": 0.0,
+        "grid_export_kwh": 0.0,
+        "grid_import_kwh": 0.0,
+        "import_price": 0.0,
+        "recommendation": None,
+        "solcast_pv_estimate_kwh": 0.0,
+    }
+    defaults.update(kwargs)
+    return HourlyRecommendation(start=start, end=end, **defaults)  # type: ignore[arg-type]
+
+
+def _live(*, pv_w: float, load_w: float) -> LiveState:
+    """Build a live snapshot with the given instantaneous power readings."""
+    live = LiveState()
+    live.solar_production_power_w = pv_w
+    live.house_consumption_power_w = load_w
+    return live
+
+
+def _accumulate(
+    tracker: ForecastTracker,
+    *,
+    now: datetime,
+    live: LiveState,
+    hourly_recommendations: list[HourlyRecommendation],
+    last_accumulation_ts: datetime | None,
+) -> datetime | None:
+    """Call accumulate_forecast_actuals with fresh diagnostic-tracker collaborators."""
+    new_ts, _ = accumulate_forecast_actuals(
+        now=now,
+        live=live,
+        hourly_recommendations=hourly_recommendations,
+        forecast_tracker=tracker,
+        last_accumulation_ts=last_accumulation_ts,
+        solar_corrector=SolarForecastCorrector(),
+        solar_corrector_processed=set(),
+        prediction_tracker=PredictionTracker(),
+        last_planner_output=None,
+        update_interval_minutes=1,
+    )
+    return new_ts
+
+
+class TestCrossSlotBoundaryAccumulation:
+    """Gap 1 — accumulate_power_interval wired into accumulate_forecast_actuals."""
+
+    def test_delayed_cycle_spanning_boundary_splits_energy(self) -> None:
+        slot_a_start = datetime(2026, 6, 1, 10, 0, tzinfo=UTC)
+        slot_a_end = datetime(2026, 6, 1, 10, 15, tzinfo=UTC)
+        slot_b_start = slot_a_end
+        slot_b_end = datetime(2026, 6, 1, 10, 30, tzinfo=UTC)
+
+        tracker = ForecastTracker()
+        planned = PlannerOutput(
+            slots=[
+                PlannedSlot(
+                    start=slot_a_start,
+                    end=slot_a_end,
+                    solcast_pv_estimate_kwh=1.0,
+                    avg_house_consumption_kwh=1.0,
+                ),
+                PlannedSlot(
+                    start=slot_b_start,
+                    end=slot_b_end,
+                    solcast_pv_estimate_kwh=1.0,
+                    avg_house_consumption_kwh=1.0,
+                ),
+            ]
+        )
+        # Register both slots well before either starts.
+        register_forecasts_from_planner(
+            planned, tracker, now=slot_a_start - timedelta(hours=1)
+        )
+
+        recommendations = [
+            _rec(slot_a_start, slot_a_end),
+            _rec(slot_b_start, slot_b_end),
+        ]
+
+        # First accumulation call only establishes the baseline timestamp,
+        # 5 seconds before the A/B boundary.
+        baseline_ts = slot_b_start - timedelta(seconds=5)
+        ts = _accumulate(
+            tracker,
+            now=baseline_ts,
+            live=_live(pv_w=3600.0, load_w=7200.0),
+            hourly_recommendations=recommendations,
+            last_accumulation_ts=None,
+        )
+        assert ts == baseline_ts
+
+        # A delayed cycle lands 10 seconds after the A/B boundary — the
+        # elapsed interval spans both slots.
+        now = slot_b_start + timedelta(seconds=5)
+        _accumulate(
+            tracker,
+            now=now,
+            live=_live(pv_w=3600.0, load_w=7200.0),
+            hourly_recommendations=recommendations,
+            last_accumulation_ts=ts,
+        )
+
+        rec_a = tracker.find_record(slot_a_start)
+        rec_b = tracker.find_record(slot_b_start)
+        assert rec_a is not None
+        assert rec_b is not None
+
+        # Before the fix this entire 10s sample would have landed on slot B
+        # (whichever slot contained `now`). Correct behaviour splits it
+        # 5s/5s by physical overlap.
+        assert rec_a.actual_pv_kwh > 0.0
+        assert rec_b.actual_pv_kwh > 0.0
+        assert rec_a.actual_pv_kwh == rec_b.actual_pv_kwh
+        assert rec_a.actual_load_kwh == rec_b.actual_load_kwh
+
+
+class TestMidCycleSlotLayoutChange:
+    """Gap 2 — reconcile_unfinalised_layout wired into both coordinator entry points."""
+
+    def test_interval_reconfiguration_discards_stale_record(self) -> None:
+        hour_start = datetime(2026, 6, 1, 10, 0, tzinfo=UTC)
+        hour_end = datetime(2026, 6, 1, 11, 0, tzinfo=UTC)
+
+        tracker = ForecastTracker()
+        register_forecasts_from_planner(
+            PlannerOutput(
+                slots=[
+                    PlannedSlot(
+                        start=hour_start,
+                        end=hour_end,
+                        solcast_pv_estimate_kwh=4.0,
+                        avg_house_consumption_kwh=1.0,
+                    )
+                ]
+            ),
+            tracker,
+            now=hour_start - timedelta(hours=1),
+        )
+
+        hourly_60min = [_rec(hour_start, hour_end)]
+
+        # Bootstrap the baseline, then accumulate one minute of energy into
+        # the 60-minute record (well within the default gap tolerance).
+        ts = _accumulate(
+            tracker,
+            now=hour_start,
+            live=_live(pv_w=1000.0, load_w=500.0),
+            hourly_recommendations=hourly_60min,
+            last_accumulation_ts=None,
+        )
+        ts = _accumulate(
+            tracker,
+            now=hour_start + timedelta(minutes=1),
+            live=_live(pv_w=1000.0, load_w=500.0),
+            hourly_recommendations=hourly_60min,
+            last_accumulation_ts=ts,
+        )
+
+        stale = tracker.find_record(hour_start)
+        assert stale is not None
+        assert stale.end == hour_end
+        assert stale.actual_pv_kwh > 0.0
+
+        # Mid-cycle replan switches to 15-minute slots for the same physical
+        # start. Without reconciliation, get_or_create_record() would keep
+        # matching (and silently reusing) the stale 60-minute record.
+        quarter_start = hour_start
+        quarter_end = hour_start + timedelta(minutes=15)
+        next_quarter_start = quarter_end
+        next_quarter_end = quarter_end + timedelta(minutes=15)
+        hourly_15min = [
+            _rec(quarter_start, quarter_end),
+            _rec(next_quarter_start, next_quarter_end),
+        ]
+
+        _accumulate(
+            tracker,
+            now=hour_start + timedelta(minutes=2),
+            live=_live(pv_w=1000.0, load_w=500.0),
+            hourly_recommendations=hourly_15min,
+            last_accumulation_ts=ts,
+        )
+
+        reconciled = tracker.find_record(quarter_start)
+        assert reconciled is not None
+        # The record now matches the new layout's end, not the stale one...
+        assert reconciled.end == quarter_end
+        # ...and does not carry over energy accumulated under the old,
+        # incompatible 60-minute layout (no interval bridges the change).
+        assert reconciled.actual_pv_kwh == 0.0
+        assert reconciled.actual_load_kwh == 0.0
+
+
+class TestStaleVsFreshForecastBaseline:
+    """Gap 3 — observed_at / freeze_forecasts wired end-to-end."""
+
+    def test_baseline_freezes_at_freshest_pre_start_estimate(self) -> None:
+        slot_start = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+        slot_end = datetime(2026, 6, 1, 12, 15, tzinfo=UTC)
+        tracker = ForecastTracker()
+
+        # Planner cycle far ahead of slot start: an early, stale estimate.
+        register_forecasts_from_planner(
+            PlannerOutput(
+                slots=[
+                    PlannedSlot(
+                        start=slot_start,
+                        end=slot_end,
+                        solcast_pv_estimate_kwh=5.0,
+                        avg_house_consumption_kwh=2.0,
+                    )
+                ]
+            ),
+            tracker,
+            now=slot_start - timedelta(hours=2),
+        )
+        rec = tracker.find_record(slot_start)
+        assert rec is not None
+        assert rec.forecast_pv_kwh == 5.0
+        assert rec.forecast_frozen is False
+
+        # A later planner cycle, still before slot start, refines the
+        # estimate — this must overwrite the stale one.
+        register_forecasts_from_planner(
+            PlannerOutput(
+                slots=[
+                    PlannedSlot(
+                        start=slot_start,
+                        end=slot_end,
+                        solcast_pv_estimate_kwh=3.0,
+                        avg_house_consumption_kwh=1.5,
+                    )
+                ]
+            ),
+            tracker,
+            now=slot_start - timedelta(minutes=5),
+        )
+        assert rec.forecast_pv_kwh == 3.0
+        assert rec.forecast_frozen is False
+
+        # The slot physically starts; the coordinator's accumulation cycle
+        # freezes whatever the freshest pre-start estimate was.
+        hourly_recommendations = [_rec(slot_start, slot_end)]
+        ts = _accumulate(
+            tracker,
+            now=slot_start - timedelta(seconds=30),
+            live=_live(pv_w=0.0, load_w=0.0),
+            hourly_recommendations=hourly_recommendations,
+            last_accumulation_ts=None,
+        )
+        _accumulate(
+            tracker,
+            now=slot_start + timedelta(seconds=5),
+            live=_live(pv_w=0.0, load_w=0.0),
+            hourly_recommendations=hourly_recommendations,
+            last_accumulation_ts=ts,
+        )
+
+        assert rec.forecast_frozen is True
+        assert rec.forecast_pv_kwh == 3.0
+        assert rec.forecast_load_kwh == 1.5
+
+        # A post-start planner cycle must not clobber the frozen baseline.
+        register_forecasts_from_planner(
+            PlannerOutput(
+                slots=[
+                    PlannedSlot(
+                        start=slot_start,
+                        end=slot_end,
+                        solcast_pv_estimate_kwh=99.0,
+                        avg_house_consumption_kwh=99.0,
+                    )
+                ]
+            ),
+            tracker,
+            now=slot_start + timedelta(seconds=10),
+        )
+        assert rec.forecast_pv_kwh == 3.0
+        assert rec.forecast_load_kwh == 1.5

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -60,3 +60,16 @@ from custom_components.hsem.time import async_setup_entry as _time_setup  # noqa
 # async_setup is referenced here so vulture knows the function is live (called by HA).
 # This suppresses any false-positive "unused" warnings on its parameters.
 _ = async_setup  # noqa: S905
+
+from custom_components.hsem.utils.forecast_tracker import (  # noqa: F401
+    ForecastTracker as _ForecastTracker,
+)
+
+# finalise_record() is an intentionally-kept single-record convenience API
+# alongside the bulk-oriented finalise_past_records() that production
+# actually calls each cycle (coordinator_tracking.py). Decided as part of
+# issue #972's ForecastTracker gap triage: Gaps 1-3
+# (reconcile_unfinalised_layout, accumulate_power_interval, freeze_forecasts)
+# were wired into coordinator_tracking.py; this one (Gap 4) was not, since
+# finalise_past_records already covers production's bulk-finalise need.
+_ = _ForecastTracker.finalise_record  # noqa: S905


### PR DESCRIPTION
## Summary

Closes #972. `ForecastTracker` (`custom_components/hsem/utils/forecast_tracker.py`)
already had three methods that were more correct than what
`coordinator_tracking.py` actually did in production, but nothing wired
them in:

- **Gap 1** — `accumulate_power_interval()`: the live coordinator attributed
  an entire elapsed-time energy sample to whichever single slot contained
  `now`. A delayed cycle (HA restart, long-running cycle, missed tick)
  spanning a slot boundary would silently dump 100% of that energy onto one
  slot, corrupting the forecast-vs-actual MAE for both that slot and its
  neighbour.
- **Gap 2** — `reconcile_unfinalised_layout()`: `get_or_create_record()`
  matches an existing record by `start` only. If the slot layout changes
  mid-flight (interval reconfiguration, DST transition, horizon change),
  the coordinator would silently reuse a stale record with the wrong `end`.
- **Gap 3** — the `observed_at` / `freeze_forecasts()` progressive-freeze
  pathway: the only production caller of `set_forecasts()` always omitted
  `observed_at`, so a forecast baseline froze at the first planner cycle
  that ever saw the slot rather than the freshest estimate right before it
  physically started.

**Gap 4** (`finalise_record()`) was decided as intentionally *not* wired:
`finalise_past_records()` already does the bulk-finalise the coordinator
needs each cycle, so the single-record variant stays as public API surface.
Documented with a note in `vulture_whitelist.py`.

### Changes

- `coordinator_tracking.py::accumulate_forecast_actuals()` now reconciles
  the slot layout, freezes started-slot baselines, and splits the elapsed
  interval's PV/load energy by physical overlap via
  `accumulate_power_interval()` instead of a single current-slot credit.
- `coordinator_tracking.py::register_forecasts_from_planner()` now creates
  a tracker record for every slot in the planner's horizon and passes
  `observed_at=now`, so a slot's forecast baseline is progressively refined
  every planner cycle until it physically starts; it also reconciles the
  layout `output.slots` just produced before registering into it.
- Both call sites (`coordinator_cycle.py`, `coordinator_planner_phase.py`)
  updated to pass the new `update_interval_minutes` / `now` arguments.
- `forecast_tracker.py` docstrings updated to describe the new production
  wiring instead of "not called in production".
- `docs/forecast-accuracy-tracking.md` updated: architecture diagram,
  method table, coordinator-integration section, and test-coverage tables.
- `docs/planner-spec.md` was checked but has no dedicated forecast-tracking
  section to update — the tracker remains purely diagnostic and does not
  affect planner decisions.

### Tests

Added `tests/test_coordinator_tracking_forecast.py`, exercising the
coordinator wiring directly against the three failure modes named in the
issue:

- Cross-slot-boundary energy accumulation splits proportionally instead of
  crediting the slot containing `now`.
- A mid-cycle slot-layout change discards the stale, incompatible
  unfinalised record instead of silently reusing it.
- A forecast baseline is progressively refined pre-start and freezes at the
  freshest estimate, not the first-ever-seen one, and can't be overwritten
  once frozen.

## Test plan

- [x] `./scripts/quality.sh lint`
- [x] `./scripts/quality.sh typing`
- [x] `./scripts/quality.sh quality` (pyright 0 errors; vulture — the four
      Gap 1-3 symbols no longer appear in the informational unused-code
      pass; `finalise_record` is now whitelisted with a rationale)
- [x] `./scripts/quality.sh translations` (0 errors — no user-facing
      strings changed)
- [x] `./scripts/quality.sh test` (3301 passed, including the 3 new
      regression tests and all existing `test_forecast_tracker.py` /
      `test_forecast_accuracy_sensor.py` tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
