### PR TITLE
fix(security): harden history-file reads and dashboard path against symlink/traversal

### DIFF
--- a/custom_components/hsem/coordinator_tracking.py
+++ b/custom_components/hsem/coordinator_tracking.py
@@ -32,6 +32,7 @@ from custom_components.hsem.utils.forecast_tracker import (
     compute_accumulated_energy,
 )
 from custom_components.hsem.utils.logger import async_log
+from custom_components.hsem.utils.persistence import read_json_history_file
 from custom_components.hsem.utils.prediction_tracker import (
     PredictionTracker,
     _action_label,
@@ -353,7 +354,7 @@ async def _load_financial_tracker(tracker: FinancialTracker) -> None:
     if not path.exists():
         return
     try:
-        data = await asyncio.to_thread(FinancialTracker._read_history_file, path)
+        data = await asyncio.to_thread(read_json_history_file, path)
         if data is not None:
             loaded = FinancialTracker.from_dict(data)
             # Copy loaded state into the existing tracker instance.

--- a/custom_components/hsem/models/daily_plan_vs_actual_tracker.py
+++ b/custom_components/hsem/models/daily_plan_vs_actual_tracker.py
@@ -20,6 +20,7 @@ from typing import Any
 from custom_components.hsem.models.daily_metrics import DailyMetrics
 from custom_components.hsem.models.daily_record import DailyRecord
 from custom_components.hsem.models.day_rollover_result import DayRolloverResult
+from custom_components.hsem.utils.persistence import read_json_history_file
 
 
 @dataclass
@@ -235,7 +236,7 @@ class DailyPlanVsActualTracker:
         if not path.exists():
             return
 
-        data = await asyncio.to_thread(self._read_history_file, path)
+        data = await asyncio.to_thread(read_json_history_file, path)
         if data is None:
             return
 
@@ -243,15 +244,6 @@ class DailyPlanVsActualTracker:
         if isinstance(days, list):
             self.history = [DailyRecord.from_dict(d) for d in days]
             self._prune_history()
-
-    @staticmethod
-    def _read_history_file(path: Path) -> dict[str, Any] | None:
-        """Read and parse the history JSON file (sync, offloaded to thread)."""
-        try:
-            with open(path, encoding="utf-8") as f:
-                return json.load(f)  # type: ignore[no-any-return]
-        except json.JSONDecodeError, OSError:
-            return None
 
     async def _save_record_to_history(self, record: DailyRecord) -> bool:
         """Append a record to the in-memory history, prune, and persist to disk.

--- a/custom_components/hsem/models/financial_tracker.py
+++ b/custom_components/hsem/models/financial_tracker.py
@@ -502,17 +502,6 @@ class FinancialTracker:
         return await asyncio.to_thread(self._write_history_file, data, path)
 
     @staticmethod
-    def _read_history_file(path: Any) -> dict[str, Any] | None:
-        """Read and parse the history JSON file (sync, offloaded to thread)."""
-        import json
-
-        try:
-            with open(str(path), encoding="utf-8") as f:
-                return json.load(f)  # type: ignore[no-any-return]
-        except json.JSONDecodeError, OSError:
-            return None
-
-    @staticmethod
     def _write_history_file(data: dict[str, Any], path: Any) -> bool:
         """Write the history data to disk atomically (sync, offloaded to thread)."""
         import json

--- a/custom_components/hsem/models/savings_tracker.py
+++ b/custom_components/hsem/models/savings_tracker.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any
 
 from custom_components.hsem.models.savings_day import SavingsDay
+from custom_components.hsem.utils.persistence import read_json_history_file
 
 
 @dataclass
@@ -211,7 +212,7 @@ class SavingsTracker:
         if not path.exists():
             return
 
-        data = await asyncio.to_thread(self._read_history_file, path)
+        data = await asyncio.to_thread(read_json_history_file, path)
         if data is None:
             return
 
@@ -228,15 +229,6 @@ class SavingsTracker:
                 self.daily[entry.date] = entry
 
         self._prune_history()
-
-    @staticmethod
-    def _read_history_file(path: Path) -> dict[str, Any] | None:
-        """Read and parse the history JSON file (sync, offloaded to thread)."""
-        try:
-            with open(path, encoding="utf-8") as f:
-                return json.load(f)  # type: ignore[no-any-return]
-        except json.JSONDecodeError, OSError:
-            return None
 
     async def save_history(self) -> bool:
         """Persist the full savings state to disk atomically."""

--- a/custom_components/hsem/services.yaml
+++ b/custom_components/hsem/services.yaml
@@ -262,4 +262,5 @@ create_dashboard:
         text:
       description: >-
         Optional absolute file path where the dashboard YAML should be written.
-        When omitted, the file is written to <config>/hsem_dashboard.yaml.
+        Must resolve inside the Home Assistant config directory. When omitted,
+        the file is written to <config>/hsem_dashboard.yaml.

--- a/custom_components/hsem/utils/dashboard.py
+++ b/custom_components/hsem/utils/dashboard.py
@@ -7,6 +7,7 @@ Lovelace dashboard so it appears in the HA sidebar.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -32,6 +33,10 @@ DASHBOARD_TITLE = "HSEM"
 DASHBOARD_ICON = "mdi:solar-power"
 DASHBOARD_STORAGE_VERSION = 1
 DASHBOARD_STORAGE_KEY = f"{DOMAIN}.dashboard_provisioned"
+
+# os.O_NOFOLLOW is POSIX-only; HSEM only runs under Home Assistant (Linux),
+# but fall back to a no-op flag rather than raising on other platforms.
+_O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 
 
 # ---------------------------------------------------------------------------
@@ -113,13 +118,46 @@ def _bundled_dashboard_path() -> Path:
     return Path(__file__).parent.parent / "dashboards" / "dashboard_en.yaml"
 
 
+def _resolve_contained_destination(hass: HomeAssistant, destination: Path) -> Path:
+    """Resolve *destination* and confirm it stays inside the HA config directory.
+
+    ``dashboard_path`` can arrive from the ``create_dashboard`` service call
+    as an arbitrary caller-supplied string, so this rejects any path — via
+    ``..`` segments or a symlinked parent directory — that would resolve
+    outside the Home Assistant config directory, before any file I/O happens.
+
+    Args:
+        hass: The Home Assistant instance.
+        destination: The requested (possibly unresolved) destination path.
+
+    Returns:
+        The resolved, contained destination path.
+
+    Raises:
+        HomeAssistantError: When *destination* resolves outside the config
+            directory.
+    """
+    config_root = Path(hass.config.path()).resolve()
+    resolved = destination.resolve()
+    if resolved != config_root and config_root not in resolved.parents:
+        raise HomeAssistantError(
+            f"Dashboard path {destination} is outside the Home Assistant "
+            "config directory."
+        )
+    return resolved
+
+
 def _write_dashboard_file_sync(
     source_path: Path,
     destination_path: Path,
 ) -> None:
     """Copy the bundled dashboard YAML to *destination_path*.
 
-    Synchronous I/O — must run inside the HA executor.
+    Synchronous I/O — must run inside the HA executor. *destination_path*
+    must already be resolved and containment-checked (see
+    :func:`_resolve_contained_destination`); this additionally opens it with
+    ``O_NOFOLLOW`` so a symlink swapped in after that check is never
+    followed for the write.
 
     Args:
         source_path: Path to the bundled YAML.
@@ -129,15 +167,25 @@ def _write_dashboard_file_sync(
         HomeAssistantError: When the bundled YAML is missing or cannot be
             copied.
     """
-    if not source_path.exists():
+    if not source_path.is_file() or source_path.is_symlink():
         raise HomeAssistantError(
             f"Bundled HSEM dashboard YAML not found at {source_path}"
         )
+    content = source_path.read_text(encoding="utf-8")
 
     destination_path.parent.mkdir(parents=True, exist_ok=True)
-    destination_path.write_text(
-        source_path.read_text(encoding="utf-8"), encoding="utf-8"
-    )
+    try:
+        fd = os.open(
+            destination_path,
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC | _O_NOFOLLOW,
+            0o644,
+        )
+    except OSError as err:
+        raise HomeAssistantError(
+            f"Cannot write dashboard YAML to {destination_path}: {err}"
+        ) from err
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write(content)
 
 
 async def async_ensure_hsem_dashboard(
@@ -160,9 +208,12 @@ async def async_ensure_hsem_dashboard(
 
     Raises:
         HomeAssistantError: When the Lovelace collection is unavailable, the
-            bundled YAML is missing, or writing the dashboard fails.
+            bundled YAML is missing, ``dashboard_path`` resolves outside the
+            Home Assistant config directory, or writing the dashboard fails.
     """
-    destination = dashboard_path or _default_dashboard_path(hass)
+    destination = _resolve_contained_destination(
+        hass, dashboard_path or _default_dashboard_path(hass)
+    )
     source = _bundled_dashboard_path()
 
     # Offload file I/O to the executor.

--- a/custom_components/hsem/utils/persistence.py
+++ b/custom_components/hsem/utils/persistence.py
@@ -2,9 +2,21 @@
 
 from __future__ import annotations
 
+import json
 import math
+import os
+import stat
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
+
+#: Hard cap on history-file size. Generous for bounded, pruned JSON logs;
+#: exists to stop a swapped-in oversized file from exhausting memory.
+_MAX_HISTORY_FILE_BYTES = 16 * 1024 * 1024
+
+# os.O_NOFOLLOW is POSIX-only; HSEM only runs under Home Assistant (Linux),
+# but fall back to a no-op flag rather than raising on other platforms.
+_O_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 
 
 def finite_float(
@@ -44,3 +56,33 @@ def aware_datetime_from_iso(value: Any) -> datetime | None:
     except OverflowError, ValueError:
         return None
     return parsed
+
+
+def read_json_history_file(path: Path) -> dict[str, Any] | None:
+    """Read and parse a bounded JSON history file from disk.
+
+    Rejects symlinks and non-regular files via ``lstat`` (so a swapped-in
+    symlink is never followed to stat its target) and re-checks with
+    ``O_NOFOLLOW`` at open time to close the TOCTOU window between the stat
+    and the read. Files over the size cap are rejected before parsing.
+
+    Args:
+        path: Path to the JSON history file.
+
+    Returns:
+        The parsed JSON object as a dict, or ``None`` if the file is
+        missing, not a plain file, too large, a symlink, or invalid JSON.
+    """
+    try:
+        info = path.lstat()
+        if not stat.S_ISREG(info.st_mode) or info.st_size > _MAX_HISTORY_FILE_BYTES:
+            return None
+        fd = os.open(path, os.O_RDONLY | _O_NOFOLLOW)
+    except OSError:
+        return None
+    try:
+        with os.fdopen(fd, encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except OSError, json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None

--- a/custom_components/hsem/utils/prediction_tracker.py
+++ b/custom_components/hsem/utils/prediction_tracker.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any
 
 from custom_components.hsem.models.prediction_record import PredictionRecord
+from custom_components.hsem.utils.persistence import read_json_history_file
 
 # 7 days × 4 slots/h × 24 h = 672
 _SEVEN_DAY_SLOTS = 672
@@ -234,7 +235,7 @@ class PredictionTracker:
         path = Path(self.history_file)
         if not path.exists():
             return
-        data = await asyncio.to_thread(self._read_history_file, path)
+        data = await asyncio.to_thread(read_json_history_file, path)
         if isinstance(data, Mapping):
             self.load_from_dict(data)
 
@@ -247,15 +248,6 @@ class PredictionTracker:
         return await asyncio.to_thread(
             self._write_history_file, path, self.to_persistence_dict()
         )
-
-    @staticmethod
-    def _read_history_file(path: Path) -> dict[str, Any] | None:
-        try:
-            with open(path, encoding="utf-8") as handle:
-                payload = json.load(handle)
-            return payload if isinstance(payload, dict) else None
-        except json.JSONDecodeError, OSError:
-            return None
 
     @staticmethod
     def _write_history_file(path: Path, data: Mapping[str, Any]) -> bool:

--- a/docs/services-reference.md
+++ b/docs/services-reference.md
@@ -133,9 +133,9 @@ registered in Home Assistant so it appears in the sidebar.
 
 **Schema:**
 
-| Field            | Required | Type   | Description                                                                            |
-| ---------------- | -------- | ------ | -------------------------------------------------------------------------------------- |
-| `dashboard_path` | No       | String | Absolute file path for the dashboard YAML. Defaults to `<config>/hsem_dashboard.yaml`. |
+| Field            | Required | Type   | Description                                                                                                                         |
+| ---------------- | -------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `dashboard_path` | No       | String | Absolute file path for the dashboard YAML, must resolve inside the HA config directory. Defaults to `<config>/hsem_dashboard.yaml`. |
 
 **Response:**
 
@@ -157,6 +157,9 @@ registered in Home Assistant so it appears in the sidebar.
 - If the user deletes the dashboard via the HA UI, the service remembers that
   choice and will not recreate it automatically.
 - You can still edit the generated YAML manually after creation.
+- `dashboard_path` must resolve inside the HA config directory; paths that
+  escape it (via `..` segments or a symlinked parent) are rejected before any
+  file is written.
 
 **Examples:**
 

--- a/tests/models/test_financial_tracker.py
+++ b/tests/models/test_financial_tracker.py
@@ -11,6 +11,7 @@ from custom_components.hsem.models.financial_tracker import (
     FinancialDayEntry,
     FinancialTracker,
 )
+from custom_components.hsem.utils.persistence import read_json_history_file
 
 
 class TestFinancialDayEntry:
@@ -509,7 +510,7 @@ class TestFinancialTrackerPersistence:
         assert history_path.exists()
 
         restored = FinancialTracker.from_dict(
-            FinancialTracker._read_history_file(history_path) or {}
+            read_json_history_file(history_path) or {}
         )
         assert restored.import_cost_total == pytest.approx(original.import_cost_total)
         assert restored.export_income_total == pytest.approx(

--- a/tests/utils/test_persistence.py
+++ b/tests/utils/test_persistence.py
@@ -1,0 +1,73 @@
+"""Tests for utils.persistence.read_json_history_file.
+
+Covers the SAST-flagged path-traversal / symlink-following read findings
+(SKY-D215, SKY-D325) across the tracker history files: valid data, missing
+files, corrupt JSON, oversized files, and symlinked files must all be
+rejected or handled without raising.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from custom_components.hsem.utils.persistence import (
+    _MAX_HISTORY_FILE_BYTES,
+    read_json_history_file,
+)
+
+
+def test_reads_valid_json_dict(tmp_path: Path) -> None:
+    """A well-formed JSON object is parsed and returned."""
+    path = tmp_path / "history.json"
+    path.write_text(json.dumps({"days": [1, 2, 3]}), encoding="utf-8")
+    assert read_json_history_file(path) == {"days": [1, 2, 3]}
+
+
+def test_missing_file_returns_none(tmp_path: Path) -> None:
+    """A nonexistent path returns None instead of raising."""
+    assert read_json_history_file(tmp_path / "missing.json") is None
+
+
+def test_corrupt_json_returns_none(tmp_path: Path) -> None:
+    """Invalid JSON content is treated as absent history, not an error."""
+    path = tmp_path / "corrupt.json"
+    path.write_text("{not valid json", encoding="utf-8")
+    assert read_json_history_file(path) is None
+
+
+def test_non_dict_json_returns_none(tmp_path: Path) -> None:
+    """A JSON array (or other non-object top level) is rejected."""
+    path = tmp_path / "array.json"
+    path.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    assert read_json_history_file(path) is None
+
+
+def test_directory_returns_none(tmp_path: Path) -> None:
+    """A directory at the given path is rejected, not opened."""
+    directory = tmp_path / "a_directory"
+    directory.mkdir()
+    assert read_json_history_file(directory) is None
+
+
+def test_oversized_file_returns_none(tmp_path: Path) -> None:
+    """Files over the size cap are rejected before parsing."""
+    path = tmp_path / "huge.json"
+    with path.open("w", encoding="utf-8") as handle:
+        handle.write('{"pad": "')
+        handle.seek(_MAX_HISTORY_FILE_BYTES + 1024)
+        handle.write('"}')
+    assert path.stat().st_size > _MAX_HISTORY_FILE_BYTES
+    assert read_json_history_file(path) is None
+
+
+def test_symlink_to_valid_file_is_rejected(tmp_path: Path) -> None:
+    """A symlink is never followed, even if the target is valid JSON."""
+    real_target = tmp_path / "real.json"
+    real_target.write_text(json.dumps({"days": []}), encoding="utf-8")
+
+    link = tmp_path / "link.json"
+    os.symlink(real_target, link)
+
+    assert read_json_history_file(link) is None


### PR DESCRIPTION
## Summary

Fixes a batch of SAST findings (path-traversal / symlink-following file I/O,
plus two SSRF findings that turned out to be false positives).

- **Centralized history-file reads.** `daily_plan_vs_actual_tracker.py`,
  `financial_tracker.py`, `savings_tracker.py`, and `prediction_tracker.py`
  each had their own copy of `_read_history_file()`. All four now delegate to
  a single `read_json_history_file()` in `utils/persistence.py`, which:
  - rejects symlinks via `lstat` (never stats/opens the symlink target),
  - re-checks with `O_NOFOLLOW` at open time to close the TOCTOU window
    between the stat and the read,
  - enforces a 16 MB size cap before parsing,
  - requires a regular file.

  These paths are all internally constructed from
  `hass.config.config_dir/.storage/...` (not attacker-controlled), so the
  traversal finding itself was theoretical, but the duplication was a
  pre-existing violation of this repo's utility-centralization rule and the
  symlink hardening is real defense-in-depth for `.storage` file tampering.

- **`dashboard.py` / `hsem.create_dashboard` service — real fix.**
  `dashboard_path` comes unvalidated from the service call, so any caller
  could previously point it anywhere on the filesystem. Added
  `_resolve_contained_destination()`, which rejects any path (via `..`
  segments or a symlinked parent directory) that resolves outside the HA
  config directory, and opens the destination with `O_NOFOLLOW` so a symlink
  swapped in after the check is never followed. `services.yaml` and
  `docs/services-reference.md` updated to document the restriction.

- **Two SSRF findings dismissed as false positives**, with the reasoning
  documented in the commit message:
  `ml/weather_forecast_reader.py:94` (a `dict.get()` on a HA service-call
  response) and `planner/milp/_ev_constraints.py:121` (a plain dict lookup).
  Neither file imports or calls any HTTP client — verified with a full grep
  for `requests`/`aiohttp`/`httpx`/`urlopen`/`session.get`/etc. across both
  files.

## Files changed

- `custom_components/hsem/utils/persistence.py` — new `read_json_history_file()`
- `custom_components/hsem/models/daily_plan_vs_actual_tracker.py`
- `custom_components/hsem/models/financial_tracker.py`
- `custom_components/hsem/models/savings_tracker.py`
- `custom_components/hsem/utils/prediction_tracker.py`
- `custom_components/hsem/coordinator_tracking.py` — updated call site for `financial_tracker`
- `custom_components/hsem/utils/dashboard.py` — containment check + `O_NOFOLLOW` write
- `custom_components/hsem/services.yaml`, `docs/services-reference.md` — doc updates
- `tests/utils/test_persistence.py` — new (7 tests: valid JSON, missing file, corrupt JSON, non-dict JSON, directory, oversized file, symlink rejection)
- `tests/models/test_financial_tracker.py` — updated call site

## Test plan

- [x] `./scripts/quality.sh lint` — clean
- [x] `./scripts/quality.sh typing` — 0 errors
- [x] `./scripts/quality.sh quality` — 0 errors (pyright + vulture)
- [x] `./scripts/quality.sh test` — 3246 passed
- [x] New symlink/size-cap/corrupt-JSON tests in `tests/utils/test_persistence.py`
- [x] `dashboard.py` existing tests (including custom `dashboard_path`) still pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
